### PR TITLE
Audit and align OTel instrumentation with official semantic conventions

### DIFF
--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -134,11 +134,19 @@ public static class DependencyInjection
             sp.GetRequiredService<ITelemetryExporterFactory>(),
             sp.GetRequiredService<DynamicTelemetryLoggerProvider>()));
 
+        // app.installation.id 的来源。注册在此处但由 TelemetryRuntime 在 apply 时才异步读取：
+        // DI 工厂与构造函数不得触发真实文件系统副作用（启动副作用所有权约束）。
+        services.AddSingleton<IInstallationIdentityService>(sp => new InstallationIdentityService(
+            sp.GetRequiredService<IAppFileStore>(),
+            sp.GetRequiredService<IAppDataService>(),
+            sp.GetRequiredService<ILogger<InstallationIdentityService>>()));
+
         services.AddSingleton<ITelemetryRuntime>(sp => new TelemetryRuntime(
             sp.GetRequiredService<ITelemetryManager>(),
             GetPlatformSamplingDefaults,
             sp.GetRequiredService<ILogger<TelemetryRuntime>>(),
-            typeof(App).Assembly.GetName().Version?.ToString()));
+            typeof(App).Assembly.GetName().Version?.ToString(),
+            sp.GetRequiredService<IInstallationIdentityService>()));
 
         // 订阅持久化边界，使任何写入方（设置页保存、云配置恢复）落盘后都立即重建管线。
         services.AddSingleton<TelemetrySettingsProjection>();

--- a/SalmonEgg/SalmonEgg/Platforms/Desktop/Observability/DesktopTelemetryExporterFactory.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Desktop/Observability/DesktopTelemetryExporterFactory.cs
@@ -14,6 +14,8 @@ public sealed class DesktopTelemetryExporterFactory : ITelemetryExporterFactory
     public bool IsGrpcSupported => true;
     public bool IsFileSupported => true;
 
+    public bool IsRuntimeInstrumentationSupported => true;
+
     public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
     {
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))

--- a/SalmonEgg/SalmonEgg/Platforms/Mobile/Observability/MobileTelemetryExporterFactory.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Mobile/Observability/MobileTelemetryExporterFactory.cs
@@ -17,6 +17,8 @@ public sealed class MobileTelemetryExporterFactory : ITelemetryExporterFactory
     public bool IsGrpcSupported => true;  // Android 支持，iOS 视网络库而定
     public bool IsFileSupported => false;  // Mobile 存储受限，不启用文件导出
 
+    public bool IsRuntimeInstrumentationSupported => true;
+
     public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
     {
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))

--- a/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Observability/WasmTelemetryExporterFactory.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Observability/WasmTelemetryExporterFactory.cs
@@ -18,6 +18,11 @@ public sealed class WasmTelemetryExporterFactory : ITelemetryExporterFactory
     public bool IsGrpcSupported => false;
     public bool IsFileSupported => false;
 
+    // AddRuntimeInstrumentation 依赖 EventSource 与 System.Diagnostics.Process，浏览器沙箱
+    // 两者都没有，调用会抛 PlatformNotSupportedException 并使整条管线装配失败
+    // （open-telemetry/opentelemetry-dotnet-contrib#2529）。
+    public bool IsRuntimeInstrumentationSupported => false;
+
     public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
     {
         // WASM 总是附加 Console Exporter（输出到浏览器 DevTools Console）

--- a/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Observability/WasmTelemetryExporterFactory.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Observability/WasmTelemetryExporterFactory.cs
@@ -12,6 +12,10 @@ namespace SalmonEgg.Platforms.WebAssembly.Observability;
 /// - 不支持文件导出
 /// - 需要 CORS 配置
 /// - 降低导出频率以减少网络请求
+///
+/// 导出器契约与 Desktop / Windows 一致：配置了 OTLP 端点 → 只走 OTLP；
+/// 未配置 → console 兜底。此前 WASM 是无条件双导出（console + OTLP 同时挂），
+/// 与其他平台不一致且生产流量被拖慢。
 /// </summary>
 public sealed class WasmTelemetryExporterFactory : ITelemetryExporterFactory
 {
@@ -25,11 +29,11 @@ public sealed class WasmTelemetryExporterFactory : ITelemetryExporterFactory
 
     public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
     {
-        // WASM 总是附加 Console Exporter（输出到浏览器 DevTools Console）
-        builder.AddConsoleExporter();
-
+        // 与 Desktop / Windows 同一契约：配置了端点只走 OTLP；未配置时 console 兜底
+        // （输出到浏览器 DevTools Console），避免生产流量被双份导出拖慢。
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))
         {
+            builder.AddConsoleExporter();
             return;
         }
 
@@ -42,10 +46,9 @@ public sealed class WasmTelemetryExporterFactory : ITelemetryExporterFactory
 
     public void ConfigureMeterProvider(MeterProviderBuilder builder, TelemetrySettings settings)
     {
-        builder.AddConsoleExporter();
-
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))
         {
+            builder.AddConsoleExporter();
             return;
         }
 
@@ -58,7 +61,11 @@ public sealed class WasmTelemetryExporterFactory : ITelemetryExporterFactory
 
     public void ConfigureLoggerProvider(OpenTelemetryLoggerOptions options, TelemetrySettings settings)
     {
-        options.AddConsoleExporter();
+        if (string.IsNullOrEmpty(settings.OtlpEndpoint))
+        {
+            options.AddConsoleExporter();
+            return;
+        }
 
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))
         {

--- a/SalmonEgg/SalmonEgg/Platforms/Windows/Observability/WinUI3TelemetryExporterFactory.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Windows/Observability/WinUI3TelemetryExporterFactory.cs
@@ -14,6 +14,8 @@ public sealed class WinUI3TelemetryExporterFactory : ITelemetryExporterFactory
     public bool IsGrpcSupported => true;
     public bool IsFileSupported => true;
 
+    public bool IsRuntimeInstrumentationSupported => true;
+
     public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
     {
         if (string.IsNullOrEmpty(settings.OtlpEndpoint))

--- a/src/SalmonEgg.Application/Observability/ApplicationMeters.cs
+++ b/src/SalmonEgg.Application/Observability/ApplicationMeters.cs
@@ -30,4 +30,34 @@ public static class ApplicationMeters
         "salmonegg.chat_service.errors",
         unit: "{error}",
         description: "Number of failures while creating a ChatService instance.");
+
+    /// <summary>
+    /// 一次 agent 调用（ACP <c>session/prompt</c>）的端到端耗时分布。
+    /// </summary>
+    /// <remarks>
+    /// 单位是**秒**：规范定义 <c>unit: "s"</c>、值类型 double。写成毫秒会让后端按
+    /// 「秒」渲染出千倍偏差的图。
+    ///
+    /// 桶边界取规范为**本指标**明文指定的那一档
+    /// （<c>docs/gen-ai/gen-ai-metrics.md</c>）。不能挪用
+    /// <c>gen_ai.client.operation.duration</c> 的阶梯（0.01–81.92）：那是单次模型调用
+    /// 的量级，而 agent 一次调用常达几十秒到数分钟，用那套阶梯会把绝大多数样本堆进
+    /// 最后一个桶，P95/P99 失去分辨率。
+    ///
+    /// 用 advice（<see cref="InstrumentAdvice{T}"/>）而非在 SDK 侧配 View：advice 随
+    /// instrument 定义一起走，任何 MeterProvider 装配都自动生效，不会因为某个宿主忘了
+    /// 加 View 而退化成默认桶。
+    /// </remarks>
+    public static readonly Histogram<double> InvokeAgentDuration = ChatServiceMeter.CreateHistogram<double>(
+        ApplicationSemanticConventions.GenAi.InvokeAgentDurationMetric,
+        unit: "s",
+        description: "The end-to-end duration of a single agent invocation.",
+        tags: null,
+        advice: new InstrumentAdvice<double>
+        {
+            HistogramBucketBoundaries = new[]
+            {
+                0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2, 102.4, 204.8, 409.6
+            }
+        });
 }

