### PR TITLE
feat(cli): global settings management + config validate/export/import

### DIFF
--- a/src/SalmonEgg.Cli/CliApplication.cs
+++ b/src/SalmonEgg.Cli/CliApplication.cs
@@ -56,6 +56,8 @@ public static class CliApplication
         services.AddSingleton<CliCommandFactory>();
         services.AddSingleton<ServerConfigurationHandler>();
         services.AddSingleton<CredentialsHandler>();
+        services.AddSingleton<AppSettingsHandler>();
+        services.AddSingleton<ConfigPackageHandler>();
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton<ILogger<FallbackSecureStorage>>(fallbackWarningState);

--- a/src/SalmonEgg.Cli/Commands/CliCommandFactory.cs
+++ b/src/SalmonEgg.Cli/Commands/CliCommandFactory.cs
@@ -23,15 +23,21 @@ public sealed class CliCommandFactory
     private readonly CliVersionProvider _versionProvider;
     private readonly ServerConfigurationHandler _serverConfigurationHandler;
     private readonly CredentialsHandler _credentialsHandler;
+    private readonly AppSettingsHandler _appSettingsHandler;
+    private readonly ConfigPackageHandler _configPackageHandler;
 
     public CliCommandFactory(
         CliVersionProvider versionProvider,
         ServerConfigurationHandler serverConfigurationHandler,
-        CredentialsHandler credentialsHandler)
+        CredentialsHandler credentialsHandler,
+        AppSettingsHandler appSettingsHandler,
+        ConfigPackageHandler configPackageHandler)
     {
         _versionProvider = versionProvider ?? throw new ArgumentNullException(nameof(versionProvider));
         _serverConfigurationHandler = serverConfigurationHandler ?? throw new ArgumentNullException(nameof(serverConfigurationHandler));
         _credentialsHandler = credentialsHandler ?? throw new ArgumentNullException(nameof(credentialsHandler));
+        _appSettingsHandler = appSettingsHandler ?? throw new ArgumentNullException(nameof(appSettingsHandler));
+        _configPackageHandler = configPackageHandler ?? throw new ArgumentNullException(nameof(configPackageHandler));
     }
 
     /// <summary>
@@ -52,6 +58,10 @@ public sealed class CliCommandFactory
 
         var config = CreateStructuralCommand("config", ConfigDescription);
         config.Subcommands.Add(ConfigServerCommandFactory.CreateServerCommand(_serverConfigurationHandler, rawArgs));
+        config.Subcommands.Add(ConfigSettingsCommandFactory.CreateSettingsCommand(_appSettingsHandler));
+        config.Subcommands.Add(ConfigPackageCommandFactory.CreateValidateCommand(_configPackageHandler));
+        config.Subcommands.Add(ConfigPackageCommandFactory.CreateExportCommand(_configPackageHandler));
+        config.Subcommands.Add(ConfigPackageCommandFactory.CreateImportCommand(_configPackageHandler));
         var credentials = CredentialsCommandFactory.CreateCredentialsNamespaceCommand();
 
         root.Subcommands.Add(config);

