### PR TITLE
🔒 Fix potential insecure deserialization via YamlDotNet

### DIFF
--- a/src/SalmonEgg.Infrastructure/Storage/YamlSerialization.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/YamlSerialization.cs
@@ -22,14 +22,14 @@ internal static class YamlSerialization
             .WithNodeTypeResolver(new StrictNodeTypeResolver(), s => s.OnTop())
             .Build();
 
-    private sealed class StrictNodeTypeResolver : INodeTypeResolver
+    internal sealed class StrictNodeTypeResolver : INodeTypeResolver
     {
         public bool Resolve(NodeEvent? nodeEvent, ref Type currentType)
         {
             if (nodeEvent?.Tag != null && !nodeEvent.Tag.IsEmpty)
             {
                 var tagValue = nodeEvent.Tag.Value;
-                if (!tagValue.StartsWith("tag:yaml.org,2002:", StringComparison.OrdinalIgnoreCase))
+                if (!tagValue.StartsWith("tag:yaml.org,2002:", StringComparison.Ordinal))
                 {
                     throw new YamlException(
                         nodeEvent.Start,

--- a/src/SalmonEgg.Infrastructure/Storage/YamlSerialization.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/YamlSerialization.cs
@@ -1,3 +1,6 @@
+using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -16,6 +19,26 @@ internal static class YamlSerialization
         new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
+            .WithNodeTypeResolver(new StrictNodeTypeResolver(), s => s.OnTop())
             .Build();
-}
 
+    private sealed class StrictNodeTypeResolver : INodeTypeResolver
+    {
+        public bool Resolve(NodeEvent? nodeEvent, ref Type currentType)
+        {
+            if (nodeEvent?.Tag != null && !nodeEvent.Tag.IsEmpty)
+            {
+                var tagValue = nodeEvent.Tag.Value;
+                if (!tagValue.StartsWith("tag:yaml.org,2002:", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new YamlException(
+                        nodeEvent.Start,
+                        nodeEvent.End,
+                        $"Insecure deserialization blocked: Unrecognized tag '{tagValue}'");
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/YamlSerializationTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/YamlSerializationTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using Xunit;
+using YamlDotNet.Core;
+using SalmonEgg.Infrastructure.Storage;
+using SalmonEgg.Infrastructure.Storage.YamlModels;
+
+namespace SalmonEgg.Infrastructure.Tests.Storage;
+
+public class YamlSerializationTests
+{
+    [Fact]
+    public void Deserializer_WithCustomTag_ThrowsYamlException()
+    {
+        var yaml = "some_object: !type:System.Diagnostics.Process { start_info: { file_name: calc } }";
+        var deserializer = YamlSerialization.CreateDeserializer();
+
+        var ex = Assert.Throws<YamlException>(() => deserializer.Deserialize<object>(yaml));
+        Assert.Contains("Insecure deserialization blocked: Unrecognized tag '!type:System.Diagnostics.Process'", ex.Message);
+    }
+
+    [Fact]
+    public void Deserializer_WithStandardTag_Succeeds()
+    {
+        var yaml = "some_object: !!str test";
+        var deserializer = YamlSerialization.CreateDeserializer();
+
+        var result = deserializer.Deserialize<dynamic>(yaml);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Deserializer_ServerConfigurationYamlV1_DoesNotRegress()
+    {
+        var yaml = @"schema_version: 1
+id: test-id
+name: test-server
+transport: stdio
+stdio_command: my_cmd
+heartbeat_interval_seconds: 60";
+        var deserializer = YamlSerialization.CreateDeserializer();
+
+        var result = deserializer.Deserialize<ServerConfigurationYamlV1>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal("test-id", result.Id);
+        Assert.Equal("test-server", result.Name);
+        Assert.Equal("stdio", result.Transport);
+        Assert.Equal("my_cmd", result.StdioCommand);
+        Assert.Equal(60, result.HeartbeatIntervalSeconds);
+    }
+
+    [Fact]
+    public void Deserializer_AppSettingsYamlV1_DoesNotRegress()
+    {
+        var yaml = @"schema_version: 1
+theme: Dark
+is_animation_enabled: false
+launch_on_startup: true";
+        var deserializer = YamlSerialization.CreateDeserializer();
+
+        var result = deserializer.Deserialize<AppSettingsYamlV1>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal("Dark", result.Theme);
+        Assert.False(result.IsAnimationEnabled);
+        Assert.True(result.LaunchOnStartup);
+    }
+}


### PR DESCRIPTION
🎯 What: A potential insecure deserialization vulnerability existed in how YAML files (e.g., ServerConfigurationYamlV1, AppSettingsYamlV1) were deserialized using YamlDotNet.
⚠️ Risk: If a malicious YAML payload with a custom type tag (e.g., '!type:System.Diagnostics.Process') was parsed, it could potentially lead to arbitrary code execution or object injection, depending on other configurations.
🛡️ Solution: We implemented and registered a strict custom INodeTypeResolver (StrictNodeTypeResolver) that is prepended to the resolver chain. It inspects all node events and explicitly blocks (via YamlException) any YAML tags that do not begin with the standard 'tag:yaml.org,2002:' prefix, strictly preventing any unexpected types from being instantiated.

---
*PR created automatically by Jules for task [2466847570588373018](https://jules.google.com/task/2466847570588373018) started by @YoungSx*