--- a/src/SalmonEgg.Application/Observability/ApplicationSemanticConventions.cs
+++ b/src/SalmonEgg.Application/Observability/ApplicationSemanticConventions.cs
@@ -18,6 +18,62 @@ namespace SalmonEgg.Application.Observability;
 public static class ApplicationSemanticConventions
 {
     /// <summary>
+    /// OTel GenAI 语义约定中本层实际发射的键。
+    ///
+    /// 这些是**标准键**（无 <c>salmonegg.</c> 前缀），故与本文件其余部分的私有键
+    /// 规则不同：标准键必须一字不差，加前缀反而会让后端的 GenAI 视图认不出来。
+    /// 之所以放在本层而非 Infrastructure 的 <c>SemanticConventions</c>：埋点位于
+    /// 本层（ChatService），而 Infrastructure 引用 Application，反向引用会成环。
+    ///
+    /// 稳定性：整个 <c>gen_ai.*</c> 命名空间在规范中仍是 Development
+    /// （已迁至独立仓库 open-telemetry/semantic-conventions-genai，尚无 release），
+    /// 键名可能变化。故只发**有真实数据源**的键，不为凑齐"看起来完整"而编造。
+    /// </summary>
+    public static class GenAi
+    {
+        /// <summary>
+        /// 操作名。本层唯一取值是 <c>invoke_agent</c>（见 <see cref="InvokeAgentOperation"/>）。
+        /// </summary>
+        public const string OperationName = "gen_ai.operation.name";
+
+        /// <summary>Agent 的可读名称，取自 ACP <c>initialize</c> 响应的 <c>agentInfo.name</c>。</summary>
+        public const string AgentName = "gen_ai.agent.name";
+
+        /// <summary>Agent 版本，取自 ACP <c>initialize</c> 响应的 <c>agentInfo.version</c>。</summary>
+        public const string AgentVersion = "gen_ai.agent.version";
+
+        /// <summary>
+        /// 会话标识。用 ACP 的 <c>sessionId</c>——它正是规范所说的
+        /// "instrumented library has one readily available"。
+        /// </summary>
+        /// <remarks>
+        /// 规范明文禁止兜底：<i>"a new UUID, a trace identifier, or a hash of request
+        /// content SHOULD NOT be used as a fallback value"</i>。因此 sessionId 缺失时
+        /// 一律不发该键，不得临时生成。
+        ///
+        /// 用它而不用 <c>session.id</c>：后者 requirement level 是 **Opt-In**
+        /// （"Instrumentation that doesn't support configuration MUST NOT populate
+        /// Opt-In attributes"），我们没有对应的用户开关，发了即违规。
+        /// </remarks>
+        public const string ConversationId = "gen_ai.conversation.id";
+
+        /// <summary><c>gen_ai.operation.name</c> 的枚举取值。</summary>
+        public const string InvokeAgentOperation = "invoke_agent";
+
+        /// <summary>
+        /// 一次 agent 调用的端到端耗时分布。
+        /// </summary>
+        /// <remarks>
+        /// 单位是**秒**（规范 <c>unit: "s"</c>，值类型 double），不是毫秒。
+        /// 属性只要 <c>gen_ai.agent.name</c> + <c>error.type</c>——该指标的属性组是
+        /// <c>attributes.gen_ai.error</c> + <c>attributes.gen_ai.invoked_agent.internal.common</c>，
+        /// **不含** <c>metric_attributes.gen_ai</c>，所以不要求 <c>gen_ai.provider.name</c>。
+        /// 这正是我们能诚实发射它的原因（见 <see cref="OperationName"/> 处的说明）。
+        /// </remarks>
+        public const string InvokeAgentDurationMetric = "gen_ai.invoke_agent.duration";
+    }
+
+    /// <summary>
     /// Chat 相关的应用私有属性。
     /// </summary>
     public static class Chat

--- a/src/SalmonEgg.Application/SalmonEgg.Application.csproj
+++ b/src/SalmonEgg.Application/SalmonEgg.Application.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Serilog" Version="4.4.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.17.0" />
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/SalmonEgg.Application/Services/Chat/ChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/ChatService.cs
@@ -26,6 +26,17 @@ namespace SalmonEgg.Application.Services.Chat
         // 保护下列四个共享可变态的所有读写:pump 线程(传输读线程续体)与请求-响应续体
         // (线程池)并发触碰它们。锁内只做同步内存读写与 HashSet 操作,绝不跨 await、
         // 绝不在锁内做协议 I/O 或调用可能重入的 _sessionManager 路径。
+        /// <summary>
+        /// 用户取消时写入指标 <c>error.type</c> 的值。
+        /// </summary>
+        /// <remarks>
+        /// 用固定字符串而非 <c>ex.GetType().FullName</c>：取消路径可能抛
+        /// <c>OperationCanceledException</c> 或其派生的 <c>TaskCanceledException</c>，
+        /// 两者混在一起会让「取消」在指标里裂成两个维度值。规范要求 <c>error.type</c>
+        /// 低基数且可枚举，故归一成一个。
+        /// </remarks>
+        private const string OperationCanceledTypeName = "System.OperationCanceledException";
+
         private readonly object _stateGate = new();
         private readonly HashSet<string> _configAuthoritativeSessionIds = new(StringComparer.Ordinal);
         private string? _currentSessionId;
@@ -806,9 +817,21 @@ namespace SalmonEgg.Application.Services.Chat
 
         public async Task<SessionPromptResponse> SendPromptAsync(SessionPromptParams @params, CancellationToken cancellationToken = default)
         {
+            var agentInfo = _acpClient.AgentInfo;
+
             using var activity = ApplicationActivitySources.ChatService.StartActivity(
-                "chat.session.prompt",
-                ActivityKind.Internal);
+                BuildInvokeAgentSpanName(agentInfo),
+                ActivityKind.Client);
+
+            // 按 GenAI 语义约定标注这是一次 agent 调用。只发有真实数据源的键——
+            // gen_ai.provider.name 故意缺席，理由见 ApplyInvokeAgentAttributes。
+            ApplyInvokeAgentAttributes(activity, agentInfo, @params.SessionId);
+
+            // 耗时用 Stopwatch 而不是读 activity.Duration：采样丢弃该 span 时
+            // activity 为 null，指标却必须照常记录（指标是聚合值，不参与采样）。
+            var startTimestamp = Stopwatch.GetTimestamp();
+            string? errorType = null;
+
             try
             {
                 var response = await _acpClient.SendPromptAsync(@params, cancellationToken).ConfigureAwait(false);
@@ -817,10 +840,15 @@ namespace SalmonEgg.Application.Services.Chat
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                // 用户主动取消不是故障，但仍要在指标里可分辨，否则取消会被算进
+                // 「成功」的耗时分布、把 P95 拖高。span 状态保持 Unset：规范只在
+                // 「操作失败」时才要求 Error。
+                errorType = OperationCanceledTypeName;
                 throw;
             }
             catch (Exception ex)
             {
+                errorType = ex.GetType().FullName;
                 activity?.SetErrorStatus(ex);
                 activity?.RecordException(ex);
                 var entry = new ErrorLogEntry(
@@ -832,6 +860,132 @@ namespace SalmonEgg.Application.Services.Chat
                     ex);
                 _errorLogger.LogError(entry);
                 throw;
+            }
+            finally
+            {
+                RecordInvokeAgentDuration(startTimestamp, agentInfo, errorType);
+            }
+        }
+
+        /// <summary>
+        /// <c>invoke_agent</c> span 的名称。
+        /// </summary>
+        /// <remarks>
+        /// 规范：<i>"SHOULD be <c>invoke_agent {gen_ai.agent.name}</c> if
+        /// <c>gen_ai.agent.name</c> is readily available. When not available, it SHOULD be
+        /// <c>invoke_agent</c>"</i>。agent 名来自 ACP <c>initialize</c> 响应，取值集合等于
+        /// 用户配置的 agent 数量，属低基数，可安全进 span 名。
+        /// </remarks>
+        private static string BuildInvokeAgentSpanName(AgentInfo? agentInfo)
+        {
+            var agentName = agentInfo?.Name;
+            return string.IsNullOrWhiteSpace(agentName)
+                ? ApplicationSemanticConventions.GenAi.InvokeAgentOperation
+                : $"{ApplicationSemanticConventions.GenAi.InvokeAgentOperation} {agentName}";
+        }
+
+        /// <summary>
+        /// 给 prompt span 打 GenAI 属性。
+        /// </summary>
+        /// <remarks>
+        /// span kind 是 <c>CLIENT</c>：ACP agent 跑在独立进程，规范对此明确
+        /// （<i>"RECOMMENDED to use CLIENT kind when the GenAI system being instrumented
+        /// usually runs in a different process than its client"</i>）。
+        ///
+        /// <b>为什么不发 <c>gen_ai.provider.name</c></b>：它在 <c>gen_ai.invoke_agent.client</c>
+        /// 上是 required，但取值是**封闭枚举**（openai / anthropic / gcp.gemini … 共 17 项，
+        /// 全为模型厂商），而 ACP 协议里没有任何 provider 或 model 字段——
+        /// <c>agentInfo</c> 只有 name / title / version。规范说该属性
+        /// <i>"acts as a discriminator that identifies the GenAI telemetry format flavor"</i>，
+        /// 猜一个填进去等于向后端声明「这条 span 是该厂商格式」，后端会据此去找对应的
+        /// <c>{provider}.*</c> 属性——那是**事实错误的遥测**，比缺字段更坏。
+        /// 因此本 span 有意不声明自己完全符合 <c>gen_ai.invoke_agent.client</c>，
+        /// 只发能被真实数据支撑的子集。若 ACP 将来暴露 provider，此处再补。
+        ///
+        /// 同理不发的键：<c>gen_ai.request.model</c>（ACP 无此字段）、
+        /// <c>gen_ai.agent.id</c>（规范要求是 provider 侧稳定资源 ID，且明确
+        /// <i>"NOT RECOMMENDED to record in-memory agent instance ids"</i>）、
+        /// <c>gen_ai.usage.*</c>（ACP 的 usage_update 是**上下文窗口占用量**的 gauge，
+        /// 不是本回合 token 收支；per-turn token 的 RFD 尚是 Draft）。
+        /// </remarks>
+        private static void ApplyInvokeAgentAttributes(Activity? activity, AgentInfo? agentInfo, string? sessionId)
+        {
+            if (activity is null)
+            {
+                return;
+            }
+
+            activity.SetTag(
+                ApplicationSemanticConventions.GenAi.OperationName,
+                ApplicationSemanticConventions.GenAi.InvokeAgentOperation);
+
+            if (!string.IsNullOrWhiteSpace(agentInfo?.Name))
+            {
+                activity.SetTag(ApplicationSemanticConventions.GenAi.AgentName, agentInfo.Name);
+            }
+
+            if (!string.IsNullOrWhiteSpace(agentInfo?.Version))
+            {
+                activity.SetTag(ApplicationSemanticConventions.GenAi.AgentVersion, agentInfo.Version);
+            }
+
+            // sessionId 缺失时一律不发：规范禁止用 UUID / traceId / 内容哈希兜底。
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                activity.SetTag(ApplicationSemanticConventions.GenAi.ConversationId, sessionId);
+            }
+        }
+
+        /// <summary>
+        /// 记录一次 agent 调用的耗时。
+        /// </summary>
+        /// <remarks>
+        /// 维度只有 <c>gen_ai.agent.name</c> 与 <c>error.type</c>——这正是规范为
+        /// <c>gen_ai.invoke_agent.duration</c> 指定的属性组
+        /// （<c>attributes.gen_ai.error</c> + <c>attributes.gen_ai.invoked_agent.internal.common</c>，
+        /// 不含要求 provider 的 <c>metric_attributes.gen_ai</c>）。两者都是低基数，
+        /// 不会打爆时间序列。
+        ///
+        /// 成功路径不发 <c>error.type</c>：规范是 <i>conditionally_required "If the
+        /// operation ended in an error"</i>，无条件发一个 "none" 之类的占位值会凭空多出
+        /// 一个维度值、并让「有没有出错」的查询失真。
+        /// </remarks>
+        private static void RecordInvokeAgentDuration(long startTimestamp, AgentInfo? agentInfo, string? errorType)
+        {
+            if (!ApplicationMeters.InvokeAgentDuration.Enabled)
+            {
+                return;
+            }
+
+            // 规范单位是秒（double），Stopwatch 提供的是高精度 TimeSpan。
+            var elapsedSeconds = Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds;
+
+            var agentName = agentInfo?.Name;
+            var hasAgentName = !string.IsNullOrWhiteSpace(agentName);
+            var hasErrorType = !string.IsNullOrWhiteSpace(errorType);
+
+            if (hasAgentName && hasErrorType)
+            {
+                ApplicationMeters.InvokeAgentDuration.Record(
+                    elapsedSeconds,
+                    new KeyValuePair<string, object?>(ApplicationSemanticConventions.GenAi.AgentName, agentName),
+                    new KeyValuePair<string, object?>(OtelErrorAttributes.Type, errorType));
+            }
+            else if (hasAgentName)
+            {
+                ApplicationMeters.InvokeAgentDuration.Record(
+                    elapsedSeconds,
+                    new KeyValuePair<string, object?>(ApplicationSemanticConventions.GenAi.AgentName, agentName));
+            }
+            else if (hasErrorType)
+            {
+                ApplicationMeters.InvokeAgentDuration.Record(
+                    elapsedSeconds,
+                    new KeyValuePair<string, object?>(OtelErrorAttributes.Type, errorType));
+            }
+            else
+            {
+                ApplicationMeters.InvokeAgentDuration.Record(elapsedSeconds);
             }
         }
 

