### PR TITLE
🧪 Add test for StartViewModel catch block handling

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.200",
+    "version": "10.0.103",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.200",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Start/StartViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Start/StartViewModelTests.cs
@@ -526,15 +526,26 @@ public sealed class StartViewModelTests
             var preferences = CreatePreferences();
             using var chat = CreateChatViewModel(syncContext, preferences, Mock.Of<ISessionManager>());
             var workflow = new Mock<IChatLaunchWorkflow>();
+            var exception = new InvalidOperationException("boom");
             workflow.Setup(w => w.StartSessionAndSendAsync("launch", It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new InvalidOperationException("boom"));
+                .ThrowsAsync(exception);
 
             using var nav = CreateNavigationViewModel(chat, Mock.Of<ISessionManager>(), preferences);
-            var startViewModel = CreateStartViewModel(chat.ViewModel, preferences, nav, workflow.Object);
+            var loggerMock = new Mock<ILogger<StartViewModel>>();
+            var startViewModel = CreateStartViewModel(chat.ViewModel, preferences, nav, workflow.Object, loggerMock.Object);
             startViewModel.OnComposerLoaded();
             startViewModel.StartPrompt = "launch";
 
             await startViewModel.StartSessionAndSendCommand.ExecuteAsync(null);
+
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Start session failed")),
+                    exception,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
 
             Assert.False(startViewModel.IsStarting);
             Assert.Equal("launch", startViewModel.StartPrompt);


### PR DESCRIPTION
🎯 What: The catch block handling in StartSessionAndSendAsync for failed workflows was not fully covered.
📊 Coverage: We now assert that a warning log is recorded with the exception when a session start fails.
✨ Result: Improved test coverage and reliability for failure scenarios.

---
*PR created automatically by Jules for task [15418209690706522597](https://jules.google.com/task/15418209690706522597) started by @YoungSx*