### PR TITLE
fix(cloud-sync): preserve sync revision when projecting app preferences

### DIFF
--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
@@ -888,6 +888,11 @@ public partial class AppPreferencesViewModel : ObservableObject
         {
             Enabled = settings.Enabled,
             ProviderId = settings.ProviderId?.Trim() ?? string.Empty,
+            // Revision 是云同步基线的一部分，投影必须原样带回。
+            // 丢掉它会让任意普通偏好保存把 app.yaml 的修订号写回 0，
+            // 指纹随之判定本地已变，启动自动同步按 fail-closed 报人工冲突（issue #82）。
+            // 反向验证记录：移除此行会使 ScheduleSave_PreservesCloudConfigSyncRevision 失败（Expected 42, Actual 0）。
+            Revision = settings.Revision,
             IncludeSecrets = settings.IncludeSecrets,
             ProviderOptions = CloneProviderOptions(settings.ProviderOptions)
         };

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AppPreferencesViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AppPreferencesViewModelTests.cs
@@ -439,6 +439,29 @@ public class AppPreferencesViewModelTests
     }
 
     [Fact]
+    public async Task ScheduleSave_PreservesCloudConfigSyncRevision()
+    {
+        var settingsService = new FakeAppSettingsService(new AppSettings
+        {
+            CloudConfigSync = new CloudConfigSyncSettings
+            {
+                Enabled = true,
+                ProviderId = "webdav",
+                Revision = 42,
+                IncludeSecrets = true
+            }
+        });
+        var vm = CreateViewModel(settingsService);
+        await vm.InitializeAsync(TestContext.Current.CancellationToken);
+
+        vm.TelemetrySharingEnabled = false;
+
+        await WaitForConditionAsync(() => settingsService.LastSaved is not null);
+
+        Assert.Equal(42, settingsService.LastSaved!.CloudConfigSync.Revision);
+    }
+
+    [Fact]
     public async Task ScheduleSave_NormalizesBlankTelemetryEndpointToNull()
     {
         var settingsService = new FakeAppSettingsService(new AppSettings


### PR DESCRIPTION
## Summary

Startup cloud config sync kept asking users to resolve a conflict (#82). Root cause is a silently lossy projection: `AppPreferencesViewModel.CloneCloudConfigSyncSettings` copied every field of `CloudConfigSyncSettings` **except `Revision`**, so the revision loaded from `app.yaml` became `0` as soon as it entered the ViewModel — and because the same helper builds the save snapshot, any unrelated preference change wrote that zero back to disk.

`ConfigContentFingerprint` strips only the root-level `updated_at_utc`, so `cloud_config_sync.revision` stays inside the hashed payload. A zeroed revision therefore makes the local config diverge from the synced baseline:

- alone, that yields a spurious `UploadLocal` — `"local dirty against unchanged remote baseline"`;
- once the other side has also advanced (the normal multi-device case, and inevitable when every device rewrites the revision independently), the same divergence lands on `"true conflict: both sides diverged from synced baseline"` and startup auto sync fail-closes with the manual prompt from the issue.

The projection has been lossy since `b6cad9c3` added `Revision` on 2026-07-13 — the hand-written clone dates to `0983fa4c` on 2026-07-07 and was never updated. A missing object-initializer member is not something the compiler can flag.

Fixes #82

## Changes

- `AppPreferencesViewModel.CloneCloudConfigSyncSettings`: carry `Revision`, with a comment recording why the field is load-bearing and the reverse-verification result.
- New regression test `ScheduleSave_PreservesCloudConfigSyncRevision`: drives the **real debounced save path** (`InitializeAsync` → change an unrelated preference → wait for the save) and asserts the revision survives.

Fixed at the single existing funnel — load projection, save snapshot and `SetCloudConfigSyncSettings` all already route through that one helper, so one initializer covers all three paths instead of scattering patches.

## Audit of the other construction sites

All three are correct and unchanged:

| Site | Verdict |
| --- | --- |
| `AppSettingsService.FromYaml` / `ToYaml` | both carry `Revision` |
| `CloudConfigSyncCoordinator.ApplyCandidateConfiguration` | assigns the freshly computed candidate revision |
| `AppPreferencesViewModel.ResetToDefaults` | intends a fresh zero |

## Verification

Rebased onto `develop` `8516454c` and re-run there:

- `SalmonEgg.Presentation.Core.Tests`: **3101/3101** passed
- `SalmonEgg.Application.Tests`: **86/86** passed
- `SalmonEgg.Infrastructure.Tests`: **505** passed, 5 skipped (env-gated ACP smoke)
- `dotnet build src/SalmonEgg.Presentation.Core -c Release`: **0 warnings, 0 errors**

**Reverse-verified rather than trusted green:** with the initializer temporarily removed, the new test fails with `Assert.Equal() Failure — Expected: 42, Actual: 0`. The guard is known to exercise the defect, not vacuously green.

## Known limits

Prod telemetry (`honeycomb prod/salmonegg`) supports the direction but cannot prove the reporter's session: 22 cloud sync decisions over 30 days, all `BaselineKnown=true`, including repeated `UploadLocal` for the same instance — but the dataset's latest event is `2026-08-19 16:32 UTC` while the issue was filed `2026-08-20 11:00 UTC`, so the post-report window is empty. The conclusion rests on the code chain plus reverse verification, not on the logs.

Not covered here: `CloudConfigSyncStateStore` silently degrades a corrupt-YAML or IO failure into an empty baseline, which is a second, independent route to a fail-closed conflict. No `BaselineKnown=false` was observed in telemetry, so it is a separate lower-priority risk and deliberately out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