--- a/src/SalmonEgg.Cli/Commands/Config/AppSettingsHandler.cs
+++ b/src/SalmonEgg.Cli/Commands/Config/AppSettingsHandler.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Cli.Output;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Cli.Commands.Config;
+
+/// <summary>
+/// Implements the <c>config settings</c> operations over the shared app-settings service.
+/// </summary>
+/// <remarks>
+/// All reads and writes go through <see cref="IAppSettingsService"/>; this handler never touches
+/// app.yaml directly. That keeps the atomic-write and Saved-event semantics owned by the service —
+/// a CLI write notifies runtime subscribers exactly like a GUI save or a cloud restore would.
+/// </remarks>
+public sealed class AppSettingsHandler
+{
+    private readonly ICliOutput _output;
+    private readonly IAppSettingsService _appSettings;
+
+    public AppSettingsHandler(ICliOutput output, IAppSettingsService appSettings)
+    {
+        _output = output ?? throw new ArgumentNullException(nameof(output));
+        _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
+    }
+
+    /// <summary>
+    /// Prints every editable setting with its current value.
+    /// </summary>
+    public async Task<int> GetAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _appSettings.LoadAsync().ConfigureAwait(false);
+        foreach (var key in AppSettingValueCatalog.EditableKeys)
+        {
+            var value = AppSettingValueCatalog.RenderValue(settings, key);
+            await _output.WriteAsync($"{key}: {value}").ConfigureAwait(false);
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    /// <summary>
+    /// Updates one setting field and persists it through the shared service.
+    /// </summary>
+    public async Task<int> SetAsync(string key, string value, CancellationToken cancellationToken)
+    {
+        if (!AppSettingValueCatalog.EditableKeys.Contains(key, StringComparer.Ordinal))
+        {
+            await _output.WriteErrorAsync(
+                $"Unknown setting '{key}'. Editable keys: {string.Join(", ", AppSettingValueCatalog.EditableKeys)}.").ConfigureAwait(false);
+            return CliExitCodes.Usage;
+        }
+
+        var settings = await _appSettings.LoadAsync().ConfigureAwait(false);
+        if (!AppSettingValueCatalog.TryApply(settings, key, value))
+        {
+            var allowed = AppSettingValueCatalog.AllowedValues(key);
+            var hint = allowed is null
+                ? "Expected true/false."
+                : $"Allowed values: {string.Join(", ", allowed)}.";
+            await _output.WriteErrorAsync($"Invalid value for '{key}': '{value}'. {hint}").ConfigureAwait(false);
+            return CliExitCodes.Usage;
+        }
+
+        // SaveAsync owns the schema guard, the atomic write, and the Saved notification.
+        try
+        {
+            await _appSettings.SaveAsync(settings).ConfigureAwait(false);
+        }
+        catch (ConfigurationPersistenceException exception) when (
+            exception.Reason == ConfigurationPersistenceFailureReason.SchemaVersionTooNew)
+        {
+            // 拒绝写回不是一般写入失败：磁盘上的文件是更新的程序写的，出路是升级而非重试。
+            await _output.WriteErrorAsync(exception.UserMessage).ConfigureAwait(false);
+            return CliExitCodes.Failure;
+        }
+
+        var persisted = AppSettingValueCatalog.RenderValue(settings, key);
+        await _output.WriteAsync($"{key}: {persisted}").ConfigureAwait(false);
+        return CliExitCodes.Success;
+    }
+}

--- a/src/SalmonEgg.Cli/Commands/Config/ConfigPackageCommandFactory.cs
+++ b/src/SalmonEgg.Cli/Commands/Config/ConfigPackageCommandFactory.cs
@@ -1,0 +1,42 @@
+using System;
+using System.CommandLine;
+
+namespace SalmonEgg.Cli.Commands.Config;
+
+/// <summary>
+/// Constructs the <c>config validate</c>, <c>config export</c>, and <c>config import</c> commands.
+/// </summary>
+public static class ConfigPackageCommandFactory
+{
+    public static Command CreateValidateCommand(ConfigPackageHandler handler)
+    {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        var cmd = new Command("validate", "Check configuration files for schema and parse problems.");
+        cmd.SetAction((_, ct) => handler.ValidateAsync(ct));
+        return cmd;
+    }
+
+    public static Command CreateExportCommand(ConfigPackageHandler handler)
+    {
+        var secretsOpt = new Option<bool>("--include-secrets")
+        {
+            Description = "Embed credentials in the package. The package then contains secret material; store it accordingly."
+        };
+
+        var cmd = new Command("export", "Export the current configuration as a portable package (zip).");
+        cmd.Options.Add(secretsOpt);
+        cmd.SetAction((parseResult, ct) => handler.ExportAsync(parseResult.GetValue(secretsOpt), ct));
+        return cmd;
+    }
+
+    public static Command CreateImportCommand(ConfigPackageHandler handler)
+    {
+        var pathArg = new Argument<string>("package-path") { Description = "Path to a previously exported configuration package (zip)." };
+
+        var cmd = new Command("import", "Import a configuration package, replacing the current configuration (a backup is kept).");
+        cmd.Arguments.Add(pathArg);
+        cmd.SetAction((parseResult, ct) => handler.ImportAsync(parseResult.GetRequiredValue(pathArg), ct));
+        return cmd;
+    }
+}

--- a/src/SalmonEgg.Cli/Commands/Config/ConfigPackageHandler.cs
+++ b/src/SalmonEgg.Cli/Commands/Config/ConfigPackageHandler.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Cli.Output;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Cli.Commands.Config;
+
+/// <summary>
+/// Implements the <c>config validate</c>, <c>config export</c>, and <c>config import</c> operations.
+/// </summary>
+/// <remarks>
+/// Validation reports what the shared diagnostics service sees; export/import delegate entirely to
+/// <see cref="ConfigSyncPackageService"/> so the CLI never re-implements packaging. Import refuses
+/// packages whose files carry a schema version newer than this build supports — the same
+/// refuse-write-back rule the services enforce on individual writes, applied before anything is
+/// swapped into the config root.
+/// </remarks>
+public sealed class ConfigPackageHandler
+{
+    private readonly ICliOutput _output;
+    private readonly ConfigurationDiagnosticsService _diagnostics;
+    private readonly ConfigSyncPackageService _packages;
+    private readonly IAppDataService _appData;
+
+    public ConfigPackageHandler(
+        ICliOutput output,
+        ConfigurationDiagnosticsService diagnostics,
+        ConfigSyncPackageService packages,
+        IAppDataService appData)
+    {
+        _output = output ?? throw new ArgumentNullException(nameof(output));
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+        _packages = packages ?? throw new ArgumentNullException(nameof(packages));
+        _appData = appData ?? throw new ArgumentNullException(nameof(appData));
+    }
+
+    /// <summary>
+    /// Validates every configuration file and prints one diagnostic line per file.
+    /// </summary>
+    public async Task<int> ValidateAsync(CancellationToken cancellationToken)
+    {
+        var results = await _diagnostics.InspectAsync(cancellationToken).ConfigureAwait(false);
+        var failures = 0;
+        foreach (var result in results)
+        {
+            switch (result.Kind)
+            {
+                case ConfigurationDiagnosticKind.Ok:
+                    await _output.WriteAsync(
+                        $"{result.FileName}: ok (schema_version {result.SchemaVersion}).").ConfigureAwait(false);
+                    break;
+                case ConfigurationDiagnosticKind.Absent:
+                    await _output.WriteAsync($"{result.FileName}: not present (defaults apply).").ConfigureAwait(false);
+                    break;
+                case ConfigurationDiagnosticKind.SchemaTooNew:
+                    failures++;
+                    await _output.WriteErrorAsync($"{result.FileName}: {result.Detail}").ConfigureAwait(false);
+                    break;
+                case ConfigurationDiagnosticKind.Unparsable:
+                    failures++;
+                    await _output.WriteErrorAsync(
+                        $"{result.FileName}: YAML could not be parsed ({result.Detail}). "
+                        + "The file is treated as defaults until it is repaired.").ConfigureAwait(false);
+                    break;
+            }
+        }
+
+        return failures == 0 ? CliExitCodes.Success : CliExitCodes.Failure;
+    }
+
+    /// <summary>
+    /// Exports a configuration package into the exports directory.
+    /// </summary>
+    public async Task<int> ExportAsync(bool includeSecrets, CancellationToken cancellationToken)
+    {
+        var bytes = await _packages.CreatePackageAsync(includeSecrets, cancellationToken).ConfigureAwait(false);
+
+        Directory.CreateDirectory(_appData.ExportsDirectoryPath);
+        var fileName = $"salmon-egg-config-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.zip";
+        var destination = Path.Combine(_appData.ExportsDirectoryPath, fileName);
+        await File.WriteAllBytesAsync(destination, bytes, cancellationToken).ConfigureAwait(false);
+
+        await _output.WriteAsync($"Exported configuration package: {destination}").ConfigureAwait(false);
+        if (!includeSecrets)
+        {
+            await _output.WriteAsync("Secrets were not included; pass --include-secrets to embed credentials.").ConfigureAwait(false);
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    /// <summary>
+    /// Imports a configuration package after refusing packages this build cannot safely write back.
+    /// </summary>
+    public async Task<int> ImportAsync(string packagePath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(packagePath))
+        {
+            await _output.WriteErrorAsync($"Package not found: {packagePath}").ConfigureAwait(false);
+            return CliExitCodes.Usage;
+        }
+
+        var package = await File.ReadAllBytesAsync(packagePath, cancellationToken).ConfigureAwait(false);
+        var packageResults = _diagnostics.InspectPackage(package);
+        var refusals = packageResults.Where(result =>
+            result.Kind is ConfigurationDiagnosticKind.SchemaTooNew or ConfigurationDiagnosticKind.Unparsable).ToList();
+        if (refusals.Count > 0)
+        {
+            foreach (var refusal in refusals)
+            {
+                await _output.WriteErrorAsync($"{refusal.FileName}: {refusal.Detail}").ConfigureAwait(false);
+            }
+
+            await _output.WriteErrorAsync(
+                "Refusing to import. Upgrade Salmon Egg to a version that supports these files, migrate there, then import here.").ConfigureAwait(false);
+            return CliExitCodes.Failure;
+        }
+
+        var backupPath = await _packages.RestorePackageAsync(package, cancellationToken).ConfigureAwait(false);
+        await _output.WriteAsync($"Imported configuration from {packagePath}.").ConfigureAwait(false);
+        await _output.WriteAsync($"Previous configuration backed up at: {backupPath}").ConfigureAwait(false);
+        return CliExitCodes.Success;
+    }
+}

--- a/src/SalmonEgg.Cli/Commands/Config/ConfigSettingsCommandFactory.cs
+++ b/src/SalmonEgg.Cli/Commands/Config/ConfigSettingsCommandFactory.cs
@@ -1,0 +1,49 @@
+using System;
+using System.CommandLine;
+
+namespace SalmonEgg.Cli.Commands.Config;
+
+/// <summary>
+/// Constructs the <c>config settings</c> command subtree.
+/// </summary>
+/// <remarks>
+/// Same split as <see cref="ConfigServerCommandFactory"/>: this factory owns only command
+/// structure and parser binding; business logic lives in <see cref="AppSettingsHandler"/>,
+/// supplied by the composition root.
+/// </remarks>
+public static class ConfigSettingsCommandFactory
+{
+    public static Command CreateSettingsCommand(AppSettingsHandler handler)
+    {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        var settings = new Command("settings", "View or update global app settings (app.yaml).");
+
+        settings.Subcommands.Add(CreateGetCommand(handler));
+        settings.Subcommands.Add(CreateSetCommand(handler));
+
+        return settings;
+    }
+
+    private static Command CreateGetCommand(AppSettingsHandler handler)
+    {
+        var cmd = new Command("get", "Show all editable global settings with their current values.");
+        cmd.SetAction((_, ct) => handler.GetAsync(ct));
+        return cmd;
+    }
+
+    private static Command CreateSetCommand(AppSettingsHandler handler)
+    {
+        var keyArg = new Argument<string>("key") { Description = "Setting key, for example theme or cache_retention_days." };
+        var valueArg = new Argument<string>("value") { Description = "New value for the setting." };
+
+        var cmd = new Command("set", "Update one global setting field.");
+        cmd.Arguments.Add(keyArg);
+        cmd.Arguments.Add(valueArg);
+        cmd.SetAction((parseResult, ct) => handler.SetAsync(
+            parseResult.GetRequiredValue(keyArg),
+            parseResult.GetRequiredValue(valueArg),
+            ct));
+        return cmd;
+    }
+}

--- a/src/SalmonEgg.Domain/Models/AppSettingValueCatalog.cs
+++ b/src/SalmonEgg.Domain/Models/AppSettingValueCatalog.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace SalmonEgg.Domain.Models;
+
+/// <summary>
+/// AppSettings 各可编辑字段的取值目录：键名、允许值、解析与渲染。
+/// </summary>
+/// <remarks>
+/// 单一事实源。GUI 的选项列表（主题/backdrop 等）与 CLI 的 <c>settings set</c> 校验都必须
+/// 从这里取合法值；任何一处另抄一份枚举值，就会出现「GUI 能选、CLI 拒收」或反向的漂移。
+/// 解析遵循与 <see cref="AppSettingsService"/> 相同的宽容读语义：未知值回退默认而非报错，
+/// 但 CLI 写入路径用 <see cref="TryParse"/> 显式拒绝，避免把用户笔误静默吞成默认值。
+/// </remarks>
+public static class AppSettingValueCatalog
+{
+    private const string DefaultTheme = "System";
+    private const string DefaultBackdrop = "System";
+    private const string DefaultHydrationCompletionMode = "StrictReplay";
+
+    public const string ThemeKey = "theme";
+    public const string AnimationEnabledKey = "animation_enabled";
+    public const string LanguageKey = "language";
+    public const string BackdropKey = "backdrop";
+    public const string SaveLocalHistoryKey = "save_local_history";
+    public const string CacheRetentionDaysKey = "cache_retention_days";
+    public const string TelemetrySharingEnabledKey = "telemetry_sharing_enabled";
+    public const string KeyboardShortcutsEnabledKey = "keyboard_shortcuts_enabled";
+
+    /// <summary>
+    /// 全部可由 CLI 编辑的设置键，按帮助文本展示顺序排列。
+    /// </summary>
+    /// <remarks>
+    /// 只收录「单标量、有明确合法值域」的字段。列表型字段（projects、key_bindings、
+    /// agent_remote_directories）结构复杂且 GUI 已有专门编辑面，CLI 逐字段改写它们
+    /// 需要另一套行级语法，超出本目录「单键单值」的契约。
+    /// </remarks>
+    public static IReadOnlyList<string> EditableKeys { get; } =
+    [
+        ThemeKey,
+        AnimationEnabledKey,
+        LanguageKey,
+        BackdropKey,
+        SaveLocalHistoryKey,
+        CacheRetentionDaysKey,
+        TelemetrySharingEnabledKey,
+        KeyboardShortcutsEnabledKey
+    ];
+
+    /// <summary>主题合法值，与 GUI 设置页选项一致。</summary>
+    public static IReadOnlyList<string> ThemeValues { get; } = ["System", "Light", "Dark"];
+
+    /// <summary>背景材质合法值，与 GUI 设置页选项一致。</summary>
+    public static IReadOnlyList<string> BackdropValues { get; } = ["System", "Mica", "Acrylic", "Solid"];
+
+    /// <summary>水合完成模式合法值。</summary>
+    public static IReadOnlyList<string> HydrationCompletionModeValues { get; } = ["StrictReplay", "LoadResponse"];
+
+    /// <summary>
+    /// 尝试把单个键值对应用到设置快照上。
+    /// </summary>
+    /// <returns>true 表示已应用；false 表示键不在 <see cref="EditableKeys"/> 内或值非法。</returns>
+    public static bool TryApply(AppSettings settings, string key, string value)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        switch (key)
+        {
+            case ThemeKey:
+                if (!Matches(ThemeValues, value)) return false;
+                settings.Theme = value;
+                return true;
+            case BackdropKey:
+                if (!Matches(BackdropValues, value)) return false;
+                settings.Backdrop = value;
+                return true;
+            case LanguageKey:
+                // 语言走目录自身的别名归一（zh-CN → zh-Hans 等），非法标签回退 System，
+                // 与 LoadAsync 的宽容读语义一致。
+                settings.Language = AppLanguageCatalog.NormalizeTag(value);
+                return true;
+            case AnimationEnabledKey:
+                return TryParseBoolean(value, parsed => settings.IsAnimationEnabled = parsed);
+            case SaveLocalHistoryKey:
+                return TryParseBoolean(value, parsed => settings.SaveLocalHistory = parsed);
+            case TelemetrySharingEnabledKey:
+                return TryParseBoolean(value, parsed => settings.TelemetrySharingEnabled = parsed);
+            case KeyboardShortcutsEnabledKey:
+                return TryParseBoolean(value, parsed => settings.KeyboardShortcutsEnabled = parsed);
+            case CacheRetentionDaysKey:
+                return TryParseRetentionDays(value, parsed => settings.CacheRetentionDays = parsed);
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// 渲染单个键的当前值，供查看命令输出。
+    /// </summary>
+    /// <returns>当前值的文本形态；键未知时为 null。</returns>
+    public static string? RenderValue(AppSettings settings, string key)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+
+        return key switch
+        {
+            ThemeKey => settings.Theme,
+            BackdropKey => settings.Backdrop,
+            LanguageKey => settings.Language,
+            AnimationEnabledKey => Render(settings.IsAnimationEnabled),
+            SaveLocalHistoryKey => Render(settings.SaveLocalHistory),
+            TelemetrySharingEnabledKey => Render(settings.TelemetrySharingEnabled),
+            KeyboardShortcutsEnabledKey => Render(settings.KeyboardShortcutsEnabled),
+            CacheRetentionDaysKey => settings.CacheRetentionDays.ToString(CultureInfo.InvariantCulture),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// 键的合法取值说明，供错误信息与帮助文本使用；无封闭值域时为 null。
+    /// </summary>
+    public static IReadOnlyList<string>? AllowedValues(string key) => key switch
+    {
+        ThemeKey => ThemeValues,
+        BackdropKey => BackdropValues,
+        LanguageKey => AppLanguageCatalog.SupportedOptions.Select(option => option.Tag).ToArray(),
+        _ => null
+    };
+
+    private static bool Matches(IReadOnlyList<string> allowed, string value) =>
+        allowed.Contains(value, StringComparer.Ordinal);
+
+    private static bool TryParseBoolean(string value, Action<bool> assign)
+    {
+        if (!bool.TryParse(value, out var parsed))
+        {
+            return false;
+        }
+
+        assign(parsed);
+        return true;
+    }
+
+    private static bool TryParseRetentionDays(string value, Action<int> assign)
+    {
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var days) || days <= 0)
+        {
+            return false;
+        }
+
+        assign(days);
+        return true;
+    }
+
+    private static string Render(bool value) => value ? "true" : "false";
+}

--- a/src/SalmonEgg.Domain/Models/AppSettingValueCatalog.cs
+++ b/src/SalmonEgg.Domain/Models/AppSettingValueCatalog.cs
@@ -58,6 +58,15 @@ public static class AppSettingValueCatalog
     /// <summary>水合完成模式合法值。</summary>
     public static IReadOnlyList<string> HydrationCompletionModeValues { get; } = ["StrictReplay", "LoadResponse"];
 
+    private static IReadOnlyList<string> LanguageTags { get; } = AppLanguageCatalog.SupportedOptions
+        .Select(option => option.Tag)
+        .ToArray();
+
+    private static bool IsKnownLanguageTag(string value) =>
+        AppLanguageCatalog.SupportedOptions.Any(option =>
+            string.Equals(option.Tag, value, StringComparison.OrdinalIgnoreCase) ||
+            option.Aliases.Contains(value, StringComparer.OrdinalIgnoreCase));
+
     /// <summary>
     /// 尝试把单个键值对应用到设置快照上。
     /// </summary>
@@ -78,8 +87,11 @@ public static class AppSettingValueCatalog
                 settings.Backdrop = value;
                 return true;
             case LanguageKey:
-                // 语言走目录自身的别名归一（zh-CN → zh-Hans 等），非法标签回退 System，
-                // 与 LoadAsync 的宽容读语义一致。
+                // 写入路径显式拒绝未知标签（读路径的宽容回退是 LoadAsync 的事，不在这里）。
+                // 校验必须针对原始输入：NormalizeTag 会把未知标签折叠成 System，若先归一再
+                // 比对，任何垃圾输入都会「变成」合法的 System 溜过守卫。
+                // 合法形态 = 规范标签本身或目录声明的别名；命中后写入规范标签。
+                if (!IsKnownLanguageTag(value.Trim())) return false;
                 settings.Language = AppLanguageCatalog.NormalizeTag(value);
                 return true;
             case AnimationEnabledKey:
@@ -126,7 +138,7 @@ public static class AppSettingValueCatalog
     {
         ThemeKey => ThemeValues,
         BackdropKey => BackdropValues,
-        LanguageKey => AppLanguageCatalog.SupportedOptions.Select(option => option.Tag).ToArray(),
+        LanguageKey => LanguageTags,
         _ => null
     };
 

--- a/src/SalmonEgg.Domain/Services/ConfigurationPersistenceException.cs
+++ b/src/SalmonEgg.Domain/Services/ConfigurationPersistenceException.cs
@@ -30,5 +30,14 @@ public enum ConfigurationPersistenceFailureReason
     ConfigurationDeleteFailed,
     ConfigurationConflict,
     ConfigurationLockUnavailable,
-    ConfigurationRecoveryRequired
+    ConfigurationRecoveryRequired,
+
+    /// <summary>
+    /// 磁盘上的配置 schema_version 比本程序支持的更新；写入被拒绝以保护前向数据。
+    /// </summary>
+    /// <remarks>
+    /// 语义是「拒绝写回」而非「写入失败」：文件本身完好，只是不能被旧程序覆盖。
+    /// 调用方据此给出升级指引，而不是把用户引向重试或权限排查。
+    /// </remarks>
+    SchemaVersionTooNew
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/DependencyInjection/DesktopConfigurationServiceCollectionExtensions.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/DependencyInjection/DesktopConfigurationServiceCollectionExtensions.cs
@@ -69,6 +69,7 @@ public static class DesktopConfigurationServiceCollectionExtensions
 
         services.AddSingleton<ConfigurationSecretSnapshotService>();
         services.AddSingleton<ConfigSyncPackageService>();
+        services.AddSingleton<ConfigurationDiagnosticsService>();
 
         return services;
     }

--- a/src/SalmonEgg.Infrastructure/Storage/AppSettingsService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/AppSettingsService.cs
@@ -13,7 +13,10 @@ namespace SalmonEgg.Infrastructure.Storage;
 
 public sealed class AppSettingsService : IAppSettingsService
 {
-    private const int CurrentSchemaVersion = 3;
+    /// <summary>本程序写入 app.yaml 时使用的 schema 版本。</summary>
+    public const int CurrentAppSettingsSchemaVersion = 3;
+
+    private const int CurrentSchemaVersion = CurrentAppSettingsSchemaVersion;
     private const string TelemetryAuthHeaderStorageKey = "SalmonEgg.TelemetryAuthHeader";
 
     private readonly IAppFileStore _fileStore;
@@ -220,13 +223,12 @@ public sealed class AppSettingsService : IAppSettingsService
             var existing = YamlSerialization.CreateDeserializer().Deserialize<AppSettingsYamlV1>(yaml);
             if (existing.SchemaVersion > CurrentSchemaVersion)
             {
-                throw new InvalidOperationException(
-                    $"App settings schema_version {existing.SchemaVersion} is newer than supported version {CurrentSchemaVersion}. Refusing to overwrite.");
+                // 类型化异常而非裸 InvalidOperationException：CLI 等宿主需要按「拒绝写回」
+                // 给出升级指引，而不是把它当一般写入失败处理。
+                throw new ConfigurationPersistenceException(
+                    ConfigurationPersistenceFailureReason.SchemaVersionTooNew,
+                    $"App settings schema_version {existing.SchemaVersion} is newer than supported version {CurrentSchemaVersion}. Refusing to overwrite. Upgrade Salmon Egg to a version that supports schema_version {existing.SchemaVersion}.");
             }
-        }
-        catch (InvalidOperationException)
-        {
-            throw;
         }
         catch (YamlException ex)
         {

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Storage.YamlModels;
+using YamlDotNet.Core;
+
+namespace SalmonEgg.Infrastructure.Storage;
+
+/// <summary>
+/// 只读配置诊断：报告 app.yaml、各 server YAML 与配置包内文件的 schema 版本与可解析性。
+/// </summary>
+/// <remarks>
+/// 与 <see cref="AppSettingsService"/> / <see cref="ConfigurationManager"/> 共享同一套
+/// YAML 模型与宽容读语义，是它们的「体检」视图而非第二套读取 owner：本类型从不写入，
+/// 也不做迁移；「高版本拒绝写回」的执行仍由两个服务各自的写入守卫负责，这里只是把
+/// 同样的判据提前暴露给用户（写盘前）与导入方（换入 config root 前）。
+///
+/// 诊断消息只含文件名、schema 版本与失败类别，绝不含文件内容——凭据在 ISecureStorage
+/// 里，但文件名、路径片段等也可能被当作敏感信息对待，因此统一只报相对路径。
+/// </remarks>
+public sealed class ConfigurationDiagnosticsService
+{
+    private const string PackageConfigEntryPrefix = "files/config/";
+    private const string PackageManifestEntryName = "manifest.json";
+
+    private readonly IAppDataService _appData;
+    private readonly IAppFileStore _fileStore;
+
+    public ConfigurationDiagnosticsService(IAppDataService appData, IAppFileStore fileStore)
+    {
+        _appData = appData ?? throw new ArgumentNullException(nameof(appData));
+        _fileStore = fileStore ?? throw new ArgumentNullException(nameof(fileStore));
+    }
+
+    /// <summary>app.yaml 支持的 schema 版本。</summary>
+    public int SupportedAppSettingsSchemaVersion => AppSettingsService.CurrentAppSettingsSchemaVersion;
+
+    /// <summary>server 配置支持的 schema 版本。</summary>
+    public int SupportedServerConfigurationSchemaVersion => ConfigurationManager.CurrentServerConfigurationSchemaVersion;
+
+    /// <summary>
+    /// 检查磁盘上的全部配置文件，返回逐文件诊断。
+    /// </summary>
+    public async Task<IReadOnlyList<ConfigurationDiagnostic>> InspectAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var results = new List<ConfigurationDiagnostic>();
+        results.Add(await InspectAppSettingsAsync(cancellationToken).ConfigureAwait(false));
+        results.AddRange(await InspectServerConfigurationsAsync(cancellationToken).ConfigureAwait(false));
+        return results;
+    }
+
+    /// <summary>
+    /// 检查一个配置包的字节内容，返回逐条目诊断；不做任何落盘或换入。
+    /// </summary>
+    /// <remarks>
+    /// 缺 manifest 的包以单条 <see cref="ConfigurationDiagnosticKind.Unparsable"/> 报告，
+    /// 让调用方在 <see cref="ConfigSyncPackageService.RestorePackageAsync"/> 抛
+    /// <see cref="InvalidDataException"/> 之前就能给出可操作的错误信息。
+    /// </remarks>
+    public IReadOnlyList<ConfigurationDiagnostic> InspectPackage(byte[] package)
+    {
+        if (package is null) throw new ArgumentNullException(nameof(package));
+
+        using var stream = new MemoryStream(package, writable: false);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+        if (archive.GetEntry(PackageManifestEntryName) is null)
+        {
+            return [new ConfigurationDiagnostic(
+                PackageManifestEntryName,
+                ConfigurationDiagnosticKind.Unparsable,
+                null,
+                "package is missing manifest.json and is not identifiable as a Salmon Egg configuration package")];
+        }
+
+        var results = new List<ConfigurationDiagnostic>();
+        foreach (var entry in archive.Entries
+                     .Where(e => e.FullName.StartsWith(PackageConfigEntryPrefix, StringComparison.Ordinal))
+                     .OrderBy(e => e.FullName, StringComparer.Ordinal))
+        {
+            var relativeName = entry.FullName.Substring(PackageConfigEntryPrefix.Length);
+            if (string.IsNullOrWhiteSpace(relativeName) || relativeName.EndsWith("/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            results.Add(InspectPackageEntry(entry, relativeName));
+        }
+
+        return results;
+    }
+
+    private ConfigurationDiagnostic InspectPackageEntry(ZipArchiveEntry entry, string relativeName)
+    {
+        try
+        {
+            using var input = entry.Open();
+            using var reader = new StreamReader(input);
+            var yaml = reader.ReadToEndAsync().GetAwaiter().GetResult();
+
+            // app.yaml 与 servers/*.yaml 各有专属模型与支持版本，按包内路径分流，
+            // 使「拒绝导入」的阈值与对应服务写入守卫的阈值完全一致。
+            if (string.Equals(relativeName, "app.yaml", StringComparison.Ordinal))
+            {
+                var model = YamlSerialization.CreateDeserializer().Deserialize<AppSettingsYamlV1>(yaml);
+                return DescribeSchema(relativeName, model.SchemaVersion, AppSettingsService.CurrentAppSettingsSchemaVersion);
+            }
+
+            var serverModel = YamlSerialization.CreateDeserializer().Deserialize<ServerConfigurationYaml>(yaml);
+            return DescribeSchema(relativeName, serverModel.SchemaVersion, ConfigurationManager.CurrentServerConfigurationSchemaVersion);
+        }
+        catch (YamlException exception)
+        {
+            return ConfigurationDiagnostic.Unparsable(relativeName, exception.Message);
+        }
+        catch (IOException exception)
+        {
+            return ConfigurationDiagnostic.Unparsable(relativeName, exception.GetType().Name);
+        }
+    }
+
+    private async Task<ConfigurationDiagnostic> InspectAppSettingsAsync(CancellationToken cancellationToken)
+    {
+        var path = Path.Combine(_appData.ConfigRootPath, "app.yaml");
+        var yaml = await ReadOrNullAsync(path, cancellationToken).ConfigureAwait(false);
+        if (yaml is null)
+        {
+            return ConfigurationDiagnostic.Absent("app.yaml");
+        }
+
+        try
+        {
+            var model = YamlSerialization.CreateDeserializer().Deserialize<AppSettingsYamlV1>(yaml);
+            return DescribeSchema("app.yaml", model.SchemaVersion, AppSettingsService.CurrentAppSettingsSchemaVersion);
+        }
+        catch (YamlException exception)
+        {
+            return ConfigurationDiagnostic.Unparsable("app.yaml", exception.Message);
+        }
+    }
+
+    private async Task<IEnumerable<ConfigurationDiagnostic>> InspectServerConfigurationsAsync(
+        CancellationToken cancellationToken)
+    {
+        var serversDirectory = Path.Combine(_appData.ConfigRootPath, "servers");
+        if (!Directory.Exists(serversDirectory))
+        {
+            return [];
+        }
+
+        var results = new List<ConfigurationDiagnostic>();
+        foreach (var path in Directory.EnumerateFiles(serversDirectory, "*.yaml").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var relativeName = Path.GetRelativePath(_appData.ConfigRootPath, path);
+            var yaml = await ReadOrNullAsync(path, cancellationToken).ConfigureAwait(false);
+            if (yaml is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                var model = YamlSerialization.CreateDeserializer().Deserialize<ServerConfigurationYaml>(yaml);
+                results.Add(DescribeSchema(relativeName, model.SchemaVersion, ConfigurationManager.CurrentServerConfigurationSchemaVersion));
+            }
+            catch (YamlException exception)
+            {
+                results.Add(ConfigurationDiagnostic.Unparsable(relativeName, exception.Message));
+            }
+        }
+
+        return results;
+    }
+
+    private async Task<string?> ReadOrNullAsync(string path, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _fileStore.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // 读不了也是一种诊断结果，但不能让整个检查中断。
+            return null;
+        }
+    }
+
+    private static ConfigurationDiagnostic DescribeSchema(string name, int schemaVersion, int supportedVersion) =>
+        schemaVersion > supportedVersion
+            ? ConfigurationDiagnostic.TooNew(name, schemaVersion, supportedVersion)
+            : ConfigurationDiagnostic.Ok(name, schemaVersion);
+}
+
+/// <summary>
+/// 单个配置文件的诊断结论。
+/// </summary>
+public sealed record ConfigurationDiagnostic(
+    string FileName,
+    ConfigurationDiagnosticKind Kind,
+    int? SchemaVersion,
+    string? Detail)
+{
+    internal static ConfigurationDiagnostic Ok(string fileName, int schemaVersion) =>
+        new(fileName, ConfigurationDiagnosticKind.Ok, schemaVersion, null);
+
+    internal static ConfigurationDiagnostic Absent(string fileName) =>
+        new(fileName, ConfigurationDiagnosticKind.Absent, null, null);
+
+    internal static ConfigurationDiagnostic TooNew(string fileName, int schemaVersion, int supportedVersion) =>
+        new(
+            fileName,
+            ConfigurationDiagnosticKind.SchemaTooNew,
+            schemaVersion,
+            $"schema_version {schemaVersion} is newer than supported version {supportedVersion}. "
+            + "Writes to this file are refused; upgrade Salmon Egg to migrate it.");
+
+    internal static ConfigurationDiagnostic Unparsable(string fileName, string detail) =>
+        new(fileName, ConfigurationDiagnosticKind.Unparsable, null, detail);
+}
+
+public enum ConfigurationDiagnosticKind
+{
+    Ok,
+    Absent,
+    SchemaTooNew,
+    Unparsable
+}

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
@@ -103,7 +103,7 @@ public sealed class ConfigurationDiagnosticsService
         {
             using var input = entry.Open();
             using var reader = new StreamReader(input);
-            var yaml = reader.ReadToEndAsync().GetAwaiter().GetResult();
+            var yaml = reader.ReadToEnd();
 
             // app.yaml 与 servers/*.yaml 各有专属模型与支持版本，按包内路径分流，
             // 使「拒绝导入」的阈值与对应服务写入守卫的阈值完全一致。
@@ -118,13 +118,20 @@ public sealed class ConfigurationDiagnosticsService
         }
         catch (YamlException exception)
         {
-            return ConfigurationDiagnostic.Unparsable(relativeName, exception.Message);
+            return ConfigurationDiagnostic.Unparsable(relativeName, DescribeYamlFailure(exception));
         }
         catch (IOException exception)
         {
             return ConfigurationDiagnostic.Unparsable(relativeName, exception.GetType().Name);
         }
     }
+
+    /// <summary>
+    /// 把 YAML 失败压缩为「异常类别 + 位置」，不携带消息原文——部分 YamlDotNet 错误类
+    /// 会在消息里引用出错行的内容，而配置文件里可能有凭据。
+    /// </summary>
+    private static string DescribeYamlFailure(YamlException exception) =>
+        $"YAML parse failed at line {exception.Start.Line}, column {exception.Start.Column} ({exception.GetType().Name}).";
 
     private async Task<ConfigurationDiagnostic> InspectAppSettingsAsync(CancellationToken cancellationToken)
     {
@@ -142,7 +149,7 @@ public sealed class ConfigurationDiagnosticsService
         }
         catch (YamlException exception)
         {
-            return ConfigurationDiagnostic.Unparsable("app.yaml", exception.Message);
+            return ConfigurationDiagnostic.Unparsable("app.yaml", DescribeYamlFailure(exception));
         }
     }
 
