### PR TITLE
🧹 Remove commented out hack markers in NavigationSmokeTests

### DIFF
--- a/tests/SalmonEgg.GuiTests.Windows/NavigationSmokeTests.cs
+++ b/tests/SalmonEgg.GuiTests.Windows/NavigationSmokeTests.cs
@@ -593,8 +593,6 @@ public sealed class NavigationSmokeTests
             return;
         }
 
-        // [HACK-REMOVED]
-        // Assert.Equal("content", winner);
         Assert.Fail($"Expected visible selection to fall back to project, but winner was {winner ?? "<null>"}. {DumpSelectionSnapshot(session, sessionId, projectId, startId)}");
     }
 
@@ -628,13 +626,6 @@ public sealed class NavigationSmokeTests
                 winner = projectId;
                 return true;
             }
-
-            // [HACK-REMOVED]
-            // if (!sessionVisible && chatHeaderVisible)
-            // {
-            //     winner = "content";
-            //     return true;
-            // }
 
             if (startSelected)
             {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed commented-out code blocks marked with `[HACK-REMOVED]` from `tests/SalmonEgg.GuiTests.Windows/NavigationSmokeTests.cs`.

💡 **Why:** How this improves maintainability
These were left over from previous hacks and comment-outs. Removing them improves maintainability and cleans up the code file.

✅ **Verification:** How you confirmed the change is safe
Verified the code builds successfully using `dotnet build` with the required parameters in the sandbox. The GUI tests themselves couldn't be run due to a missing Windows runtime test framework in the test environment, but removing a comment is guaranteed not to alter functionality. 

✨ **Result:** The improvement achieved
A cleaner `NavigationSmokeTests.cs` file with less commented-out code.

---
*PR created automatically by Jules for task [8015312943556291408](https://jules.google.com/task/8015312943556291408) started by @YoungSx*