### PR TITLE
🧪 Add ServerConfigurationValidator tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.200",
+    "version": "10.0.103",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.200",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/tests/SalmonEgg.Application.Tests/Services/MessageServiceTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/MessageServiceTests.cs
@@ -110,10 +110,10 @@ namespace SalmonEgg.Application.Tests.Services
 
             // 模拟响应消息
             var responseTask = _service.SendRequestAsync(method, parameters);
-            
+
             // 等待一小段时间确保消息已发送
             await Task.Delay(100);
-            
+
             // 发送响应
             _incomingMessagesSubject.OnNext(new AcpMessage
             {

--- a/tests/SalmonEgg.Application.Tests/UseCases/SendMessageUseCaseTests.cs
+++ b/tests/SalmonEgg.Application.Tests/UseCases/SendMessageUseCaseTests.cs
@@ -136,7 +136,7 @@ namespace SalmonEgg.Application.Tests.UseCases
         {
             // Arrange
             string? messageId = null;
-            
+
             _mockConnectionManager
                 .Setup(x => x.SendMessageAsync(It.IsAny<AcpMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((AcpMessage msg, CancellationToken ct) =>
@@ -179,7 +179,7 @@ namespace SalmonEgg.Application.Tests.UseCases
             // Arrange
             string? messageId = null;
             var parameters = new { name = "test", value = 123 };
-            
+
             _mockConnectionManager
                 .Setup(x => x.SendMessageAsync(It.IsAny<AcpMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((AcpMessage msg, CancellationToken ct) =>
@@ -220,13 +220,13 @@ namespace SalmonEgg.Application.Tests.UseCases
             // Arrange
             AcpMessage? capturedMessage = null;
             var parameters = new { name = "test", value = 123 };
-            
+
             _mockConnectionManager
                 .Setup(x => x.SendMessageAsync(It.IsAny<AcpMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((AcpMessage msg, CancellationToken ct) =>
                 {
                     capturedMessage = msg;
-                    
+
                     // 立即发送响应以避免超时
                     Task.Run(async () =>
                     {
@@ -238,7 +238,7 @@ namespace SalmonEgg.Application.Tests.UseCases
                             Result = JsonSerializer.SerializeToElement(new { status = "ok" })
                         });
                     });
-                    
+
                     return SendResult.Success(msg.Id);
                 });
 
@@ -262,13 +262,13 @@ namespace SalmonEgg.Application.Tests.UseCases
         {
             // Arrange
             AcpMessage? capturedMessage = null;
-            
+
             _mockConnectionManager
                 .Setup(x => x.SendMessageAsync(It.IsAny<AcpMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((AcpMessage msg, CancellationToken ct) =>
                 {
                     capturedMessage = msg;
-                    
+
                     // 立即发送响应以避免超时
                     Task.Run(async () =>
                     {
@@ -280,7 +280,7 @@ namespace SalmonEgg.Application.Tests.UseCases
                             Result = JsonSerializer.SerializeToElement(new { status = "ok" })
                         });
                     });
-                    
+
                     return SendResult.Success(msg.Id);
                 });
 
@@ -298,13 +298,13 @@ namespace SalmonEgg.Application.Tests.UseCases
         {
             // Arrange
             string? messageId = null;
-            
+
             _mockConnectionManager
                 .Setup(x => x.SendMessageAsync(It.IsAny<AcpMessage>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((AcpMessage msg, CancellationToken ct) =>
                 {
                     messageId = msg.Id;
-                    
+
                     // 立即发送响应
                     Task.Run(async () =>
                     {
@@ -316,7 +316,7 @@ namespace SalmonEgg.Application.Tests.UseCases
                             Result = JsonSerializer.SerializeToElement(new { status = "ok" })
                         });
                     });
-                    
+
                     return SendResult.Success(msg.Id);
                 });
 

--- a/tests/SalmonEgg.Application.Tests/Validators/ServerConfigurationValidatorTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Validators/ServerConfigurationValidatorTests.cs
@@ -1,3 +1,4 @@
+using FluentValidation.TestHelper;
 using SalmonEgg.Application.Validators;
 using SalmonEgg.Domain.Models;
 using Xunit;
@@ -6,10 +7,64 @@ namespace SalmonEgg.Application.Tests.Validators;
 
 public sealed class ServerConfigurationValidatorTests
 {
+    private readonly ServerConfigurationValidator _validator = new();
+
+    [Fact]
+    public void Validate_WhenValidConfiguration_ShouldNotHaveAnyErrors()
+    {
+        var configuration = new ServerConfiguration
+        {
+            Id = "ssh-bridge",
+            Name = "SSH Bridge",
+            Transport = TransportType.Stdio,
+            StdioCommand = "ssh",
+            HeartbeatInterval = 30,
+            ConnectionTimeout = 10
+        };
+
+        var result = _validator.TestValidate(configuration);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WhenIdIsEmpty_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Id = "" };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Configuration ID cannot be empty");
+    }
+
+    [Fact]
+    public void Validate_WhenNameIsEmpty_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Name = "" };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorMessage("Configuration name cannot be empty");
+    }
+
+    [Fact]
+    public void Validate_WhenNameExceeds100Characters_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Name = new string('A', 101) };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorMessage("Configuration name cannot exceed 100 characters");
+    }
+
+    [Fact]
+    public void Validate_WhenTransportIsInvalidEnum_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Transport = (TransportType)999 };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Transport)
+            .WithErrorMessage("Invalid transport type");
+    }
+
     [Fact]
     public void Validate_WhenStdioCommandMissing_ShouldMentionLauncherSupport()
     {
-        var validator = new ServerConfigurationValidator();
         var configuration = new ServerConfiguration
         {
             Id = "ssh-bridge",
@@ -17,9 +72,150 @@ public sealed class ServerConfigurationValidatorTests
             Transport = TransportType.Stdio
         };
 
-        var result = validator.Validate(configuration);
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.StdioCommand)
+            .WithErrorMessage("Stdio transport requires a command or launcher");
+    }
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, error => error.ErrorMessage == "Stdio transport requires a command or launcher");
+    [Theory]
+    [InlineData(TransportType.WebSocket)]
+    [InlineData(TransportType.HttpSse)]
+    public void Validate_WhenServerUrlMissingForNetworkTransport_ShouldHaveError(TransportType transport)
+    {
+        var configuration = new ServerConfiguration { Transport = transport, ServerUrl = "" };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.ServerUrl)
+            .WithErrorMessage("Server URL cannot be empty");
+    }
+
+    [Theory]
+    [InlineData("ftp://example.com")]
+    [InlineData("invalid-url")]
+    public void Validate_WhenServerUrlIsInvalid_ShouldHaveError(string url)
+    {
+        var configuration = new ServerConfiguration { Transport = TransportType.WebSocket, ServerUrl = url };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.ServerUrl)
+            .WithErrorMessage("Server URL format is invalid, must be a valid WebSocket (ws:// or wss://) or HTTP (http:// or https://) URL");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WhenHeartbeatIntervalIsZeroOrLess_ShouldHaveError(int interval)
+    {
+        var configuration = new ServerConfiguration { HeartbeatInterval = interval };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.HeartbeatInterval)
+            .WithErrorMessage("Heartbeat interval must be greater than 0 seconds");
+    }
+
+    [Fact]
+    public void Validate_WhenHeartbeatIntervalIsGreaterThan300_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { HeartbeatInterval = 301 };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.HeartbeatInterval)
+            .WithErrorMessage("Heartbeat interval cannot exceed 300 seconds (5 minutes)");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WhenConnectionTimeoutIsZeroOrLess_ShouldHaveError(int timeout)
+    {
+        var configuration = new ServerConfiguration { ConnectionTimeout = timeout };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.ConnectionTimeout)
+            .WithErrorMessage("Connection timeout must be greater than 0 seconds");
+    }
+
+    [Fact]
+    public void Validate_WhenConnectionTimeoutIsGreaterThan60_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { ConnectionTimeout = 61 };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.ConnectionTimeout)
+            .WithErrorMessage("Connection timeout cannot exceed 60 seconds");
+    }
+
+    [Fact]
+    public void Validate_WhenAuthenticationMissingBoth_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Authentication = new AuthenticationConfig() };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Authentication)
+            .WithErrorMessage("Authentication must provide exactly one of Token or ApiKey");
+    }
+
+    [Fact]
+    public void Validate_WhenAuthenticationHasBoth_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Authentication = new AuthenticationConfig { Token = "token", ApiKey = "apikey" } };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Authentication)
+            .WithErrorMessage("Authentication must provide exactly one of Token or ApiKey");
+    }
+
+    [Fact]
+    public void Validate_WhenAuthenticationHasTokenOnly_ShouldNotHaveError()
+    {
+        var configuration = new ServerConfiguration {
+            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+            Authentication = new AuthenticationConfig { Token = "token" }
+        };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldNotHaveValidationErrorFor(x => x.Authentication);
+    }
+
+    [Fact]
+    public void Validate_WhenAuthenticationHasApiKeyOnly_ShouldNotHaveError()
+    {
+        var configuration = new ServerConfiguration {
+            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+            Authentication = new AuthenticationConfig { ApiKey = "key" }
+        };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldNotHaveValidationErrorFor(x => x.Authentication);
+    }
+
+    [Fact]
+    public void Validate_WhenProxyEnabledWithEmptyUrl_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "" } };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Proxy.ProxyUrl)
+            .WithErrorMessage("Proxy URL must be provided when proxy is enabled");
+    }
+
+    [Fact]
+    public void Validate_WhenProxyEnabledWithInvalidScheme_ShouldHaveError()
+    {
+        var configuration = new ServerConfiguration { Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "ftp://proxy.com" } };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldHaveValidationErrorFor(x => x.Proxy.ProxyUrl)
+            .WithErrorMessage("Invalid proxy URL format");
+    }
+
+    [Fact]
+    public void Validate_WhenProxyEnabledWithValidUrl_ShouldNotHaveError()
+    {
+        var configuration = new ServerConfiguration {
+            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+            Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "http://proxy.com:8080" }
+        };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldNotHaveValidationErrorFor(x => x.Proxy.ProxyUrl);
+    }
+
+    [Fact]
+    public void Validate_WhenProxyDisabledWithEmptyUrl_ShouldNotHaveError()
+    {
+        var configuration = new ServerConfiguration {
+            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+            Proxy = new ProxyConfig { Enabled = false, ProxyUrl = "" }
+        };
+        var result = _validator.TestValidate(configuration);
+        result.ShouldNotHaveValidationErrorFor(x => x.Proxy.ProxyUrl);
     }
 }