@@ -173,7 +180,7 @@ public sealed class ConfigurationDiagnosticsService
             }
             catch (YamlException exception)
             {
-                results.Add(ConfigurationDiagnostic.Unparsable(relativeName, exception.Message));
+                results.Add(ConfigurationDiagnostic.Unparsable(relativeName, DescribeYamlFailure(exception)));
             }
         }
 

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
@@ -19,7 +19,10 @@ namespace SalmonEgg.Infrastructure.Storage;
 /// </summary>
 public sealed class ConfigurationManager : IConfigurationService, IConfigurationRecoveryService
 {
-    private const int CurrentSchemaVersion = 2;
+    /// <summary>本程序写入 server 配置时使用的 schema 版本。</summary>
+    public const int CurrentServerConfigurationSchemaVersion = 2;
+
+    private const int CurrentSchemaVersion = CurrentServerConfigurationSchemaVersion;
 
     private readonly ISecureStorage _secureStorage;
     private readonly IConfigurationFileStore _fileStore;
@@ -426,8 +429,11 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
     {
         if (current.Model is not null && current.Model.SchemaVersion > CurrentSchemaVersion)
         {
-            throw new InvalidOperationException(
-                $"Configuration schema_version {current.Model.SchemaVersion} is newer than supported version {CurrentSchemaVersion}. Refusing to overwrite.");
+            // 类型化异常而非裸 InvalidOperationException：CLI 等宿主需要按「拒绝写回」
+            // 给出升级指引，而不是把它当一般写入失败处理。
+            throw new ConfigurationPersistenceException(
+                ConfigurationPersistenceFailureReason.SchemaVersionTooNew,
+                $"Configuration schema_version {current.Model.SchemaVersion} is newer than supported version {CurrentSchemaVersion}. Refusing to overwrite. Upgrade Salmon Egg to a version that supports schema_version {current.Model.SchemaVersion}.");
         }
 
         var currentRevision = current.Model?.Revision ?? string.Empty;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
@@ -1078,22 +1078,32 @@ public partial class AppPreferencesViewModel : ObservableObject
                 option.Tag,
                 option.DisplayNameResourceKey)));
 
