### PR TITLE
🧪 [Add tests for ConnectToServerUseCase error handling]

### DIFF
--- a/tests/SalmonEgg.Application.Tests/UseCases/ConnectToServerUseCaseTests.cs
+++ b/tests/SalmonEgg.Application.Tests/UseCases/ConnectToServerUseCaseTests.cs
@@ -203,5 +203,26 @@ namespace SalmonEgg.Application.Tests.UseCases
                 x => x.ConnectAsync(validConfig, It.IsAny<CancellationToken>()),
                 Times.Once);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenExceptionThrown_ShouldReturnFailureAndLogError()
+        {
+            // Arrange
+            var exception = new Exception("Test exception");
+            _mockConfigService
+                .Setup(x => x.LoadConfigurationAsync("test-id"))
+                .ThrowsAsync(exception);
+
+            // Act
+            var result = await _useCase.ExecuteAsync("test-id");
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("连接失败：发生未预期的错误", result.Error);
+
+            _mockLogger.Verify(
+                x => x.Error(exception, "连接到服务器时发生未预期的错误，配置 ID: {ConfigId}", "test-id"),
+                Times.Once);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `ConnectToServerUseCase.cs` for the top-level error handling block (`catch (Exception ex)`) has been addressed. The original code logged an unexpected error and returned a failure result but was not covered by any test.
📊 **Coverage:** A new test scenario, `ExecuteAsync_WhenExceptionThrown_ShouldReturnFailureAndLogError`, was added. This covers the edge condition where an unexpected exception is thrown during the execution flow (specifically mocked at the configuration loading stage).
✨ **Result:** The test coverage for `ConnectToServerUseCase.cs` is improved by completely verifying the failure output and ensuring the error is logged correctly using Serilog.

---
*PR created automatically by Jules for task [10586841021431816594](https://jules.google.com/task/10586841021431816594) started by @YoungSx*