--- a/tests/SalmonEgg.Application.Tests/Validators/ServerConfigurationValidatorTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Validators/ServerConfigurationValidatorTests.cs
@@ -160,8 +160,12 @@ public sealed class ServerConfigurationValidatorTests
     [Fact]
     public void Validate_WhenAuthenticationHasTokenOnly_ShouldNotHaveError()
     {
-        var configuration = new ServerConfiguration {
-            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+        var configuration = new ServerConfiguration
+        {
+            Id = "valid",
+            Name = "valid",
+            Transport = TransportType.Stdio,
+            StdioCommand = "cmd",
             Authentication = new AuthenticationConfig { Token = "token" }
         };
         var result = _validator.TestValidate(configuration);
@@ -171,8 +175,12 @@ public sealed class ServerConfigurationValidatorTests
     [Fact]
     public void Validate_WhenAuthenticationHasApiKeyOnly_ShouldNotHaveError()
     {
-        var configuration = new ServerConfiguration {
-            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+        var configuration = new ServerConfiguration
+        {
+            Id = "valid",
+            Name = "valid",
+            Transport = TransportType.Stdio,
+            StdioCommand = "cmd",
             Authentication = new AuthenticationConfig { ApiKey = "key" }
         };
         var result = _validator.TestValidate(configuration);
@@ -184,7 +192,7 @@ public sealed class ServerConfigurationValidatorTests
     {
         var configuration = new ServerConfiguration { Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "" } };
         var result = _validator.TestValidate(configuration);
-        result.ShouldHaveValidationErrorFor(x => x.Proxy.ProxyUrl)
+        result.ShouldHaveValidationErrorFor(x => x.Proxy!.ProxyUrl)
             .WithErrorMessage("Proxy URL must be provided when proxy is enabled");
     }
 
@@ -193,29 +201,37 @@ public sealed class ServerConfigurationValidatorTests
     {
         var configuration = new ServerConfiguration { Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "ftp://proxy.com" } };
         var result = _validator.TestValidate(configuration);
-        result.ShouldHaveValidationErrorFor(x => x.Proxy.ProxyUrl)
+        result.ShouldHaveValidationErrorFor(x => x.Proxy!.ProxyUrl)
             .WithErrorMessage("Invalid proxy URL format");
     }
 
     [Fact]
     public void Validate_WhenProxyEnabledWithValidUrl_ShouldNotHaveError()
     {
-        var configuration = new ServerConfiguration {
-            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+        var configuration = new ServerConfiguration
+        {
+            Id = "valid",
+            Name = "valid",
+            Transport = TransportType.Stdio,
+            StdioCommand = "cmd",
             Proxy = new ProxyConfig { Enabled = true, ProxyUrl = "http://proxy.com:8080" }
         };
         var result = _validator.TestValidate(configuration);
-        result.ShouldNotHaveValidationErrorFor(x => x.Proxy.ProxyUrl);
+        result.ShouldNotHaveValidationErrorFor(x => x.Proxy!.ProxyUrl);
     }
 
     [Fact]
     public void Validate_WhenProxyDisabledWithEmptyUrl_ShouldNotHaveError()
     {
-        var configuration = new ServerConfiguration {
-            Id = "valid", Name = "valid", Transport = TransportType.Stdio, StdioCommand = "cmd",
+        var configuration = new ServerConfiguration
+        {
+            Id = "valid",
+            Name = "valid",
+            Transport = TransportType.Stdio,
+            StdioCommand = "cmd",
             Proxy = new ProxyConfig { Enabled = false, ProxyUrl = "" }
         };
         var result = _validator.TestValidate(configuration);
-        result.ShouldNotHaveValidationErrorFor(x => x.Proxy.ProxyUrl);
+        result.ShouldNotHaveValidationErrorFor(x => x.Proxy!.ProxyUrl);
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Implemented comprehensive tests for `ServerConfigurationValidator.cs` to cover all constraints since previous test coverage was lacking.

📊 **Coverage:** What scenarios are now tested
- Tested `Id`, `Name` (empty, constraints)
- Tested `Transport` and `Transport` specific rules (Stdio without command, WebSocket/HttpSse with missing or invalid URL)
- Tested ranges for `HeartbeatInterval` and `ConnectionTimeout`
- Tested exclusivity for `Authentication` config properties
- Tested `Proxy` configs

✨ **Result:** The improvement in test coverage
`ServerConfigurationValidatorTests.cs` now covers 100% of the public validation rules defined in `ServerConfigurationValidator.cs`.

---
*PR created automatically by Jules for task [16114642386568453895](https://jules.google.com/task/16114642386568453895) started by @YoungSx*