+    // 值域来自 AppSettingValueCatalog（与 CLI settings set 共享的单一事实源）；
+    // 本处只负责把值映射到展示资源键。
     private static ObservableCollection<SettingsOptionViewModel> CreateThemeOptions() =>
-        new(
-        [
-            new SettingsOptionViewModel("System", "Appearance_ThemeSystem.Content"),
-            new SettingsOptionViewModel("Light", "Appearance_ThemeLight.Content"),
-            new SettingsOptionViewModel("Dark", "Appearance_ThemeDark.Content")
-        ]);
+        new(AppSettingValueCatalog.ThemeValues.Select(MakeThemeOption));
+
+    private static SettingsOptionViewModel MakeThemeOption(string value) => new(
+        value,
+        value switch
+        {
+            "Light" => "Appearance_ThemeLight.Content",
+            "Dark" => "Appearance_ThemeDark.Content",
+            _ => "Appearance_ThemeSystem.Content"
+        });
 
     private static ObservableCollection<SettingsOptionViewModel> CreateBackdropOptions() =>
-        new(
-        [
-            new SettingsOptionViewModel("System", "Appearance_BackdropSystem.Content"),
-            new SettingsOptionViewModel("Mica", "Appearance_BackdropMica.Content"),
-            new SettingsOptionViewModel("Acrylic", "Appearance_BackdropAcrylic.Content"),
-            new SettingsOptionViewModel("Solid", "Appearance_BackdropSolid.Content")
-        ]);
+        new(AppSettingValueCatalog.BackdropValues.Select(MakeBackdropOption));
+
+    private static SettingsOptionViewModel MakeBackdropOption(string value) => new(
+        value,
+        value switch
+        {
+            "Mica" => "Appearance_BackdropMica.Content",
+            "Acrylic" => "Appearance_BackdropAcrylic.Content",
+            "Solid" => "Appearance_BackdropSolid.Content",
+            _ => "Appearance_BackdropSystem.Content"
+        });
 
     private AppLanguageOptionViewModel ResolveLanguageOption(string? tag)
     {

--- a/tests/SalmonEgg.Cli.Tests/Commands/Config/AppSettingsHandlerTests.cs
+++ b/tests/SalmonEgg.Cli.Tests/Commands/Config/AppSettingsHandlerTests.cs
@@ -113,6 +113,20 @@ public sealed class AppSettingsHandlerTests
         Assert.False(File.Exists(fixture.AppYamlPath));
     }
 
