### PR TITLE
chore: add Ko-fi sponsorship link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: shangxin


### PR DESCRIPTION
## Summary
- add GitHub FUNDING.yml configuration for Ko-fi
- configure the sponsor link for the `shangxin` account

## Validation
- `git diff --check`
- YAML content verified as `ko_fi: shangxin`
- No application tests run; this is repository metadata only.