--- a/src/SalmonEgg.Application/Services/Chat/ChatServiceFactory.cs
+++ b/src/SalmonEgg.Application/Services/Chat/ChatServiceFactory.cs
@@ -63,7 +63,7 @@ public class ChatServiceFactory
         string? url = null)
     {
         using var activity = ApplicationActivitySources.ChatService.StartActivity(
-            "CreateChatService",
+            "chat.service.create",
             ActivityKind.Internal);
 
         activity?.SetTag(ApplicationSemanticConventions.Chat.TransportType, transportType.ToString());
@@ -114,7 +114,7 @@ public class ChatServiceFactory
         }
 
         using var activity = ApplicationActivitySources.ChatService.StartActivity(
-            "CreateChatServiceFromConfiguration",
+            "chat.service.create_from_configuration",
             ActivityKind.Internal);
 
         activity?.SetTag(ApplicationSemanticConventions.Chat.TransportType, configuration.Transport.ToString());

--- a/src/SalmonEgg.Domain/Services/IInstallationIdentityService.cs
+++ b/src/SalmonEgg.Domain/Services/IInstallationIdentityService.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Domain.Services;
+
+/// <summary>
+/// 本次安装的稳定标识，用于让遥测能区分「多少台设备在用」而不采集任何个人信息。
+/// </summary>
+/// <remarks>
+/// 对应 OTel 的 <c>app.installation.id</c>（Recommended，故可默认上报，无需用户开关）。
+/// 规范对取值的硬约束：跨启动与跨应用升级保持不变；卸载后应改变；**硬件 ID
+/// （序列号 / IMEI / MAC）MUST NOT 用作该值**。因此实现只能是持久化的随机 GUID，
+/// 不得从机器名、用户名、MAC 等派生。
+///
+/// 与 <c>service.instance.id</c> 的分工必须分清：后者规范上只保证「同时存在的实例之间
+/// 唯一」，SDK 默认每进程随机生成，因此它是**进程/启动**判别符，`count(distinct)` 约等于
+/// 启动次数而非设备数。两者都要有，但不可互相顶替。
+///
+/// 也不要改用 <c>device.id</c>（Opt-In，允许硬件派生，规范自称会招致应用商店拒绝）或
+/// <c>host.id</c>（machine-id 类，跨应用共享且卸载不变，恰好破坏上面那条硬件 ID 禁令的目的）。
+/// </remarks>
+public interface IInstallationIdentityService
+{
+    /// <summary>
+    /// 取得本次安装的标识；首次调用时生成并持久化，之后恒返回同一值。
+    /// </summary>
+    /// <remarks>
+    /// 实现必须容忍持久化失败：遥测是旁路能力，读写标识文件出错只应让本次会话退化为
+    /// 无装机标识，不得让启动流程失败。
+    /// </remarks>
+    Task<string?> GetOrCreateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedExportProcessor.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedExportProcessor.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace SalmonEgg.Infrastructure.Observability;
+
+/// <summary>
+/// 在 span 结束时把出错的 span 提升为「可导出」，使低采样率下错误 trace 不被丢弃。
+/// 与 <see cref="ErrorBiasedSampler"/> 配对：采样器负责「记录但不导出」，本处理器负责
+/// 在状态已知后做真正的导出裁决。
+/// </summary>
+/// <remarks>
+/// 注册顺序有硬要求：本处理器必须排在导出处理器**之前**。OTel 按注册顺序串成链，
+/// 导出处理器读的是它被调用那一刻的 <see cref="ActivityTraceFlags.Recorded"/>；排在后面
+/// 提升 flag 就晚了，错误 span 依旧不会被导出（而且不报错，只是静默丢失）。
+///
+/// 关于孤儿 span：OnEnd 的实际顺序是**子先父后**，且子 span 的整条处理器链（含导出）会在
+/// 父 span 开始处理之前跑完，SDK 没有 trace 级缓冲，因此「等整条 trace 结束再统一裁决」
+/// 做不到——不要为此设计跨 span 的协调状态。实践中这不构成问题：异常沿调用栈冒泡时，每层
+/// catch 各自 <c>SetErrorStatus</c> 后 rethrow，于是每一级都独立被提升，导出的是完整的错误
+/// 链。只有「子出错但父吞掉异常并判成功」时才会出现单独的错误子 span，而那种情况父确实不
+/// 该算失败，后端仍可按 traceId 把它聚合到所属 trace 下。
+/// </remarks>
+internal sealed class ErrorBiasedExportProcessor : BaseProcessor<Activity>
+{
+    public override void OnEnd(Activity data)
+    {
+        if (data is null)
+        {
+            return;
+        }
+
+        if (data.Status == ActivityStatusCode.Error)
+        {
+            data.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedSampler.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedSampler.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+
+namespace SalmonEgg.Infrastructure.Observability;
+
+/// <summary>
+/// 把「未中签」从 <see cref="SamplingDecision.Drop"/> 降级为
+/// <see cref="SamplingDecision.RecordOnly"/> 的采样器，使 span 仍被完整记录但默认不导出；
+/// 最终是否导出由 <see cref="ErrorBiasedExportProcessor"/> 在 span 结束时按状态决定。
+/// </summary>
+/// <remarks>
+/// 为什么必须这样绕：采样决策发生在 span **开始**时，而 <c>SamplingParameters</c> 的全部
+/// 公开面只有 ParentContext / TraceId / Name / Kind / Tags / Links——**没有任何状态字段**。
+/// 那一刻错误尚未发生，因此「出错必留」不可能由采样器直接实现。OTel 为此提供的机制正是
+/// <c>RecordOnly</c>：记录但不导出，把导出决定推迟到 <c>BaseProcessor.OnEnd</c>，届时
+/// <see cref="Activity.Status"/> 已确定。
+///
+/// 代价是被降级的 span 仍要付出记录开销（分配 tag / event），只省下了网络导出。对客户端
+/// 应用这是正确的取舍：省流量与后端成本是采样的真实目的，而低采样率下丢掉错误 trace 会
+/// 直接让线上排障失效（移动端 2% 采样意味着用户报障时 98% 概率没有对应 trace）。
+/// </remarks>
+internal sealed class ErrorBiasedSampler : Sampler
+{
+    private readonly Sampler _normalRateSampler;
+
+    public ErrorBiasedSampler(double normalRate)
+    {
+        _normalRateSampler = new TraceIdRatioBasedSampler(normalRate);
+        Description = $"ErrorBiasedSampler{{normalRate={normalRate}}}";
+    }
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        var result = _normalRateSampler.ShouldSample(in samplingParameters);
+
+        // 中签者保持原样（含其 Attributes / TraceStateString，不可重建丢弃）。
+        return result.Decision == SamplingDecision.RecordAndSample
+            ? result
+            : new SamplingResult(SamplingDecision.RecordOnly);
+    }
+}
+
+/// <summary>
+/// 恒返回 <see cref="SamplingDecision.RecordOnly"/>。
+/// </summary>
+/// <remarks>
+/// 用于 <see cref="ParentBasedSampler"/> 的 parent-not-sampled 分支。这不是可选的润色：
+/// <c>ParentBasedSampler</c> 的单参构造把 localParentNotSampled / remoteParentNotSampled
+/// 默认成 <c>AlwaysOffSampler</c>，而本方案下父 span 常态是 RecordOnly（未 Recorded），
+/// 于是子 span 会**根本不被创建**（实测连 OnEnd 都不触发），error-biased 就只对 root span
+/// 生效、内层 ACP 请求的错误永久丢失。必须显式把这两个分支也设为 RecordOnly，让整条链都
+/// 保持「已记录、待裁决」状态。
+/// </remarks>
+internal sealed class RecordOnlySampler : Sampler
+{
+    public RecordOnlySampler() => Description = "RecordOnlySampler";
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        => new(SamplingDecision.RecordOnly);
+}

--- a/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedSampler.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/ErrorBiasedSampler.cs
@@ -11,9 +11,18 @@ namespace SalmonEgg.Infrastructure.Observability;
 /// <remarks>
 /// 为什么必须这样绕：采样决策发生在 span **开始**时，而 <c>SamplingParameters</c> 的全部
 /// 公开面只有 ParentContext / TraceId / Name / Kind / Tags / Links——**没有任何状态字段**。
-/// 那一刻错误尚未发生，因此「出错必留」不可能由采样器直接实现。OTel 为此提供的机制正是
-/// <c>RecordOnly</c>：记录但不导出，把导出决定推迟到 <c>BaseProcessor.OnEnd</c>，届时
-/// <see cref="Activity.Status"/> 已确定。
+/// 那一刻错误尚未发生，因此「出错必留」不可能由采样器直接实现。规范对此有明文：head sampling
+/// 下「cannot ensure that all traces with an error within them are sampled」。OTel 为此提供的
+/// 机制正是 <c>RecordOnly</c>：记录但不导出，把导出决定推迟到 <c>BaseProcessor.OnEnd</c>，
+/// 届时 <see cref="Activity.Status"/> 已确定。本组合与 opentelemetry-dotnet 仓库的
+/// <c>docs/trace/tail-based-sampling-span-level/</c> 示例同型。
+///
+/// 另一个副作用是必要的：<c>RecordOnly</c> 使 <c>Activity.IsAllDataRequested</c> 保持 true，
+/// 插装才会继续填属性——否则被降级的 span 即使最终被提升导出，内容也已是空的。
+///
+/// 注：完整的 whole-trace 错误偏置需要 Collector 端的 <c>tail_sampling</c> 处理器
+/// （policy <c>status_code: [ERROR]</c>）。客户端进程内只能做到 per-span 裁决，这是本方案
+/// 明确的能力边界，不是遗漏。
 ///
 /// 代价是被降级的 span 仍要付出记录开销（分配 tag / event），只省下了网络导出。对客户端
 /// 应用这是正确的取舍：省流量与后端成本是采样的真实目的，而低采样率下丢掉错误 trace 会

--- a/src/SalmonEgg.Infrastructure/Observability/ITelemetryExporterFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/ITelemetryExporterFactory.cs
@@ -21,6 +21,20 @@ public interface ITelemetryExporterFactory
     bool IsFileSupported { get; }
 
     /// <summary>
+    /// 平台是否支持 .NET 运行时指标插装（GC / JIT / 线程池 / 工作集）。
+    /// </summary>
+    /// <remarks>
+    /// WASM 必须为 <c>false</c>：<c>AddRuntimeInstrumentation()</c> 依赖 <c>EventSource</c> 与
+    /// <c>System.Diagnostics.Process</c>，浏览器沙箱两者都没有，调用会直接抛
+    /// <c>PlatformNotSupportedException</c>（open-telemetry/opentelemetry-dotnet-contrib#2529）。
+    /// 该异常发生在装配阶段，会让整条遥测管线构造失败，而不只是少掉运行时指标。
+    ///
+    /// 之所以做成能力位而不是在装配处写 <c>#if __WASM__</c>：平台差异必须集中在平台服务
+    /// （AGENTS.md 第 4/9 条），与 <see cref="IsGrpcSupported"/> 同型。
+    /// </remarks>
+    bool IsRuntimeInstrumentationSupported { get; }
+
+    /// <summary>
     /// 配置 TracerProvider（Traces 维度）
     /// </summary>
     /// <param name="builder">TracerProviderBuilder 实例</param>

--- a/src/SalmonEgg.Infrastructure/Observability/SemanticConventions.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/SemanticConventions.cs
@@ -102,30 +102,12 @@ public static class SemanticConventions
         public const string Type = "error.type";
     }
 
-    /// <summary>
-    /// 应用自定义 Attributes。
-    ///
-    /// 归属规则：只定义 Infrastructure 层埋点实际使用的键。Chat 相关键归 Application
-    /// 层（ChatService 实现在那一层，见 <c>ApplicationSemanticConventions.Chat</c>），
-    /// 此处不重复定义，避免同一语义在两层各有一份常量而漂移。
-    ///
-    /// 未定义 Database 组：本项目使用文件 / IndexedDB 存储，没有 SQL 数据库，
-    /// 保留 <c>db.*</c> 常量只会诱导误用（且旧的 db.system / db.statement / db.name
-    /// 在规范中均已弃用，分别被 db.system.name / db.query.text / db.namespace 取代）。
-    /// </summary>
-    public static class SalmonEgg
-    {
-        // Session
-        public const string SessionId = "salmonegg.session.id";
-        public const string SessionName = "salmonegg.session.name";
-        public const string SessionAction = "salmonegg.session.action";
-
-        // Transport
-        public const string TransportType = "salmonegg.transport.type";
-        public const string TransportConnectionId = "salmonegg.transport.connection_id";
-
-        // Storage
-        public const string StorageKeyPrefix = "salmonegg.storage.key_prefix";
-        public const string StorageOperation = "salmonegg.storage.operation";
-    }
+    // 应用自定义 Attributes 组已整体移除：其中 Session/Transport/Storage 七个常量
+    // 自始至终没有任何埋点引用（死代码），保留只会诱导将来误用。若将来某处真的要发
+    // salmonegg.* 键，届时在**实际使用的层**定义——归属规则同前（Chat 相关键归
+    // Application 层，见 <c>ApplicationSemanticConventions</c>），避免两层各留一份漂移。
+    //
+    // Database 组同样不定义：本项目使用文件 / IndexedDB 存储，没有 SQL 数据库，
+    // 保留 <c>db.*</c> 常量只会诱导误用（且旧的 db.system / db.statement / db.name
+    // 在规范中均已弃用，分别被 db.system.name / db.query.text / db.namespace 取代）。
 }

--- a/src/SalmonEgg.Infrastructure/Observability/SemanticConventions.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/SemanticConventions.cs
@@ -14,7 +14,23 @@ public static class SemanticConventions
     {
         public const string ServiceName = "service.name";
         public const string ServiceVersion = "service.version";
+
+        /// <summary>
+        /// 注意：规范上只保证「同时存在的实例之间唯一」，SDK 默认每进程随机生成，
+        /// 因此这是**进程/启动**判别符。<c>count(distinct)</c> 约等于启动次数而非设备数；
+        /// 要数设备用 <see cref="AppInstallationId"/>，两者不可互相顶替。
+        /// </summary>
         public const string ServiceInstanceId = "service.instance.id";
+
+        /// <summary>
+        /// 本次安装在本设备上的稳定标识，用于统计设备数 / DAU。
+        /// </summary>
+        /// <remarks>
+        /// 规范要求跨启动与跨升级保持不变、卸载后改变，且**硬件 ID（序列号 / IMEI / MAC）
+        /// MUST NOT 用作该值**。requirement level 是 Recommended（不是 Opt-In），故可默认
+        /// 上报、不需要额外的用户开关；用户仍可通过关闭遥测总开关来停止上报。
+        /// </remarks>
+        public const string AppInstallationId = "app.installation.id";
 
         /// <summary>
         /// 注意：旧名 <c>deployment.environment</c> 已被规范弃用，

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
@@ -67,8 +67,18 @@ public sealed class TelemetryManager : ITelemetryManager, IDisposable
             var resourceBuilder = BuildResource(targetSettings);
             var tracerBuilder = Sdk.CreateTracerProviderBuilder()
                 .SetResourceBuilder(resourceBuilder)
+                // parent-not-sampled 的两个分支必须显式设为 RecordOnly：单参构造会把它们默认成
+                // AlwaysOff，而本方案下父 span 常态未 Recorded，子 span 会根本不被创建，
+                // error-biased 就只对 root 生效、内层 ACP 请求的错误永久丢失。
                 .SetSampler(new ParentBasedSampler(
-                    new TraceIdRatioBasedSampler(targetSettings.Sampling.NormalRate)));
+                    rootSampler: new ErrorBiasedSampler(targetSettings.Sampling.NormalRate),
+                    remoteParentSampled: new AlwaysOnSampler(),
+                    remoteParentNotSampled: new RecordOnlySampler(),
+                    localParentSampled: new AlwaysOnSampler(),
+                    localParentNotSampled: new RecordOnlySampler()))
+                // 必须在导出器之前注册：处理器按注册顺序成链，导出器读的是被调用那一刻的
+                // Recorded flag，晚于它提升就不会被导出（且静默无错）。
+                .AddProcessor(new ErrorBiasedExportProcessor());
 
             foreach (var sourceName in TelemetrySourceNames.ActivitySources)
             {

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
@@ -95,6 +95,14 @@ public sealed class TelemetryManager : ITelemetryManager, IDisposable
                 meterBuilder.AddMeter(meterName);
             }
 
