### PR TITLE
test(telemetry): round-trip rebuild coverage and honest gateway warning

### DIFF
--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -1435,7 +1435,7 @@
     <value>Advanced: Custom telemetry endpoint</value>
   </data>
   <data name="DataStorage_TelemetryAdvancedWarning.Text" xml:space="preserve">
-    <value>For developers only. Telemetry stays inactive unless this endpoint or an OTLP deployment environment variable is configured. Make sure you trust the endpoint before entering credentials.</value>
+    <value>For developers only. Telemetry goes to the app's built-in gateway by default; configuring this endpoint or an OTLP deployment environment variable redirects it to your address. Make sure you trust the endpoint before entering credentials.</value>
   </data>
   <data name="DataStorage_TelemetryCustomEndpoint.Header" xml:space="preserve">
     <value>OTLP endpoint</value>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1540,7 +1540,7 @@
     <value>Advanced: Custom telemetry endpoint</value>
   </data>
   <data name="DataStorage_TelemetryAdvancedWarning.Text" xml:space="preserve">
-    <value>For developers only. Telemetry stays inactive unless this endpoint or an OTLP deployment environment variable is configured. Make sure you trust the endpoint before entering credentials.</value>
+    <value>For developers only. Telemetry goes to the app's built-in gateway by default; configuring this endpoint or an OTLP deployment environment variable redirects it to your address. Make sure you trust the endpoint before entering credentials.</value>
   </data>
   <data name="DataStorage_TelemetryCustomEndpoint.Header" xml:space="preserve">
     <value>OTLP endpoint</value>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -1435,7 +1435,7 @@
     <value>高级：自定义上报端点</value>
   </data>
   <data name="DataStorage_TelemetryAdvancedWarning.Text" xml:space="preserve">
-    <value>仅供开发者使用。只有配置此端点或部署环境中的 OTLP 环境变量后，遥测才会启用；填入凭证前请确认你信任该端点。</value>
+    <value>仅供开发者使用。默认情况下遥测发往应用内置网关；配置此端点或部署环境中的 OTLP 环境变量后，将改发你指定的地址。填入凭证前请确认你信任该端点。</value>
   </data>
   <data name="DataStorage_TelemetryCustomEndpoint.Header" xml:space="preserve">
     <value>OTLP 端点</value>

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryManagerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryManagerTests.cs
@@ -170,6 +170,35 @@ public class TelemetryManagerTests
     }
 
     [Fact]
+    public void Reconfigure_ToDisabledThenBackToEnabled_RebuildsAllSignals()
+    {
+        // 关闭会拆掉 provider；重新打开必须能在拆除后的状态上完整重建三路信号，
+        // 否则用户"关了再开"会得到一个静默失效的遥测管线。
+        var factory = new TestTelemetryExporterFactory();
+        using var loggerProvider = new DynamicTelemetryLoggerProvider(factory);
+        var manager = new TelemetryManager(
+            TelemetrySettings.CreateInactiveBootstrap(),
+            factory,
+            loggerProvider);
+        manager.Reconfigure(CreateEnabledSettings("http://first.example.com:4318"));
+        manager.Reconfigure(new TelemetrySettings { Enabled = false, ServiceName = "Test" });
+        Assert.False(manager.IsEnabled);
+        Assert.Null(manager.TracerProvider);
+        Assert.Null(manager.MeterProvider);
+
+        manager.Reconfigure(CreateEnabledSettings("http://second.example.com:4318"));
+
+        Assert.True(manager.IsEnabled);
+        Assert.NotNull(manager.TracerProvider);
+        Assert.NotNull(manager.MeterProvider);
+        Assert.Equal(2, factory.TracerConfigureCount);
+        Assert.Equal(2, factory.MeterConfigureCount);
+        Assert.Equal(
+            new[] { "http://first.example.com:4318", "http://second.example.com:4318" },
+            factory.LoggerEndpoints);
+    }
+
+    [Fact]
     public void Reconfigure_WhenReplacementBuildFails_KeepsCurrentPipelineAndAllowsRetry()
     {
         var factory = new TestTelemetryExporterFactory();
@@ -264,6 +293,8 @@ public class TelemetryManagerTests
         public bool IsFileSupported => true;
         public bool TracerProviderConfigured { get; private set; }
         public bool MeterProviderConfigured { get; private set; }
+        public int TracerConfigureCount { get; private set; }
+        public int MeterConfigureCount { get; private set; }
 
         public bool ThrowOnMeterConfiguration { get; set; }
 
@@ -274,6 +305,7 @@ public class TelemetryManagerTests
             TelemetrySettings settings)
         {
             TracerProviderConfigured = true;
+            TracerConfigureCount++;
         }
 
         public void ConfigureMeterProvider(
@@ -286,6 +318,7 @@ public class TelemetryManagerTests
             }
 
             MeterProviderConfigured = true;
+            MeterConfigureCount++;
         }
 
         /// <summary>每次装配 Logs 维度时收到的端点，用于证明日志与 traces 一起切换。</summary>


### PR DESCRIPTION
## Summary

Follow-up hardening for #86 (closed as already-implemented). Two independent, low-risk changes:

1. **Test**: cover the disable → re-enable round trip in `TelemetryManager`. Tearing down on disable was covered (`Reconfigure_ToDisabled_TearsDownWithoutRebuilding`), but nothing asserted that re-enabling rebuilds all three signals from the torn-down state — a regression that silently skips `BuildProvidersUnderLock` on re-enable would have gone unnoticed.
2. **Fix**: the telemetry advanced-section warning claimed "telemetry stays inactive unless this endpoint or an OTLP environment variable is configured", but the built-in gateway activates by default. Reworded to state actual behavior so users are not misled into thinking a blank endpoint means no reporting.

## Test plan

- [x] Mutation check: injected a skip-rebuild mutation into `TelemetryManager.Reconfigure` — new test fails (`Assert.True() Failure` at the `IsEnabled` assertion); production code restored afterwards
- [x] 82/82 telemetry-related tests green (TelemetryManagerTests / TelemetrySettingsTests / TelemetryRuntimeTests / DynamicTelemetryLoggerProviderTests / AppSettingsServiceTests)
- [x] Main app project builds with 0 warnings / 0 errors

Closes context of #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)