+    [Fact]
+    public async Task SetAsync_WithUnknownLanguageTag_RejectsWithAllowedValuesHint()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("language", "gibberish", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Usage, exitCode);
+        var error = Assert.Single(fixture.Output.Errors);
+        Assert.Contains("Allowed values", error, StringComparison.Ordinal);
+        Assert.Contains(AppLanguageCatalog.SimplifiedChineseTag, error, StringComparison.Ordinal);
+        Assert.False(File.Exists(fixture.AppYamlPath));
+    }
+
     /// <summary>
     /// Saved 事件语义：CLI 写入必须像 GUI 保存一样触发订阅方，且订阅方异常不阻断落盘。
     /// </summary>

--- a/tests/SalmonEgg.Cli.Tests/Commands/Config/AppSettingsHandlerTests.cs
+++ b/tests/SalmonEgg.Cli.Tests/Commands/Config/AppSettingsHandlerTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Cli.Commands.Config;
+using SalmonEgg.Cli.Output;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Cli.Tests.Commands.Config;
+
+/// <summary>
+/// Tests for the <c>config settings</c> handler over the real app-settings stack.
+/// </summary>
+public sealed class AppSettingsHandlerTests
+{
+    [Fact]
+    public async Task GetAsync_PrintsEveryEditableKeyWithCurrentValue()
+    {
+        using var fixture = new SettingsFixture();
+        fixture.SeedAppYaml(
+            """
+            schema_version: 3
+            theme: Dark
+            cache_retention_days: 14
+            """);
+
+        var exitCode = await fixture.Handler.GetAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var lines = fixture.Output.Lines;
+        Assert.Contains("theme: Dark", lines, StringComparer.Ordinal);
+        Assert.Contains("cache_retention_days: 14", lines, StringComparer.Ordinal);
+        Assert.Equal(AppSettingValueCatalog.EditableKeys.Count, lines.Count);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithoutAppYaml_ShowsDefaults()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.GetAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Contains("theme: System", fixture.Output.Lines, StringComparer.Ordinal);
+        Assert.Contains("cache_retention_days: 7", fixture.Output.Lines, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task SetAsync_UpdatesSingleFieldAndPersistsIt()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("theme", "Dark", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Contains("theme: Dark", fixture.Output.Lines, StringComparer.Ordinal);
+        var reloaded = await fixture.AppSettings.LoadAsync();
+        Assert.Equal("Dark", reloaded.Theme);
+        // 其余字段保持默认：单字段更新不得顺带改写别的设置。
+        Assert.True(reloaded.IsAnimationEnabled);
+        Assert.Equal(7, reloaded.CacheRetentionDays);
+    }
+
+    [Fact]
+    public async Task SetAsync_NormalizesLanguageAliasToCanonicalTag()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("language", "zh-CN", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var reloaded = await fixture.AppSettings.LoadAsync();
+        Assert.Equal(AppLanguageCatalog.SimplifiedChineseTag, reloaded.Language);
+    }
+
+    [Fact]
+    public async Task SetAsync_RejectsUnknownKeyWithoutWriting()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("not_a_setting", "true", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Usage, exitCode);
+        Assert.Empty(fixture.Output.Lines);
+        Assert.NotEmpty(fixture.Output.Errors);
+        Assert.False(File.Exists(fixture.AppYamlPath));
+    }
+
+    [Fact]
+    public async Task SetAsync_RejectsInvalidEnumValueWithoutWriting()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("theme", "Neon", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Usage, exitCode);
+        Assert.Contains("Allowed values", Assert.Single(fixture.Output.Errors), StringComparison.Ordinal);
+        Assert.False(File.Exists(fixture.AppYamlPath));
+    }
+
+    [Fact]
+    public async Task SetAsync_RejectsNonPositiveRetentionDays()
+    {
+        using var fixture = new SettingsFixture();
+
+        var exitCode = await fixture.Handler.SetAsync("cache_retention_days", "0", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Usage, exitCode);
+        Assert.False(File.Exists(fixture.AppYamlPath));
+    }
+
+    /// <summary>
+    /// Saved 事件语义：CLI 写入必须像 GUI 保存一样触发订阅方，且订阅方异常不阻断落盘。
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_NotifiesSavedSubscribersWithPersistedSnapshot()
+    {
+        using var fixture = new SettingsFixture();
+        var received = new List<AppSettings>();
+        fixture.AppSettings.Saved += (_, args) => received.Add(args.Settings);
+
+        await fixture.Handler.SetAsync("backdrop", "Acrylic", TestContext.Current.CancellationToken);
+
+        var snapshot = Assert.Single(received);
+        Assert.Equal("Acrylic", snapshot.Backdrop);
+        var onDisk = await fixture.AppSettings.LoadAsync();
+        Assert.Equal(snapshot.Backdrop, onDisk.Backdrop);
+    }
+
+    [Fact]
+    public async Task SetAsync_SubscriberThrowDoesNotFailTheSave()
+    {
+        using var fixture = new SettingsFixture();
+        fixture.AppSettings.Saved += (_, _) => throw new InvalidOperationException("subscriber blew up");
+
+        var exitCode = await fixture.Handler.SetAsync("animation_enabled", "false", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var reloaded = await fixture.AppSettings.LoadAsync();
+        Assert.False(reloaded.IsAnimationEnabled);
+    }
+
+    [Fact]
+    public async Task SetAsync_OnSchemaTooNewFile_RefusesWriteWithUpgradeGuidance()
+    {
+        using var fixture = new SettingsFixture();
+        fixture.SeedAppYaml(
+            """
+            schema_version: 99
+            theme: Dark
+            """);
+
+        var exitCode = await fixture.Handler.SetAsync("theme", "Light", TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Failure, exitCode);
+        var error = Assert.Single(fixture.Output.Errors);
+        Assert.Contains("Refusing to overwrite", error, StringComparison.Ordinal);
+        Assert.Contains("Upgrade", error, StringComparison.Ordinal);
+        // 拒绝写回后磁盘上的高版本文件必须原样保留。
+        var yaml = File.ReadAllText(fixture.AppYamlPath);
+        Assert.Contains("schema_version: 99", yaml, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Builds the settings handler over the real app-settings service in an isolated app-data root.
+/// </summary>
+internal sealed class SettingsFixture : IDisposable
+{
+    private readonly string _root;
+
+    public SettingsFixture()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "SalmonEggCliSettingsTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", _root, EnvironmentVariableTarget.Process);
+
+        Output = new RecordingCliOutput();
+        AppSettings = new AppSettingsService(
+            new FileSystemAppFileStore(),
+            new AppDataService(),
+            NullLogger<AppSettingsService>.Instance,
+            new RecordingSecureStorage());
+        Handler = new AppSettingsHandler(Output, AppSettings);
+    }
+
+    public RecordingCliOutput Output { get; }
+
+    public AppSettingsService AppSettings { get; }
+
+    public AppSettingsHandler Handler { get; }
+
+    public string AppYamlPath => Path.Combine(_root, "config", "app.yaml");
+
+    public void SeedAppYaml(string yaml)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(AppYamlPath)!);
+        File.WriteAllText(AppYamlPath, yaml);
+        Output.Reset();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", null, EnvironmentVariableTarget.Process);
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures.
+        }
+    }
+}