+            // 运行时指标（GC / JIT / 线程池 / 工作集）由平台能力位门控：WASM 上调用会抛
+            // PlatformNotSupportedException 并使整条管线装配失败。不需要另外 AddMeter——
+            // 实测该插装自行注册其 meter（System.Runtime），补一次 AddMeter 是纯冗余。
+            if (_exporterFactory.IsRuntimeInstrumentationSupported)
+            {
+                meterBuilder.AddRuntimeInstrumentation();
+            }
+
             _exporterFactory.ConfigureMeterProvider(meterBuilder, targetSettings);
             candidateMeter = meterBuilder.Build();
 

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetryRuntime.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetryRuntime.cs
@@ -19,6 +19,7 @@ public sealed class TelemetryRuntime : ITelemetryRuntime
 {
     private readonly ITelemetryManager _telemetryManager;
     private readonly Func<SamplingSettings> _samplingDefaultsProvider;
+    private readonly IInstallationIdentityService? _installationIdentity;
     private readonly ILogger<TelemetryRuntime> _logger;
     private readonly string? _serviceVersion;
 
@@ -31,16 +32,22 @@ public sealed class TelemetryRuntime : ITelemetryRuntime
 
     private TelemetrySettings? _appliedSettings;
 
+    /// <param name="installationIdentity">
+    /// 提供 <c>app.installation.id</c>。可为 null（不上报装机标识），使既有测试与不需要
+    /// 该维度的宿主无需构造它。
+    /// </param>
     public TelemetryRuntime(
         ITelemetryManager telemetryManager,
         Func<SamplingSettings> samplingDefaultsProvider,
         ILogger<TelemetryRuntime> logger,
-        string? serviceVersion = null)
+        string? serviceVersion = null,
+        IInstallationIdentityService? installationIdentity = null)
     {
         _telemetryManager = telemetryManager ?? throw new ArgumentNullException(nameof(telemetryManager));
         _samplingDefaultsProvider = samplingDefaultsProvider ?? throw new ArgumentNullException(nameof(samplingDefaultsProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceVersion = serviceVersion;
+        _installationIdentity = installationIdentity;
     }
 
     public async Task ApplyAsync(AppSettings settings, CancellationToken cancellationToken = default)
@@ -51,10 +58,15 @@ public sealed class TelemetryRuntime : ITelemetryRuntime
 
         try
         {
+            // 在等 apply 闸门之前取：这是一次性的本地读（之后走内存缓存），放在锁内会把
+            // 首启的文件 IO 串到每次 apply 的临界区里。
+            var installationId = await GetInstallationIdAsync(cancellationToken).ConfigureAwait(false);
+
             var target = TelemetrySettings.Build(
                 settings,
                 _samplingDefaultsProvider(),
-                _serviceVersion);
+                _serviceVersion,
+                installationId);
 
             await _applyGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
@@ -96,6 +108,31 @@ public sealed class TelemetryRuntime : ITelemetryRuntime
         {
             // 遥测是旁路能力：重建失败只应停用遥测，不得让设置保存或应用启动失败。
             _logger.LogError(ex, "Failed to apply telemetry configuration; telemetry may be inactive");
+        }
+    }
+
+    /// <summary>
+    /// 取装机标识；失败一律降级为 null（不上报该维度），不得让遥测 apply 失败。
+    /// </summary>
+    private async Task<string?> GetInstallationIdAsync(CancellationToken cancellationToken)
+    {
+        if (_installationIdentity is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _installationIdentity.GetOrCreateAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve installation identity; telemetry omits app.installation.id");
+            return null;
         }
     }
 

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetrySettings.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetrySettings.cs
@@ -108,10 +108,16 @@ public sealed class TelemetrySettings
     /// When no endpoint is configured the built-in gateway (<see cref="TelemetryDefaults.DefaultOtlpEndpoint"/>)
     /// is used so telemetry can flow without per-deployment setup; the gateway injects upstream auth.
     /// </summary>
+    /// <param name="installationId">
+    /// <c>app.installation.id</c>：本次安装的稳定标识，使后端能区分设备数。为 null 时不写该
+    /// 属性——写入空串会在后端形成一个无意义的维度取值。由调用方异步取得后传入，本方法保持
+    /// 同步且只读环境变量。
+    /// </param>
     public static TelemetrySettings Build(
         Domain.Models.AppSettings? userSettings,
         SamplingSettings platformSamplingDefaults,
-        string? serviceVersion = null)
+        string? serviceVersion = null,
+        string? installationId = null)
     {
         ArgumentNullException.ThrowIfNull(platformSamplingDefaults);
 
@@ -138,6 +144,21 @@ public sealed class TelemetrySettings
         var logs = ResolveSignal(OtlpSignal.Logs, userEndpoint, userHeaders, genericEndpoint, genericHeaders, genericProtocol, useFallbackGateway);
         var enabled = !userDisabled && !sdkDisabled && traces.IsConfigured && metrics.IsConfigured && logs.IsConfigured;
 
+        var resourceAttributes = new Dictionary<string, string>
+        {
+            [SemanticConventions.Resource.DeploymentEnvironmentName] =
+                NormalizeOptional(Environment.GetEnvironmentVariable("OTEL_ENVIRONMENT")) ?? TelemetryDefaults.DefaultEnvironment,
+            [SemanticConventions.Resource.ServiceInstanceId] = ProcessInstanceId
+        };
+
+        // 取不到时省略而非写空串：空串会在后端形成一个无意义的维度取值，且无法与「这台设备
+        // 还没生成标识」区分开。
+        var normalizedInstallationId = NormalizeOptional(installationId);
+        if (normalizedInstallationId is not null)
+        {
+            resourceAttributes[SemanticConventions.Resource.AppInstallationId] = normalizedInstallationId;
+        }
+
         return new TelemetrySettings
         {
             Enabled = enabled,
@@ -149,12 +170,7 @@ public sealed class TelemetrySettings
             Logs = logs,
             ServiceName = NormalizeOptional(Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME")) ?? TelemetryDefaults.ServiceName,
             ServiceVersion = serviceVersion,
-            ResourceAttributes = new Dictionary<string, string>
-            {
-                [SemanticConventions.Resource.DeploymentEnvironmentName] =
-                    NormalizeOptional(Environment.GetEnvironmentVariable("OTEL_ENVIRONMENT")) ?? TelemetryDefaults.DefaultEnvironment,
-                [SemanticConventions.Resource.ServiceInstanceId] = ProcessInstanceId
-            },
+            ResourceAttributes = resourceAttributes,
             Sampling = platformSamplingDefaults
         };
     }

--- a/src/SalmonEgg.Infrastructure/Storage/InstallationIdentityService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/InstallationIdentityService.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Infrastructure.Storage;
+
+/// <summary>
+/// <see cref="IInstallationIdentityService"/> 的实现：把安装标识持久化在 app data 根目录下的
+/// 独立文件里。
+/// </summary>
+/// <remarks>
+/// 落点选择是硬约束，不是风格问题：<see cref="IAppDataService.ConfigRootPath"/>
+/// （即 <c>&lt;appdata&gt;/config</c>）整棵子树会被云配置同步用
+/// <c>EnumerateFiles(ConfigRootPath, "*", AllDirectories)</c> 通配打包。装机标识一旦落在
+/// 那里，用户开启同步后第二台设备会恢复出同一个值，两台机器从此上报相同标识——装机数与
+/// DAU 永久偏低，且数据侧完全看不出异常（无报错、无缺口）。因此本文件放在 app data **根**
+/// 目录下，与 <c>config-migrations</c> 同级，天然在同步范围之外。
+///
+/// 不复用 <c>AppSettings</c> 同理：那是 app.yaml 的内容，属于可携带配置。
+///
+/// 采用 <see cref="IAppFileStore"/> 而非直接 <c>File.*</c>：WASM 的存储后端不是本地文件系统，
+/// 该抽象已承担平台差异。
+/// </remarks>
+public sealed class InstallationIdentityService : IInstallationIdentityService
+{
+    /// <summary>文件名。放 app data 根目录，不进 config 子树（会被云同步打包）。</summary>
+    internal const string FileName = "installation-id";
+
+    private readonly IAppFileStore _fileStore;
+    private readonly IAppDataService _appData;
+    private readonly ILogger<InstallationIdentityService> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private string? _cached;
+
+    public InstallationIdentityService(
+        IAppFileStore fileStore,
+        IAppDataService appData,
+        ILogger<InstallationIdentityService> logger)
+    {
+        _fileStore = fileStore ?? throw new ArgumentNullException(nameof(fileStore));
+        _appData = appData ?? throw new ArgumentNullException(nameof(appData));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> GetOrCreateAsync(CancellationToken cancellationToken = default)
+    {
+        var cached = Volatile.Read(ref _cached);
+        if (cached is not null)
+        {
+            return cached;
+        }
+
+        // 串行化首次生成：并发首启会各生成一个 GUID，后写者覆盖前者，于是同一台设备在同一次
+        // 启动内先后上报两个不同标识，装机数偏高。
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cached = Volatile.Read(ref _cached);
+            if (cached is not null)
+            {
+                return cached;
+            }
+
+            var path = GetIdentityFilePath();
+            var existing = await ReadExistingAsync(path, cancellationToken).ConfigureAwait(false);
+            if (existing is not null)
+            {
+                Volatile.Write(ref _cached, existing);
+                return existing;
+            }
+
+            // 规范禁止用硬件 ID（序列号 / IMEI / MAC）派生，故只能是随机值。
+            var generated = Guid.NewGuid().ToString("D");
+            if (!await TryPersistAsync(path, generated, cancellationToken).ConfigureAwait(false))
+            {
+                // 持久化失败时不缓存：下次启动仍会重试，避免把一个只存在于内存的值当成
+                // 「本次安装的稳定标识」上报（那会让每次启动都算一台新设备）。
+                return null;
+            }
+
+            Volatile.Write(ref _cached, generated);
+            return generated;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private string GetIdentityFilePath()
+        => Path.Combine(_appData.AppDataRootPath, FileName);
+
+    private async Task<string?> ReadExistingAsync(string path, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var content = await _fileStore.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            // 只接受规范形态的 GUID：文件被外部改坏时重新生成，而不是把任意字符串当标识
+            // 上报（否则会污染后端的维度取值）。
+            return Guid.TryParse(content.Trim(), out var parsed)
+                ? parsed.ToString("D")
+                : null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read installation identity; a new value will be generated");
+            return null;
+        }
+    }
+
+    private async Task<bool> TryPersistAsync(string path, string value, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _fileStore.WriteAllTextAsync(path, value, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // 遥测是旁路能力：写不进去只应让本次会话没有装机标识，不得让启动失败。
+            _logger.LogWarning(ex, "Failed to persist installation identity; telemetry will omit it this session");
+            return false;
+        }
+    }
+}

--- a/tests/SalmonEgg.Application.Tests/Services/Chat/ChatServiceTracingTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/Chat/ChatServiceTracingTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Moq;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Acp.Protocol;
@@ -67,12 +68,251 @@ public sealed class ChatServiceTracingTests
             new SessionPromptParams("session-1", []),
             cancellation.Token));
 
