### PR TITLE
fix(ci): run pull request gates against develop

### DIFF
--- a/.github/workflows/ci-acp-sdk.yml
+++ b/.github/workflows/ci-acp-sdk.yml
@@ -14,7 +14,7 @@ on:
       - "NuGet.config"
       - "global.json"
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - "src/SalmonEgg.Acp/**"
       - "src/SalmonEgg.Acp/README.md"

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 concurrency:
   group: ci-core-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 concurrency:
   group: code-quality-${{ github.workflow }}-${{ github.ref }}
@@ -45,13 +45,25 @@ jobs:
         shell: pwsh
         run: |
           $eventName = "${{ github.event_name }}"
-          $base = if ($eventName -eq "pull_request") { "${{ github.event.pull_request.base.sha }}" } else { "${{ github.event.before }}" }
+          if ($eventName -eq "pull_request")
+          {
+              $baseRef = "${{ github.base_ref }}"
+              $head = "${{ github.event.pull_request.head.sha }}"
+              git fetch --no-tags origin $baseRef
+              $base = git merge-base "origin/$baseRef" $head
+          }
+          else
+          {
+              $base = "${{ github.event.before }}"
+              $head = "${{ github.sha }}"
+          }
+
           if ([string]::IsNullOrWhiteSpace($base) -or $base -eq "0000000000000000000000000000000000000000")
           {
               $base = "HEAD~1"
           }
 
-          $changed = git diff --name-only $base ${{ github.sha }} -- "*.cs"
+          $changed = git diff --name-only $base $head -- "*.cs"
           $existing = @($changed | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path $_) })
 
           if ($existing.Count -eq 0)

--- a/.github/workflows/gui-smoke-gates.yml
+++ b/.github/workflows/gui-smoke-gates.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 concurrency:
   group: gui-smoke-gates-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 concurrency:
   group: platform-build-gates-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/wasm-smoke-gates.yml
+++ b/.github/workflows/wasm-smoke-gates.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:

--- a/tests/SalmonEgg.Presentation.Core.Tests/Build/GitHubWorkflowContractTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Build/GitHubWorkflowContractTests.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace SalmonEgg.Presentation.Core.Tests.Build;
+
+public sealed class GitHubWorkflowContractTests
+{
+    private static readonly string[] PullRequestGateWorkflowNames =
+    [
+        "ci-acp-sdk.yml",
+        "ci-core.yml",
+        "code-quality.yml",
+        "gui-smoke-gates.yml",
+        "platform-build-gates.yml",
+        "wasm-smoke-gates.yml"
+    ];
+
+    [Fact]
+    public void PullRequestGates_TargetDevelopBaseline()
+    {
+        foreach (var workflowName in PullRequestGateWorkflowNames)
+        {
+            var workflow = ReadWorkflow(workflowName);
+
+            Assert.Contains("pull_request:\n    branches: [develop]", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("pull_request:\n    branches: [main]", workflow, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void CodeQuality_UsesCurrentBaseBranchMergeBaseForPullRequests()
+    {
+        var workflow = ReadWorkflow("code-quality.yml");
+
+        Assert.Contains("$baseRef = \"${{ github.base_ref }}\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("$head = \"${{ github.event.pull_request.head.sha }}\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("$base = git merge-base \"origin/$baseRef\" $head", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("github.event.pull_request.base.sha", workflow, StringComparison.Ordinal);
+    }
+
+    private static string ReadWorkflow(string workflowName) =>
+        TestSourceFiles.ReadAllText($@".github\workflows\{workflowName}").Replace("\r\n", "\n", StringComparison.Ordinal);
+}


### PR DESCRIPTION
## Summary

- target all application pull-request workflows at the repository baseline `develop`
- make Code Quality compare the current base branch merge-base to the PR head
- add contract tests preventing the workflow baseline from drifting back to `main`

## Why

The repository uses `develop` as the integration baseline, but all pull-request gates were filtered to `main`. Correct develop PRs therefore skipped Windows/iOS and other authoritative gates. Code Quality also used the PR creation-time base SHA, which caused long-lived PRs to scan unrelated historical files.

## Validation

- Presentation.Core tests: 3146/3146 passed
- all workflow YAML files parsed successfully
- `git diff --check` passed
- touched workflow contract tests: 2/2 passed