### PR TITLE
fix(platform): restore iOS build and portable config paths

### DIFF
--- a/SalmonEgg/SalmonEgg/Platforms/iOS/IosSystemNotificationService.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/iOS/IosSystemNotificationService.cs
@@ -187,7 +187,7 @@ public sealed class IosSystemNotificationService : ISystemNotificationService, I
                     new NSString(ConversationIdUserInfoKey));
             }
 
-            var trigger = UNTimeIntervalNotificationTrigger.Create(1, repeats: false);
+            var trigger = UNTimeIntervalNotificationTrigger.CreateTrigger(1, false);
 
             // The request identifier keys the notification, so re-notifying one turn replaces it.
             var notificationRequest = UNNotificationRequest.FromIdentifier(

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigSyncPackageService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigSyncPackageService.cs
@@ -66,7 +66,8 @@ public sealed class ConfigSyncPackageService
             {
                 CreatedAtUtc = DateTimeOffset.UtcNow.ToString("O"),
                 IncludesSecrets = includeSecrets,
-                Files = files.Select(GetRelativeConfigPath).OrderBy(x => x, StringComparer.Ordinal).ToList()
+                // manifest 是便携包元数据，路径契约与 zip 条目一致（恒定 '/'），不得携带平台分隔符。
+                Files = files.Select(GetRelativeConfigPath).Select(ConfigurationPackagePaths.Normalize).OrderBy(x => x, StringComparer.Ordinal).ToList()
             };
 
             await WriteManifestEntryAsync(archive, manifest, cancellationToken).ConfigureAwait(false);
@@ -85,7 +86,11 @@ public sealed class ConfigSyncPackageService
                     continue;
                 }
 
-                await WriteFileEntryAsync(archive, ConfigEntryPrefix + ToZipPath(GetRelativeConfigPath(path)), path, cancellationToken)
+                await WriteFileEntryAsync(
+                        archive,
+                        ConfigEntryPrefix + ConfigurationPackagePaths.Normalize(GetRelativeConfigPath(path)),
+                        path,
+                        cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -464,6 +469,4 @@ public sealed class ConfigSyncPackageService
 
         return relative;
     }
-
-    private static string ToZipPath(string relativePath) => relativePath.Replace(Path.DirectorySeparatorChar, '/');
 }

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationDiagnosticsService.cs
@@ -166,7 +166,8 @@ public sealed class ConfigurationDiagnosticsService
         foreach (var path in Directory.EnumerateFiles(serversDirectory, "*.yaml").OrderBy(p => p, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var relativeName = Path.GetRelativePath(_appData.ConfigRootPath, path);
+            // FileName 是逻辑包内路径（CLI 展示与测试契约），跨平台恒定用 '/'，不随平台分隔符漂移。
+            var relativeName = ConfigurationPackagePaths.Normalize(Path.GetRelativePath(_appData.ConfigRootPath, path));
             var yaml = await ReadOrNullAsync(path, cancellationToken).ConfigureAwait(false);
             if (yaml is null)
             {

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationPackagePaths.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationPackagePaths.cs
@@ -1,0 +1,6 @@
+namespace SalmonEgg.Infrastructure.Storage;
+
+internal static class ConfigurationPackagePaths
+{
+    internal static string Normalize(string relativePath) => relativePath.Replace('\\', '/');
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigSyncPackageServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigSyncPackageServiceTests.cs
@@ -111,6 +111,34 @@ public sealed class ConfigSyncPackageServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreatePackageAsync_ManifestFilesUsePortableSlashSeparators()
+    {
+        var serversDirectory = Path.Combine(_appData.ConfigRootPath, "servers");
+        Directory.CreateDirectory(serversDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(serversDirectory, "agent.yaml"),
+            "schema_version: 2\nid: agent\n",
+            TestContext.Current.CancellationToken);
+
+        var package = await _packageService.CreatePackageAsync(
+            includeSecrets: false,
+            TestContext.Current.CancellationToken);
+
+        using var stream = new MemoryStream(package, writable: false);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var manifestEntry = archive.GetEntry("manifest.json");
+        Assert.NotNull(manifestEntry);
+        using var reader = new StreamReader(manifestEntry!.Open());
+        var manifest = System.Text.Json.JsonDocument.Parse(reader.ReadToEnd());
+        var files = manifest.RootElement.GetProperty("files").EnumerateArray()
+            .Select(value => value.GetString())
+            .ToList();
+        // 便携包元数据的路径契约与 zip 条目一致：恒定 '/'（相对 config root），不随平台分隔符漂移。
+        Assert.Contains("servers/agent.yaml", files);
+        Assert.All(files, file => Assert.False(file!.Contains('\\', StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public async Task CreatePackageAsync_ExcludesConfigurationRecoveryDirectory()
     {
         Directory.CreateDirectory(Path.Combine(_appData.ConfigRootPath, "recovery"));

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationDiagnosticsServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class ConfigurationDiagnosticsServiceTests : IDisposable
         var app = Assert.Single(results, r => r.FileName == "app.yaml");
         Assert.Equal(ConfigurationDiagnosticKind.Ok, app.Kind);
         Assert.Equal(3, app.SchemaVersion);
-        var server = Assert.Single(results, r => r.FileName == Path.Combine("servers", "alpha.yaml"));
+        var server = Assert.Single(results, r => r.FileName == "servers/alpha.yaml");
         Assert.Equal(ConfigurationDiagnosticKind.Ok, server.Kind);
         Assert.Equal(2, server.SchemaVersion);
     }

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationPackagePathsTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationPackagePathsTests.cs
@@ -1,0 +1,14 @@
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Infrastructure.Tests.Storage;
+
+public sealed class ConfigurationPackagePathsTests
+{
+    [Fact]
+    public void Normalize_WindowsSeparator_UsesPortableSlash()
+    {
+        var result = ConfigurationPackagePaths.Normalize(@"servers\agent.yaml");
+
+        Assert.Equal("servers/agent.yaml", result);
+    }
+}


### PR DESCRIPTION
## Summary

- use the current .NET iOS `UNTimeIntervalNotificationTrigger.CreateTrigger` factory
- normalize logical configuration-package paths to portable forward slashes
- cover Windows-style separators and manifest metadata with regression tests

## Validation

- `SalmonEgg.Cli.Tests`: 87/87 passed
- `SalmonEgg.Infrastructure.Tests`: 556 passed, 6 platform/external smokes skipped
- focused package path tests passed
- Release Desktop build: 0 warnings, 0 errors
- Release BrowserWasm build: 0 warnings, 0 errors
- mobile target contract gate passed
- `dotnet format --verify-no-changes` passed for all touched files
- `git diff --check` passed

## Platform limits

- Linux cannot compile the real iOS target; the macOS/iOS CI job is the authoritative compile gate for the API correction.
- Windows CI is the authoritative reproduction gate for the original path-separator failure.