-        // Assert
+        // Assert：取消时 span 名退化为裸操作名（mock 未设 AgentInfo），状态保持 Unset。
         var activity = Assert.Single(stoppedActivities);
-        Assert.Equal("chat.session.prompt", activity.DisplayName);
+        Assert.Equal(ApplicationSemanticConventions.GenAi.InvokeAgentOperation, activity.DisplayName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
         Assert.False(activity.Events.Any());
     }
+
+    [Fact]
+    public async Task SendPromptAsync_Success_EmitsInvokeAgentSpanWithGenAiAttributes()
+    {
+        // Arrange
+        var acpClient = new Mock<IAcpClient>();
+        acpClient.Setup(client => client.AgentInfo)
+            .Returns(new AgentInfo("TestAgent", "2.3.4"));
+        acpClient
+            .Setup(client => client.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionPromptResponse(StopReason.EndTurn));
+        var stoppedActivities = new List<Activity>();
+        using var parent = new Activity("test.chat.prompt.success").Start();
+        using var listener = CreateListener(parent.TraceId, stoppedActivities);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        await service.SendPromptAsync(new SessionPromptParams("session-42", []));
+
+        // Assert
+        var activity = Assert.Single(stoppedActivities);
+        Assert.Equal("invoke_agent TestAgent", activity.DisplayName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal(ActivityStatusCode.Ok, activity.Status);
+        Assert.Equal(
+            ApplicationSemanticConventions.GenAi.InvokeAgentOperation,
+            activity.GetTagItem(ApplicationSemanticConventions.GenAi.OperationName));
+        Assert.Equal(
+            "TestAgent",
+            activity.GetTagItem(ApplicationSemanticConventions.GenAi.AgentName));
+        Assert.Equal(
+            "2.3.4",
+            activity.GetTagItem(ApplicationSemanticConventions.GenAi.AgentVersion));
+        Assert.Equal(
+            "session-42",
+            activity.GetTagItem(ApplicationSemanticConventions.GenAi.ConversationId));
+        // 封闭枚举的 provider 与无数据源的 usage/model 键必须缺席（见 ApplyInvokeAgentAttributes 备注）。
+        Assert.Null(activity.GetTagItem("gen_ai.provider.name"));
+        Assert.Null(activity.GetTagItem("gen_ai.request.model"));
+        Assert.Null(activity.GetTagItem("gen_ai.usage.input_tokens"));
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_UnknownAgent_UsesBareSpanNameAndSkipsAgentTags()
+    {
+        // Arrange：AgentInfo 为 null（未完成 initialize）。
+        var acpClient = new Mock<IAcpClient>();
+        acpClient
+            .Setup(client => client.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionPromptResponse(StopReason.EndTurn));
+        var stoppedActivities = new List<Activity>();
+        using var parent = new Activity("test.chat.prompt.unknown-agent").Start();
+        using var listener = CreateListener(parent.TraceId, stoppedActivities);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        await service.SendPromptAsync(new SessionPromptParams("session-7", []));
+
+        // Assert
+        var activity = Assert.Single(stoppedActivities);
+        Assert.Equal(ApplicationSemanticConventions.GenAi.InvokeAgentOperation, activity.DisplayName);
+        Assert.Null(activity.GetTagItem(ApplicationSemanticConventions.GenAi.AgentName));
+        // sessionId 存在，conversation.id 照发——它不依赖 AgentInfo。
+        Assert.NotNull(activity.GetTagItem(ApplicationSemanticConventions.GenAi.ConversationId));
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_EmptySessionId_OmitsConversationId()
+    {
+        // Arrange：规范禁止用 UUID / traceId / 哈希兜底 conversation.id。
+        var acpClient = new Mock<IAcpClient>();
+        acpClient
+            .Setup(client => client.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionPromptResponse(StopReason.EndTurn));
+        var stoppedActivities = new List<Activity>();
+        using var parent = new Activity("test.chat.prompt.no-session").Start();
+        using var listener = CreateListener(parent.TraceId, stoppedActivities);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        await service.SendPromptAsync(new SessionPromptParams(string.Empty, []));
+
+        // Assert
+        var activity = Assert.Single(stoppedActivities);
+        Assert.Null(activity.GetTagItem(ApplicationSemanticConventions.GenAi.ConversationId));
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_Failure_MarksSpanErrorAndTagsCanonicalErrorType()
+    {
+        // Arrange
+        var acpClient = new Mock<IAcpClient>();
+        acpClient.Setup(client => client.AgentInfo)
+            .Returns(new AgentInfo("TestAgent", "2.3.4"));
+        acpClient
+            .Setup(client => client.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var stoppedActivities = new List<Activity>();
+        using var parent = new Activity("test.chat.prompt.failure").Start();
+        using var listener = CreateListener(parent.TraceId, stoppedActivities);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.SendPromptAsync(
+            new SessionPromptParams("session-9", [])));
+
+        // Assert
+        var activity = Assert.Single(stoppedActivities);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal(
+            typeof(InvalidOperationException).FullName,
+            activity.GetTagItem(OtelErrorAttributes.Type));
+        Assert.True(activity.Events.Any(@event => @event.Name == "exception"));
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_Success_RecordsDurationWithAgentDimensionOnly()
+    {
+        // Arrange：成功样本只带 gen_ai.agent.name 维度；error.type 必须缺席，
+        // 否则「有没有出错」的查询会失真。
+        var acpClient = new Mock<IAcpClient>();
+        acpClient.Setup(client => client.AgentInfo)
+            .Returns(new AgentInfo("TestAgent", "2.3.4"));
+        acpClient
+            .Setup(client => client.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionPromptResponse(StopReason.EndTurn));
+        using var parent = new Activity("test.chat.metric.success").Start();
+        using var activityListener = CreateListener(parent.TraceId, []);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        List<Measurement<double>> measurements;
+        using (var collector = CreateDurationCollector())
+        {
+            await service.SendPromptAsync(new SessionPromptParams("session-42", []));
+            measurements = collector.Snapshot();
+        }
+
+        // Assert
+        var measurement = Assert.Single(measurements);
+        Assert.True(measurement.Value > 0);
+        Assert.Equal("TestAgent", TagValue(measurement, ApplicationSemanticConventions.GenAi.AgentName));
+        Assert.Null(TagValue(measurement, OtelErrorAttributes.Type));
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_Cancellation_TagsDurationWithNormalizedCancelType()
+    {
+        // Arrange：取消要进耗时分布且可分辨（error.type 归一化为 OperationCanceledException），
+        // 但不得污染成功分布。
+        var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var acpClient = new Mock<IAcpClient>();
+        acpClient.Setup(client => client.AgentInfo)
+            .Returns(new AgentInfo("TestAgent", "2.3.4"));
+        acpClient
+            .Setup(client => client.SendPromptAsync(
+                It.IsAny<SessionPromptParams>(),
+                cancellation.Token))
+            .Returns(Task.FromCanceled<SessionPromptResponse>(cancellation.Token));
+        using var parent = new Activity("test.chat.metric.cancelled").Start();
+        using var activityListener = CreateListener(parent.TraceId, []);
+        using var service = new ChatService(
+            acpClient.Object,
+            new Mock<IErrorLogger>().Object,
+            new SessionManager());
+
+        // Act
+        List<Measurement<double>> measurements;
+        using (var collector = CreateDurationCollector())
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.SendPromptAsync(
+                new SessionPromptParams("session-42", []),
+                cancellation.Token));
+            measurements = collector.Snapshot();
+        }
+
+        // Assert
+        var measurement = Assert.Single(measurements);
+        Assert.Equal(
+            "System.OperationCanceledException",
+            TagValue(measurement, OtelErrorAttributes.Type));
+    }
+
+    private static string? TagValue(Measurement<double> measurement, string key) =>
+        measurement.Tags.ToArray().FirstOrDefault(tag => tag.Key == key).Value as string;
+
+    /// <summary>
+    /// 挂一个只收 <c>gen_ai.invoke_agent.duration</c> 的 MeterListener；Dispose 即停。
+    /// </summary>
+    private sealed class DurationCollector : IDisposable
+    {
+        private readonly List<Measurement<double>> _measurements = [];
+        private readonly MeterListener _listener = new()
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == ApplicationMeters.ChatServiceMeterName
+                    && instrument.Name == ApplicationSemanticConventions.GenAi.InvokeAgentDurationMetric)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+
+        public DurationCollector()
+        {
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            {
+                if (instrument.Name == ApplicationSemanticConventions.GenAi.InvokeAgentDurationMetric)
+                {
+                    _measurements.Add(new Measurement<double>(measurement, tags.ToArray()));
+                }
+            });
+            _listener.Start();
+        }
+
+        public List<Measurement<double>> Snapshot() => [.. _measurements];
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private static DurationCollector CreateDurationCollector() => new();
 
     private static ActivityListener CreateListener(
         ActivityTraceId traceId,

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/DynamicTelemetryLoggerProviderTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/DynamicTelemetryLoggerProviderTests.cs
@@ -143,6 +143,8 @@ public sealed class DynamicTelemetryLoggerProviderTests
 
         public bool IsFileSupported => true;
 
+        public bool IsRuntimeInstrumentationSupported => true;
+
         public void ConfigureTracerProvider(TracerProviderBuilder builder, TelemetrySettings settings)
         {
         }

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/ErrorBiasedSamplingTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/ErrorBiasedSamplingTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using SalmonEgg.Infrastructure.Observability;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Observability;
+
+/// <summary>
+/// error-biased 采样的行为门禁：断言「哪些 span 真的被导出」这一可观察结果，
+/// 而非采样器/处理器的内部形态。
+/// </summary>
+/// <remarks>
+/// 采样率一律取 0.0：这不是「关闭采样」，而是把「正常流量未中签」这一条件确定化。
+/// 用真实比率会让断言依赖 traceId 随机性而 flaky，且无法区分「错误被救回」与「碰巧中签」。
+/// 反向验证记录：把 <c>ErrorBiasedSampler</c> 换回裸 <c>TraceIdRatioBasedSampler</c>，
+/// ErrorSpan_IsExported* 会因导出集为空而失败；移除 <c>ErrorBiasedExportProcessor</c> 亦同。
+/// 把 ParentBasedSampler 改回单参构造，则 NestedErrorUnderNonSampledParent_* 会因子 span
+/// 根本不被创建而失败。
+/// </remarks>
+public sealed class ErrorBiasedSamplingTests
+{
+    private const string SourceName = "SalmonEgg.Tests.ErrorBiasedSampling";
+
+    [Fact]
+    public void SuccessfulSpan_IsNotExported_WhenNormalRateExcludesIt()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        harness.EmitSpan("ok", ActivityStatusCode.Ok);
+
+        Assert.Empty(harness.ExportedSpanNames);
+    }
+
+    [Fact]
+    public void ErrorSpan_IsExported_EvenWhenNormalRateExcludesIt()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        harness.EmitSpan("failed", ActivityStatusCode.Error);
+
+        Assert.Equal(["failed"], harness.ExportedSpanNames);
+    }
+
+    [Fact]
+    public void ErrorSpan_IsExportedAlongsideDroppedSuccesses()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        harness.EmitSpan("ok-1", ActivityStatusCode.Ok);
+        harness.EmitSpan("failed", ActivityStatusCode.Error);
+        harness.EmitSpan("ok-2", ActivityStatusCode.Ok);
+
+        // 只有错误 span 穿过采样，成功的两个被丢弃：这正是 error-biased 的用户可观察效果。
+        Assert.Equal(["failed"], harness.ExportedSpanNames);
+    }
+
+    [Fact]
+    public void UnsetStatusSpan_IsNotExported()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        // 取消属于正常路径（ChatService 对调用方取消刻意不标 Error），不应因此产生导出。
+        harness.EmitSpan("cancelled", ActivityStatusCode.Unset);
+
+        Assert.Empty(harness.ExportedSpanNames);
+    }
+
+    [Fact]
+    public void NestedErrorUnderNonSampledParent_IsStillRecordedAndExported()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        // 父 span 处于 RecordOnly。若 parent-not-sampled 分支落到 AlwaysOff，
+        // 子 span 会根本不被创建，内层 ACP 错误将永久丢失。
+        using (var parent = harness.Source.StartActivity("parent"))
+        {
+            Assert.NotNull(parent);
+            using (var child = harness.Source.StartActivity("child"))
+            {
+                Assert.NotNull(child);
+                child.SetStatus(ActivityStatusCode.Error, "inner failure");
+            }
+
+            parent.SetStatus(ActivityStatusCode.Ok);
+        }
+
+        harness.Flush();
+        Assert.Equal(["child"], harness.ExportedSpanNames);
+    }
+
+    [Fact]
+    public void ErrorPropagatedThroughCallStack_ExportsWholeChainWithoutOrphans()
+    {
+        using var harness = new SamplingHarness(normalRate: 0.0);
+
+        // 现有代码的真实形态：每层 catch 各自 SetStatus(Error) 后 rethrow。
+        try
+        {
+            using var parent = harness.Source.StartActivity("chat.session.prompt");
+            try
+            {
+                using var child = harness.Source.StartActivity("acp.request");
+                try
+                {
+                    throw new InvalidOperationException("rpc failure");
+                }
+                catch (Exception ex)
+                {
+                    child?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                    throw;
+                }
+            }
+            catch (Exception ex)
+            {
+                parent?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // 已在两级 span 上记录，向上冒泡到此为止。
+        }
+
+        harness.Flush();
+
+        // 两级都被独立提升，导出的是完整链：错误 trace 在后端可从 root 一路下钻。
+        Assert.Equal(2, harness.ExportedSpans.Count);
+        Assert.Single(harness.ExportedSpans, span => span.ParentSpanId == default);
+        var root = harness.ExportedSpans.Single(span => span.ParentSpanId == default);
+        var inner = harness.ExportedSpans.Single(span => span.ParentSpanId != default);
+        Assert.Equal(root.SpanId, inner.ParentSpanId);
+    }
+
+    private sealed class SamplingHarness : IDisposable
+    {
+        private readonly TracerProvider _provider;
+        private readonly RecordingExporter _exporter = new();
+
+        public SamplingHarness(double normalRate)
+        {
+            Source = new ActivitySource(SourceName, "1.0.0");
+            _provider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(SourceName)
+                .SetSampler(new ParentBasedSampler(
+                    rootSampler: new ErrorBiasedSampler(normalRate),
+                    remoteParentSampled: new AlwaysOnSampler(),
+                    remoteParentNotSampled: new RecordOnlySampler(),
+                    localParentSampled: new AlwaysOnSampler(),
+                    localParentNotSampled: new RecordOnlySampler()))
+                .AddProcessor(new ErrorBiasedExportProcessor())
+                .AddProcessor(new SimpleActivityExportProcessor(_exporter))
+                .Build();
+        }
+
+        public ActivitySource Source { get; }
+
+        public IReadOnlyList<Activity> ExportedSpans => _exporter.Exported;
+
+        public IReadOnlyList<string> ExportedSpanNames
+            => _exporter.Exported.Select(static span => span.DisplayName).ToList();
+
+        public void EmitSpan(string name, ActivityStatusCode status)
+        {
+            using (var activity = Source.StartActivity(name))
+            {
+                // span 必须真的被创建，否则「未导出」会是假绿（根本没产生数据）。
+                Assert.NotNull(activity);
+                if (status != ActivityStatusCode.Unset)
+                {
+                    activity.SetStatus(status);
+                }
+            }
+
+            Flush();
+        }
+
+        public void Flush() => _provider.ForceFlush(5000);
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+            Source.Dispose();
+        }
+    }
+
+    private sealed class RecordingExporter : BaseExporter<Activity>
+    {
+        private readonly List<Activity> _exported = [];
+
+        public IReadOnlyList<Activity> Exported => _exported;
+
+        public override ExportResult Export(in Batch<Activity> batch)
+        {
+            foreach (var activity in batch)
+            {
+                _exported.Add(activity);
+            }
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/RuntimeInstrumentationTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/RuntimeInstrumentationTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using SalmonEgg.Infrastructure.Observability;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Observability;
+
+/// <summary>
+/// 运行时指标（<c>dotnet.*</c>）的装配门禁。
+/// </summary>
+/// <remarks>
+/// 断言的是「导出器真的收到了 dotnet.* 指标」这一可观察结果，而不是「调用过
+/// AddRuntimeInstrumentation」这类实现摆放：后者无法区分「插装接上了」与「接上但收不到
+/// 数据」。
+///
+/// 反向验证记录：移除 <c>TelemetryManager</c> 中的 <c>AddRuntimeInstrumentation()</c>
+/// 调用，EmitsDotnetRuntimeMetrics 会因导出集里没有 dotnet.* 而失败；把能力位判断改成
+/// 无条件调用，SkipsRuntimeInstrumentation_WhenPlatformDoesNotSupportIt 会失败。
+/// </remarks>
+public sealed class RuntimeInstrumentationTests
+{
+    [Fact]
+    public void EmitsDotnetRuntimeMetrics_WhenPlatformSupportsIt()
+    {
+        var exporter = new MetricNameCollectingExporter();
+        var factory = new RuntimeCapableExporterFactory(
+            runtimeInstrumentationSupported: true,
+            exporter);
+        var manager = new TelemetryManager(CreateEnabledSettings(), factory);
+
+        try
+        {
+            manager.Reconfigure(CreateEnabledSettings());
+
+            // 触发若干 GC / 分配，使运行时插装有可观测数值可上报。
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.True(manager.Flush(10000), "metrics flush should complete");
+
+            Assert.Contains(exporter.MetricNames, name => name.StartsWith("dotnet.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            manager.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SkipsRuntimeInstrumentation_WhenPlatformDoesNotSupportIt()
+    {
+        var exporter = new MetricNameCollectingExporter();
+        var factory = new RuntimeCapableExporterFactory(
+            runtimeInstrumentationSupported: false,
+            exporter);
+        var manager = new TelemetryManager(CreateEnabledSettings(), factory);
+
+        try
+        {
+            // WASM 上无条件调用 AddRuntimeInstrumentation 会抛 PlatformNotSupportedException
+            // 并让整条管线装配失败，因此这里首先要求 Reconfigure 本身不抛。
+            var exception = Record.Exception(() => manager.Reconfigure(CreateEnabledSettings()));
+            Assert.Null(exception);
+
+            GC.Collect();
+            manager.Flush(10000);
+
+            Assert.DoesNotContain(exporter.MetricNames, name => name.StartsWith("dotnet.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            manager.Dispose();
+        }
+    }
+
+    private static TelemetrySettings CreateEnabledSettings() => new()
+    {
+        Enabled = true,
+        ServiceName = "RuntimeInstrumentationTests",
+        OtlpEndpoint = "http://localhost:4318",
+        Traces = new OtlpSignalSettings { Endpoint = "http://localhost:4318" },
+        Metrics = new OtlpSignalSettings { Endpoint = "http://localhost:4318" },
+        Logs = new OtlpSignalSettings { Endpoint = "http://localhost:4318" },
+        Sampling = SamplingSettings.CreateDesktopDefaults()
+    };
+
+    /// <summary>
+    /// 只提供一个记录用的 metric reader，不接真实 OTLP：本门禁验证的是
+    /// meter 注册与插装门控，与导出协议无关。
+    /// </summary>
+    private sealed class RuntimeCapableExporterFactory(
+        bool runtimeInstrumentationSupported,
+        MetricNameCollectingExporter exporter) : ITelemetryExporterFactory
+    {
+        public bool IsGrpcSupported => true;
+
+        public bool IsFileSupported => true;
+
+        public bool IsRuntimeInstrumentationSupported { get; } = runtimeInstrumentationSupported;
+
+        public void ConfigureTracerProvider(
+            OpenTelemetry.Trace.TracerProviderBuilder builder,
+            TelemetrySettings settings)
+        {
+        }
+
+        public void ConfigureMeterProvider(MeterProviderBuilder builder, TelemetrySettings settings)
+        {
+            // 手动 reader：ForceFlush 时同步收集，避免依赖周期性导出的时序。
+            builder.AddReader(new BaseExportingMetricReader(exporter));
+        }
+
+        public void ConfigureLoggerProvider(
+            OpenTelemetry.Logs.OpenTelemetryLoggerOptions options,
+            TelemetrySettings settings)
+        {
+        }
+    }
+
+    private sealed class MetricNameCollectingExporter : BaseExporter<Metric>
+    {
+        private readonly HashSet<string> _names = new(StringComparer.Ordinal);
+        private readonly Lock _sync = new();
+
+        public IReadOnlyCollection<string> MetricNames
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _names.ToList();
+                }
+            }
+        }
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            // Batch<T> 是 ref struct，不能在 lock 作用域外枚举，先取出名称再合并。
+            var collected = new List<string>();
+            foreach (var metric in batch)
+            {
+                collected.Add(metric.Name);
+            }
+
+            lock (_sync)
+            {
+                foreach (var name in collected)
+                {
+                    _names.Add(name);
+                }
+            }
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryManagerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryManagerTests.cs
@@ -291,6 +291,10 @@ public class TelemetryManagerTests
     {
         public bool IsGrpcSupported => true;
         public bool IsFileSupported => true;
+
+        /// <summary>可切换，用于覆盖 WASM（不支持运行时插装）与其余平台两条装配分支。</summary>
+        public bool IsRuntimeInstrumentationSupported { get; set; } = true;
+
         public bool TracerProviderConfigured { get; private set; }
         public bool MeterProviderConfigured { get; private set; }
         public int TracerConfigureCount { get; private set; }

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/InstallationIdentityServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/InstallationIdentityServiceTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Storage;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Storage;
+
+/// <summary>
+/// 装机标识的行为门禁。
+/// </summary>
+/// <remarks>
+/// 最重要的一条是落点：标识文件必须**不在** <see cref="IAppDataService.ConfigRootPath"/>
+/// 子树内，因为云配置同步用 <c>EnumerateFiles(ConfigRootPath, "*", AllDirectories)</c> 通配
+/// 打包该子树。落进去会让第二台设备恢复出同一标识，装机数与 DAU 永久偏低且数据侧无异常可见。
+/// 该缺陷不会有任何运行时症状，只能靠这条断言拦住。
+/// </remarks>
+public sealed class InstallationIdentityServiceTests
+{
+    [Fact]
+    public async Task GetOrCreateAsync_PersistsOutsideCloudSyncedConfigSubtree()
+    {
+        var store = new RecordingFileStore();
+        var appData = new FakeAppDataService();
+        var service = CreateService(store, appData);
+
+        var id = await service.GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(id);
+        var writtenPath = Assert.Single(store.Writes.Keys);
+
+        // config 子树整棵会被云同步打包；标识必须在其外。
+        var configPrefix = appData.ConfigRootPath + Path.DirectorySeparatorChar;
+        Assert.DoesNotContain(configPrefix, writtenPath, StringComparison.Ordinal);
+        Assert.NotEqual(appData.ConfigRootPath, Path.GetDirectoryName(writtenPath));
+
+        // 而且必须确实在 app data 根下，否则只是"碰巧不在 config 里"。
+        Assert.Equal(appData.AppDataRootPath, Path.GetDirectoryName(writtenPath));
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ReturnsStableValueAcrossCalls()
+    {
+        var store = new RecordingFileStore();
+        var service = CreateService(store, new FakeAppDataService());
+
+        var first = await service.GetOrCreateAsync(TestContext.Current.CancellationToken);
+        var second = await service.GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(first, second);
+        // 第二次不得重新写盘，否则每次调用都会换值。
+        Assert.Single(store.Writes);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ReusesPersistedValue_SimulatingRelaunch()
+    {
+        var store = new RecordingFileStore();
+        var appData = new FakeAppDataService();
+
+        var firstRun = await CreateService(store, appData).GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        // 新实例 + 同一存储 = 重启：规范要求跨启动（含应用升级）保持同一值。
+        var secondRun = await CreateService(store, appData).GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(firstRun, secondRun);
+        Assert.Single(store.Writes);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ProducesRandomGuid_NotDerivedFromHardwareOrMachineIdentity()
+    {
+        var appData = new FakeAppDataService();
+
+        var first = await CreateService(new RecordingFileStore(), appData)
+            .GetOrCreateAsync(TestContext.Current.CancellationToken);
+        var second = await CreateService(new RecordingFileStore(), appData)
+            .GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        // 规范：硬件 ID（序列号 / IMEI / MAC）MUST NOT 用作该值。两个空存储上生成的值必须
+        // 不同——若实现改成从机器名 / MAC 派生，同一台机器上会得到相同值，此断言即失败。
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(first, second);
+        Assert.True(Guid.TryParse(first, out _));
+
+        // 也不得包含本机可识别信息。
+        Assert.DoesNotContain(Environment.MachineName, first, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(Environment.UserName, first, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_RegeneratesWhenPersistedValueIsCorrupted()
+    {
+        var appData = new FakeAppDataService();
+        var store = new RecordingFileStore();
+        store.Seed(Path.Combine(appData.AppDataRootPath, InstallationIdentityService.FileName), "not-a-guid");
+
+        var id = await CreateService(store, appData).GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        // 不把任意字符串当标识上报（会污染后端维度取值）。
+        Assert.NotNull(id);
+        Assert.True(Guid.TryParse(id, out _));
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ReturnsNullWithoutThrowing_WhenPersistenceFails()
+    {
+        var store = new RecordingFileStore { FailWrites = true };
+        var service = CreateService(store, new FakeAppDataService());
+
+        // 遥测是旁路能力：写不进去只应让本次会话没有装机标识，不得让启动流程失败。
+        var id = await service.GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_DoesNotCacheUnpersistedValue()
+    {
+        var store = new RecordingFileStore { FailWrites = true };
+        var service = CreateService(store, new FakeAppDataService());
+
+        Assert.Null(await service.GetOrCreateAsync(TestContext.Current.CancellationToken));
+
+        // 恢复写入能力后应重试并成功：缓存一个只存在于内存的值会让每次启动都算一台新设备。
+        store.FailWrites = false;
+        var recovered = await service.GetOrCreateAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(recovered);
+        Assert.True(Guid.TryParse(recovered, out _));
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ConcurrentFirstLaunch_YieldsSingleIdentity()
+    {
+        var store = new RecordingFileStore();
+        var service = CreateService(store, new FakeAppDataService());
+
+        // 并发首启若各自生成再互相覆盖，同一台设备会在一次启动内上报两个不同标识。
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ =>
+                service.GetOrCreateAsync(TestContext.Current.CancellationToken)));
+
+        Assert.Single(results.Distinct(StringComparer.Ordinal));
+        Assert.Single(store.Writes);
+    }
+
+    private static InstallationIdentityService CreateService(
+        RecordingFileStore store,
+        FakeAppDataService appData)
+        => new(store, appData, NullLogger<InstallationIdentityService>.Instance);
+
+    private sealed class FakeAppDataService : IAppDataService
+    {
+        public string AppDataRootPath { get; } =
+            Path.Combine(Path.GetTempPath(), "salmonegg-install-id-tests", Guid.NewGuid().ToString("N"));
+
+        public string ConfigRootPath => Path.Combine(AppDataRootPath, "config");
+
+        public string LogsDirectoryPath => Path.Combine(AppDataRootPath, "logs");
+
+        public string CacheRootPath => Path.Combine(AppDataRootPath, "cache");
+
+        public string ExportsDirectoryPath => Path.Combine(AppDataRootPath, "exports");
+    }
+
+    /// <summary>内存文件存储：不触真实磁盘，且能记录写入路径供落点断言。</summary>
+    private sealed class RecordingFileStore : IAppFileStore
+    {
+        private readonly Dictionary<string, string> _files = new(StringComparer.Ordinal);
+        private readonly Lock _sync = new();
+
+        public bool FailWrites { get; set; }
+
+        public Dictionary<string, string> Writes
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return new Dictionary<string, string>(_files, StringComparer.Ordinal);
+                }
+            }
+        }
+
+        public void Seed(string path, string content)
+        {
+            lock (_sync)
+            {
+                _files[path] = content;
+            }
+        }
+
+        public Task<bool> ExistsAsync(string path, CancellationToken cancellationToken = default)
+        {
+            lock (_sync)
+            {
+                return Task.FromResult(_files.ContainsKey(path));
+            }
+        }
+
+        public Task<string?> ReadAllTextAsync(string path, CancellationToken cancellationToken = default)
+        {
+            lock (_sync)
+            {
+                return Task.FromResult(_files.TryGetValue(path, out var content) ? content : null);
+            }
+        }
+
+        public Task WriteAllTextAsync(string path, string content, CancellationToken cancellationToken = default)
+        {
+            if (FailWrites)
+            {
+                throw new IOException("simulated persistence failure");
+            }
+
+            lock (_sync)
+            {
+                _files[path] = content;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string path, CancellationToken cancellationToken = default)
+        {
+            lock (_sync)
+            {
+                _files.Remove(path);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<string> EnumerateFilesAsync(
+            string directory,
+            string searchPattern,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            List<string> snapshot;
+            lock (_sync)
+            {
+                snapshot = _files.Keys.Where(key => key.StartsWith(directory, StringComparison.Ordinal)).ToList();
+            }
+
+            foreach (var path in snapshot)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return path;
+            }
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## 背景

对现有 OTel 插装做了全面审计：插装合理性、架构分层、与官方语义约定的一致性、线上 debug 可用性（能否快速回答「有几个用户」这类问题）。本 PR 落地审计结论，全部以官方规范原文为依据（semantic-conventions + semantic-conventions-genai 主干），不凭记忆。

## 改动清单

| # | 提交 | 内容 |
|---|---|---|
| 1 | `1cfd3c48` | 删掉未使用的 OTel 依赖、统一 span 命名 |
| 2 | `19a4fbe2` | error-biased 采样：错误 trace 在低采样率下必留 |
| 3 | `ab3c20cc` | 为采样器补官方文档引用（RecordOnly→IsAllDataRequested 副作用等） |
| 4 | `b2f05e4f` | .NET 运行时指标按平台能力位装配（WASM 关闭，上游 #2529） |
| 5 | `f250a510` | 稳定装机标识（app.installation.id，不入云同步，装机数不失真） |
| 6 | `b0711e47` | invoke_agent span/histogram 按 gen_ai 约定插装 |
| 7 | `fc51df38` | 删 7 个死属性常量；统一 WASM 导出契约 |

## 关键设计决策（均引官方原文）

**invoke_agent 只发有真实数据源的键。** `gen_ai.provider.name` 在 span 上是 required，但它是 17 家模型厂商的**封闭枚举**，ACP 协议没有任何 provider/model 字段——编一个填进去等于向后端声明错误的遥测格式，比缺字段更坏。同理不发 `usage.*`（ACP 的 usage_update 是上下文窗口 gauge，不是本回合 token 收支）。

**conversation.id 用 ACP sessionId 直发，缺失时宁缺勿造。** 规范禁止 UUID/traceId/内容哈希兜底；`session.id` 是 Opt-In 键不许无条件发，故不用。

**取消不是故障。** 用户取消计入耗时直方图并打归一化的 `error.type=System.OperationCanceledException`，但 span status 保持 Unset——规范只要求「操作失败」时置 Error。

**耗时用 Stopwatch 不读 Activity.Duration。** 指标是聚合值不参与头采样；采样丢弃 span 时 activity 为 null，指标必须照记。桶边界 0.1–409.6s 双倍阶梯（agent 回合是秒到分钟级，官方 client.operation.duration 的 0.01–81.92s 阶梯会把样本堆进末桶）。

**装机标识不入 app.yaml 云同步**（否则会被复制到所有设备，装机数永久失真）；也不顶替 `service.instance.id`（语义不同）。

## 反向验证记录（AGENTS.md 纪律）

- 取消 errorType 归一化拆掉 → 对应测试红 ✅
- span 名 agent 后缀拆掉 → 对应测试红 ✅
- AddRuntimeInstrumentation 门控（前次提交已验）✅
- InstallationIdentityService 断言（8 测试覆盖）✅

## 门禁结果

Application 92 ✅ / ACP 336 ✅ / Domain 62 ✅ / Presentation.Core 3158 ✅ / CLI 87 ✅ / Infrastructure 579 ✅ / 官方 core-gates 脚本 exit 0 ✅ / WASM+Desktop 头编译 0 告警 ✅

## 未纳入本 PR（后续项）

- ACP `_meta` 传播 traceparent（三方收敛方案已有结论）
- TelemetryDefaults 的硬编码端点与默认 environment
- SetSessionModeAsync / CancelSessionAsync 补 span

🤖 Generated with [Claude Code](https://claude.com/claude-code)