--- a/tests/SalmonEgg.Cli.Tests/Commands/Config/ConfigPackageHandlerTests.cs
+++ b/tests/SalmonEgg.Cli.Tests/Commands/Config/ConfigPackageHandlerTests.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Cli.Commands.Config;
+using SalmonEgg.Cli.Output;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Cli.Tests.Commands.Config;
+
+/// <summary>
+/// Tests for the <c>config validate/export/import</c> handler over the real configuration stack.
+/// </summary>
+public sealed class ConfigPackageHandlerTests
+{
+    [Fact]
+    public async Task ValidateAsync_WithHealthyConfigs_ReportsOkAndSucceeds()
+    {
+        using var fixture = new PackageFixture();
+        await fixture.SeedServerAsync("alpha", "Alpha", "https://alpha.example");
+        fixture.WriteAppYaml("schema_version: 3\ntheme: Dark\n");
+
+        var exitCode = await fixture.Handler.ValidateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Contains(fixture.Output.Lines, line => line.StartsWith("app.yaml:", StringComparison.Ordinal) && line.Contains("ok", StringComparison.Ordinal));
+        Assert.Contains(fixture.Output.Lines, line => line.Contains("servers/alpha.yaml", StringComparison.Ordinal) && line.Contains("schema_version 2", StringComparison.Ordinal));
+        Assert.Empty(fixture.Output.Errors);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithoutAnyConfig_ReportsAbsentDefaults()
+    {
+        using var fixture = new PackageFixture();
+
+        var exitCode = await fixture.Handler.ValidateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Contains("app.yaml: not present (defaults apply).", fixture.Output.Lines, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithTooNewAppYaml_FailsAndReportsUpgradePathOnStderr()
+    {
+        using var fixture = new PackageFixture();
+        fixture.WriteAppYaml(
+            """
+            schema_version: 42
+            theme: Dark
+            """);
+
+        var exitCode = await fixture.Handler.ValidateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Failure, exitCode);
+        var error = Assert.Single(fixture.Output.Errors);
+        Assert.Contains("app.yaml", error, StringComparison.Ordinal);
+        Assert.Contains("schema_version 42", error, StringComparison.Ordinal);
+        Assert.Contains("upgrade", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithCorruptServerYaml_FailsWithoutEchoingFileContent()
+    {
+        using var fixture = new PackageFixture();
+        Directory.CreateDirectory(Path.Combine(fixture.AppDataRoot, "config", "servers"));
+        // 故意写一段含「伪凭据」的坏 YAML：诊断必须报文件与失败类别，不得回显内容。
+        File.WriteAllText(
+            Path.Combine(fixture.AppDataRoot, "config", "servers", "broken.yaml"),
+            "schema_version: 2\nname: [unclosed\nsecret_token_value: super-secret-token\n");
+
+        var exitCode = await fixture.Handler.ValidateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Failure, exitCode);
+        Assert.NotEmpty(fixture.Output.Errors);
+        Assert.DoesNotContain(fixture.Output.Errors, error => error.Contains("super-secret-token", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExportThenImport_RoundTripsConfigurationThroughRealPackageService()
+    {
+        using var fixture = new PackageFixture();
+        await fixture.SeedServerAsync("roundtrip", "Round Trip", "https://roundtrip.example");
+        fixture.WriteAppYaml("schema_version: 3\ntheme: Dark\n");
+
+        var exportExit = await fixture.Handler.ExportAsync(includeSecrets: false, TestContext.Current.CancellationToken);
+        Assert.Equal(CliExitCodes.Success, exportExit);
+        var packagePath = Assert.Single(Directory.GetFiles(fixture.ExportsDirectory, "*.zip"));
+
+        // 清空当前配置，模拟「换一台机器导入」。
+        fixture.ResetConfigRoot();
+        fixture.Output.Reset();
+
+        var importExit = await fixture.Handler.ImportAsync(packagePath, TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Success, importExit);
+        var reloaded = await fixture.Configurations.LoadConfigurationAsync("roundtrip");
+        Assert.NotNull(reloaded);
+        Assert.Equal("Round Trip", reloaded!.Name);
+        Assert.Equal("Dark", (await fixture.AppSettings.LoadAsync()).Theme);
+        Assert.Contains(fixture.Output.Lines, line => line.Contains("backed up at:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithMissingFile_ReturnsUsage()
+    {
+        using var fixture = new PackageFixture();
+
+        var exitCode = await fixture.Handler.ImportAsync(
+            Path.Combine(fixture.AppDataRoot, "no-such-package.zip"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Usage, exitCode);
+        Assert.Contains(fixture.Output.Errors, error => error.Contains("not found", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithSchemaTooNewEntry_RefusesBeforeRestore()
+    {
+        using var fixture = new PackageFixture();
+        await fixture.SeedServerAsync("existing", "Existing", "https://existing.example");
+        var packagePath = fixture.BuildForeignPackage(
+        [
+            ("files/config/servers/future.yaml", "schema_version: 77\nid: future\nname: Future\ntransport: websocket\nserver_url: https://future.example\n")
+        ]);
+
+        var existingYaml = Path.Combine(fixture.AppDataRoot, "config", "servers", "existing.yaml");
+        Assert.True(File.Exists(existingYaml));
+
+        var exitCode = await fixture.Handler.ImportAsync(packagePath, TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Failure, exitCode);
+        Assert.Contains(fixture.Output.Errors, error => error.Contains("schema_version 77", StringComparison.Ordinal));
+        Assert.Contains(fixture.Output.Errors, error => error.Contains("Refusing to import", StringComparison.Ordinal));
+        // 拒绝导入后，现有配置必须原样保留，且不得混入包内的高版本文件。
+        Assert.True(File.Exists(existingYaml));
+        Assert.False(File.Exists(Path.Combine(fixture.AppDataRoot, "config", "servers", "future.yaml")));
+    }
+
+    [Fact]
+    public async Task ImportAsync_WithMissingManifest_RefusesWithIdentifiableMessage()
+    {
+        using var fixture = new PackageFixture();
+        var packagePath = fixture.BuildForeignPackage(
+            [("files/config/app.yaml", "schema_version: 3\ntheme: Dark\n")],
+            includeManifest: false);
+
+        var exitCode = await fixture.Handler.ImportAsync(packagePath, TestContext.Current.CancellationToken);
+
+        Assert.Equal(CliExitCodes.Failure, exitCode);
+        Assert.Contains(fixture.Output.Errors, error => error.Contains("manifest.json", StringComparison.Ordinal));
+    }
+}
+
+/// <summary>
+/// Builds the package handler over the real diagnostics + packaging stack in an isolated root.
+/// </summary>
+internal sealed class PackageFixture : IDisposable
+{
+    private readonly string _root;
+
+    public PackageFixture()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "SalmonEggCliPackageTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", _root, EnvironmentVariableTarget.Process);
+
+        Output = new RecordingCliOutput();
+        AppDataService = new AppDataService();
+        Configurations = new ConfigurationManager(
+            new RecordingSecureStorage(),
+            new FileSystemAppFileStore(),
+            AppDataService,
+            NullLogger<ConfigurationManager>.Instance);
+        AppSettings = new AppSettingsService(
+            new FileSystemAppFileStore(),
+            AppDataService,
+            NullLogger<AppSettingsService>.Instance,
+            new RecordingSecureStorage());
+        Handler = new ConfigPackageHandler(
+            Output,
+            new ConfigurationDiagnosticsService(AppDataService, new FileSystemAppFileStore()),
+            new ConfigSyncPackageService(
+                AppDataService,
+                new ConfigurationSecretSnapshotService(
+                    new RecordingSecureStorage(),
+                    new FileSystemAppFileStore(),
+                    AppDataService),
+                new ConfigChangeSignal(),
+                new NoOpFileSystemPersistence(),
+                NullLogger<ConfigSyncPackageService>.Instance),
+            AppDataService);
+    }
+
+    public RecordingCliOutput Output { get; }
+
+    public AppDataService AppDataService { get; }
+
+    public IConfigurationService Configurations { get; }
+
+    public AppSettingsService AppSettings { get; }
+
+    public ConfigPackageHandler Handler { get; }
+
+    public string AppDataRoot => _root;
+
+    public string ExportsDirectory => Path.Combine(_root, "exports");
+
+    public async Task SeedServerAsync(string id, string name, string url)
+    {
+        await Configurations.SaveConfigurationAsync(new ServerConfiguration
+        {
+            Id = id,
+            Name = name,
+            ServerUrl = url,
+            Transport = TransportType.WebSocket,
+            ConnectionTimeout = AcpConnectionTimeoutPolicy.DefaultSeconds
+        });
+        Output.Reset();
+    }
+
+    public void WriteAppYaml(string yaml)
+    {
+        var path = Path.Combine(_root, "config", "app.yaml");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, yaml);
+        Output.Reset();
+    }
+
+    /// <summary>Removes everything under the config root to simulate a fresh machine.</summary>
+    public void ResetConfigRoot()
+    {
+        var configRoot = Path.Combine(_root, "config");
+        if (Directory.Exists(configRoot))
+        {
+            Directory.Delete(configRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Builds a zip that looks like a config package but with arbitrary entry contents.
+    /// </summary>
+    public string BuildForeignPackage((string EntryName, string Content)[] entries, bool includeManifest = true)
+    {
+        var packagePath = Path.Combine(_root, $"{Guid.NewGuid():N}.zip");
+        using var stream = File.Create(packagePath);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+        if (includeManifest)
+        {
+            var manifest = archive.CreateEntry("manifest.json");
+            using (var writer = new StreamWriter(manifest.Open()))
+            {
+                writer.Write("""{"schemaVersion":1,"appId":"SalmonEgg","includesSecrets":false,"files":[]}""");
+            }
+        }
+
+        foreach (var (entryName, content) in entries)
+        {
+            var entry = archive.CreateEntry(entryName);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+
+        return packagePath;
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", null, EnvironmentVariableTarget.Process);
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures.
+        }
+    }
+
+    private sealed class RecordingSecureStorage : ISecureStorage
+    {
+        private readonly ConcurrentDictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        public Task SaveAsync(string key, string value)
+        {
+            _values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> LoadAsync(string key)
+        {
+            _values.TryGetValue(key, out var value);
+            return Task.FromResult(value);
+        }
+
+        public Task DeleteAsync(string key)
+        {
+            _values.TryRemove(key, out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/SalmonEgg.Domain.Tests/Models/AppSettingValueCatalogTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/AppSettingValueCatalogTests.cs
@@ -1,0 +1,106 @@
+using System;
+using SalmonEgg.Domain.Models;
+using Xunit;
+
+namespace SalmonEgg.Domain.Tests.Models;
+
+/// <summary>
+/// Tests for the shared app-setting value catalog (keys, parsing, rendering).
+/// </summary>
+public sealed class AppSettingValueCatalogTests
+{
+    [Fact]
+    public void EditableKeys_CoversExactlyTheRenderableKeys()
+    {
+        // 目录契约：每个可编辑键都必须能渲染当前值，否则 get 输出会缺行。
+        var settings = new AppSettings();
+
+        foreach (var key in AppSettingValueCatalog.EditableKeys)
+        {
+            Assert.NotNull(AppSettingValueCatalog.RenderValue(settings, key));
+        }
+    }
+
+    [Theory]
+    [InlineData("theme", "Dark")]
+    [InlineData("backdrop", "Acrylic")]
+    [InlineData("animation_enabled", "false")]
+    [InlineData("save_local_history", "false")]
+    [InlineData("telemetry_sharing_enabled", "false")]
+    [InlineData("keyboard_shortcuts_enabled", "false")]
+    [InlineData("cache_retention_days", "30")]
+    public void TryApply_WithValidValues_AssignsField(string key, string value)
+    {
+        var settings = new AppSettings();
+
+        Assert.True(AppSettingValueCatalog.TryApply(settings, key, value));
+
+        Assert.Equal(value, AppSettingValueCatalog.RenderValue(settings, key), StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void TryApply_WithLanguageAlias_NormalizesToCanonicalTag()
+    {
+        var settings = new AppSettings();
+
+        Assert.True(AppSettingValueCatalog.TryApply(settings, "language", "zh-CN"));
+
+        Assert.Equal(AppLanguageCatalog.SimplifiedChineseTag, settings.Language);
+    }
+
+    [Theory]
+    [InlineData("theme", "Neon")]
+    [InlineData("backdrop", "Glass")]
+    [InlineData("animation_enabled", "yes")]
+    [InlineData("cache_retention_days", "0")]
+    [InlineData("cache_retention_days", "-3")]
+    [InlineData("cache_retention_days", "many")]
+    [InlineData("language", "   ")]
+    public void TryApply_WithInvalidValues_RejectsAndLeavesDefaults(string key, string value)
+    {
+        var settings = new AppSettings();
+
+        Assert.False(AppSettingValueCatalog.TryApply(settings, key, value));
+
+        Assert.Equal(new AppSettings().Theme, settings.Theme);
+        Assert.Equal(new AppSettings().CacheRetentionDays, settings.CacheRetentionDays);
+    }
+
+    [Fact]
+    public void TryApply_WithUnknownKey_ReturnsFalse()
+    {
+        var settings = new AppSettings();
+
+        Assert.False(AppSettingValueCatalog.TryApply(settings, "not_a_setting", "true"));
+    }
+
+    [Fact]
+    public void AllowedValues_ExposesClosedSetsForEnumKeys()
+    {
+        Assert.Equal(["System", "Light", "Dark"], AppSettingValueCatalog.AllowedValues("theme"));
+        Assert.Equal(["System", "Mica", "Acrylic", "Solid"], AppSettingValueCatalog.AllowedValues("backdrop"));
+
+        var languageTags = AppSettingValueCatalog.AllowedValues("language");
+        Assert.Contains(AppLanguageCatalog.SystemTag, languageTags!);
+        Assert.Contains(AppLanguageCatalog.SimplifiedChineseTag, languageTags!);
+
+        // 布尔与整数键没有封闭值域说明。
+        Assert.Null(AppSettingValueCatalog.AllowedValues("animation_enabled"));
+        Assert.Null(AppSettingValueCatalog.AllowedValues("cache_retention_days"));
+    }
+
+    [Fact]
+    public void RenderValue_WithUnknownKey_ReturnsNull()
+    {
+        Assert.Null(AppSettingValueCatalog.RenderValue(new AppSettings(), "not_a_setting"));
+    }
+
+    [Fact]
+    public void ThemeAndBackdropValues_MatchGuiOptionLists()
+    {
+        // GUI 选项列表（AppPreferencesViewModel.CreateThemeOptions/CreateBackdropOptions）
+        // 与本目录必须同源同序；此处锁定值集，防止两处漂移。
+        Assert.Equal(3, AppSettingValueCatalog.ThemeValues.Count);
+        Assert.Equal(4, AppSettingValueCatalog.BackdropValues.Count);
+    }
+}

--- a/tests/SalmonEgg.Domain.Tests/Models/AppSettingValueCatalogTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/AppSettingValueCatalogTests.cs
@@ -56,6 +56,7 @@ public sealed class AppSettingValueCatalogTests
     [InlineData("cache_retention_days", "-3")]
     [InlineData("cache_retention_days", "many")]
     [InlineData("language", "   ")]
+    [InlineData("language", "gibberish")]
     public void TryApply_WithInvalidValues_RejectsAndLeavesDefaults(string key, string value)
     {
         var settings = new AppSettings();
@@ -64,6 +65,7 @@ public sealed class AppSettingValueCatalogTests
 
         Assert.Equal(new AppSettings().Theme, settings.Theme);
         Assert.Equal(new AppSettings().CacheRetentionDays, settings.CacheRetentionDays);
+        Assert.Equal(new AppSettings().Language, settings.Language);
     }
 
     [Fact]
@@ -96,11 +98,11 @@ public sealed class AppSettingValueCatalogTests
     }
 
     [Fact]
-    public void ThemeAndBackdropValues_MatchGuiOptionLists()
+    public void ThemeAndBackdropValues_AreTheCanonicalSets()
     {
-        // GUI 选项列表（AppPreferencesViewModel.CreateThemeOptions/CreateBackdropOptions）
-        // 与本目录必须同源同序；此处锁定值集，防止两处漂移。
-        Assert.Equal(3, AppSettingValueCatalog.ThemeValues.Count);
-        Assert.Equal(4, AppSettingValueCatalog.BackdropValues.Count);
+        // GUI 选项列表（AppPreferencesViewModel）已改为从本目录取值；这里锁定规范值集本身，
+        // 防止未来有人把目录改坏（例如改名 "Dark" → "Dim" 而存储层不认）。
+        Assert.Equal(new[] { "System", "Light", "Dark" }, AppSettingValueCatalog.ThemeValues);
+        Assert.Equal(new[] { "System", "Mica", "Acrylic", "Solid" }, AppSettingValueCatalog.BackdropValues);
     }
 }

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/AppSettingsServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/AppSettingsServiceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
 using SalmonEgg.Infrastructure.Storage;
 using Xunit;
 
@@ -450,6 +451,29 @@ public sealed class AppSettingsServiceTests : IDisposable
         await Assert.ThrowsAnyAsync<Exception>(() => service.SaveAsync(new AppSettings()));
 
         Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenSchemaTooNew_ThrowsTypedRefusalAndLeavesFileUntouched()
+    {
+        // 高版本文件是更新的程序写的；拒绝写回必须可被宿主按类型识别（给出升级指引而非
+        // 重试建议），且拒绝后原文件必须原样保留。
+        var appYamlPath = Path.Combine(_testDirectory, "SalmonEgg", "config", "app.yaml");
+        Directory.CreateDirectory(Path.GetDirectoryName(appYamlPath)!);
+        const string foreignYaml = "schema_version: 99\ntheme: Dark\n";
+        await File.WriteAllTextAsync(appYamlPath, foreignYaml, TestContext.Current.CancellationToken);
+        var service = CreateService();
+        var raised = 0;
+        service.Saved += (_, _) => raised++;
+
+        var exception = await Assert.ThrowsAsync<ConfigurationPersistenceException>(
+            () => service.SaveAsync(new AppSettings { Theme = "Light" }));
+
+        Assert.Equal(ConfigurationPersistenceFailureReason.SchemaVersionTooNew, exception.Reason);
+        Assert.Contains("schema_version 99", exception.UserMessage, StringComparison.Ordinal);
+        Assert.Contains("Refusing to overwrite", exception.UserMessage, StringComparison.Ordinal);
+        Assert.Equal(0, raised);
+        Assert.Equal(foreignYaml, await File.ReadAllTextAsync(appYamlPath, TestContext.Current.CancellationToken));
     }
 
     private AppSettingsService CreateService(ISecureStorage? secureStorage = null)

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
@@ -83,8 +83,10 @@ public sealed class ConfigurationDiagnosticsServiceTests : IDisposable
 
         var unparsable = Assert.Single(results, r => r.Kind == ConfigurationDiagnosticKind.Unparsable);
         Assert.Contains("broken", unparsable.FileName, StringComparison.Ordinal);
-        // 诊断不得回显文件内容。
+        // 诊断不得回显文件内容：Detail 只含位置与异常类别。
         Assert.DoesNotContain(unparsable.Detail!, "do-not-echo", StringComparison.Ordinal);
+        Assert.DoesNotContain(unparsable.Detail!, "unclosed", StringComparison.Ordinal);
+        Assert.StartsWith("YAML parse failed at line", unparsable.Detail, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Infrastructure.Tests.Storage;
+
+/// <summary>
+/// Tests for the read-only configuration diagnostics view.
+/// </summary>
+public sealed class ConfigurationDiagnosticsServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public ConfigurationDiagnosticsServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), "SalmonEggConfigDiagnosticsTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testDirectory);
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", Path.Combine(_testDirectory, "SalmonEgg"), EnvironmentVariableTarget.Process);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("SALMONEGG_APPDATA_ROOT", null, EnvironmentVariableTarget.Process);
+        try
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures.
+        }
+    }
+
+    [Fact]
+    public async Task InspectAsync_WithHealthyFiles_ReportsOkVersions()
+    {
+        WriteAppYaml("schema_version: 3\ntheme: Dark\n");
+        WriteServerYaml("alpha", "schema_version: 2\nid: alpha\nname: Alpha\ntransport: websocket\nserver_url: ws://a\n");
+
+        var service = CreateService();
+        var results = await service.InspectAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.Count);
+        var app = Assert.Single(results, r => r.FileName == "app.yaml");
+        Assert.Equal(ConfigurationDiagnosticKind.Ok, app.Kind);
+        Assert.Equal(3, app.SchemaVersion);
+        var server = Assert.Single(results, r => r.FileName == Path.Combine("servers", "alpha.yaml"));
+        Assert.Equal(ConfigurationDiagnosticKind.Ok, server.Kind);
+        Assert.Equal(2, server.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task InspectAsync_WithoutConfigs_ReportsAbsentAppYamlOnly()
+    {
+        var service = CreateService();
+
+        var results = await service.InspectAsync(TestContext.Current.CancellationToken);
+
+        var app = Assert.Single(results);
+        Assert.Equal(ConfigurationDiagnosticKind.Absent, app.Kind);
+    }
+
+    [Fact]
+    public async Task InspectAsync_WithTooNewAndCorruptFiles_ReportsBothKinds()
+    {
+        WriteAppYaml("schema_version: 50\ntheme: Dark\n");
+        WriteServerYaml("broken", "schema_version: 2\nname: [unclosed\nsecret_value: do-not-echo\n");
+
+        var service = CreateService();
+        var results = await service.InspectAsync(TestContext.Current.CancellationToken);
+
+        var tooNew = Assert.Single(results, r => r.Kind == ConfigurationDiagnosticKind.SchemaTooNew);
+        Assert.Equal("app.yaml", tooNew.FileName);
+        Assert.Equal(50, tooNew.SchemaVersion);
+        Assert.Contains("upgrade", tooNew.Detail, StringComparison.OrdinalIgnoreCase);
+
+        var unparsable = Assert.Single(results, r => r.Kind == ConfigurationDiagnosticKind.Unparsable);
+        Assert.Contains("broken", unparsable.FileName, StringComparison.Ordinal);
+        // 诊断不得回显文件内容。
+        Assert.DoesNotContain(unparsable.Detail!, "do-not-echo", StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InspectPackage_WithMixedEntries_AppliesPerFileSchemaThresholds()
+    {
+        var package = BuildPackage(
+            ("manifest.json", """{"schemaVersion":1,"appId":"SalmonEgg","includesSecrets":false,"files":[]}"""),
+            ("files/config/app.yaml", "schema_version: 3\ntheme: Dark\n"),
+            ("files/config/servers/current.yaml", "schema_version: 2\nid: current\nname: Current\ntransport: websocket\nserver_url: ws://c\n"),
+            ("files/config/servers/future.yaml", "schema_version: 90\nid: future\nname: Future\ntransport: websocket\nserver_url: ws://f\n"));
+
+        var service = CreateService();
+        var results = service.InspectPackage(package);
+
+        Assert.Equal(3, results.Count);
+        Assert.All(results.Where(r => r.FileName != "servers/future.yaml"), r => Assert.Equal(ConfigurationDiagnosticKind.Ok, r.Kind));
+        var future = Assert.Single(results, r => r.FileName == "servers/future.yaml");
+        Assert.Equal(ConfigurationDiagnosticKind.SchemaTooNew, future.Kind);
+        Assert.Equal(90, future.SchemaVersion);
+    }
+
+    [Fact]
+    public void InspectPackage_WithMissingManifest_ReportsUnidentifiablePackage()
+    {
+        var package = BuildPackage(("files/config/app.yaml", "schema_version: 3\n"));
+
+        var service = CreateService();
+        var results = service.InspectPackage(package);
+
+        var manifest = Assert.Single(results);
+        Assert.Equal("manifest.json", manifest.FileName);
+        Assert.Equal(ConfigurationDiagnosticKind.Unparsable, manifest.Kind);
+        Assert.Contains("manifest.json", manifest.Detail, StringComparison.Ordinal);
+    }
+
+    private ConfigurationDiagnosticsService CreateService() =>
+        new(new AppDataService(), new FileSystemAppFileStore());
+
+    private void WriteAppYaml(string yaml)
+    {
+        var path = Path.Combine(_testDirectory, "SalmonEgg", "config", "app.yaml");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, yaml);
+    }
+
+    private void WriteServerYaml(string id, string yaml)
+    {
+        var path = Path.Combine(_testDirectory, "SalmonEgg", "config", "servers", $"{id}.yaml");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, yaml);
+    }
+
+    private static byte[] BuildPackage(params (string EntryName, string Content)[] entries)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (entryName, content) in entries)
+            {
+                var entry = archive.CreateEntry(entryName);
+                using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+                writer.Write(content);
+            }
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
@@ -718,6 +718,25 @@ public sealed class ConfigurationManagerTests : IDisposable
         Assert.False(Directory.Exists(serversDirectory));
     }
 
+    [Fact]
+    public async Task SaveConfigurationAsync_WhenSchemaTooNew_ThrowsTypedRefusalAndLeavesFileUntouched()
+    {
+        // 高版本 server 文件必须拒绝写回且原样保留；宿主按 Reason 识别后给出升级指引。
+        const string foreignYaml =
+            "schema_version: 88\nid: future-001\nname: Future\ntransport: websocket\nserver_url: ws://localhost:1\n";
+        var path = GetServerYamlPath("future-001");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, foreignYaml, TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<ConfigurationPersistenceException>(
+            () => _configManager.SaveConfigurationAsync(CreateTestConfiguration("future-001")));
+
+        Assert.Equal(ConfigurationPersistenceFailureReason.SchemaVersionTooNew, exception.Reason);
+        Assert.Contains("schema_version 88", exception.UserMessage, StringComparison.Ordinal);
+        Assert.Contains("Refusing to overwrite", exception.UserMessage, StringComparison.Ordinal);
+        Assert.Equal(foreignYaml, await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken));
+    }
+
     private string GetServerYamlPath(string id) =>
         Path.Combine(_testDirectory, "SalmonEgg", "config", "servers", $"{id}.yaml");
 


### PR DESCRIPTION
Closes #74, closes #76, closes #71

## What

Implements the two remaining CLI issues on top of the shared configuration stack.

### #74 — `config settings get` / `set <key> <value>`
- All reads/writes go through `IAppSettingsService` (`LoadAsync`/`SaveAsync`) — atomic write and `Saved`-event semantics are owned by the service; a CLI write notifies runtime subscribers exactly like a GUI save.
- Keys and allowed values come from the new `AppSettingValueCatalog` (Domain). The GUI theme/backdrop option lists now consume the same catalog, so there is one source of truth for the value domain across GUI and CLI.
- Unknown key → usage exit code with editable-key list. Invalid value → usage exit code with allowed-values hint. Language aliases normalize (`zh-CN` → `zh-Hans`); unknown tags are rejected (validation runs against the raw input because `NormalizeTag` folds unknown tags into `System`).

### #76 — `config validate` / `export` / `import`
- `validate`: reports per-file schema version and parseability via the new read-only `ConfigurationDiagnosticsService`; problems go to stderr with a non-zero exit code.
- `export [--include-secrets]` / `import <zip>`: fully delegate to `ConfigSyncPackageService`. Import inspects package entries first and refuses packages whose files declare a newer schema than this build supports — before anything is swapped into the config root. A backup of the previous config is kept.
- Schema-too-new refusals in `AppSettingsService`/`ConfigurationManager` now throw typed `ConfigurationPersistenceException(SchemaVersionTooNew)` instead of bare `InvalidOperationException`, so hosts can offer an upgrade path instead of a retry hint. Verified no caller relied on the old type.

## Security
- Diagnostics report file names, schema versions, and failure kinds only — YAML failures render as position + exception kind, never message text (YamlDotNet messages can quote offending line content).
- Export without `--include-secrets` embeds no credentials and says so.

## Tests
- New: settings handler (10), package handler (8), diagnostics service (5), value catalog (21+), plus schema-refusal coverage in `AppSettingsServiceTests`/`ConfigurationManagerTests` that was previously missing.
- Local full regression: CLI 87 ✓, Infrastructure 554 ✓ (+6 pre-existing skips), Domain 62 ✓, Presentation.Core 3107 ✓.
- End-to-end smoke against the real binary: get/set/validate/export→import round-trip with backup verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)