### PR TITLE
feat(acp): ACP 配置向导（closes #95）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ SalmonEgg/SalmonEgg.Package/*.pfx
 # "release" path segment at any depth, which would otherwise make this directory uncommittable.
 !scripts/release/
 !scripts/release/**
+.impeccable/

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Application.Services.Acp;
+using SalmonEgg.Application.Services.AcpSetup;
 using SalmonEgg.Application.Services.Chat;
 using SalmonEgg.Application.Validators;
 using SalmonEgg.Domain.Interfaces;
@@ -15,7 +16,9 @@ using SalmonEgg.Domain.Interfaces.Storage;
 using SalmonEgg.Domain.Interfaces.Transport;
 using SalmonEgg.Domain.Models;
 using SalmonEgg.Domain.Services;
+using SalmonEgg.Domain.Services.AcpSetup;
 using SalmonEgg.Domain.Services.Security;
+using SalmonEgg.Infrastructure.AcpSetup;
 using SalmonEgg.Infrastructure.Client;
 using SalmonEgg.Infrastructure.Logging;
 using SalmonEgg.Infrastructure.Network;
@@ -39,11 +42,13 @@ using SalmonEgg.Presentation.ViewModels;
 using SalmonEgg.Presentation.ViewModels.Chat;
 using SalmonEgg.Presentation.ViewModels.Navigation;
 using SalmonEgg.Presentation.ViewModels.Settings;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
 using SalmonEgg.Presentation.ViewModels.Start;
 using Serilog;
 using Uno.Extensions.Reactive;
 using SalmonEgg.Infrastructure.Observability;
 #if !__WASM__ && !__ANDROID__ && !__IOS__
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
 using SalmonEgg.Infrastructure.Desktop.DependencyInjection;
 #endif
 #if __WASM__
@@ -498,6 +503,41 @@ public static class DependencyInjection
                 : new UnsupportedTerminalSessionManager());
 #endif
         services.AddSingleton<IAcpClientFactory, AcpClientFactory>();
+
+        // ACP setup wizard. The catalog is pure data and safe everywhere; every probing, installing and
+        // testing seam gets an unsupported default so platforms without a child-process host report
+        // "undetermined" instead of failing to resolve a service.
+        services.AddSingleton<IAcpAgentCatalog, AcpAgentCatalog>();
+#if __WASM__ || __ANDROID__ || __IOS__
+        services.AddSingleton<IAcpExecutableProbe, UnsupportedAcpExecutableProbe>();
+        services.AddSingleton<IAcpComponentInstaller, UnsupportedAcpComponentInstaller>();
+        services.AddSingleton<IAcpSetupConnectivityTester, UnsupportedAcpSetupConnectivityTester>();
+#else
+        services.AddSingleton<IAcpExecutableProbe>(sp =>
+            sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
+                ? new DesktopAcpExecutableProbe()
+                : new UnsupportedAcpExecutableProbe());
+        services.AddSingleton<IAcpComponentInstaller>(sp =>
+            sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
+                ? new DesktopAcpComponentInstaller(sp.GetRequiredService<IAcpExecutableProbe>())
+                : new UnsupportedAcpComponentInstaller());
+        services.AddSingleton<IAcpSetupHandshakeProbe>(sp =>
+            new StdioAcpSetupHandshakeProbe(
+                sp.GetRequiredService<IStdioTransportFactory>(),
+                transport => sp.GetRequiredService<IAcpClientFactory>().CreateClient(transport)));
+        services.AddSingleton<IAcpSetupConnectivityTester>(sp =>
+            sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
+                ? new DesktopAcpSetupConnectivityTester(sp.GetRequiredService<IAcpSetupHandshakeProbe>())
+                : new UnsupportedAcpSetupConnectivityTester());
+#endif
+        services.AddSingleton<AcpSetupWizardViewModel>();
+        services.AddSingleton<AcpSetupWizardOrchestrator>(sp =>
+            new AcpSetupWizardOrchestrator(
+                sp.GetRequiredService<IAcpAgentCatalog>(),
+                sp.GetRequiredService<IAcpExecutableProbe>(),
+                sp.GetRequiredService<IAcpComponentInstaller>(),
+                sp.GetRequiredService<IAcpSetupConnectivityTester>(),
+                sp.GetRequiredService<IConfigurationService>()));
         services.AddSingleton<ChatServiceFactory>(sp =>
         {
             var transportFactory = sp.GetRequiredService<ITransportFactory>();

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -530,7 +530,9 @@ public static class DependencyInjection
                 ? new DesktopAcpSetupConnectivityTester(sp.GetRequiredService<IAcpSetupHandshakeProbe>())
                 : new UnsupportedAcpSetupConnectivityTester());
 #endif
-        services.AddSingleton<AcpSetupWizardViewModel>();
+        // Transient: the wizard must open on its first step every time, so each navigation gets a fresh
+        // ViewModel instead of one still showing the previous run's saved state.
+        services.AddTransient<AcpSetupWizardViewModel>();
         services.AddSingleton<AcpSetupWizardOrchestrator>(sp =>
             new AcpSetupWizardOrchestrator(
                 sp.GetRequiredService<IAcpAgentCatalog>(),

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml
@@ -106,6 +106,10 @@
                                             AutomationProperties.AutomationId="Acp.Profiles.Refresh"
                                             Command="{x:Bind ViewModel.Profiles.RefreshCommand}"
                                             IsEnabled="{x:Bind ViewModel.CanRefreshProfiles, Mode=OneWay}"/>
+                                    <Button x:Name="AcpProfilesWizardButton"
+                                            x:Uid="Acp_ProfilesSetupWizard"
+                                            AutomationProperties.AutomationId="Acp.Profiles.SetupWizard"
+                                            Click="OnOpenSetupWizardClick"/>
                                     <Button x:Name="AcpProfilesAddButton"
                                             x:Uid="Acp_ProfilesAdd"
                                             AutomationProperties.AutomationId="Acp.Profiles.Add"

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml.cs
@@ -139,6 +139,14 @@ public sealed partial class AcpConnectionSettingsPage : SettingsPageBase
         }
     }
 
+    private void OnOpenSetupWizardClick(object sender, RoutedEventArgs e)
+    {
+        Frame?.Navigate(
+            typeof(AcpSetupWizardPage),
+            null,
+            UiMotionController.Current.CreateNavigationTransitionInfo());
+    }
+
     private void OnAddProfileClick(object sender, RoutedEventArgs e)
     {
         Frame?.Navigate(

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -1,0 +1,238 @@
+<views:SettingsPageBase
+    x:Class="SalmonEgg.Presentation.Views.Settings.AcpSetupWizardPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:SalmonEgg.Controls"
+    xmlns:views="using:SalmonEgg.Presentation.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:SalmonEgg.Presentation.Converters"
+    xmlns:acpvm="using:SalmonEgg.Presentation.ViewModels.Settings.AcpSetup"
+    mc:Ignorable="d"
+    Background="Transparent"
+    NavigationCacheMode="Disabled">
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
+    </Page.Resources>
+
+    <Grid>
+        <ScrollViewer Padding="0" HorizontalScrollBarVisibility="Disabled">
+            <controls:ResponsiveContentHost MaxContentWidth="{StaticResource SettingsContentMaxWidth}">
+                <controls:ResponsiveContentHost.Child>
+                    <StackPanel x:Name="WizardContentRoot" Spacing="16">
+
+                        <StackPanel Spacing="8">
+                            <TextBlock x:Uid="AcpSetup_PageTitle"
+                                       Text="ACP Setup Wizard"
+                                       Style="{StaticResource SettingsPageTitleTextStyle}"/>
+                            <TextBlock x:Uid="AcpSetup_PageSummary"
+                                       Style="{StaticResource SettingsPageSummaryTextStyle}"/>
+                        </StackPanel>
+
+                        <!-- Operation failure surface, shared by every command. -->
+                        <InfoBar x:Name="AcpSetupErrorBar"
+                                 IsOpen="{x:Bind ViewModel.HasErrorMessage, Mode=OneWay}"
+                                 Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}"
+                                 Severity="Error"
+                                 IsClosable="True"/>
+
+                        <!-- ── Step 1: agent selection ─────────────────────── -->
+                        <StackPanel x:Name="AgentSelectionPanel"
+                                    Visibility="{x:Bind ViewModel.IsOnAgentSelection, Mode=OneWay}"
+                                    Spacing="12">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock x:Uid="AcpSetup_AgentsTitle"
+                                           Style="{StaticResource SettingsSectionTitleTextStyle}"
+                                           VerticalAlignment="Center"/>
+                                <Button Grid.Column="1"
+                                        x:Name="AcpSetupDetectAgentsButton"
+                                        x:Uid="AcpSetup_DetectAgents"
+                                        AutomationProperties.AutomationId="AcpSetup.Agents.Detect"
+                                        Command="{x:Bind ViewModel.DetectAgentsCommand}"/>
+                            </Grid>
+
+                            <ListView x:Name="AcpSetupAgentsList"
+                                      ItemsSource="{x:Bind ViewModel.Agents}"
+                                      SelectedItem="{x:Bind ViewModel.SelectedAgent, Mode=TwoWay}"
+                                      SelectionMode="Single">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate x:DataType="acpvm:AcpSetupAgentRowViewModel">
+                                        <StackPanel Spacing="4" Padding="12,8">
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBlock Text="{x:Bind DisplayName}" FontWeight="SemiBold"/>
+                                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                                                    <TextBlock Text="{x:Bind Version}"
+                                                              Visibility="{x:Bind HasVersion, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              Glyph="&#xE73E;"
+                                                              FontSize="14"
+                                                              Visibility="{x:Bind IsInstalled, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              Glyph="&#xE711;"
+                                                              FontSize="14"
+                                                              Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                    <ProgressRing IsActive="{x:Bind IsChecking}" Width="16" Height="16"/>
+                                                </StackPanel>
+                                            </Grid>
+                                            <TextBlock Text="{x:Bind DescriptionKey}"
+                                                      Style="{StaticResource CaptionTextBlockStyle}"
+                                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                            <StackPanel Orientation="Horizontal" Spacing="8"
+                                                        Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                <Button x:Name="InstallAgentInlineButton"
+                                                        Content="{x:Bind DisplayName}"
+                                                        Tag="{x:Bind}"
+                                                        Click="OnInstallAgentRowClick"
+                                                        AutomationProperties.AutomationId="AcpSetup.Agents.InstallRow"
+                                                        Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                <HyperlinkButton NavigateUri="{x:Bind InstallDocumentation}"
+                                                                 x:Uid="AcpSetup_InstallDocs"
+                                                                 Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource InverseBooleanConverter}}"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+                        </StackPanel>
+
+                        <!-- ── Step 2: components (runtime + adapter) ──────── -->
+                        <StackPanel x:Name="ComponentSetupPanel"
+                                    Visibility="{x:Bind ViewModel.IsOnComponentSetup, Mode=OneWay}"
+                                    Spacing="12">
+                            <TextBlock x:Uid="AcpSetup_ComponentsTitle"
+                                       Style="{StaticResource SettingsSectionTitleTextStyle}"/>
+
+                            <InfoBar x:Name="AcpSetupAdapterMissingBar"
+                                     IsOpen="{x:Bind ViewModel.IsAdapterMissing, Mode=OneWay}"
+                                     Severity="Warning"
+                                     IsClosable="False">
+                                <InfoBar.Content>
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Button x:Name="AcpSetupInstallAdapterButton"
+                                                x:Uid="AcpSetup_InstallAdapter"
+                                                Command="{x:Bind ViewModel.InstallAdapterCommand}"/>
+                                        <Button x:Name="AcpSetupRedetectAdapterButton"
+                                                x:Uid="AcpSetup_RedetectAdapter"
+                                                Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
+                                    </StackPanel>
+                                </InfoBar.Content>
+                            </InfoBar>
+
+                            <ComboBox x:Name="AcpSetupAdaptersPicker"
+                                      Header="{x:Null}"
+                                      IsFocusEngagementEnabled="True"
+                                      ItemsSource="{x:Bind ViewModel.Adapters}"
+                                      SelectedItem="{x:Bind ViewModel.SelectedAdapter, Mode=TwoWay}"
+                                      DisplayMemberPath="Component.DisplayName"
+                                      MinWidth="280"
+                                      HorizontalAlignment="Left"/>
+                            <TextBox x:Name="AcpSetupInstallOutputBox"
+                                     Header=""
+                                     Text="{x:Bind ViewModel.LatestInstallOutputLine, Mode=OneWay}"
+                                     IsReadOnly="True"
+                                     Visibility="{x:Bind ViewModel.HasInstallOutput, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                        </StackPanel>
+
+                        <!-- ── Step 3: launch parameters ───────────────────── -->
+                        <StackPanel x:Name="ParametersPanel"
+                                    Visibility="{x:Bind ViewModel.IsOnParameters, Mode=OneWay}"
+                                    Spacing="12">
+                            <TextBlock x:Uid="AcpSetup_ParametersTitle"
+                                       Style="{StaticResource SettingsSectionTitleTextStyle}"/>
+                            <TextBlock x:Uid="AcpSetup_CommandPreviewLabel"
+                                       Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock x:Name="AcpSetupCommandPreview"
+                                       Text="{x:Bind ViewModel.LaunchCommandPreview, Mode=OneWay}"
+                                       FontFamily="Consolas"
+                                       TextWrapping="Wrap"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <ListView x:Name="AcpSetupParametersList"
+                                      ItemsSource="{x:Bind ViewModel.Parameters}"
+                                      SelectionMode="None">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate x:DataType="acpvm:AcpSetupParameterRowViewModel">
+                                        <StackPanel Spacing="4" Padding="0,8">
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+                                                <TextBlock Text="{x:Bind DisplayName}" VerticalAlignment="Center" MinWidth="160"/>
+                                                <ComboBox Grid.Column="1"
+                                                          IsFocusEngagementEnabled="True"
+                                                          ItemsSource="{x:Bind AllowedValues}"
+                                                          SelectedItem="{x:Bind Value, Mode=TwoWay}"
+                                                          Visibility="{x:Bind HasAllowedValues, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                          HorizontalAlignment="Stretch"/>
+                                                <TextBox Grid.Column="1"
+                                                         Text="{x:Bind Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                         PlaceholderText="{x:Bind Example}"
+                                                         Visibility="{x:Bind HasAllowedValues, Converter={StaticResource InverseBooleanConverter}}"/>
+                                            </Grid>
+                                            <TextBlock Text="{x:Bind Description}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                            <TextBlock Text="{x:Bind ValidationMessage}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       Visibility="{x:Bind HasValidationMessage, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+                        </StackPanel>
+
+                        <!-- ── Step 4: test ────────────────────────────────── -->
+                        <StackPanel x:Name="TestPanel"
+                                    Visibility="{x:Bind ViewModel.IsOnTest, Mode=OneWay}"
+                                    Spacing="12">
+                            <TextBlock x:Uid="AcpSetup_TestTitle"
+                                       Style="{StaticResource SettingsSectionTitleTextStyle}"/>
+                            <InfoBar x:Name="AcpSetupTestSuccessBar"
+                                     IsOpen="{x:Bind ViewModel.IsTestSuccessful, Mode=OneWay}"
+                                     Severity="Success"
+                                     IsClosable="False"/>
+                            <InfoBar x:Name="AcpSetupTestFailureBar"
+                                     IsOpen="{x:Bind ViewModel.HasTestResult, Mode=OneWay}"
+                                     Severity="Error"
+                                     IsClosable="False"
+                                     Title="{x:Bind ViewModel.TestFailureStageText, Mode=OneWay}"
+                                     Message="{x:Bind ViewModel.TestRemediationText, Mode=OneWay}"/>
+                            <Button x:Name="AcpSetupTestRunButton"
+                                    x:Uid="AcpSetup_RunTest"
+                                    Command="{x:Bind ViewModel.TestCommand}"/>
+                        </StackPanel>
+
+                        <!-- ── Step 5: save ────────────────────────────────── -->
+                        <StackPanel x:Name="SavePanel"
+                                    Visibility="{x:Bind ViewModel.IsOnSave, Mode=OneWay}"
+                                    Spacing="12">
+                            <TextBlock x:Uid="AcpSetup_SaveTitle"
+                                       Style="{StaticResource SettingsSectionTitleTextStyle}"/>
+                            <TextBox x:Name="AcpSetupProfileNameBox"
+                                     Header="{x:Null}"
+                                     Text="{x:Bind ViewModel.ProfileName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     MinWidth="320"
+                                     HorizontalAlignment="Left"/>
+                            <InfoBar x:Name="AcpSetupSavedBar"
+                                     IsOpen="{x:Bind ViewModel.HasSavedProfile, Mode=OneWay}"
+                                     Severity="Success"
+                                     IsClosable="False"/>
+                        </StackPanel>
+
+                        <!-- ── Wizard navigation bar ───────────────────────── -->
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8" Margin="0,8,0,24">
+                            <Button x:Name="AcpSetupBackStepButton"
+                                    x:Uid="AcpSetup_Back"
+                                    Command="{x:Bind ViewModel.GoBackCommand}"/>
+                            <Button x:Name="AcpSetupNextStepButton"
+                                    Grid.Column="2"
+                                    x:Uid="AcpSetup_Next"
+                                    Style="{StaticResource AccentButtonStyle}"
+                                    Command="{x:Bind ViewModel.GoNextCommand}"/>
+                        </Grid>
+                    </StackPanel>
+                </controls:ResponsiveContentHost.Child>
+            </controls:ResponsiveContentHost>
+        </ScrollViewer>
+    </Grid>
+</views:SettingsPageBase>

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -29,6 +29,10 @@
                                        Style="{StaticResource SettingsPageTitleTextStyle}"/>
                             <TextBlock x:Uid="AcpSetup_PageSummary"
                                        Style="{StaticResource SettingsPageSummaryTextStyle}"/>
+                            <TextBlock x:Name="AcpSetupStepPosition"
+                                       Text="{x:Bind ViewModel.StepPositionText, Mode=OneWay}"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         </StackPanel>
 
                         <!-- Operation failure surface, shared by every command. -->
@@ -68,10 +72,12 @@
                                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                               Glyph="&#xE73E;"
+                                                              x:Uid="AcpSetup_StatusInstalled"
                                                               FontSize="14"
                                                               Visibility="{x:Bind IsInstalled, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                               Glyph="&#xE711;"
+                                                              x:Uid="AcpSetup_StatusMissing"
                                                               FontSize="14"
                                                               Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                     <ProgressRing IsActive="{x:Bind IsChecking}" Width="16" Height="16"/>
@@ -83,7 +89,7 @@
                                             <StackPanel Orientation="Horizontal" Spacing="8"
                                                         Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}">
                                                 <Button x:Name="InstallAgentInlineButton"
-                                                        Content="{x:Bind DisplayName}"
+                                                        x:Uid="AcpSetup_InstallAgentRow"
                                                         Tag="{x:Bind}"
                                                         Click="OnInstallAgentRowClick"
                                                         AutomationProperties.AutomationId="AcpSetup.Agents.InstallRow"
@@ -188,6 +194,7 @@
                             <TextBlock x:Uid="AcpSetup_TestTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>
                             <InfoBar x:Name="AcpSetupTestSuccessBar"
+                                     x:Uid="AcpSetup_TestSuccessBar"
                                      IsOpen="{x:Bind ViewModel.IsTestSuccessful, Mode=OneWay}"
                                      Severity="Success"
                                      IsClosable="False"/>
@@ -209,14 +216,31 @@
                             <TextBlock x:Uid="AcpSetup_SaveTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>
                             <TextBox x:Name="AcpSetupProfileNameBox"
-                                     Header="{x:Null}"
+                                     x:Uid="AcpSetup_ProfileName"
                                      Text="{x:Bind ViewModel.ProfileName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      MinWidth="320"
                                      HorizontalAlignment="Left"/>
+                            <Button x:Name="AcpSetupSaveButton"
+                                    x:Uid="AcpSetup_Save"
+                                    Style="{StaticResource AccentButtonStyle}"
+                                    Command="{x:Bind ViewModel.SaveCommand}"
+                                    AutomationProperties.AutomationId="AcpSetup.Save"/>
                             <InfoBar x:Name="AcpSetupSavedBar"
+                                     x:Uid="AcpSetup_SavedBar"
                                      IsOpen="{x:Bind ViewModel.HasSavedProfile, Mode=OneWay}"
                                      Severity="Success"
                                      IsClosable="False"/>
+                        </StackPanel>
+
+                        <!-- Busy feedback shared by every long operation. -->
+                        <StackPanel Orientation="Horizontal" Spacing="8"
+                                    Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <ProgressRing IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}"
+                                          Width="16"
+                                          Height="16"/>
+                            <TextBlock x:Uid="AcpSetup_Working"
+                                       VerticalAlignment="Center"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         </StackPanel>
 
                         <!-- ── Wizard navigation bar ───────────────────────── -->

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml.cs
@@ -1,0 +1,41 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SalmonEgg.Presentation.Models.Navigation;
+using SalmonEgg.Presentation.Models.Settings;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+using SalmonEgg.Presentation.Views;
+
+namespace SalmonEgg.Presentation.Views.Settings;
+
+/// <summary>
+/// Hosts the ACP setup wizard. Display and command wiring only: every rule lives in
+/// <see cref="AcpSetupWizardViewModel"/>, so the steps stay testable without a view.
+/// </summary>
+public sealed partial class AcpSetupWizardPage : SettingsPageBase
+{
+    public AcpSetupWizardViewModel ViewModel { get; }
+
+    public AcpSetupWizardPage()
+    {
+        ViewModel = App.ServiceProvider.GetRequiredService<AcpSetupWizardViewModel>();
+        InitializeComponent();
+        SetBreadcrumb(
+            SettingsBreadcrumbItem.Link(ResolveSettingsRootTitle(), SettingsSectionCatalog.GeneralKey),
+            SettingsBreadcrumbItem.Link(
+                ResolveSettingsSectionTitle(SettingsSectionCatalog.AgentAcpKey),
+                SettingsSectionCatalog.AgentAcpKey),
+            SettingsBreadcrumbItem.Current(
+                ResolveResourceString("AcpSetup_PageTitle.Text", "ACP Setup Wizard")));
+    }
+
+    protected override Control? GetSectionEntryFocusTarget()
+        => AcpSetupAgentsList;
+
+    private void OnInstallAgentRowClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: AcpSetupAgentRowViewModel row })
+        {
+            row.RequestInstall();
+        }
+    }
+}

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -834,6 +834,54 @@
   <data name="Acp_RemoteDirectoryDelete.Content" xml:space="preserve">
     <value>Delete</value>
   </data>
+  <data name="Acp_ProfilesSetupWizard.Content" xml:space="preserve">
+    <value>Setup wizard</value>
+  </data>
+  <data name="AcpSetup_PageTitle.Text" xml:space="preserve">
+    <value>ACP Setup Wizard</value>
+  </data>
+  <data name="AcpSetup_PageSummary.Text" xml:space="preserve">
+    <value>Detect your agent, install the ACP adapter, fill in launch parameters, verify the connection, and save it as a profile.</value>
+  </data>
+  <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
+    <value>1. Choose an agent</value>
+  </data>
+  <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
+    <value>Detect again</value>
+  </data>
+  <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
+    <value>2. Check components</value>
+  </data>
+  <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
+    <value>Install adapter</value>
+  </data>
+  <data name="AcpSetup_RedetectAdapter.Content" xml:space="preserve">
+    <value>Detect again</value>
+  </data>
+  <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
+    <value>Install docs</value>
+  </data>
+  <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
+    <value>3. Launch parameters</value>
+  </data>
+  <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
+    <value>Command preview</value>
+  </data>
+  <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
+    <value>4. Test connection</value>
+  </data>
+  <data name="AcpSetup_RunTest.Content" xml:space="preserve">
+    <value>Run test</value>
+  </data>
+  <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
+    <value>5. Save profile</value>
+  </data>
+  <data name="AcpSetup_Back.Content" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="AcpSetup_Next.Content" xml:space="preserve">
+    <value>Next</value>
+  </data>
   <data name="Start_Title.Text" xml:space="preserve">
     <value>Salmon Egg</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -879,6 +879,39 @@
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>Back</value>
   </data>
+  <data name="AcpSetup_Save.Content" xml:space="preserve">
+    <value>Save configuration</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Title" xml:space="preserve">
+    <value>Connection test passed</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Message" xml:space="preserve">
+    <value>The configuration works and can be saved as a profile.</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Title" xml:space="preserve">
+    <value>Saved</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Message" xml:space="preserve">
+    <value>The profile was added to your connection list.</value>
+  </data>
+  <data name="AcpSetup_ProfileName.Header" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="AcpSetup_InstallAgentRow.Content" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="AcpSetup_Working.Text" xml:space="preserve">
+    <value>Working, please wait…</value>
+  </data>
+  <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
+    <value>Installed</value>
+  </data>
+  <data name="AcpSetup_StatusMissing.AutomationProperties.Name" xml:space="preserve">
+    <value>Not installed</value>
+  </data>
+  <data name="AcpSetup_Step_Position.Text" xml:space="preserve">
+    <value>Step {0} of {1}</value>
+  </data>
   <data name="AcpSetup_Next.Content" xml:space="preserve">
     <value>Next</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1362,6 +1362,54 @@
   <data name="Acp_RemoteDirectoryDelete.Content" xml:space="preserve">
     <value>Delete</value>
   </data>
+  <data name="Acp_ProfilesSetupWizard.Content" xml:space="preserve">
+    <value>Setup wizard</value>
+  </data>
+  <data name="AcpSetup_PageTitle.Text" xml:space="preserve">
+    <value>ACP Setup Wizard</value>
+  </data>
+  <data name="AcpSetup_PageSummary.Text" xml:space="preserve">
+    <value>Detect your agent, install the ACP adapter, fill in launch parameters, verify the connection, and save it as a profile.</value>
+  </data>
+  <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
+    <value>1. Choose an agent</value>
+  </data>
+  <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
+    <value>Detect again</value>
+  </data>
+  <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
+    <value>2. Check components</value>
+  </data>
+  <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
+    <value>Install adapter</value>
+  </data>
+  <data name="AcpSetup_RedetectAdapter.Content" xml:space="preserve">
+    <value>Detect again</value>
+  </data>
+  <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
+    <value>Install docs</value>
+  </data>
+  <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
+    <value>3. Launch parameters</value>
+  </data>
+  <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
+    <value>Command preview</value>
+  </data>
+  <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
+    <value>4. Test connection</value>
+  </data>
+  <data name="AcpSetup_RunTest.Content" xml:space="preserve">
+    <value>Run test</value>
+  </data>
+  <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
+    <value>5. Save profile</value>
+  </data>
+  <data name="AcpSetup_Back.Content" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="AcpSetup_Next.Content" xml:space="preserve">
+    <value>Next</value>
+  </data>
   <data name="Acp_RemoteDirectoriesTitle.Text" xml:space="preserve">
     <value>Remote projects</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1407,6 +1407,39 @@
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>Back</value>
   </data>
+  <data name="AcpSetup_Save.Content" xml:space="preserve">
+    <value>Save configuration</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Title" xml:space="preserve">
+    <value>Connection test passed</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Message" xml:space="preserve">
+    <value>The configuration works and can be saved as a profile.</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Title" xml:space="preserve">
+    <value>Saved</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Message" xml:space="preserve">
+    <value>The profile was added to your connection list.</value>
+  </data>
+  <data name="AcpSetup_ProfileName.Header" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="AcpSetup_InstallAgentRow.Content" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="AcpSetup_Working.Text" xml:space="preserve">
+    <value>Working, please wait…</value>
+  </data>
+  <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
+    <value>Installed</value>
+  </data>
+  <data name="AcpSetup_StatusMissing.AutomationProperties.Name" xml:space="preserve">
+    <value>Not installed</value>
+  </data>
+  <data name="AcpSetup_Step_Position.Text" xml:space="preserve">
+    <value>Step {0} of {1}</value>
+  </data>
   <data name="AcpSetup_Next.Content" xml:space="preserve">
     <value>Next</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -759,6 +759,54 @@
   <data name="Acp_RemoteDirectoryDelete.Content" xml:space="preserve">
     <value>删除</value>
   </data>
+  <data name="Acp_ProfilesSetupWizard.Content" xml:space="preserve">
+    <value>配置向导</value>
+  </data>
+  <data name="AcpSetup_PageTitle.Text" xml:space="preserve">
+    <value>ACP 配置向导</value>
+  </data>
+  <data name="AcpSetup_PageSummary.Text" xml:space="preserve">
+    <value>按步骤检测 Agent、安装 ACP 适配器、填写启动参数并验证连接，最后保存为配置。</value>
+  </data>
+  <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
+    <value>1. 选择 Agent</value>
+  </data>
+  <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
+    <value>重新检测</value>
+  </data>
+  <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
+    <value>2. 检查组件</value>
+  </data>
+  <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
+    <value>一键安装适配器</value>
+  </data>
+  <data name="AcpSetup_RedetectAdapter.Content" xml:space="preserve">
+    <value>重新检测</value>
+  </data>
+  <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
+    <value>安装文档</value>
+  </data>
+  <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
+    <value>3. 启动参数</value>
+  </data>
+  <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
+    <value>启动命令预览</value>
+  </data>
+  <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
+    <value>4. 测试连接</value>
+  </data>
+  <data name="AcpSetup_RunTest.Content" xml:space="preserve">
+    <value>开始测试</value>
+  </data>
+  <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
+    <value>5. 保存配置</value>
+  </data>
+  <data name="AcpSetup_Back.Content" xml:space="preserve">
+    <value>上一步</value>
+  </data>
+  <data name="AcpSetup_Next.Content" xml:space="preserve">
+    <value>下一步</value>
+  </data>
   <data name="Start_Title.Text" xml:space="preserve">
     <value>Salmon Egg</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -804,6 +804,39 @@
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>上一步</value>
   </data>
+  <data name="AcpSetup_Save.Content" xml:space="preserve">
+    <value>保存配置</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Title" xml:space="preserve">
+    <value>连接测试通过</value>
+  </data>
+  <data name="AcpSetup_TestSuccessBar.Message" xml:space="preserve">
+    <value>配置可用，可以保存为连接配置了。</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Title" xml:space="preserve">
+    <value>已保存</value>
+  </data>
+  <data name="AcpSetup_SavedBar.Message" xml:space="preserve">
+    <value>配置已加入连接列表，可返回使用。</value>
+  </data>
+  <data name="AcpSetup_ProfileName.Header" xml:space="preserve">
+    <value>配置名称</value>
+  </data>
+  <data name="AcpSetup_InstallAgentRow.Content" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="AcpSetup_Working.Text" xml:space="preserve">
+    <value>正在处理，请稍候…</value>
+  </data>
+  <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
+    <value>已安装</value>
+  </data>
+  <data name="AcpSetup_StatusMissing.AutomationProperties.Name" xml:space="preserve">
+    <value>未安装</value>
+  </data>
+  <data name="AcpSetup_Step_Position.Text" xml:space="preserve">
+    <value>第 {0} 步，共 {1} 步</value>
+  </data>
   <data name="AcpSetup_Next.Content" xml:space="preserve">
     <value>下一步</value>
   </data>

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Application.Services.AcpSetup;
+
+/// <summary>
+/// Detection outcome for one catalog agent: the runtime probe plus the probe of the adapter the wizard
+/// would use. Adapter detection is only meaningful once a runtime is present, so it is optional here.
+/// </summary>
+public sealed class AcpAgentDetectionState
+{
+    public required AcpAgentDescriptor Agent { get; init; }
+
+    public required AcpComponentProbeResult Runtime { get; init; }
+
+    /// <summary>Probe of the recommended adapter, or null when the adapter has not been probed yet.</summary>
+    public AcpComponentProbeResult? Adapter { get; init; }
+
+    /// <summary>True when the agent can be configured without installing anything.</summary>
+    public bool IsReady => Runtime.IsUsable && Adapter?.IsUsable == true;
+}
+
+/// <summary>
+/// The configuration a completed wizard produces, before it is persisted.
+/// </summary>
+public sealed class AcpSetupDraft
+{
+    public required AcpAgentDescriptor Agent { get; init; }
+
+    public required AcpAdapterDescriptor Adapter { get; init; }
+
+    public required IReadOnlyDictionary<string, string> ParameterValues { get; init; }
+
+    /// <summary>Profile name the configuration is saved under.</summary>
+    public required string ProfileName { get; init; }
+
+    public AcpLaunchPlan BuildLaunchPlan()
+        => AcpLaunchPlanBuilder.Build(Adapter.LaunchTemplate, ParameterValues);
+}

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Application.Services.AcpSetup;
+
+/// <summary>
+/// Resolves one component's availability by dispatching its declared detection mode to the platform
+/// probe. Keeps the wizard free of detection branching, and keeps "we could not look" distinct from
+/// "it is not installed" so the UI never tells the user to install something they already have.
+/// </summary>
+public sealed class AcpComponentDetector
+{
+    internal const string ProbingUnsupportedDetail = "Process probing is unavailable on this platform.";
+
+    private readonly IAcpExecutableProbe _probe;
+
+    public AcpComponentDetector(IAcpExecutableProbe probe)
+    {
+        _probe = probe ?? throw new ArgumentNullException(nameof(probe));
+    }
+
+    public async Task<AcpComponentProbeResult> DetectAsync(
+        AcpComponentDescriptor component,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        if (component.DetectionMode is AcpComponentDetectionMode.None || component.IsBuiltIn)
+        {
+            return AcpComponentProbeResult.BuiltIn(component.Id);
+        }
+
+        if (component.DetectionMode is AcpComponentDetectionMode.Manual)
+        {
+            return AcpComponentProbeResult.Undetermined(component.Id);
+        }
+
+        if (!_probe.SupportsProcessProbing)
+        {
+            return AcpComponentProbeResult.Undetermined(component.Id, ProbingUnsupportedDetail);
+        }
+
+        return component.DetectionMode switch
+        {
+            AcpComponentDetectionMode.ExecutableOnPath
+                => await DetectExecutableAsync(component, cancellationToken).ConfigureAwait(false),
+            AcpComponentDetectionMode.GlobalNodePackage
+                => await DetectPackageAsync(
+                    component,
+                    _probe.IsGlobalNodePackageInstalledAsync,
+                    cancellationToken).ConfigureAwait(false),
+            AcpComponentDetectionMode.GlobalUvTool
+                => await DetectPackageAsync(
+                    component,
+                    _probe.IsGlobalUvToolInstalledAsync,
+                    cancellationToken).ConfigureAwait(false),
+            _ => AcpComponentProbeResult.Undetermined(component.Id)
+        };
+    }
+
+    private async Task<AcpComponentProbeResult> DetectExecutableAsync(
+        AcpComponentDescriptor component,
+        CancellationToken cancellationToken)
+    {
+        var executablePath = await _probe
+            .ResolveExecutablePathAsync(component.ProbeCommand, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            return AcpComponentProbeResult.Missing(component.Id);
+        }
+
+        var version = component.ProbeVersionArguments.Count == 0
+            ? null
+            : await _probe
+                .ReadVersionAsync(component.ProbeCommand, component.ProbeVersionArguments, cancellationToken)
+                .ConfigureAwait(false);
+
+        return AcpComponentProbeResult.Installed(component.Id, executablePath, version);
+    }
+
+    /// <summary>
+    /// A package-manager component is only usable when its launcher exists too: <c>npx @scope/pkg</c>
+    /// cannot run without <c>npx</c> on PATH, however the package query answers. The query is passed as
+    /// a factory so it is never started — and never left unawaited — when the launcher is absent.
+    /// </summary>
+    private async Task<AcpComponentProbeResult> DetectPackageAsync(
+        AcpComponentDescriptor component,
+        Func<string, CancellationToken, Task<bool?>> queryPackageAsync,
+        CancellationToken cancellationToken)
+    {
+        var launcherPath = await _probe
+            .ResolveExecutablePathAsync(component.ProbeCommand, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(launcherPath))
+        {
+            return AcpComponentProbeResult.Missing(component.Id, LauncherMissingDetail(component.ProbeCommand));
+        }
+
+        var isInstalled = await queryPackageAsync(component.PackageId, cancellationToken).ConfigureAwait(false);
+        return isInstalled switch
+        {
+            true => AcpComponentProbeResult.Installed(component.Id, launcherPath, version: null),
+            false => AcpComponentProbeResult.Missing(component.Id),
+            null => AcpComponentProbeResult.Undetermined(component.Id)
+        };
+    }
+
+    private static string LauncherMissingDetail(string launcher)
+        => $"Launcher '{launcher}' was not found on PATH.";
+}

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpLaunchPlanBuilder.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpLaunchPlanBuilder.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Application.Services.AcpSetup;
+
+/// <summary>
+/// Turns a launch template plus the user's parameter values into a concrete launch plan.
+/// Pure and deterministic: the same inputs always produce the same command line.
+/// </summary>
+public static class AcpLaunchPlanBuilder
+{
+    /// <summary>
+    /// Seeds one value per template parameter, preferring the declared default. Callers use this as the
+    /// prefilled form state so required parameters are visible even when they have no default.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> CreatePrefilledValues(AcpLaunchTemplate template)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var parameter in template.Parameters)
+        {
+            values[parameter.Key] = parameter.DefaultValue;
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Builds the launch plan. Parameters with no value are omitted entirely rather than emitted as
+    /// empty flags or empty environment variables, which agents reject.
+    /// </summary>
+    public static AcpLaunchPlan Build(
+        AcpLaunchTemplate template,
+        IReadOnlyDictionary<string, string>? parameterValues)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        var arguments = new List<string>(template.FixedArguments);
+        var environment = new Dictionary<string, string>(template.FixedEnvironment, StringComparer.Ordinal);
+
+        foreach (var parameter in template.Parameters)
+        {
+            if (parameter.IsSecret)
+            {
+                // Launch plans are persisted in clear text. Refuse rather than write a credential to disk;
+                // see AcpSetupParameterDefinition.IsSecret.
+                throw new InvalidOperationException(
+                    $"Launch parameter '{parameter.Key}' is marked secret and cannot be carried in a launch plan.");
+            }
+
+            if (parameterValues is null
+                || !parameterValues.TryGetValue(parameter.Key, out var rawValue))
+            {
+                continue;
+            }
+
+            var value = (rawValue ?? string.Empty).Trim();
+            if (value.Length == 0)
+            {
+                continue;
+            }
+
+            if (parameter.Target == AcpSetupParameterTarget.EnvironmentVariable)
+            {
+                environment[parameter.Key] = value;
+            }
+            else
+            {
+                arguments.Add(parameter.Key);
+                arguments.Add(value);
+            }
+        }
+
+        return new AcpLaunchPlan
+        {
+            Command = template.Command,
+            Arguments = arguments,
+            Environment = environment
+        };
+    }
+}

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupParameterValidator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupParameterValidator.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Application.Services.AcpSetup;
+
+/// <summary>
+/// One rejected parameter, carrying the localization key the presentation layer renders.
+/// </summary>
+public readonly record struct AcpSetupParameterViolation(string ParameterKey, string MessageKey);
+
+/// <summary>
+/// Validates wizard parameter values before a launch plan is tested or saved. Deliberately limited to
+/// checks that are certainly wrong regardless of agent: missing required values and values outside a
+/// declared closed set. Anything agent-specific is left to the connectivity test, which reports real
+/// failures instead of guesses.
+/// </summary>
+public static class AcpSetupParameterValidator
+{
+    /// <summary>
+    /// Localization key reported when a required parameter has no value. Public because the
+    /// presentation layer resolves <see cref="AcpSetupParameterViolation.MessageKey"/> against its
+    /// own resource table, so the value domain is part of this type's published contract.
+    /// </summary>
+    public const string MissingRequiredValueKey = "AcpSetup_Validation_MissingRequiredValue";
+
+    /// <summary>
+    /// Localization key reported when a value falls outside the parameter's declared closed set.
+    /// </summary>
+    public const string ValueNotAllowedKey = "AcpSetup_Validation_ValueNotAllowed";
+
+    public static IReadOnlyList<AcpSetupParameterViolation> Validate(
+        AcpLaunchTemplate template,
+        IReadOnlyDictionary<string, string>? parameterValues)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        var violations = new List<AcpSetupParameterViolation>();
+        foreach (var parameter in template.Parameters)
+        {
+            var value = ResolveValue(parameterValues, parameter.Key);
+
+            if (value.Length == 0)
+            {
+                if (parameter.IsRequired)
+                {
+                    violations.Add(new AcpSetupParameterViolation(parameter.Key, MissingRequiredValueKey));
+                }
+
+                continue;
+            }
+
+            if (parameter.AllowedValues.Count > 0
+                && !ContainsValue(parameter.AllowedValues, value))
+            {
+                violations.Add(new AcpSetupParameterViolation(parameter.Key, ValueNotAllowedKey));
+            }
+        }
+
+        return violations;
+    }
+
+    private static string ResolveValue(IReadOnlyDictionary<string, string>? values, string key)
+        => values is not null && values.TryGetValue(key, out var value)
+            ? (value ?? string.Empty).Trim()
+            : string.Empty;
+
+    private static bool ContainsValue(IReadOnlyList<string> allowedValues, string value)
+    {
+        foreach (var allowed in allowedValues)
+        {
+            if (string.Equals(allowed, value, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Application.Services.AcpSetup;
+
+/// <summary>
+/// Drives the ACP setup wizard: detects catalog agents and their adapters, installs missing components,
+/// tests a launch plan, and persists the result as a connection profile. Owns no UI state — the
+/// presentation layer keeps the step machine and calls into this for every side effect.
+/// </summary>
+public sealed class AcpSetupWizardOrchestrator
+{
+    private readonly IAcpAgentCatalog _catalog;
+    private readonly AcpComponentDetector _detector;
+    private readonly IAcpComponentInstaller _installer;
+    private readonly IAcpSetupConnectivityTester _connectivityTester;
+    private readonly IConfigurationService _configurationService;
+
+    public AcpSetupWizardOrchestrator(
+        IAcpAgentCatalog catalog,
+        IAcpExecutableProbe probe,
+        IAcpComponentInstaller installer,
+        IAcpSetupConnectivityTester connectivityTester,
+        IConfigurationService configurationService)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _detector = new AcpComponentDetector(probe ?? throw new ArgumentNullException(nameof(probe)));
+        _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _connectivityTester = connectivityTester ?? throw new ArgumentNullException(nameof(connectivityTester));
+        _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
+    }
+
+    /// <summary>True when this platform can install components for the user.</summary>
+    public bool SupportsAutomaticInstall => _installer.SupportsAutomaticInstall;
+
+    public IReadOnlyList<AcpAgentDescriptor> Agents => _catalog.Agents;
+
+    /// <summary>
+    /// Probes every catalog agent's runtime. Adapters are not probed here: probing every adapter up front
+    /// would multiply process launches for agents the user will never pick.
+    /// </summary>
+    public async Task<IReadOnlyList<AcpAgentDetectionState>> DetectAgentsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var states = new List<AcpAgentDetectionState>(_catalog.Agents.Count);
+        foreach (var agent in _catalog.Agents)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var runtime = await _detector.DetectAsync(agent.Runtime, cancellationToken).ConfigureAwait(false);
+            states.Add(new AcpAgentDetectionState { Agent = agent, Runtime = runtime });
+        }
+
+        return states;
+    }
+
+    public Task<AcpComponentProbeResult> DetectComponentAsync(
+        AcpComponentDescriptor component,
+        CancellationToken cancellationToken = default)
+        => _detector.DetectAsync(component, cancellationToken);
+
+    /// <summary>
+    /// Installs a component and re-probes it, so callers always see verified availability rather than
+    /// trusting the installer's exit code.
+    /// </summary>
+    public async Task<(AcpComponentInstallResult Install, AcpComponentProbeResult Probe)> InstallComponentAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        var install = await _installer
+            .InstallAsync(component, onOutput, cancellationToken)
+            .ConfigureAwait(false);
+        var probe = await _detector.DetectAsync(component, cancellationToken).ConfigureAwait(false);
+        return (install, probe);
+    }
+
+    /// <summary>
+    /// Validates the draft's parameters and, when they pass, tests the launch plan end to end.
+    /// Validation failures short-circuit as a <see cref="AcpSetupTestStage.Validation"/> result so the
+    /// caller has one uniform shape to render.
+    /// </summary>
+    public async Task<AcpSetupTestResult> TestDraftAsync(
+        AcpSetupDraft draft,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+
+        var violations = AcpSetupParameterValidator.Validate(
+            draft.Adapter.LaunchTemplate,
+            draft.ParameterValues);
+        if (violations.Count > 0)
+        {
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.Validation,
+                errorDetail: null,
+                remediationKey: violations[0].MessageKey);
+        }
+
+        return await _connectivityTester
+            .TestAsync(draft.BuildLaunchPlan(), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Persists the draft as a new stdio connection profile and returns it. The caller is expected to have
+    /// tested the draft first; this method does not re-test, so a caller that skips testing saves an
+    /// unverified configuration deliberately rather than by accident.
+    /// </summary>
+    public async Task<ServerConfiguration> SaveDraftAsync(
+        AcpSetupDraft draft,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var configuration = CreateConfiguration(draft);
+        await _configurationService.SaveConfigurationAsync(configuration).ConfigureAwait(false);
+        return configuration;
+    }
+
+    internal static ServerConfiguration CreateConfiguration(AcpSetupDraft draft)
+    {
+        var launchPlan = draft.BuildLaunchPlan();
+        return new ServerConfiguration
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = draft.ProfileName,
+            Transport = TransportType.Stdio,
+            StdioCommand = launchPlan.Command,
+            StdioArguments = new List<string>(launchPlan.Arguments),
+            StdioEnvironment = new Dictionary<string, string>(launchPlan.Environment, StringComparer.Ordinal)
+        };
+    }
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpAgentDescriptor.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpAgentDescriptor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// One agent the wizard knows how to configure: the runtime the user installs, the ACP adapters
+/// that can front it, and the launch template each adapter needs.
+/// </summary>
+public sealed class AcpAgentDescriptor
+{
+    /// <summary>Stable identifier, aligned with the ACP registry agent id where one exists.</summary>
+    public required string Id { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The agent runtime itself (for example the Claude Code CLI). Detected first so the wizard can
+    /// tell "agent missing" apart from "adapter missing".
+    /// </summary>
+    public required AcpComponentDescriptor Runtime { get; init; }
+
+    /// <summary>Adapters that can expose this agent over ACP, in display order.</summary>
+    public required IReadOnlyList<AcpAdapterDescriptor> Adapters { get; init; }
+
+    /// <summary>
+    /// The adapter the wizard preselects. Falls back to the first declared adapter when the
+    /// recommendation is unset or unknown.
+    /// </summary>
+    public string RecommendedAdapterId { get; init; } = string.Empty;
+
+    public AcpAdapterDescriptor? FindAdapter(string? adapterId)
+        => string.IsNullOrWhiteSpace(adapterId)
+            ? null
+            : Adapters.FirstOrDefault(adapter => string.Equals(adapter.Component.Id, adapterId, StringComparison.Ordinal));
+
+    public AcpAdapterDescriptor? ResolveRecommendedAdapter()
+        => FindAdapter(RecommendedAdapterId) ?? Adapters.FirstOrDefault();
+}
+
+/// <summary>
+/// An ACP adapter paired with the launch template it requires.
+/// </summary>
+public sealed class AcpAdapterDescriptor
+{
+    public required AcpComponentDescriptor Component { get; init; }
+
+    public required AcpLaunchTemplate LaunchTemplate { get; init; }
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentAvailability.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentAvailability.cs
@@ -1,0 +1,29 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Outcome of probing one ACP component on the local machine.
+/// </summary>
+public enum AcpComponentAvailability
+{
+    /// <summary>Not probed yet.</summary>
+    Unknown,
+
+    /// <summary>Probing is in flight.</summary>
+    Checking,
+
+    /// <summary>Found on the machine and callable.</summary>
+    Installed,
+
+    /// <summary>Nothing to install; the agent ships ACP support itself.</summary>
+    BuiltIn,
+
+    /// <summary>Not found on the machine.</summary>
+    Missing,
+
+    /// <summary>
+    /// The probe itself could not run (no process support on this platform, or the probe failed for
+    /// a reason unrelated to the component). Distinguished from <see cref="Missing"/> so the wizard
+    /// does not claim a component is absent when it simply could not look.
+    /// </summary>
+    Undetermined
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// One installable ACP component: either the agent runtime the user already has on the machine, or
+/// the ACP adapter that fronts it. Detection and installation are declared per component so the
+/// wizard never needs component-specific branches.
+/// </summary>
+public sealed class AcpComponentDescriptor
+{
+    /// <summary>Stable identifier used by persistence, telemetry, and probe correlation.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-facing name. Vendor product names are not localized.</summary>
+    public required string DisplayName { get; init; }
+
+    public AcpDistributionKind Distribution { get; init; } = AcpDistributionKind.Npx;
+
+    public AcpComponentDetectionMode DetectionMode { get; init; } = AcpComponentDetectionMode.ExecutableOnPath;
+
+    /// <summary>
+    /// Executable probed for <see cref="AcpComponentDetectionMode.ExecutableOnPath"/>, and the
+    /// launcher whose presence gates package detection for the global-package modes.
+    /// </summary>
+    public string ProbeCommand { get; init; } = string.Empty;
+
+    /// <summary>Arguments appended to <see cref="ProbeCommand"/> when asking for a version.</summary>
+    public IReadOnlyList<string> ProbeVersionArguments { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Package coordinate for package-manager distributions, without a pinned version so the
+    /// launcher resolves the current release.
+    /// </summary>
+    public string PackageId { get; init; } = string.Empty;
+
+    /// <summary>Documentation offered when automatic installation is unavailable or fails.</summary>
+    public Uri? InstallDocumentation { get; init; }
+
+    /// <summary>
+    /// True when the wizard can install this component itself. Binary distributions are
+    /// download + checksum + unpack flows the wizard deliberately does not automate.
+    /// </summary>
+    public bool SupportsAutomaticInstall
+        => Distribution is AcpDistributionKind.Npx or AcpDistributionKind.Uvx
+            && !string.IsNullOrWhiteSpace(PackageId);
+
+    /// <summary>True when nothing has to exist on the machine for this component to be usable.</summary>
+    public bool IsBuiltIn => Distribution == AcpDistributionKind.BuiltIn;
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDetectionMode.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDetectionMode.cs
@@ -1,0 +1,26 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// How a component's presence is established. Declared per component because "is it installed" means
+/// different things for a CLI on PATH and for a package the launcher resolves.
+/// </summary>
+public enum AcpComponentDetectionMode
+{
+    /// <summary>Nothing to detect; the component ships with the agent.</summary>
+    None,
+
+    /// <summary>Probe for an executable on PATH.</summary>
+    ExecutableOnPath,
+
+    /// <summary>Query the Node global package list for the declared package.</summary>
+    GlobalNodePackage,
+
+    /// <summary>Query the uv tool list for the declared package.</summary>
+    GlobalUvTool,
+
+    /// <summary>
+    /// Cannot be detected automatically; the wizard shows install documentation and lets the user
+    /// confirm manually.
+    /// </summary>
+    Manual
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentInstallResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentInstallResult.cs
@@ -1,0 +1,38 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Result of a one-click component install attempt. The wizard always re-probes after an install, so
+/// this type reports the attempt only — never availability.
+/// </summary>
+public sealed class AcpComponentInstallResult
+{
+    public required string ComponentId { get; init; }
+
+    public required bool IsSuccess { get; init; }
+
+    /// <summary>Installer exit code, when the installer ran to completion.</summary>
+    public int? ExitCode { get; init; }
+
+    /// <summary>Trailing installer output, retained for the failure surface.</summary>
+    public string? Output { get; init; }
+
+    /// <summary>Reason the installer could not run or did not succeed.</summary>
+    public string? ErrorDetail { get; init; }
+
+    public static AcpComponentInstallResult Success(string componentId, string? output)
+        => new() { ComponentId = componentId, IsSuccess = true, ExitCode = 0, Output = output };
+
+    public static AcpComponentInstallResult Failure(
+        string componentId,
+        int? exitCode,
+        string? output,
+        string? errorDetail)
+        => new()
+        {
+            ComponentId = componentId,
+            IsSuccess = false,
+            ExitCode = exitCode,
+            Output = output,
+            ErrorDetail = errorDetail
+        };
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentProbeResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentProbeResult.cs
@@ -1,0 +1,45 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// What a probe learned about one component: whether it is usable, where it lives, and its version
+/// when the component reports one.
+/// </summary>
+public sealed class AcpComponentProbeResult
+{
+    public required string ComponentId { get; init; }
+
+    public required AcpComponentAvailability Availability { get; init; }
+
+    /// <summary>Resolved absolute path when the probe located an executable.</summary>
+    public string? ExecutablePath { get; init; }
+
+    /// <summary>Version string as reported by the component, when it could be read.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Diagnostic detail for <see cref="AcpComponentAvailability.Missing"/> and
+    /// <see cref="AcpComponentAvailability.Undetermined"/>. Never surfaced as the primary message.
+    /// </summary>
+    public string? Detail { get; init; }
+
+    public bool IsUsable
+        => Availability is AcpComponentAvailability.Installed or AcpComponentAvailability.BuiltIn;
+
+    public static AcpComponentProbeResult BuiltIn(string componentId)
+        => new() { ComponentId = componentId, Availability = AcpComponentAvailability.BuiltIn };
+
+    public static AcpComponentProbeResult Missing(string componentId, string? detail = null)
+        => new() { ComponentId = componentId, Availability = AcpComponentAvailability.Missing, Detail = detail };
+
+    public static AcpComponentProbeResult Undetermined(string componentId, string? detail = null)
+        => new() { ComponentId = componentId, Availability = AcpComponentAvailability.Undetermined, Detail = detail };
+
+    public static AcpComponentProbeResult Installed(string componentId, string? executablePath, string? version)
+        => new()
+        {
+            ComponentId = componentId,
+            Availability = AcpComponentAvailability.Installed,
+            ExecutablePath = executablePath,
+            Version = version
+        };
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpDistributionKind.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpDistributionKind.cs
@@ -1,0 +1,20 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// How an ACP component (agent runtime or ACP adapter) reaches the local machine.
+/// Mirrors the ACP registry <c>distribution</c> shapes the wizard can act on.
+/// </summary>
+public enum AcpDistributionKind
+{
+    /// <summary>Shipped with the agent itself; nothing to install.</summary>
+    BuiltIn,
+
+    /// <summary>Node package executed through <c>npx</c>.</summary>
+    Npx,
+
+    /// <summary>Python package executed through <c>uvx</c>.</summary>
+    Uvx,
+
+    /// <summary>Prebuilt binary the user installs out of band.</summary>
+    Binary
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpLaunchPlan.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpLaunchPlan.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// A fully resolved ACP launch command: template plus the user's parameter values. This is what the
+/// wizard tests, and what it persists into a <see cref="ServerConfiguration"/> on save.
+/// </summary>
+public sealed class AcpLaunchPlan
+{
+    public required string Command { get; init; }
+
+    public required IReadOnlyList<string> Arguments { get; init; }
+
+    public IReadOnlyDictionary<string, string> Environment { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Single-line rendering used for review surfaces and diagnostics.</summary>
+    public string CommandLineDisplay
+        => Arguments.Count == 0
+            ? Command
+            : Command + " " + StdioCommandLine.FormatArgumentsText(Arguments);
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpLaunchTemplate.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpLaunchTemplate.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The invariant part of an agent's ACP launch command, plus the parameters the user still owns.
+/// A template plus resolved parameter values yields an <see cref="AcpLaunchPlan"/>.
+/// </summary>
+public sealed class AcpLaunchTemplate
+{
+    /// <summary>Executable that starts the ACP conversation (for example <c>npx</c>).</summary>
+    public required string Command { get; init; }
+
+    /// <summary>Arguments that are always present, in order, before user parameters.</summary>
+    public IReadOnlyList<string> FixedArguments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Environment variables that are always present.</summary>
+    public IReadOnlyDictionary<string, string> FixedEnvironment { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Parameters surfaced to the user, in display order.</summary>
+    public IReadOnlyList<AcpSetupParameterDefinition> Parameters { get; init; }
+        = Array.Empty<AcpSetupParameterDefinition>();
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupParameterDefinition.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupParameterDefinition.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Where a wizard parameter lands in the launch plan it produces.
+/// </summary>
+public enum AcpSetupParameterTarget
+{
+    /// <summary>Appended to the launch arguments.</summary>
+    Argument,
+
+    /// <summary>Exported as an environment variable on the agent process.</summary>
+    EnvironmentVariable
+}
+
+/// <summary>
+/// One user-facing launch parameter declared by an agent's launch template. The wizard renders
+/// these generically, so adding an agent never requires new form code.
+/// </summary>
+public sealed class AcpSetupParameterDefinition
+{
+    /// <summary>
+    /// Argument flag (for example <c>--model</c>) or environment variable name, depending on
+    /// <see cref="Target"/>. Also the stable key used to correlate user input with the definition.
+    /// </summary>
+    public required string Key { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public AcpSetupParameterTarget Target { get; init; } = AcpSetupParameterTarget.Argument;
+
+    /// <summary>Prefilled when the value is known up front; may be empty.</summary>
+    public string DefaultValue { get; init; } = string.Empty;
+
+    /// <summary>Shown as placeholder guidance when no value has been entered.</summary>
+    public string Example { get; init; } = string.Empty;
+
+    /// <summary>Explains the parameter to a user who has never configured ACP.</summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>When true, the wizard blocks test and save until a value is present.</summary>
+    public bool IsRequired { get; init; }
+
+    /// <summary>
+    /// Marks the value as a credential.
+    /// </summary>
+    /// <remarks>
+    /// Launch plans are persisted in profile YAML in clear text, so a secret parameter cannot be carried
+    /// there. The authoritative credential path is <c>authentication.mode</c> plus secure storage, which
+    /// has fixed slots an arbitrary parameter does not map onto. Until a parameter can be routed into
+    /// secure storage, the catalog declares no secret parameters and the launch-plan builder rejects any
+    /// that appear, so a future catalog edit fails loudly instead of leaking a credential to disk.
+    /// </remarks>
+    public bool IsSecret { get; init; }
+
+    /// <summary>
+    /// Closed set of accepted values. Empty means free-form text.
+    /// </summary>
+    public IReadOnlyList<string> AllowedValues { get; init; } = Array.Empty<string>();
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupTestResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupTestResult.cs
@@ -1,0 +1,49 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Result of testing a launch plan end to end. Carries the stage reached so a failure can be
+/// attributed, and a remediation hint key the presentation layer localizes.
+/// </summary>
+public sealed class AcpSetupTestResult
+{
+    public required bool IsSuccess { get; init; }
+
+    /// <summary>Stage reached. On success this is <see cref="AcpSetupTestStage.Completed"/>.</summary>
+    public required AcpSetupTestStage Stage { get; init; }
+
+    /// <summary>Agent-reported protocol version, when the handshake completed.</summary>
+    public int? NegotiatedProtocolVersion { get; init; }
+
+    /// <summary>Agent name reported by <c>initialize</c>, when available.</summary>
+    public string? AgentName { get; init; }
+
+    /// <summary>Raw failure detail (process error, protocol error, stderr excerpt).</summary>
+    public string? ErrorDetail { get; init; }
+
+    /// <summary>
+    /// Localization key for the remediation hint matching <see cref="Stage"/>. Null when the failure
+    /// has no actionable advice beyond <see cref="ErrorDetail"/>.
+    /// </summary>
+    public string? RemediationKey { get; init; }
+
+    public static AcpSetupTestResult Success(int? protocolVersion, string? agentName)
+        => new()
+        {
+            IsSuccess = true,
+            Stage = AcpSetupTestStage.Completed,
+            NegotiatedProtocolVersion = protocolVersion,
+            AgentName = agentName
+        };
+
+    public static AcpSetupTestResult Failure(
+        AcpSetupTestStage stage,
+        string? errorDetail,
+        string? remediationKey = null)
+        => new()
+        {
+            IsSuccess = false,
+            Stage = stage,
+            ErrorDetail = errorDetail,
+            RemediationKey = remediationKey
+        };
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupTestStage.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpSetupTestStage.cs
@@ -1,0 +1,23 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The link in the launch chain a configuration test reached. Reported on failure so the user learns
+/// which part broke instead of a single opaque "test failed".
+/// </summary>
+public enum AcpSetupTestStage
+{
+    /// <summary>Launch plan is still incomplete or malformed; nothing was started.</summary>
+    Validation,
+
+    /// <summary>Resolving the launch command to an executable on this machine.</summary>
+    CommandResolution,
+
+    /// <summary>Starting the adapter process.</summary>
+    AdapterStartup,
+
+    /// <summary>ACP <c>initialize</c> handshake over the transport.</summary>
+    Handshake,
+
+    /// <summary>Handshake succeeded and the negotiated capabilities were accepted.</summary>
+    Completed
+}

--- a/src/SalmonEgg.Domain/Models/ServerConfiguration.cs
+++ b/src/SalmonEgg.Domain/Models/ServerConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SalmonEgg.Domain.Models
@@ -38,6 +39,16 @@ namespace SalmonEgg.Domain.Models
         /// Stdio 参数（仅当 Transport=Stdio 时使用）
         /// </summary>
         public List<string> StdioArguments { get; set; } = new();
+
+        /// <summary>
+        /// Stdio 进程环境变量（仅当 Transport=Stdio 时使用）。
+        /// 部分 ACP agent 只从环境变量读取模型选择与凭据，无法用命令行参数表达。
+        /// </summary>
+        /// <remarks>
+        /// 值随 YAML 明文持久化，因此只用于非敏感运行配置；凭据必须走
+        /// <see cref="Authentication"/> 并落入安全存储。
+        /// </remarks>
+        public Dictionary<string, string> StdioEnvironment { get; set; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// 传输类型

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpAgentCatalog.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpAgentCatalog.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>
+/// The set of agents the ACP wizard can configure. Backed by a curated snapshot of the ACP registry
+/// so the wizard works offline; the catalog never performs I/O.
+/// </summary>
+public interface IAcpAgentCatalog
+{
+    /// <summary>Agents in display order, recommended entries first.</summary>
+    IReadOnlyList<AcpAgentDescriptor> Agents { get; }
+
+    /// <summary>Returns the agent with the given id, or null when it is not in the catalog.</summary>
+    AcpAgentDescriptor? FindAgent(string? agentId);
+}

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>
+/// Installs an ACP component through its declared package manager. Only distributions that report
+/// <see cref="AcpComponentDescriptor.SupportsAutomaticInstall"/> may be passed in.
+/// </summary>
+public interface IAcpComponentInstaller
+{
+    /// <summary>
+    /// True when this platform can run installers at all. When false the wizard shows manual
+    /// instructions instead of a one-click button.
+    /// </summary>
+    bool SupportsAutomaticInstall { get; }
+
+    /// <summary>
+    /// Installs <paramref name="component"/>, reporting installer output lines through
+    /// <paramref name="onOutput"/> as they arrive so the UI can show progress.
+    /// </summary>
+    Task<AcpComponentInstallResult> InstallAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>
+/// Inspects the local machine for the executables and packages an ACP component needs. Platform PATH
+/// rules and package-manager invocations live behind this seam so wizard orchestration stays
+/// platform-agnostic.
+/// </summary>
+public interface IAcpExecutableProbe
+{
+    /// <summary>
+    /// True when this platform can start child processes. When false, callers must report
+    /// <c>Undetermined</c> rather than claiming a component is missing.
+    /// </summary>
+    bool SupportsProcessProbing { get; }
+
+    /// <summary>
+    /// Resolves <paramref name="command"/> to an absolute path, or null when it is not on PATH.
+    /// </summary>
+    Task<string?> ResolveExecutablePathAsync(string command, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs <paramref name="command"/> with <paramref name="versionArguments"/> and returns the first
+    /// non-empty output line, or null when the command could not be run or printed nothing.
+    /// </summary>
+    Task<string?> ReadVersionAsync(
+        string command,
+        IReadOnlyList<string> versionArguments,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// True when <paramref name="packageId"/> is installed as a Node global package. Null when the
+    /// query itself could not run, which callers must not read as "absent".
+    /// </summary>
+    Task<bool?> IsGlobalNodePackageInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// True when <paramref name="packageId"/> is installed as a uv tool. Null when the query itself
+    /// could not run.
+    /// </summary>
+    Task<bool?> IsGlobalUvToolInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSetupConnectivityTester.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSetupConnectivityTester.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>
+/// Starts a launch plan and performs an ACP handshake against it, then tears the attempt down. Used
+/// by the wizard to prove a configuration works before it is saved.
+/// </summary>
+public interface IAcpSetupConnectivityTester
+{
+    Task<AcpSetupTestResult> TestAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSetupProcessRunner.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSetupProcessRunner.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Outcome of one short-lived helper process: whether it ran at all, its exit code, and its combined
+/// output. "Did not start" is distinct from "exited non-zero" because the wizard reports the former as
+/// an undetermined probe and the latter as a real failure.
+/// </summary>
+internal sealed record AcpSetupProcessResult(
+    bool Started,
+    int? ExitCode,
+    string StandardOutput,
+    string StandardError,
+    string? FailureDetail)
+{
+    public bool Succeeded => Started && ExitCode == 0;
+
+    public string CombinedOutput
+        => string.IsNullOrEmpty(StandardError)
+            ? StandardOutput
+            : string.IsNullOrEmpty(StandardOutput)
+                ? StandardError
+                : StandardOutput + Environment.NewLine + StandardError;
+}
+
+/// <summary>
+/// Runs the short-lived helper processes the ACP wizard needs — version probes, package-list queries,
+/// and package installs — to completion, capturing output.
+/// </summary>
+/// <remarks>
+/// Deliberately separate from <c>StdioTransport</c>: that type owns a long-lived ACP conversation and
+/// keeps stdin open, whereas these are fire-and-collect invocations. Sharing one implementation would
+/// force one of the two behaviours onto the other.
+///
+/// Output is capped so a runaway installer cannot grow the buffer without bound; the tail is kept
+/// because installer diagnostics land at the end.
+/// </remarks>
+internal static class AcpSetupProcessRunner
+{
+    private const int MaxCapturedCharacters = 64 * 1024;
+
+    public static async Task<AcpSetupProcessResult> RunAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        Action<string>? onOutputLine = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return NotStarted("Executable name was empty.");
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var standardOutput = new OutputAccumulator(onOutputLine);
+        var standardError = new OutputAccumulator(onOutputLine);
+        process.OutputDataReceived += (_, e) => standardOutput.Append(e.Data);
+        process.ErrorDataReceived += (_, e) => standardError.Append(e.Data);
+
+        try
+        {
+            if (!process.Start())
+            {
+                return NotStarted($"Failed to start '{fileName}'.");
+            }
+        }
+        catch (Exception ex)
+        {
+            return NotStarted($"Failed to start '{fileName}': {ex.Message}");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        // Some launchers (npm on Windows in particular) block on stdin when it stays open; closing it
+        // immediately turns that hang into a normal exit.
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException)
+        {
+            // The child already closed its end. Nothing to do — the wait below still governs the outcome.
+        }
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            cancellationToken.ThrowIfCancellationRequested();
+            return new AcpSetupProcessResult(
+                Started: true,
+                ExitCode: null,
+                standardOutput.ToString(),
+                standardError.ToString(),
+                $"'{fileName}' did not finish within {timeout.TotalSeconds:0}s.");
+        }
+
+        return new AcpSetupProcessResult(
+            Started: true,
+            process.ExitCode,
+            standardOutput.ToString(),
+            standardError.ToString(),
+            FailureDetail: null);
+    }
+
+    private static AcpSetupProcessResult NotStarted(string detail)
+        => new(Started: false, ExitCode: null, string.Empty, string.Empty, detail);
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                // entireProcessTree, because these launchers spawn the real worker as a child: npm runs
+                // through a shim, and killing only the shim would leave the worker holding the pipes.
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+        {
+            // Already gone, or the platform refused the kill. Either way the result is already decided.
+        }
+    }
+
+    /// <summary>
+    /// Collects a stream's lines, forwarding each to the caller for progress display while retaining a
+    /// bounded tail for the failure surface.
+    /// </summary>
+    private sealed class OutputAccumulator
+    {
+        private readonly Action<string>? _onLine;
+        private readonly StringBuilder _builder = new();
+        private readonly object _gate = new();
+
+        public OutputAccumulator(Action<string>? onLine)
+        {
+            _onLine = onLine;
+        }
+
+        public void Append(string? line)
+        {
+            if (line is null)
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                _builder.AppendLine(line);
+                if (_builder.Length > MaxCapturedCharacters)
+                {
+                    _builder.Remove(0, _builder.Length - MaxCapturedCharacters);
+                }
+            }
+
+            _onLine?.Invoke(line);
+        }
+
+        public override string ToString()
+        {
+            lock (_gate)
+            {
+                return _builder.ToString().TrimEnd();
+            }
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Installs ACP components through their declared package manager: npm for Node packages, uv for
+/// Python tools. Installs globally so the resulting launch command works from any working directory.
+/// </summary>
+/// <remarks>
+/// Binary distributions are not installed here. They are archive downloads with checksums to verify,
+/// and silently fetching and unpacking executables is a materially different trust decision from
+/// invoking a package manager the user already has configured — so the wizard shows documentation for
+/// those and lets the user install them deliberately.
+/// </remarks>
+public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
+{
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(10);
+
+    private readonly IAcpExecutableProbe _probe;
+
+    public DesktopAcpComponentInstaller(IAcpExecutableProbe probe)
+    {
+        _probe = probe ?? throw new ArgumentNullException(nameof(probe));
+    }
+
+    public bool SupportsAutomaticInstall => true;
+
+    public async Task<AcpComponentInstallResult> InstallAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        if (!component.SupportsAutomaticInstall)
+        {
+            return AcpComponentInstallResult.Failure(
+                component.Id,
+                exitCode: null,
+                output: null,
+                errorDetail: $"'{component.DisplayName}' must be installed manually.");
+        }
+
+        var (launcher, arguments) = ResolveInstallCommand(component);
+        var launcherPath = await _probe
+            .ResolveExecutablePathAsync(launcher, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(launcherPath))
+        {
+            return AcpComponentInstallResult.Failure(
+                component.Id,
+                exitCode: null,
+                output: null,
+                errorDetail: $"'{launcher}' was not found on PATH.");
+        }
+
+        var result = await AcpSetupProcessRunner
+            .RunAsync(launcherPath, arguments, InstallTimeout, onOutput, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.Succeeded)
+        {
+            return AcpComponentInstallResult.Success(component.Id, result.CombinedOutput);
+        }
+
+        return AcpComponentInstallResult.Failure(
+            component.Id,
+            result.ExitCode,
+            result.CombinedOutput,
+            result.FailureDetail ?? $"'{launcher}' exited with code {result.ExitCode}.");
+    }
+
+    /// <summary>
+    /// Maps a distribution to its global-install invocation.
+    /// </summary>
+    /// <remarks>
+    /// The package coordinate is passed verbatim, including any pinned version: the catalog decides
+    /// which version the wizard installs, and rewriting it here would silently disagree with what the
+    /// launch command later resolves.
+    /// </remarks>
+    private static (string Launcher, IReadOnlyList<string> Arguments) ResolveInstallCommand(
+        AcpComponentDescriptor component)
+        => component.Distribution switch
+        {
+            AcpDistributionKind.Npx => ("npm", new[] { "install", "--global", component.PackageId }),
+            AcpDistributionKind.Uvx => ("uv", new[] { "tool", "install", component.PackageId }),
+            _ => throw new NotSupportedException(
+                $"Distribution '{component.Distribution}' has no automatic install path.")
+        };
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Desktop implementation of <see cref="IAcpExecutableProbe"/>: resolves executables against the real
+/// PATH and asks the Node/uv launchers what they have installed.
+/// </summary>
+/// <remarks>
+/// Every query answers with a tri-state where the caller can act on "unknown": a launcher that fails to
+/// run yields null rather than false, so the wizard reports an undetermined probe instead of telling the
+/// user to install something that may already be there.
+/// </remarks>
+public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
+{
+    private static readonly TimeSpan VersionProbeTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan PackageQueryTimeout = TimeSpan.FromSeconds(60);
+
+    public bool SupportsProcessProbing => true;
+
+    public Task<string?> ResolveExecutablePathAsync(
+        string command,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(ResolveExecutablePath(command));
+    }
+
+    public async Task<string?> ReadVersionAsync(
+        string command,
+        IReadOnlyList<string> versionArguments,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(command) || versionArguments is null)
+        {
+            return null;
+        }
+
+        var executable = ResolveExecutablePath(command);
+        if (executable is null)
+        {
+            return null;
+        }
+
+        var result = await AcpSetupProcessRunner
+            .RunAsync(executable, versionArguments, VersionProbeTimeout, onOutputLine: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Succeeded ? FirstNonEmptyLine(result.CombinedOutput) : null;
+    }
+
+    /// <summary>
+    /// Asks npm for the global package list. <c>--depth 0</c> keeps the walk to top-level packages, and
+    /// <c>--parseable</c> yields one path per line, which is stable across npm versions.
+    /// </summary>
+    public Task<bool?> IsGlobalNodePackageInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => QueryPackageListAsync(
+            launcher: "npm",
+            arguments: new[] { "ls", "--global", "--depth", "0", "--parseable" },
+            packageId,
+            cancellationToken);
+
+    public Task<bool?> IsGlobalUvToolInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => QueryPackageListAsync(
+            launcher: "uv",
+            arguments: new[] { "tool", "list" },
+            packageId,
+            cancellationToken);
+
+    /// <summary>
+    /// Runs a package-list command and looks for the package name in its output.
+    /// </summary>
+    /// <remarks>
+    /// Returns null — not false — when the launcher is missing or the command fails, because an
+    /// unanswerable query must not be reported as a definitive absence.
+    ///
+    /// npm exits non-zero for unrelated reasons (peer-dependency complaints in the global root, for
+    /// instance) while still printing a usable list, so output that contains the package is trusted even
+    /// on a non-zero exit. The reverse is not true: a failed run with no match stays unknown.
+    /// </remarks>
+    private static async Task<bool?> QueryPackageListAsync(
+        string launcher,
+        IReadOnlyList<string> arguments,
+        string packageId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+        {
+            return null;
+        }
+
+        var executable = ResolveExecutablePath(launcher);
+        if (executable is null)
+        {
+            return null;
+        }
+
+        var result = await AcpSetupProcessRunner
+            .RunAsync(executable, arguments, PackageQueryTimeout, onOutputLine: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!result.Started)
+        {
+            return null;
+        }
+
+        var packageName = StripVersionSuffix(packageId);
+        if (ContainsPackage(result.CombinedOutput, packageName))
+        {
+            return true;
+        }
+
+        return result.Succeeded ? false : null;
+    }
+
+    private static bool ContainsPackage(string output, string packageName)
+        => !string.IsNullOrWhiteSpace(output)
+            && !string.IsNullOrWhiteSpace(packageName)
+            && output.Contains(packageName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Drops a pinned version from a package coordinate, preserving the leading '@' of a scoped name.
+    /// </summary>
+    internal static string StripVersionSuffix(string packageId)
+    {
+        var trimmed = packageId.Trim();
+        var separator = trimmed.LastIndexOf('@');
+        return separator > 0 ? trimmed[..separator] : trimmed;
+    }
+
+    private static string? FirstNonEmptyLine(string output)
+    {
+        foreach (var line in output.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0)
+            {
+                return trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="command"/> the way a shell would: an explicit path is used as given,
+    /// otherwise PATH is searched, applying PATHEXT on Windows so <c>npm</c> finds <c>npm.cmd</c>.
+    /// </summary>
+    private static string? ResolveExecutablePath(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return null;
+        }
+
+        var trimmed = command.Trim();
+        if (trimmed.IndexOfAny(new[] { '/', '\\' }) >= 0)
+        {
+            return File.Exists(trimmed) ? Path.GetFullPath(trimmed) : null;
+        }
+
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var pathSeparator = isWindows ? ';' : ':';
+        var directories = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var extension in ResolveExtensions(isWindows))
+        {
+            var candidateName = trimmed + extension;
+            foreach (var directory in directories)
+            {
+                string candidate;
+                try
+                {
+                    candidate = Path.Combine(directory, candidateName);
+                }
+                catch (ArgumentException)
+                {
+                    // PATH entries can contain characters that are invalid for this platform's paths.
+                    continue;
+                }
+
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> ResolveExtensions(bool isWindows)
+    {
+        if (!isWindows)
+        {
+            yield return string.Empty;
+            yield break;
+        }
+
+        var pathExt = Environment.GetEnvironmentVariable("PATHEXT");
+        foreach (var extension in (string.IsNullOrWhiteSpace(pathExt) ? ".COM;.EXE;.BAT;.CMD" : pathExt)
+                 .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            yield return extension.StartsWith('.') ? extension : "." + extension;
+        }
+
+        yield return string.Empty;
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpSetupConnectivityTester.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpSetupConnectivityTester.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Proves a launch plan works by starting it and performing a real ACP initialize handshake, then
+/// tearing the attempt down.
+/// </summary>
+public sealed class DesktopAcpSetupConnectivityTester : IAcpSetupConnectivityTester
+{
+    private readonly IAcpSetupHandshakeProbe _handshakeProbe;
+
+    public DesktopAcpSetupConnectivityTester(IAcpSetupHandshakeProbe handshakeProbe)
+    {
+        _handshakeProbe = handshakeProbe ?? throw new ArgumentNullException(nameof(handshakeProbe));
+    }
+
+    public async Task<AcpSetupTestResult> TestAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(launchPlan);
+
+        if (string.IsNullOrWhiteSpace(launchPlan.Command))
+        {
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.Validation,
+                errorDetail: "Launch command is empty.");
+        }
+
+        return await _handshakeProbe.ProbeAsync(launchPlan, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Performs the ACP handshake for a launch plan. Split from the tester so the staged failure mapping can
+/// be tested without launching processes, and so the ACP client dependency stays out of this assembly's
+/// public surface.
+/// </summary>
+public interface IAcpSetupHandshakeProbe
+{
+    Task<AcpSetupTestResult> ProbeAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/StdioAcpSetupHandshakeProbe.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/StdioAcpSetupHandshakeProbe.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Interfaces.Transport;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Transport;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Starts a launch plan over stdio and performs a real ACP <c>initialize</c> handshake, attributing any
+/// failure to the stage it happened in.
+/// </summary>
+/// <remarks>
+/// This deliberately exercises the same transport and ACP client the app uses for real conversations, so
+/// a passing test means the saved profile will work rather than merely that the executable exists.
+///
+/// The attempt is always torn down: a wizard test must not leave an agent process running.
+/// </remarks>
+public sealed class StdioAcpSetupHandshakeProbe : IAcpSetupHandshakeProbe
+{
+    private static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly IStdioTransportFactory _transportFactory;
+    private readonly Func<ITransport, IAcpClient> _createClient;
+
+    public StdioAcpSetupHandshakeProbe(
+        IStdioTransportFactory transportFactory,
+        Func<ITransport, IAcpClient> createClient)
+    {
+        _transportFactory = transportFactory ?? throw new ArgumentNullException(nameof(transportFactory));
+        _createClient = createClient ?? throw new ArgumentNullException(nameof(createClient));
+    }
+
+    public async Task<AcpSetupTestResult> ProbeAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(launchPlan);
+
+        ITransport transport;
+        try
+        {
+            transport = _transportFactory.Create(
+                launchPlan.Command,
+                CopyArguments(launchPlan.Arguments),
+                Encoding.UTF8,
+                launchPlan.Environment);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.CommandResolution,
+                ex.Message,
+                RemediationKeys.CommandResolution);
+        }
+
+        var stderr = new StderrCollector(transport);
+        try
+        {
+            return await ProbeWithTransportAsync(transport, stderr, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            stderr.Detach();
+            transport.Dispose();
+        }
+    }
+
+    private async Task<AcpSetupTestResult> ProbeWithTransportAsync(
+        ITransport transport,
+        StderrCollector stderr,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(HandshakeTimeout);
+
+        var client = _createClient(transport);
+        try
+        {
+            if (!await transport.ConnectAsync(timeoutSource.Token).ConfigureAwait(false))
+            {
+                return AcpSetupTestResult.Failure(
+                    AcpSetupTestStage.AdapterStartup,
+                    stderr.Describe() ?? "The adapter process did not start.",
+                    RemediationKeys.AdapterStartup);
+            }
+
+            var response = await client
+                .InitializeAsync(CreateInitializeParams(), timeoutSource.Token)
+                .ConfigureAwait(false);
+
+            return AcpSetupTestResult.Success(
+                response.ProtocolVersion,
+                response.AgentInfo?.Name);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The linked source fired, so the deadline elapsed rather than the user cancelling.
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.Handshake,
+                stderr.Describe() ?? $"No ACP response within {HandshakeTimeout.TotalSeconds:0}s.",
+                RemediationKeys.Handshake);
+        }
+        catch (AcpException ex)
+        {
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.Handshake,
+                Combine(ex.Message, stderr.Describe()),
+                RemediationKeys.Handshake);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return AcpSetupTestResult.Failure(
+                AcpSetupTestStage.Handshake,
+                Combine(ex.Message, stderr.Describe()),
+                RemediationKeys.Handshake);
+        }
+        finally
+        {
+            await TryDisconnectAsync(client).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task TryDisconnectAsync(IAcpClient client)
+    {
+        try
+        {
+            await client.DisconnectAsync().ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Teardown of a probe attempt: the result is already decided, and the transport is disposed
+            // by the caller regardless.
+        }
+    }
+
+    private static InitializeParams CreateInitializeParams()
+        => new()
+        {
+            ProtocolVersion = AcpProtocolVersion.Default,
+            ClientInfo = new ClientInfo
+            {
+                Name = "SalmonEgg",
+                Title = "SalmonEgg",
+                Version = "1.0.0"
+            },
+            ClientCapabilities = ClientCapabilityDefaults.Create()
+        };
+
+    private static string[] CopyArguments(IReadOnlyList<string> arguments)
+    {
+        var copy = new string[arguments.Count];
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            copy[index] = arguments[index];
+        }
+
+        return copy;
+    }
+
+    private static string? Combine(string? primary, string? secondary)
+        => string.IsNullOrWhiteSpace(secondary)
+            ? primary
+            : string.IsNullOrWhiteSpace(primary)
+                ? secondary
+                : primary + Environment.NewLine + secondary;
+
+    private static class RemediationKeys
+    {
+        public const string CommandResolution = "AcpSetup_Remediation_CommandResolution";
+        public const string AdapterStartup = "AcpSetup_Remediation_AdapterStartup";
+        public const string Handshake = "AcpSetup_Remediation_Handshake";
+    }
+
+    /// <summary>
+    /// Captures the adapter's stderr so a failed handshake can report what the agent complained about
+    /// instead of only a timeout.
+    /// </summary>
+    private sealed class StderrCollector
+    {
+        private const int MaxLength = 2000;
+
+        private readonly ITransport _transport;
+        private readonly StringBuilder _builder = new();
+        private readonly object _gate = new();
+
+        public StderrCollector(ITransport transport)
+        {
+            _transport = transport;
+            _transport.ErrorOccurred += OnError;
+        }
+
+        public void Detach() => _transport.ErrorOccurred -= OnError;
+
+        public string? Describe()
+        {
+            lock (_gate)
+            {
+                return _builder.Length == 0 ? null : _builder.ToString().TrimEnd();
+            }
+        }
+
+        private void OnError(object? sender, TransportErrorEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(e.ErrorMessage))
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                if (_builder.Length >= MaxLength)
+                {
+                    return;
+                }
+
+                _builder.AppendLine(e.ErrorMessage);
+            }
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/DesktopStdioTransportFactory.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/DesktopStdioTransportFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using SalmonEgg.Domain.Interfaces.Transport;
 
@@ -9,13 +10,14 @@ public sealed class DesktopStdioTransportFactory : IStdioTransportFactory
     public ITransport Create(
         string command,
         string[] args,
-        Encoding encoding)
+        Encoding encoding,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         if (string.IsNullOrWhiteSpace(command))
         {
             throw new ArgumentException("Stdio transport requires a command.", nameof(command));
         }
 
-        return new StdioTransport(command, args, encoding);
+        return new StdioTransport(command, args, encoding, environment);
     }
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -26,10 +27,13 @@ namespace SalmonEgg.Infrastructure.Transport
         private StreamReader? _stderr;
         private CancellationTokenSource? _readCts;
         private static readonly TimeSpan StartupObservationTimeout = TimeSpan.FromMilliseconds(500);
+        private static readonly IReadOnlyDictionary<string, string> EmptyEnvironment =
+            new Dictionary<string, string>(StringComparer.Ordinal);
         private readonly string _command;
         private readonly string[] _args;
         private readonly Encoding _encoding;
         private readonly string _workingDirectory;
+        private readonly IReadOnlyDictionary<string, string> _environment;
         private bool _disposed;
         private readonly object _lock = new();
 
@@ -59,10 +63,14 @@ namespace SalmonEgg.Infrastructure.Transport
         /// <param name="command">Agent 可执行文件的命令</param>
         /// <param name="args">命令行参数</param>
         /// <param name="encoding">字符编码</param>
+        /// <param name="environment">
+        /// 附加到子进程环境的变量。叠加在继承环境之上，null 或空表示不修改环境。
+        /// </param>
         public StdioTransport(
             string command,
             string[]? args = null,
-            Encoding? encoding = null)
+            Encoding? encoding = null,
+            IReadOnlyDictionary<string, string>? environment = null)
         {
             // 去除命令和参数中的首尾空格（避免意外输入导致找不到文件）
             string trimmedCommand = (command ?? string.Empty).Trim();
@@ -87,6 +95,32 @@ namespace SalmonEgg.Infrastructure.Transport
             }
 
             _encoding = NormalizeTransportEncoding(encoding ?? Encoding.UTF8);
+            _environment = NormalizeEnvironment(environment);
+        }
+
+        /// <summary>
+        /// 复制并去掉空名条目，使传输持有自己的不可变副本，避免调用方后续修改影响已建连的进程。
+        /// </summary>
+        private static IReadOnlyDictionary<string, string> NormalizeEnvironment(
+            IReadOnlyDictionary<string, string>? environment)
+        {
+            if (environment is null || environment.Count == 0)
+            {
+                return EmptyEnvironment;
+            }
+
+            var normalized = new Dictionary<string, string>(environment.Count, StringComparer.Ordinal);
+            foreach (var entry in environment)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key))
+                {
+                    continue;
+                }
+
+                normalized[entry.Key.Trim()] = entry.Value ?? string.Empty;
+            }
+
+            return normalized;
         }
 
         private static Encoding NormalizeTransportEncoding(Encoding encoding)
@@ -222,6 +256,12 @@ namespace SalmonEgg.Infrastructure.Transport
             foreach (var argument in _args)
             {
                 processInfo.ArgumentList.Add(argument);
+            }
+
+            // Applied after construction so configured values win over the inherited environment.
+            foreach (var entry in _environment)
+            {
+                processInfo.Environment[entry.Key] = entry.Value;
             }
 
             return processInfo;

--- a/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalog.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalog.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Serves the curated ACP agent catalog. Immutable and I/O-free, so it is safe as a singleton on every
+/// platform including WASM.
+/// </summary>
+public sealed class AcpAgentCatalog : IAcpAgentCatalog
+{
+    private readonly Dictionary<string, AcpAgentDescriptor> _agentsById;
+
+    public AcpAgentCatalog()
+    {
+        Agents = AcpAgentCatalogEntries.Create();
+        _agentsById = Agents.ToDictionary(agent => agent.Id, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<AcpAgentDescriptor> Agents { get; }
+
+    public AcpAgentDescriptor? FindAgent(string? agentId)
+        => string.IsNullOrWhiteSpace(agentId)
+            ? null
+            : _agentsById.TryGetValue(agentId, out var agent) ? agent : null;
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Curated snapshot of the ACP agent registry (<c>cdn.agentclientprotocol.com/registry/v1</c>),
+/// limited to agents whose ACP entry point is a documented stdio command.
+///
+/// Packages are intentionally unpinned: the launcher resolves the current release, so the wizard does
+/// not go stale when the registry advances. Pinning would freeze users to whatever version happened to
+/// ship with the app.
+/// </summary>
+internal static class AcpAgentCatalogEntries
+{
+    private const string NpxCommand = "npx";
+
+    internal static IReadOnlyList<AcpAgentDescriptor> Create()
+        => new[]
+        {
+            CreateClaudeCode(),
+            CreateGeminiCli(),
+            CreateCodex(),
+            CreateGitHubCopilot(),
+            CreateQwenCode(),
+            CreateCline(),
+            CreateAuggie(),
+            CreateGoose()
+        };
+
+    /// <summary>
+    /// Agent fronted by a separate npx adapter: the runtime CLI is detected on PATH, the adapter is a
+    /// Node package the wizard can install.
+    /// </summary>
+    private static AcpAgentDescriptor CreateAdapterFrontedAgent(
+        string agentId,
+        string displayName,
+        string descriptionKey,
+        string runtimeProbeCommand,
+        string runtimePackageId,
+        Uri runtimeDocumentation,
+        string adapterId,
+        string adapterDisplayName,
+        string adapterPackageId,
+        Uri adapterDocumentation,
+        IReadOnlyList<string> launchArguments,
+        IReadOnlyList<AcpSetupParameterDefinition> parameters)
+        => new()
+        {
+            Id = agentId,
+            DisplayName = displayName,
+            Description = descriptionKey,
+            RecommendedAdapterId = adapterId,
+            Runtime = new AcpComponentDescriptor
+            {
+                Id = agentId + "-cli",
+                DisplayName = displayName,
+                Distribution = AcpDistributionKind.Npx,
+                DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                ProbeCommand = runtimeProbeCommand,
+                ProbeVersionArguments = new[] { "--version" },
+                PackageId = runtimePackageId,
+                InstallDocumentation = runtimeDocumentation
+            },
+            Adapters = new[]
+            {
+                new AcpAdapterDescriptor
+                {
+                    Component = new AcpComponentDescriptor
+                    {
+                        Id = adapterId,
+                        DisplayName = adapterDisplayName,
+                        Distribution = AcpDistributionKind.Npx,
+                        DetectionMode = AcpComponentDetectionMode.GlobalNodePackage,
+                        ProbeCommand = NpxCommand,
+                        PackageId = adapterPackageId,
+                        InstallDocumentation = adapterDocumentation
+                    },
+                    LaunchTemplate = new AcpLaunchTemplate
+                    {
+                        Command = NpxCommand,
+                        FixedArguments = launchArguments,
+                        Parameters = parameters
+                    }
+                }
+            }
+        };
+
+    /// <summary>
+    /// Agent that speaks ACP itself: the runtime CLI is both the thing to install and the adapter, so
+    /// the adapter is reported as built in.
+    /// </summary>
+    private static AcpAgentDescriptor CreateSelfHostedAgent(
+        string agentId,
+        string displayName,
+        string descriptionKey,
+        string probeCommand,
+        string packageId,
+        Uri documentation,
+        IReadOnlyList<string> launchArguments,
+        IReadOnlyList<AcpSetupParameterDefinition> parameters,
+        IReadOnlyDictionary<string, string>? fixedEnvironment = null)
+    {
+        var adapterId = agentId + "-builtin-acp";
+        return new AcpAgentDescriptor
+        {
+            Id = agentId,
+            DisplayName = displayName,
+            Description = descriptionKey,
+            RecommendedAdapterId = adapterId,
+            Runtime = new AcpComponentDescriptor
+            {
+                Id = agentId + "-cli",
+                DisplayName = displayName,
+                Distribution = AcpDistributionKind.Npx,
+                DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                ProbeCommand = probeCommand,
+                ProbeVersionArguments = new[] { "--version" },
+                PackageId = packageId,
+                InstallDocumentation = documentation
+            },
+            Adapters = new[]
+            {
+                new AcpAdapterDescriptor
+                {
+                    Component = new AcpComponentDescriptor
+                    {
+                        Id = adapterId,
+                        DisplayName = displayName + " (ACP)",
+                        Distribution = AcpDistributionKind.BuiltIn,
+                        DetectionMode = AcpComponentDetectionMode.None,
+                        InstallDocumentation = documentation
+                    },
+                    LaunchTemplate = new AcpLaunchTemplate
+                    {
+                        Command = NpxCommand,
+                        FixedArguments = launchArguments,
+                        FixedEnvironment = fixedEnvironment
+                            ?? new Dictionary<string, string>(StringComparer.Ordinal),
+                        Parameters = parameters
+                    }
+                }
+            }
+        };
+    }
+
+    private static AcpAgentDescriptor CreateClaudeCode()
+        => CreateAdapterFrontedAgent(
+            agentId: "claude-code",
+            displayName: "Claude Code",
+            descriptionKey: "AcpSetup_Agent_ClaudeCode_Description",
+            runtimeProbeCommand: "claude",
+            runtimePackageId: "@anthropic-ai/claude-code",
+            runtimeDocumentation: new Uri("https://docs.claude.com/en/docs/claude-code/setup"),
+            adapterId: "claude-agent-acp",
+            adapterDisplayName: "Claude Agent ACP",
+            adapterPackageId: "@agentclientprotocol/claude-agent-acp",
+            adapterDocumentation: new Uri("https://github.com/agentclientprotocol/claude-agent-acp"),
+            launchArguments: new[] { "-y", "@agentclientprotocol/claude-agent-acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>());
+
+    private static AcpAgentDescriptor CreateCodex()
+        => CreateAdapterFrontedAgent(
+            agentId: "codex",
+            displayName: "Codex CLI",
+            descriptionKey: "AcpSetup_Agent_Codex_Description",
+            runtimeProbeCommand: "codex",
+            runtimePackageId: "@openai/codex",
+            runtimeDocumentation: new Uri("https://developers.openai.com/codex/cli/"),
+            adapterId: "codex-acp",
+            adapterDisplayName: "Codex ACP",
+            adapterPackageId: "@agentclientprotocol/codex-acp",
+            adapterDocumentation: new Uri("https://github.com/agentclientprotocol/codex-acp"),
+            launchArguments: new[] { "-y", "@agentclientprotocol/codex-acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>());
+
+    private static AcpAgentDescriptor CreateGeminiCli()
+        => CreateSelfHostedAgent(
+            agentId: "gemini",
+            displayName: "Gemini CLI",
+            descriptionKey: "AcpSetup_Agent_Gemini_Description",
+            probeCommand: "gemini",
+            packageId: "@google/gemini-cli",
+            documentation: new Uri("https://geminicli.com"),
+            launchArguments: new[] { "-y", "@google/gemini-cli", "--acp" },
+            parameters: new[]
+            {
+                AcpSetupParameters.ModelEnvironment("GEMINI_MODEL", "gemini-2.5-pro")
+            });
+
+    private static AcpAgentDescriptor CreateGitHubCopilot()
+        => CreateSelfHostedAgent(
+            agentId: "github-copilot",
+            displayName: "GitHub Copilot CLI",
+            descriptionKey: "AcpSetup_Agent_GitHubCopilot_Description",
+            probeCommand: "copilot",
+            packageId: "@github/copilot",
+            documentation: new Uri("https://github.com/features/copilot/cli/"),
+            launchArguments: new[] { "-y", "@github/copilot", "--acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>());
+
+    private static AcpAgentDescriptor CreateQwenCode()
+        => CreateSelfHostedAgent(
+            agentId: "qwen-code",
+            displayName: "Qwen Code",
+            descriptionKey: "AcpSetup_Agent_QwenCode_Description",
+            probeCommand: "qwen",
+            packageId: "@qwen-code/qwen-code",
+            documentation: new Uri("https://qwenlm.github.io/qwen-code-docs/en/users/overview"),
+            launchArguments: new[] { "-y", "@qwen-code/qwen-code", "--acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>());
+
+    private static AcpAgentDescriptor CreateCline()
+        => CreateSelfHostedAgent(
+            agentId: "cline",
+            displayName: "Cline",
+            descriptionKey: "AcpSetup_Agent_Cline_Description",
+            probeCommand: "cline",
+            packageId: "cline",
+            documentation: new Uri("https://cline.bot/cli"),
+            launchArguments: new[] { "-y", "cline", "--acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>());
+
+    private static AcpAgentDescriptor CreateAuggie()
+        => CreateSelfHostedAgent(
+            agentId: "auggie",
+            displayName: "Auggie CLI",
+            descriptionKey: "AcpSetup_Agent_Auggie_Description",
+            probeCommand: "auggie",
+            packageId: "@augmentcode/auggie",
+            documentation: new Uri("https://www.augmentcode.com/"),
+            launchArguments: new[] { "-y", "@augmentcode/auggie", "--acp" },
+            parameters: Array.Empty<AcpSetupParameterDefinition>(),
+            // Registry declares this so the adapter does not self-update mid-session, which would
+            // restart the process the ACP transport is attached to.
+            fixedEnvironment: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["AUGMENT_DISABLE_AUTO_UPDATE"] = "1"
+            });
+
+    /// <summary>
+    /// Distributed as a prebuilt binary, so the wizard detects the CLI on PATH and points at the
+    /// vendor installer instead of offering one-click installation.
+    /// </summary>
+    private static AcpAgentDescriptor CreateGoose()
+    {
+        const string adapterId = "goose-builtin-acp";
+        var documentation = new Uri("https://block.github.io/goose/docs/getting-started/installation");
+        return new AcpAgentDescriptor
+        {
+            Id = "goose",
+            DisplayName = "goose",
+            Description = "AcpSetup_Agent_Goose_Description",
+            RecommendedAdapterId = adapterId,
+            Runtime = new AcpComponentDescriptor
+            {
+                Id = "goose-cli",
+                DisplayName = "goose",
+                Distribution = AcpDistributionKind.Binary,
+                DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                ProbeCommand = "goose",
+                ProbeVersionArguments = new[] { "--version" },
+                InstallDocumentation = documentation
+            },
+            Adapters = new[]
+            {
+                new AcpAdapterDescriptor
+                {
+                    Component = new AcpComponentDescriptor
+                    {
+                        Id = adapterId,
+                        DisplayName = "goose (ACP)",
+                        Distribution = AcpDistributionKind.BuiltIn,
+                        DetectionMode = AcpComponentDetectionMode.None,
+                        InstallDocumentation = documentation
+                    },
+                    LaunchTemplate = new AcpLaunchTemplate
+                    {
+                        Command = "goose",
+                        FixedArguments = new[] { "acp" },
+                        Parameters = Array.Empty<AcpSetupParameterDefinition>()
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/AcpSetupParameters.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/AcpSetupParameters.cs
@@ -1,0 +1,28 @@
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Factories for the launch parameters agents share, so the catalog declares intent rather than
+/// repeating localization keys.
+///
+/// Credentials are deliberately absent. Launch parameters are persisted in the profile YAML in clear
+/// text, and the authoritative credential path (<c>authentication.mode</c> plus secure storage) has two
+/// fixed slots bound to that mode — an arbitrary API-key environment variable fits neither. ACP agents
+/// are signed in through their own CLI and carry that session into the adapter, so the wizard directs
+/// users there instead of collecting secrets it cannot store safely.
+/// </summary>
+internal static class AcpSetupParameters
+{
+    /// <summary>Model override passed as an environment variable.</summary>
+    internal static AcpSetupParameterDefinition ModelEnvironment(string variableName, string example)
+        => new()
+        {
+            Key = variableName,
+            DisplayName = variableName,
+            Target = AcpSetupParameterTarget.EnvironmentVariable,
+            Description = "AcpSetup_Parameter_Model_Description",
+            Example = example,
+            IsRequired = false
+        };
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpComponentInstaller.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Installer used on platforms that cannot run package managers. Reports
+/// <see cref="SupportsAutomaticInstall"/> as false so the wizard offers documentation instead of a
+/// one-click button, and fails any call that arrives anyway rather than reporting a phantom success.
+/// </summary>
+public sealed class UnsupportedAcpComponentInstaller : IAcpComponentInstaller
+{
+    private const string UnsupportedDetail =
+        "Automatic installation requires a desktop process host and is not supported on this platform.";
+
+    public bool SupportsAutomaticInstall => false;
+
+    public Task<AcpComponentInstallResult> InstallAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        return Task.FromResult(AcpComponentInstallResult.Failure(
+            component.Id,
+            exitCode: null,
+            output: null,
+            errorDetail: UnsupportedDetail));
+    }
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Probe used on platforms with no child-process host (WASM in particular).
+/// </summary>
+/// <remarks>
+/// Reports <see cref="SupportsProcessProbing"/> as false and answers every query with "unknown" rather
+/// than "absent", so the wizard shows an undetermined state and manual instructions instead of telling
+/// the user to install components it never actually looked for.
+/// </remarks>
+public sealed class UnsupportedAcpExecutableProbe : IAcpExecutableProbe
+{
+    public bool SupportsProcessProbing => false;
+
+    public Task<string?> ResolveExecutablePathAsync(
+        string command,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>(null);
+
+    public Task<string?> ReadVersionAsync(
+        string command,
+        IReadOnlyList<string> versionArguments,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>(null);
+
+    public Task<bool?> IsGlobalNodePackageInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(null);
+
+    public Task<bool?> IsGlobalUvToolInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(null);
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpSetupConnectivityTester.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpSetupConnectivityTester.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Connectivity tester used on platforms that cannot start child processes (WASM in particular).
+/// </summary>
+/// <remarks>
+/// Fails at <see cref="AcpSetupTestStage.CommandResolution"/> rather than reporting success: a stdio
+/// launch plan genuinely cannot run here, and a green test would let the wizard save a profile that
+/// can never connect on this platform.
+/// </remarks>
+public sealed class UnsupportedAcpSetupConnectivityTester : IAcpSetupConnectivityTester
+{
+    private const string UnsupportedDetail =
+        "Testing a stdio launch plan requires a desktop process host and is not supported on this platform.";
+
+    public Task<AcpSetupTestResult> TestAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(launchPlan);
+
+        return Task.FromResult(AcpSetupTestResult.Failure(
+            AcpSetupTestStage.CommandResolution,
+            errorDetail: UnsupportedDetail));
+    }
+}

--- a/src/SalmonEgg.Infrastructure/Client/TransportFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Client/TransportFactory.cs
@@ -75,7 +75,8 @@ public class TransportFactory : ITransportFactory
             configuration.Transport == TransportType.Stdio ? configuration.StdioArguments : null,
             configuration.Transport == TransportType.Stdio ? null : configuration.ServerUrl,
             connectTimeout,
-            configuration.Proxy);
+            configuration.Proxy,
+            configuration.Transport == TransportType.Stdio ? configuration.StdioEnvironment : null);
     }
 
     private SalmonEgg.Domain.Interfaces.Transport.ITransport CreateTransportCore(
@@ -84,13 +85,14 @@ public class TransportFactory : ITransportFactory
         IReadOnlyList<string>? arguments,
         string? url,
         TimeSpan connectTimeout,
-        ProxyConfig? proxy = null)
+        ProxyConfig? proxy = null,
+        IReadOnlyDictionary<string, string>? stdioEnvironment = null)
     {
         _logger.Information("Creating transport instance. TransportType={TransportType}", transportType);
 
         return transportType switch
         {
-            TransportType.Stdio => CreateStdioTransport(command, arguments),
+            TransportType.Stdio => CreateStdioTransport(command, arguments, stdioEnvironment),
             TransportType.WebSocket => CreateWebSocketTransport(url, connectTimeout, proxy),
             TransportType.StreamableHttp => CreateStreamableHttpTransport(url, connectTimeout, proxy),
             _ => throw new NotSupportedException($"Unsupported transport type: {transportType}.")
@@ -102,11 +104,13 @@ public class TransportFactory : ITransportFactory
     /// </summary>
     /// <param name="command">命令</param>
     /// <param name="arguments">命令行参数</param>
+    /// <param name="environment">叠加到子进程环境的变量</param>
     /// <returns>Stdio 传输实例</returns>
     /// <exception cref="ArgumentException">当命令为空时抛出</exception>
     private SalmonEgg.Domain.Interfaces.Transport.ITransport CreateStdioTransport(
         string? command,
-        IReadOnlyList<string>? arguments)
+        IReadOnlyList<string>? arguments,
+        IReadOnlyDictionary<string, string>? environment)
     {
         if (!_transportSupportPolicy.IsSupported(TransportType.Stdio))
         {
@@ -123,7 +127,7 @@ public class TransportFactory : ITransportFactory
         var argsArray = arguments?.ToArray() ?? Array.Empty<string>();
         _logger.Information("Creating Stdio transport. Command={Command}, ArgsCount={ArgsCount}", command, argsArray.Length);
 
-        return _stdioTransportFactory.Create(command.Trim(), argsArray, Encoding.UTF8);
+        return _stdioTransportFactory.Create(command.Trim(), argsArray, Encoding.UTF8, environment);
     }
 
     /// <summary>

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,7 +20,7 @@ namespace SalmonEgg.Infrastructure.Storage;
 public sealed class ConfigurationManager : IConfigurationService, IConfigurationRecoveryService
 {
     /// <summary>本程序写入 server 配置时使用的 schema 版本。</summary>
-    public const int CurrentServerConfigurationSchemaVersion = 2;
+    public const int CurrentServerConfigurationSchemaVersion = 3;
 
     private const int CurrentSchemaVersion = CurrentServerConfigurationSchemaVersion;
 
@@ -573,6 +573,7 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
             ServerUrl = config.ServerUrl,
             StdioCommand = config.StdioCommand,
             StdioArguments = config.StdioArguments?.ToList() ?? new List<string>(),
+            StdioEnvironment = ToYamlStdioEnvironment(config.StdioEnvironment),
             ConnectionTimeoutSeconds = config.ConnectionTimeout,
             Authentication = new AuthenticationYamlV1 { Mode = mode },
             Proxy = new ProxyYamlV1
@@ -593,6 +594,7 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
             ServerUrl = yamlModel.ServerUrl ?? string.Empty,
             StdioCommand = yamlModel.StdioCommand ?? string.Empty,
             StdioArguments = yamlModel.StdioArguments ?? new List<string>(),
+            StdioEnvironment = CloneStdioEnvironment(yamlModel.StdioEnvironment),
             Transport = TransportFromString(yamlModel.Transport),
             ConnectionTimeout = AcpConnectionTimeoutPolicy.ResolveSeconds(yamlModel.ConnectionTimeoutSeconds)
         };
@@ -607,6 +609,47 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
         };
 
         return config;
+    }
+
+    /// <summary>
+    /// Projects the environment overlay for YAML, returning null when there is nothing to persist.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than an empty map so the serializer's OmitNull drops the key instead of writing a
+    /// flow-style <c>{}</c>: configuration YAML stays block-style, which is what keeps it readable and
+    /// mergeable.
+    /// </remarks>
+    private static Dictionary<string, string>? ToYamlStdioEnvironment(
+        IReadOnlyDictionary<string, string>? environment)
+    {
+        var clone = CloneStdioEnvironment(environment);
+        return clone.Count == 0 ? null : clone;
+    }
+
+    /// <summary>
+    /// Copies the environment overlay, dropping blank names so a hand-edited YAML cannot produce an
+    /// unnamed variable that the process launcher would reject.
+    /// </summary>
+    private static Dictionary<string, string> CloneStdioEnvironment(
+        IReadOnlyDictionary<string, string>? environment)
+    {
+        var clone = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (environment is null)
+        {
+            return clone;
+        }
+
+        foreach (var entry in environment)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key))
+            {
+                continue;
+            }
+
+            clone[entry.Key.Trim()] = entry.Value ?? string.Empty;
+        }
+
+        return clone;
     }
 
     private async Task HydrateSecretsAsync(ServerConfiguration config, string? mode)

--- a/src/SalmonEgg.Infrastructure/Storage/YamlModels/ServerConfigurationYaml.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/YamlModels/ServerConfigurationYaml.cs
@@ -5,7 +5,7 @@ namespace SalmonEgg.Infrastructure.Storage.YamlModels;
 
 internal sealed class ServerConfigurationYaml
 {
-    public int SchemaVersion { get; set; } = 2;
+    public int SchemaVersion { get; set; } = 3;
 
     public string UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow.ToString("O");
 
@@ -22,6 +22,17 @@ internal sealed class ServerConfigurationYaml
     public string StdioCommand { get; set; } = string.Empty;
 
     public List<string> StdioArguments { get; set; } = new();
+
+    /// <summary>
+    /// Stdio child-process environment overlay. Added in schema_version 3; absent in v2 files, which
+    /// deserialize to null and therefore need no migration step.
+    /// </summary>
+    /// <remarks>
+    /// Nullable and left null when there is nothing to write, so <c>OmitNull</c> drops the key entirely
+    /// rather than emitting a flow-style <c>{}</c>. Configuration YAML stays block-style so it remains
+    /// readable and mergeable, which is the shape the persistence spec requires.
+    /// </remarks>
+    public Dictionary<string, string>? StdioEnvironment { get; set; }
 
     public int ConnectionTimeoutSeconds { get; set; } = AcpConnectionTimeoutPolicy.DefaultSeconds;
 

--- a/src/SalmonEgg.Infrastructure/Transport/IStdioTransportFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Transport/IStdioTransportFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 using SalmonEgg.Domain.Interfaces.Transport;
 
@@ -5,5 +6,13 @@ namespace SalmonEgg.Infrastructure.Transport;
 
 public interface IStdioTransportFactory
 {
-    ITransport Create(string command, string[] args, Encoding encoding);
+    /// <summary>
+    /// Creates a stdio transport. <paramref name="environment"/> entries are applied on top of the
+    /// inherited process environment; null or empty leaves the environment untouched.
+    /// </summary>
+    ITransport Create(
+        string command,
+        string[] args,
+        Encoding encoding,
+        IReadOnlyDictionary<string, string>? environment = null);
 }

--- a/src/SalmonEgg.Infrastructure/Transport/UnsupportedStdioTransportFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Transport/UnsupportedStdioTransportFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using SalmonEgg.Domain.Interfaces.Transport;
 
@@ -9,6 +10,10 @@ public sealed class UnsupportedStdioTransportFactory : IStdioTransportFactory
     private const string UnsupportedMessage =
         "Stdio transport requires a desktop process host and is not supported on this platform.";
 
-    public ITransport Create(string command, string[] args, Encoding encoding)
+    public ITransport Create(
+        string command,
+        string[] args,
+        Encoding encoding,
+        IReadOnlyDictionary<string, string>? environment = null)
         => throw new NotSupportedException(UnsupportedMessage);
 }

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -500,6 +500,66 @@ Create the corresponding Markdown file in:
   <data name="AcpProfiles_RefreshFailed" xml:space="preserve">
     <value>Failed to refresh agent profiles. Please try again later.</value>
   </data>
+  <data name="AcpSetup_Install_Failed" xml:space="preserve">
+    <value>Installation failed.</value>
+  </data>
+  <data name="AcpSetup_Stage_Validation" xml:space="preserve">
+    <value>Parameter validation</value>
+  </data>
+  <data name="AcpSetup_Stage_CommandResolution" xml:space="preserve">
+    <value>Command resolution</value>
+  </data>
+  <data name="AcpSetup_Stage_AdapterStartup" xml:space="preserve">
+    <value>Adapter startup</value>
+  </data>
+  <data name="AcpSetup_Stage_Handshake" xml:space="preserve">
+    <value>Protocol handshake</value>
+  </data>
+  <data name="AcpSetup_Stage_Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="AcpSetup_Remediation_CommandResolution" xml:space="preserve">
+    <value>The launch command was not found. Make sure the agent runtime is installed and on PATH, then detect again.</value>
+  </data>
+  <data name="AcpSetup_Remediation_AdapterStartup" xml:space="preserve">
+    <value>The adapter failed to start. Check the install output for details and confirm the adapter supports this agent.</value>
+  </data>
+  <data name="AcpSetup_Remediation_Handshake" xml:space="preserve">
+    <value>The connection opened but the handshake failed. Confirm the agent supports the ACP protocol and check the launch parameters.</value>
+  </data>
+  <data name="AcpSetup_Agent_ClaudeCode_Description" xml:space="preserve">
+    <value>Anthropic's terminal coding agent (Claude Code CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_Codex_Description" xml:space="preserve">
+    <value>OpenAI's terminal coding agent (Codex CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_Gemini_Description" xml:space="preserve">
+    <value>Google's terminal coding agent (Gemini CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_GitHubCopilot_Description" xml:space="preserve">
+    <value>GitHub Copilot command-line coding agent.</value>
+  </data>
+  <data name="AcpSetup_Agent_QwenCode_Description" xml:space="preserve">
+    <value>Alibaba Qwen's terminal coding agent (Qwen Code).</value>
+  </data>
+  <data name="AcpSetup_Agent_Cline_Description" xml:space="preserve">
+    <value>Cline terminal coding agent.</value>
+  </data>
+  <data name="AcpSetup_Agent_Auggie_Description" xml:space="preserve">
+    <value>Augment Code's terminal coding agent (Auggie).</value>
+  </data>
+  <data name="AcpSetup_Agent_Goose_Description" xml:space="preserve">
+    <value>Block's open-source coding agent (Goose).</value>
+  </data>
+  <data name="AcpSetup_Parameter_Model_Description" xml:space="preserve">
+    <value>Model name, for example sonnet, opus, or a specific model identifier. Leave empty to use the agent's default.</value>
+  </data>
+  <data name="AcpSetup_Validation_MissingRequiredValue" xml:space="preserve">
+    <value>This parameter is required. Fill it in before continuing.</value>
+  </data>
+  <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
+    <value>Value not allowed. Pick one from the list.</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>Failed to delete the agent profile. Please try again later.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -500,6 +500,66 @@ Create the corresponding Markdown file in:
   <data name="AcpProfiles_RefreshFailed" xml:space="preserve">
     <value>Failed to refresh agent profiles. Please try again later.</value>
   </data>
+  <data name="AcpSetup_Install_Failed" xml:space="preserve">
+    <value>Installation failed.</value>
+  </data>
+  <data name="AcpSetup_Stage_Validation" xml:space="preserve">
+    <value>Parameter validation</value>
+  </data>
+  <data name="AcpSetup_Stage_CommandResolution" xml:space="preserve">
+    <value>Command resolution</value>
+  </data>
+  <data name="AcpSetup_Stage_AdapterStartup" xml:space="preserve">
+    <value>Adapter startup</value>
+  </data>
+  <data name="AcpSetup_Stage_Handshake" xml:space="preserve">
+    <value>Protocol handshake</value>
+  </data>
+  <data name="AcpSetup_Stage_Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="AcpSetup_Remediation_CommandResolution" xml:space="preserve">
+    <value>The launch command was not found. Make sure the agent runtime is installed and on PATH, then detect again.</value>
+  </data>
+  <data name="AcpSetup_Remediation_AdapterStartup" xml:space="preserve">
+    <value>The adapter failed to start. Check the install output for details and confirm the adapter supports this agent.</value>
+  </data>
+  <data name="AcpSetup_Remediation_Handshake" xml:space="preserve">
+    <value>The connection opened but the handshake failed. Confirm the agent supports the ACP protocol and check the launch parameters.</value>
+  </data>
+  <data name="AcpSetup_Agent_ClaudeCode_Description" xml:space="preserve">
+    <value>Anthropic's terminal coding agent (Claude Code CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_Codex_Description" xml:space="preserve">
+    <value>OpenAI's terminal coding agent (Codex CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_Gemini_Description" xml:space="preserve">
+    <value>Google's terminal coding agent (Gemini CLI).</value>
+  </data>
+  <data name="AcpSetup_Agent_GitHubCopilot_Description" xml:space="preserve">
+    <value>GitHub Copilot command-line coding agent.</value>
+  </data>
+  <data name="AcpSetup_Agent_QwenCode_Description" xml:space="preserve">
+    <value>Alibaba Qwen's terminal coding agent (Qwen Code).</value>
+  </data>
+  <data name="AcpSetup_Agent_Cline_Description" xml:space="preserve">
+    <value>Cline terminal coding agent.</value>
+  </data>
+  <data name="AcpSetup_Agent_Auggie_Description" xml:space="preserve">
+    <value>Augment Code's terminal coding agent (Auggie).</value>
+  </data>
+  <data name="AcpSetup_Agent_Goose_Description" xml:space="preserve">
+    <value>Block's open-source coding agent (Goose).</value>
+  </data>
+  <data name="AcpSetup_Parameter_Model_Description" xml:space="preserve">
+    <value>Model name, for example sonnet, opus, or a specific model identifier. Leave empty to use the agent's default.</value>
+  </data>
+  <data name="AcpSetup_Validation_MissingRequiredValue" xml:space="preserve">
+    <value>This parameter is required. Fill it in before continuing.</value>
+  </data>
+  <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
+    <value>Value not allowed. Pick one from the list.</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>Failed to delete the agent profile. Please try again later.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -502,6 +502,66 @@
   <data name="AcpProfiles_RefreshFailed" xml:space="preserve">
     <value>刷新 Agent 配置失败，请稍后重试。</value>
   </data>
+  <data name="AcpSetup_Install_Failed" xml:space="preserve">
+    <value>安装失败。</value>
+  </data>
+  <data name="AcpSetup_Stage_Validation" xml:space="preserve">
+    <value>参数校验</value>
+  </data>
+  <data name="AcpSetup_Stage_CommandResolution" xml:space="preserve">
+    <value>命令解析</value>
+  </data>
+  <data name="AcpSetup_Stage_AdapterStartup" xml:space="preserve">
+    <value>适配器启动</value>
+  </data>
+  <data name="AcpSetup_Stage_Handshake" xml:space="preserve">
+    <value>协议握手</value>
+  </data>
+  <data name="AcpSetup_Stage_Completed" xml:space="preserve">
+    <value>已完成</value>
+  </data>
+  <data name="AcpSetup_Remediation_CommandResolution" xml:space="preserve">
+    <value>找不到启动命令。请确认 Agent 运行时已安装并在 PATH 中，然后重新检测。</value>
+  </data>
+  <data name="AcpSetup_Remediation_AdapterStartup" xml:space="preserve">
+    <value>适配器无法启动。请查看安装输出中的错误详情，确认适配器与该 Agent 兼容。</value>
+  </data>
+  <data name="AcpSetup_Remediation_Handshake" xml:space="preserve">
+    <value>连接已建立但握手失败。请确认该 Agent 支持 ACP 协议，并检查启动参数是否正确。</value>
+  </data>
+  <data name="AcpSetup_Agent_ClaudeCode_Description" xml:space="preserve">
+    <value>Anthropic 的终端编码 Agent（Claude Code CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Codex_Description" xml:space="preserve">
+    <value>OpenAI 的终端编码 Agent（Codex CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Gemini_Description" xml:space="preserve">
+    <value>Google 的终端编码 Agent（Gemini CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_GitHubCopilot_Description" xml:space="preserve">
+    <value>GitHub Copilot 命令行编码 Agent。</value>
+  </data>
+  <data name="AcpSetup_Agent_QwenCode_Description" xml:space="preserve">
+    <value>阿里云通义千问的终端编码 Agent（Qwen Code）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Cline_Description" xml:space="preserve">
+    <value>Cline 终端编码 Agent。</value>
+  </data>
+  <data name="AcpSetup_Agent_Auggie_Description" xml:space="preserve">
+    <value>Augment Code 的终端编码 Agent（Auggie）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Goose_Description" xml:space="preserve">
+    <value>Block 的开源编码 Agent（Goose）。</value>
+  </data>
+  <data name="AcpSetup_Parameter_Model_Description" xml:space="preserve">
+    <value>模型名称，例如 sonnet、opus 或具体模型标识。留空则使用 Agent 默认模型。</value>
+  </data>
+  <data name="AcpSetup_Validation_MissingRequiredValue" xml:space="preserve">
+    <value>此参数为必填项，请填写后再继续。</value>
+  </data>
+  <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
+    <value>取值不在允许范围内，请从列表中选择。</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>删除 Agent 配置失败，请稍后重试。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -502,6 +502,66 @@
   <data name="AcpProfiles_RefreshFailed" xml:space="preserve">
     <value>刷新 Agent 配置失败，请稍后重试。</value>
   </data>
+  <data name="AcpSetup_Install_Failed" xml:space="preserve">
+    <value>安装失败。</value>
+  </data>
+  <data name="AcpSetup_Stage_Validation" xml:space="preserve">
+    <value>参数校验</value>
+  </data>
+  <data name="AcpSetup_Stage_CommandResolution" xml:space="preserve">
+    <value>命令解析</value>
+  </data>
+  <data name="AcpSetup_Stage_AdapterStartup" xml:space="preserve">
+    <value>适配器启动</value>
+  </data>
+  <data name="AcpSetup_Stage_Handshake" xml:space="preserve">
+    <value>协议握手</value>
+  </data>
+  <data name="AcpSetup_Stage_Completed" xml:space="preserve">
+    <value>已完成</value>
+  </data>
+  <data name="AcpSetup_Remediation_CommandResolution" xml:space="preserve">
+    <value>找不到启动命令。请确认 Agent 运行时已安装并在 PATH 中，然后重新检测。</value>
+  </data>
+  <data name="AcpSetup_Remediation_AdapterStartup" xml:space="preserve">
+    <value>适配器无法启动。请查看安装输出中的错误详情，确认适配器与该 Agent 兼容。</value>
+  </data>
+  <data name="AcpSetup_Remediation_Handshake" xml:space="preserve">
+    <value>连接已建立但握手失败。请确认该 Agent 支持 ACP 协议，并检查启动参数是否正确。</value>
+  </data>
+  <data name="AcpSetup_Agent_ClaudeCode_Description" xml:space="preserve">
+    <value>Anthropic 的终端编码 Agent（Claude Code CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Codex_Description" xml:space="preserve">
+    <value>OpenAI 的终端编码 Agent（Codex CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Gemini_Description" xml:space="preserve">
+    <value>Google 的终端编码 Agent（Gemini CLI）。</value>
+  </data>
+  <data name="AcpSetup_Agent_GitHubCopilot_Description" xml:space="preserve">
+    <value>GitHub Copilot 命令行编码 Agent。</value>
+  </data>
+  <data name="AcpSetup_Agent_QwenCode_Description" xml:space="preserve">
+    <value>阿里云通义千问的终端编码 Agent（Qwen Code）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Cline_Description" xml:space="preserve">
+    <value>Cline 终端编码 Agent。</value>
+  </data>
+  <data name="AcpSetup_Agent_Auggie_Description" xml:space="preserve">
+    <value>Augment Code 的终端编码 Agent（Auggie）。</value>
+  </data>
+  <data name="AcpSetup_Agent_Goose_Description" xml:space="preserve">
+    <value>Block 的开源编码 Agent（Goose）。</value>
+  </data>
+  <data name="AcpSetup_Parameter_Model_Description" xml:space="preserve">
+    <value>模型名称，例如 sonnet、opus 或具体模型标识。留空则使用 Agent 默认模型。</value>
+  </data>
+  <data name="AcpSetup_Validation_MissingRequiredValue" xml:space="preserve">
+    <value>此参数为必填项，请填写后再继续。</value>
+  </data>
+  <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
+    <value>取值不在允许范围内，请从列表中选择。</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>删除 Agent 配置失败，请稍后重试。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
@@ -1,0 +1,71 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+/// <summary>
+/// One catalog agent as the selection step shows it: the descriptor plus what detection learned about
+/// the runtime on this machine.
+/// </summary>
+/// <remarks>
+/// Availability is projected as separate booleans rather than one status string so the view can style
+/// each state without a converter, and so "undetermined" stays visibly distinct from "missing" — the
+/// wizard must never tell a user to install something it merely failed to look for.
+/// </remarks>
+public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
+{
+    public AcpSetupAgentRowViewModel(AcpAgentDescriptor agent)
+    {
+        Agent = agent ?? throw new ArgumentNullException(nameof(agent));
+        _runtime = AcpComponentProbeResult.Undetermined(agent.Runtime.Id);
+    }
+
+    public AcpAgentDescriptor Agent { get; }
+
+    public string AgentId => Agent.Id;
+
+    public string DisplayName => Agent.DisplayName;
+
+    /// <summary>Localization key for the agent's one-line description.</summary>
+    public string DescriptionKey => Agent.Description;
+
+    /// <summary>Latest runtime probe. Replaced wholesale so every derived flag updates together.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Availability))]
+    [NotifyPropertyChangedFor(nameof(IsInstalled))]
+    [NotifyPropertyChangedFor(nameof(IsMissing))]
+    [NotifyPropertyChangedFor(nameof(IsUndetermined))]
+    [NotifyPropertyChangedFor(nameof(IsChecking))]
+    [NotifyPropertyChangedFor(nameof(Version))]
+    [NotifyPropertyChangedFor(nameof(HasVersion))]
+    private AcpComponentProbeResult _runtime;
+
+    public AcpComponentAvailability Availability => Runtime.Availability;
+
+    public bool IsInstalled => Runtime.IsUsable;
+
+    public bool IsMissing => Runtime.Availability == AcpComponentAvailability.Missing;
+
+    public bool IsUndetermined => Runtime.Availability == AcpComponentAvailability.Undetermined;
+
+    public bool IsChecking => Runtime.Availability == AcpComponentAvailability.Checking;
+
+    public string Version => Runtime.Version ?? string.Empty;
+
+    public bool HasVersion => !string.IsNullOrWhiteSpace(Runtime.Version);
+
+    /// <summary>True when this agent can be installed by the wizard rather than by hand.</summary>
+    public bool SupportsAutomaticInstall => Agent.Runtime.SupportsAutomaticInstall;
+
+    /// <summary>Documentation to offer when automatic installation is unavailable or fails.</summary>
+    public Uri? InstallDocumentation => Agent.Runtime.InstallDocumentation;
+
+    /// <summary>
+    /// Raised when the user asks this row to be installed; the owning wizard subscribes because it
+    /// owns the busy flag and the error surface. Null when nobody is listening.
+    /// </summary>
+    public event Action<AcpSetupAgentRowViewModel>? InstallRequested;
+
+    public void RequestInstall() => InstallRequested?.Invoke(this);
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupParameterRowViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupParameterRowViewModel.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+/// <summary>
+/// One editable launch parameter. The wizard renders these generically from the adapter's declared
+/// parameters, so adding an agent to the catalog never requires new form code.
+/// </summary>
+public sealed partial class AcpSetupParameterRowViewModel : ObservableObject
+{
+    private readonly Action? _onValueChanged;
+
+    public AcpSetupParameterRowViewModel(
+        AcpSetupParameterDefinition definition,
+        Action? onValueChanged = null)
+    {
+        Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _onValueChanged = onValueChanged;
+        _value = definition.DefaultValue;
+        AllowedValues = new ReadOnlyCollection<string>(new List<string>(definition.AllowedValues));
+    }
+
+    public AcpSetupParameterDefinition Definition { get; }
+
+    /// <summary>Stable key used to correlate this row with the definition that produced it.</summary>
+    public string Key => Definition.Key;
+
+    public string DisplayName => Definition.DisplayName;
+
+    public string Description => Definition.Description;
+
+    public string Example => Definition.Example;
+
+    public bool IsRequired => Definition.IsRequired;
+
+    /// <summary>True when the parameter offers a closed set the UI can render as a picker.</summary>
+    public bool HasAllowedValues => AllowedValues.Count > 0;
+
+    public IReadOnlyList<string> AllowedValues { get; }
+
+    /// <summary>
+    /// The user's current value. Trimming is deliberately left to validation and plan building so the
+    /// text box does not fight the user mid-edit.
+    /// </summary>
+    [ObservableProperty]
+    private string _value;
+
+    /// <summary>Localized validation message for this row, empty when the row is accepted.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasValidationMessage))]
+    private string _validationMessage = string.Empty;
+
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+
+    partial void OnValueChanged(string value) => _onValueChanged?.Invoke();
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardStep.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardStep.cs
@@ -1,0 +1,23 @@
+namespace SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+/// <summary>
+/// The wizard's steps, in the order the user walks them. Ordinal order is meaningful: the step machine
+/// advances and rewinds by comparing values, so new steps must be inserted at their real position.
+/// </summary>
+public enum AcpSetupWizardStep
+{
+    /// <summary>Pick an agent from the catalog, after detection reports what is on the machine.</summary>
+    AgentSelection,
+
+    /// <summary>Install or verify the agent runtime and the ACP adapter it needs.</summary>
+    ComponentSetup,
+
+    /// <summary>Fill in the launch parameters the chosen adapter declares.</summary>
+    Parameters,
+
+    /// <summary>Run the end-to-end connectivity test.</summary>
+    Test,
+
+    /// <summary>Name the profile and persist it.</summary>
+    Save
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -78,6 +78,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsOnParameters))]
     [NotifyPropertyChangedFor(nameof(IsOnTest))]
     [NotifyPropertyChangedFor(nameof(IsOnSave))]
+    [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpSetupWizardStep _step = AcpSetupWizardStep.AgentSelection;
 
     [ObservableProperty]
@@ -155,6 +156,15 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     public bool IsOnTest => Step == AcpSetupWizardStep.Test;
 
     public bool IsOnSave => Step == AcpSetupWizardStep.Save;
+
+    /// <summary>Human-readable step position ("Step 2 of 5"), so the walk's place is always stated.</summary>
+    public string StepPositionText => Localize(
+        "AcpSetup_Step_Position",
+        $"Step {(int)Step + 1} of {TotalSteps}")
+        .Replace("{0}", ((int)Step + 1).ToString(System.Globalization.CultureInfo.CurrentCulture))
+        .Replace("{1}", TotalSteps.ToString(System.Globalization.CultureInfo.CurrentCulture));
+
+    private const int TotalSteps = 5;
 
     public bool HasSavedProfile => SavedProfile is not null;
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -1,0 +1,722 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
+
+namespace SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+/// <summary>
+/// Step machine for the ACP setup wizard: detect agents, install what is missing, fill in launch
+/// parameters, prove the configuration works, then save it as a connection profile.
+/// </summary>
+/// <remarks>
+/// Owns no UI types and performs no I/O of its own — every side effect goes through
+/// <see cref="AcpSetupWizardOrchestrator"/>, so this type stays unit-testable on every platform.
+///
+/// Advancing is blocked only on facts the wizard actually knows. A component probed as
+/// <see cref="AcpComponentAvailability.Undetermined"/> does not block, because an unanswerable probe is
+/// not evidence of absence; the end-to-end test is the real gate before saving.
+/// </remarks>
+public sealed partial class AcpSetupWizardViewModel : ObservableObject
+{
+    private const int MaxInstallOutputLines = 200;
+
+    private readonly AcpSetupWizardOrchestrator _orchestrator;
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly IStringLocalizer<CoreStrings>? _localizer;
+    private readonly ILogger<AcpSetupWizardViewModel> _logger;
+
+    public AcpSetupWizardViewModel(
+        AcpSetupWizardOrchestrator orchestrator,
+        IUiDispatcher uiDispatcher,
+        ILogger<AcpSetupWizardViewModel> logger,
+        IStringLocalizer<CoreStrings>? localizer = null)
+    {
+        _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
+        _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _localizer = localizer;
+
+        foreach (var agent in _orchestrator.Agents)
+        {
+            var row = new AcpSetupAgentRowViewModel(agent);
+            row.InstallRequested += InstallAgentRow;
+            Agents.Add(row);
+        }
+    }
+
+    /// <summary>Catalog agents, each carrying its own runtime probe.</summary>
+    public ObservableCollection<AcpSetupAgentRowViewModel> Agents { get; } = new();
+
+    /// <summary>Adapters offered for the selected agent, in catalog display order.</summary>
+    public ObservableCollection<AcpAdapterDescriptor> Adapters { get; } = new();
+
+    /// <summary>Editable launch parameters for the selected adapter.</summary>
+    public ObservableCollection<AcpSetupParameterRowViewModel> Parameters { get; } = new();
+
+    /// <summary>Live installer output, capped so a chatty installer cannot grow without bound.</summary>
+    public ObservableCollection<string> InstallOutput { get; } = new();
+
+    /// <summary>True when this platform can install components rather than only linking documentation.</summary>
+    public bool SupportsAutomaticInstall => _orchestrator.SupportsAutomaticInstall;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(GoBackCommand))]
+    [NotifyPropertyChangedFor(nameof(IsOnAgentSelection))]
+    [NotifyPropertyChangedFor(nameof(IsOnComponentSetup))]
+    [NotifyPropertyChangedFor(nameof(IsOnParameters))]
+    [NotifyPropertyChangedFor(nameof(IsOnTest))]
+    [NotifyPropertyChangedFor(nameof(IsOnSave))]
+    private AcpSetupWizardStep _step = AcpSetupWizardStep.AgentSelection;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallRuntimeCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DetectAgentsCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallRuntimeCommand))]
+    private AcpSetupAgentRowViewModel? _selectedAgent;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
+    private AcpAdapterDescriptor? _selectedAdapter;
+
+    /// <summary>Latest adapter probe for the selected adapter, or null before it has been probed.</summary>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterMissing))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterUsable))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterUndetermined))]
+    private AcpComponentProbeResult? _adapterProbe;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    private string _profileName = string.Empty;
+
+    /// <summary>Latest end-to-end test result, or null before the first test.</summary>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyPropertyChangedFor(nameof(HasTestResult))]
+    [NotifyPropertyChangedFor(nameof(IsTestSuccessful))]
+    [NotifyPropertyChangedFor(nameof(TestFailureStageText))]
+    [NotifyPropertyChangedFor(nameof(TestRemediationText))]
+    private AcpSetupTestResult? _testResult;
+
+    /// <summary>Single-line rendering of the command the wizard will save, for user review.</summary>
+    [ObservableProperty]
+    private string _launchCommandPreview = string.Empty;
+
+    /// <summary>Operation failure message, empty when the last operation succeeded.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasErrorMessage))]
+    private string _errorMessage = string.Empty;
+
+    /// <summary>The profile the wizard saved, or null until the save step completes.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSavedProfile))]
+    private ServerConfiguration? _savedProfile;
+
+    public bool HasErrorMessage => !string.IsNullOrEmpty(ErrorMessage);
+
+    /// <summary>Most recent installer output line, or empty before any install has run.</summary>
+    public string LatestInstallOutputLine => InstallOutput.Count > 0 ? InstallOutput[^1] : string.Empty;
+
+    /// <summary>True once an installer has produced at least one output line.</summary>
+    public bool HasInstallOutput => InstallOutput.Count > 0;
+
+    public bool IsOnAgentSelection => Step == AcpSetupWizardStep.AgentSelection;
+
+    public bool IsOnComponentSetup => Step == AcpSetupWizardStep.ComponentSetup;
+
+    public bool IsOnParameters => Step == AcpSetupWizardStep.Parameters;
+
+    public bool IsOnTest => Step == AcpSetupWizardStep.Test;
+
+    public bool IsOnSave => Step == AcpSetupWizardStep.Save;
+
+    public bool HasSavedProfile => SavedProfile is not null;
+
+    public bool IsAdapterUsable => AdapterProbe?.IsUsable == true;
+
+    public bool IsAdapterMissing => AdapterProbe?.Availability == AcpComponentAvailability.Missing;
+
+    public bool IsAdapterUndetermined
+        => AdapterProbe?.Availability == AcpComponentAvailability.Undetermined;
+
+    public bool HasTestResult => TestResult is not null;
+
+    public bool IsTestSuccessful => TestResult?.IsSuccess == true;
+
+    /// <summary>Localized name of the stage a failed test reached, empty on success.</summary>
+    public string TestFailureStageText
+        => TestResult is null || TestResult.IsSuccess
+            ? string.Empty
+            : Localize(StageKeys.Resolve(TestResult.Stage), TestResult.Stage.ToString());
+
+    /// <summary>Localized remediation advice for a failed test, empty when none applies.</summary>
+    public string TestRemediationText
+        => string.IsNullOrEmpty(TestResult?.RemediationKey)
+            ? string.Empty
+            : Localize(TestResult!.RemediationKey!, string.Empty);
+
+    // ── Detection ───────────────────────────────────────────────────────────
+
+    [RelayCommand(CanExecute = nameof(CanRunOperation))]
+    private async Task DetectAgentsAsync(CancellationToken cancellationToken)
+    {
+        await RunOperationAsync(
+            async token =>
+            {
+                MarkAgentsChecking();
+                var states = await _orchestrator.DetectAgentsAsync(token).ConfigureAwait(false);
+                await _uiDispatcher.EnqueueAsync(() => ApplyRuntimeProbes(states)).ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDetectAdapter))]
+    private async Task DetectAdapterAsync(CancellationToken cancellationToken)
+    {
+        var adapter = SelectedAdapter;
+        if (adapter is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(
+            async token =>
+            {
+                var probe = await _orchestrator
+                    .DetectComponentAsync(adapter.Component, token)
+                    .ConfigureAwait(false);
+                await _uiDispatcher.EnqueueAsync(() => AdapterProbe = probe).ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool CanDetectAdapter() => !IsBusy && SelectedAdapter is not null;
+
+    // ── Installation ────────────────────────────────────────────────────────
+
+    [RelayCommand(CanExecute = nameof(CanInstallRuntime))]
+    private async Task InstallRuntimeAsync(CancellationToken cancellationToken)
+    {
+        var row = SelectedAgent;
+        if (row is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(
+            async token =>
+            {
+                var (install, probe) = await _orchestrator
+                    .InstallComponentAsync(row.Agent.Runtime, AppendInstallOutput, token)
+                    .ConfigureAwait(false);
+                await _uiDispatcher
+                    .EnqueueAsync(() =>
+                    {
+                        row.Runtime = probe;
+                        ReportInstallFailure(install);
+                    })
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool CanInstallRuntime()
+        => !IsBusy
+            && SelectedAgent is not null
+            && SupportsAutomaticInstall
+            && SelectedAgent.SupportsAutomaticInstall;
+
+    /// <summary>Per-row install entry point; keeps busy/error handling in one place.</summary>
+    private void InstallAgentRow(AcpSetupAgentRowViewModel row)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        _ = RunOperationAsync(
+            async token =>
+            {
+                var (install, probe) = await _orchestrator
+                    .InstallComponentAsync(row.Agent.Runtime, AppendInstallOutput, token)
+                    .ConfigureAwait(false);
+                await _uiDispatcher
+                    .EnqueueAsync(() =>
+                    {
+                        row.Runtime = probe;
+                        ReportInstallFailure(install);
+                    })
+                    .ConfigureAwait(false);
+            },
+            CancellationToken.None);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanInstallAdapter))]
+    private async Task InstallAdapterAsync(CancellationToken cancellationToken)
+    {
+        var adapter = SelectedAdapter;
+        if (adapter is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(
+            async token =>
+            {
+                var (install, probe) = await _orchestrator
+                    .InstallComponentAsync(adapter.Component, AppendInstallOutput, token)
+                    .ConfigureAwait(false);
+                await _uiDispatcher
+                    .EnqueueAsync(() =>
+                    {
+                        AdapterProbe = probe;
+                        ReportInstallFailure(install);
+                    })
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool CanInstallAdapter()
+        => !IsBusy
+            && SelectedAdapter is not null
+            && SupportsAutomaticInstall
+            && SelectedAdapter.Component.SupportsAutomaticInstall;
+
+    // ── Test and save ───────────────────────────────────────────────────────
+
+    [RelayCommand(CanExecute = nameof(CanTest))]
+    private async Task TestAsync(CancellationToken cancellationToken)
+    {
+        var draft = BuildDraft();
+        if (draft is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(
+            async token =>
+            {
+                var result = await _orchestrator.TestDraftAsync(draft, token).ConfigureAwait(false);
+                await _uiDispatcher
+                    .EnqueueAsync(() =>
+                    {
+                        TestResult = result;
+                        ApplyValidationMessages(result);
+                    })
+                    .ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool CanTest() => !IsBusy && SelectedAdapter is not null;
+
+    [RelayCommand(CanExecute = nameof(CanSave))]
+    private async Task SaveAsync(CancellationToken cancellationToken)
+    {
+        // RelayCommand invocation does not consult CanExecute, so the rule is restated here: a
+        // profile that never passed the test must not reach the connection list looking verified.
+        if (!CanSave())
+        {
+            return;
+        }
+
+        var draft = BuildDraft();
+        if (draft is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(
+            async token =>
+            {
+                var saved = await _orchestrator.SaveDraftAsync(draft, token).ConfigureAwait(false);
+                await _uiDispatcher.EnqueueAsync(() => SavedProfile = saved).ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Saving requires a successful test. The issue's acceptance criteria put the test before the save,
+    /// and a profile saved without one would appear in the connection list as if it had been verified.
+    /// </summary>
+    private bool CanSave()
+        => !IsBusy
+            && IsTestSuccessful
+            && SelectedAdapter is not null
+            && !string.IsNullOrWhiteSpace(ProfileName);
+
+    // ── Step machine ────────────────────────────────────────────────────────
+
+    [RelayCommand(CanExecute = nameof(CanGoNext))]
+    private async Task GoNextAsync(CancellationToken cancellationToken)
+    {
+        switch (Step)
+        {
+            case AcpSetupWizardStep.AgentSelection:
+                PrepareComponentSetup();
+                Step = AcpSetupWizardStep.ComponentSetup;
+                await DetectAdapterAsync(cancellationToken).ConfigureAwait(false);
+                break;
+            case AcpSetupWizardStep.ComponentSetup:
+                PrepareParameters();
+                Step = AcpSetupWizardStep.Parameters;
+                break;
+            case AcpSetupWizardStep.Parameters:
+                if (!TryPrepareTest())
+                {
+                    return;
+                }
+
+                Step = AcpSetupWizardStep.Test;
+                break;
+            case AcpSetupWizardStep.Test:
+                PrepareSave();
+                Step = AcpSetupWizardStep.Save;
+                break;
+            case AcpSetupWizardStep.Save:
+            default:
+                break;
+        }
+    }
+
+    private bool CanGoNext() => !IsBusy && Step switch
+    {
+        AcpSetupWizardStep.AgentSelection => SelectedAgent is not null,
+        // Only a probe that positively found nothing blocks the walk; "undetermined" does not.
+        AcpSetupWizardStep.ComponentSetup =>
+            SelectedAdapter is not null
+                && SelectedAgent?.IsMissing != true
+                && !IsAdapterMissing,
+        AcpSetupWizardStep.Parameters => true,
+        AcpSetupWizardStep.Test => IsTestSuccessful,
+        _ => false
+    };
+
+    [RelayCommand(CanExecute = nameof(CanGoBack))]
+    private void GoBack()
+    {
+        if (Step == AcpSetupWizardStep.AgentSelection)
+        {
+            return;
+        }
+
+        Step = (AcpSetupWizardStep)((int)Step - 1);
+        ErrorMessage = string.Empty;
+    }
+
+    private bool CanGoBack() => Step != AcpSetupWizardStep.AgentSelection;
+
+    // ── Step preparation ────────────────────────────────────────────────────
+
+    private void PrepareComponentSetup()
+    {
+        var agent = SelectedAgent?.Agent;
+        Adapters.Clear();
+        InstallOutput.Clear();
+        AdapterProbe = null;
+        if (agent is null)
+        {
+            SelectedAdapter = null;
+            return;
+        }
+
+        foreach (var adapter in agent.Adapters)
+        {
+            Adapters.Add(adapter);
+        }
+
+        SelectedAdapter = agent.ResolveRecommendedAdapter();
+    }
+
+    private void PrepareParameters()
+    {
+        Parameters.Clear();
+        TestResult = null;
+        var template = SelectedAdapter?.LaunchTemplate;
+        if (template is null)
+        {
+            LaunchCommandPreview = string.Empty;
+            return;
+        }
+
+        foreach (var definition in template.Parameters)
+        {
+            Parameters.Add(new AcpSetupParameterRowViewModel(definition, RefreshLaunchCommandPreview));
+        }
+
+        RefreshLaunchCommandPreview();
+    }
+
+    /// <summary>
+    /// Validates before the test step so obviously incomplete input is corrected in the form the user is
+    /// already looking at, instead of coming back as a test failure.
+    /// </summary>
+    private bool TryPrepareTest()
+    {
+        var template = SelectedAdapter?.LaunchTemplate;
+        if (template is null)
+        {
+            return false;
+        }
+
+        var violations = AcpSetupParameterValidator.Validate(template, CollectParameterValues());
+        ApplyViolations(violations);
+        if (violations.Count > 0)
+        {
+            return false;
+        }
+
+        TestResult = null;
+        RefreshLaunchCommandPreview();
+        return true;
+    }
+
+    private void PrepareSave()
+    {
+        if (string.IsNullOrWhiteSpace(ProfileName) && SelectedAgent is not null)
+        {
+            ProfileName = SelectedAgent.DisplayName;
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private AcpSetupDraft? BuildDraft()
+    {
+        var agent = SelectedAgent?.Agent;
+        var adapter = SelectedAdapter;
+        if (agent is null || adapter is null)
+        {
+            return null;
+        }
+
+        return new AcpSetupDraft
+        {
+            Agent = agent,
+            Adapter = adapter,
+            ParameterValues = CollectParameterValues(),
+            ProfileName = string.IsNullOrWhiteSpace(ProfileName) ? agent.DisplayName : ProfileName.Trim()
+        };
+    }
+
+    private Dictionary<string, string> CollectParameterValues()
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var row in Parameters)
+        {
+            values[row.Key] = row.Value;
+        }
+
+        return values;
+    }
+
+    private void RefreshLaunchCommandPreview()
+    {
+        var template = SelectedAdapter?.LaunchTemplate;
+        if (template is null)
+        {
+            LaunchCommandPreview = string.Empty;
+            return;
+        }
+
+        try
+        {
+            LaunchCommandPreview = AcpLaunchPlanBuilder
+                .Build(template, CollectParameterValues())
+                .CommandLineDisplay;
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The builder refuses to place a secret into a persisted plan. Surface it rather than
+            // rendering a partial command that hides why the preview stopped updating.
+            LaunchCommandPreview = string.Empty;
+            _logger.LogWarning(ex, "ACP setup launch preview rejected the current parameter values.");
+        }
+    }
+
+    private void MarkAgentsChecking()
+    {
+        _uiDispatcher.Enqueue(() =>
+        {
+            foreach (var row in Agents)
+            {
+                row.Runtime = new AcpComponentProbeResult
+                {
+                    ComponentId = row.Agent.Runtime.Id,
+                    Availability = AcpComponentAvailability.Checking
+                };
+            }
+        });
+    }
+
+    private void ApplyRuntimeProbes(IReadOnlyList<AcpAgentDetectionState> states)
+    {
+        var byAgentId = new Dictionary<string, AcpComponentProbeResult>(StringComparer.Ordinal);
+        foreach (var state in states)
+        {
+            byAgentId[state.Agent.Id] = state.Runtime;
+        }
+
+        foreach (var row in Agents)
+        {
+            if (byAgentId.TryGetValue(row.AgentId, out var probe))
+            {
+                row.Runtime = probe;
+            }
+        }
+    }
+
+    private void ApplyViolations(IReadOnlyList<AcpSetupParameterViolation> violations)
+    {
+        foreach (var row in Parameters)
+        {
+            row.ValidationMessage = string.Empty;
+        }
+
+        foreach (var violation in violations)
+        {
+            foreach (var row in Parameters)
+            {
+                if (string.Equals(row.Key, violation.ParameterKey, StringComparison.Ordinal))
+                {
+                    row.ValidationMessage = Localize(violation.MessageKey, violation.MessageKey);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Mirrors a validation-stage test failure back onto the row it belongs to, so the user sees the
+    /// problem in the form rather than only in the test panel.
+    /// </summary>
+    private void ApplyValidationMessages(AcpSetupTestResult result)
+    {
+        if (result.IsSuccess || result.Stage != AcpSetupTestStage.Validation)
+        {
+            return;
+        }
+
+        var template = SelectedAdapter?.LaunchTemplate;
+        if (template is null)
+        {
+            return;
+        }
+
+        ApplyViolations(AcpSetupParameterValidator.Validate(template, CollectParameterValues()));
+    }
+
+    private void AppendInstallOutput(string line)
+    {
+        _uiDispatcher.Enqueue(() =>
+        {
+            InstallOutput.Add(line);
+            while (InstallOutput.Count > MaxInstallOutputLines)
+            {
+                InstallOutput.RemoveAt(0);
+            }
+        });
+    }
+
+    private void ReportInstallFailure(AcpComponentInstallResult install)
+    {
+        if (install.IsSuccess)
+        {
+            return;
+        }
+
+        ErrorMessage = install.ErrorDetail ?? Localize(InstallFailedKey, "Installation failed.");
+    }
+
+    private bool CanRunOperation() => !IsBusy;
+
+    /// <summary>
+    /// Runs one wizard operation with the shared busy flag and failure surface, so no command has to
+    /// re-implement that bookkeeping and none can leave the wizard stuck busy.
+    /// </summary>
+    private async Task RunOperationAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        ErrorMessage = string.Empty;
+        try
+        {
+            await operation(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is a user action, not a failure to report.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ACP setup wizard operation failed.");
+            await _uiDispatcher
+                .EnqueueAsync(() => ErrorMessage = ex.Message)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await _uiDispatcher.EnqueueAsync(() => IsBusy = false).ConfigureAwait(false);
+        }
+    }
+
+    private string Localize(string key, string fallback)
+    {
+        if (_localizer is null || string.IsNullOrEmpty(key))
+        {
+            return fallback;
+        }
+
+        var localized = _localizer[key];
+        return localized.ResourceNotFound || string.IsNullOrWhiteSpace(localized.Value)
+            ? fallback
+            : localized.Value;
+    }
+
+    private const string InstallFailedKey = "AcpSetup_Install_Failed";
+
+    /// <summary>Localization keys for the stage a failed test reached.</summary>
+    private static class StageKeys
+    {
+        public static string Resolve(AcpSetupTestStage stage) => stage switch
+        {
+            AcpSetupTestStage.Validation => "AcpSetup_Stage_Validation",
+            AcpSetupTestStage.CommandResolution => "AcpSetup_Stage_CommandResolution",
+            AcpSetupTestStage.AdapterStartup => "AcpSetup_Stage_AdapterStartup",
+            AcpSetupTestStage.Handshake => "AcpSetup_Stage_Handshake",
+            _ => "AcpSetup_Stage_Completed"
+        };
+    }
+}

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpLaunchPlanBuilderTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpLaunchPlanBuilderTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Application.Tests.Services.AcpSetup;
+
+public class AcpLaunchPlanBuilderTests
+{
+    [Fact]
+    public void Build_WithArgumentParameter_AppendsFlagAndValueAfterFixedArguments()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            fixedArguments: new[] { "-y", "@scope/adapter" },
+            parameters: new[] { CreateParameter("--model", AcpSetupParameterTarget.Argument) });
+
+        // Act
+        var plan = AcpLaunchPlanBuilder.Build(
+            template,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["--model"] = "fast" });
+
+        // Assert
+        Assert.Equal(new[] { "-y", "@scope/adapter", "--model", "fast" }, plan.Arguments);
+    }
+
+    [Fact]
+    public void Build_WithEnvironmentParameter_PlacesValueInEnvironmentNotArguments()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            parameters: new[] { CreateParameter("AGENT_MODEL", AcpSetupParameterTarget.EnvironmentVariable) });
+
+        // Act
+        var plan = AcpLaunchPlanBuilder.Build(
+            template,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["AGENT_MODEL"] = "pro" });
+
+        // Assert
+        Assert.Empty(plan.Arguments);
+        Assert.Equal("pro", plan.Environment["AGENT_MODEL"]);
+    }
+
+    [Fact]
+    public void Build_WithBlankValue_OmitsParameterEntirely()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            parameters: new[]
+            {
+                CreateParameter("--model", AcpSetupParameterTarget.Argument),
+                CreateParameter("AGENT_MODEL", AcpSetupParameterTarget.EnvironmentVariable)
+            });
+
+        // Act
+        var plan = AcpLaunchPlanBuilder.Build(
+            template,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["--model"] = "   ",
+                ["AGENT_MODEL"] = string.Empty
+            });
+
+        // Assert
+        Assert.Empty(plan.Arguments);
+        Assert.Empty(plan.Environment);
+    }
+
+    [Fact]
+    public void Build_WithSecretParameter_ThrowsSoCredentialIsNeverPersisted()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            parameters: new[]
+            {
+                new AcpSetupParameterDefinition
+                {
+                    Key = "AGENT_TOKEN",
+                    DisplayName = "AGENT_TOKEN",
+                    Target = AcpSetupParameterTarget.EnvironmentVariable,
+                    IsSecret = true
+                }
+            });
+        var values = new Dictionary<string, string>(StringComparer.Ordinal) { ["AGENT_TOKEN"] = "sk-live" };
+
+        // Act
+        var exception = Record.Exception(() => AcpLaunchPlanBuilder.Build(template, values));
+
+        // Assert
+        var invalidOperation = Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("AGENT_TOKEN", invalidOperation.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_WithParameterMatchingFixedEnvironmentName_LetsUserValueWin()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            fixedEnvironment: new Dictionary<string, string>(StringComparer.Ordinal) { ["AGENT_MODEL"] = "default" },
+            parameters: new[] { CreateParameter("AGENT_MODEL", AcpSetupParameterTarget.EnvironmentVariable) });
+
+        // Act
+        var plan = AcpLaunchPlanBuilder.Build(
+            template,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["AGENT_MODEL"] = "chosen" });
+
+        // Assert
+        Assert.Equal("chosen", plan.Environment["AGENT_MODEL"]);
+    }
+
+    [Fact]
+    public void CreatePrefilledValues_SeedsEveryParameterWithItsDefault()
+    {
+        // Arrange
+        var template = CreateTemplate(
+            parameters: new[]
+            {
+                new AcpSetupParameterDefinition
+                {
+                    Key = "--model",
+                    DisplayName = "--model",
+                    DefaultValue = "fast"
+                },
+                CreateParameter("AGENT_MODEL", AcpSetupParameterTarget.EnvironmentVariable)
+            });
+
+        // Act
+        var values = AcpLaunchPlanBuilder.CreatePrefilledValues(template);
+
+        // Assert
+        Assert.Equal("fast", values["--model"]);
+        Assert.Equal(string.Empty, values["AGENT_MODEL"]);
+    }
+
+    [Fact]
+    public void CommandLineDisplay_WithoutArguments_RendersCommandAlone()
+    {
+        // Arrange
+        var template = CreateTemplate();
+
+        // Act
+        var plan = AcpLaunchPlanBuilder.Build(template, parameterValues: null);
+
+        // Assert
+        Assert.Equal("npx", plan.CommandLineDisplay);
+    }
+
+    private static AcpLaunchTemplate CreateTemplate(
+        IReadOnlyList<string>? fixedArguments = null,
+        IReadOnlyDictionary<string, string>? fixedEnvironment = null,
+        IReadOnlyList<AcpSetupParameterDefinition>? parameters = null)
+        => new()
+        {
+            Command = "npx",
+            FixedArguments = fixedArguments ?? Array.Empty<string>(),
+            FixedEnvironment = fixedEnvironment ?? new Dictionary<string, string>(StringComparer.Ordinal),
+            Parameters = parameters ?? Array.Empty<AcpSetupParameterDefinition>()
+        };
+
+    private static AcpSetupParameterDefinition CreateParameter(string key, AcpSetupParameterTarget target)
+        => new()
+        {
+            Key = key,
+            DisplayName = key,
+            Target = target
+        };
+}

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpSetupParameterValidatorTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpSetupParameterValidatorTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Application.Tests.Services.AcpSetup;
+
+public class AcpSetupParameterValidatorTests
+{
+    [Fact]
+    public void Validate_WhenRequiredValueMissing_ReportsViolationForThatParameter()
+    {
+        // Arrange
+        var template = CreateTemplate(new AcpSetupParameterDefinition
+        {
+            Key = "--project",
+            DisplayName = "--project",
+            IsRequired = true
+        });
+
+        // Act
+        var violations = AcpSetupParameterValidator.Validate(template, parameterValues: null);
+
+        // Assert
+        var violation = Assert.Single(violations);
+        Assert.Equal("--project", violation.ParameterKey);
+        Assert.Equal(AcpSetupParameterValidator.MissingRequiredValueKey, violation.MessageKey);
+    }
+
+    [Fact]
+    public void Validate_WhenRequiredValueIsWhitespace_TreatsItAsMissing()
+    {
+        // Arrange
+        var template = CreateTemplate(new AcpSetupParameterDefinition
+        {
+            Key = "--project",
+            DisplayName = "--project",
+            IsRequired = true
+        });
+        var values = new Dictionary<string, string>(StringComparer.Ordinal) { ["--project"] = "  " };
+
+        // Act
+        var violations = AcpSetupParameterValidator.Validate(template, values);
+
+        // Assert
+        Assert.Equal(AcpSetupParameterValidator.MissingRequiredValueKey, Assert.Single(violations).MessageKey);
+    }
+
+    [Fact]
+    public void Validate_WhenOptionalValueMissing_ReportsNothing()
+    {
+        // Arrange
+        var template = CreateTemplate(new AcpSetupParameterDefinition
+        {
+            Key = "--model",
+            DisplayName = "--model"
+        });
+
+        // Act
+        var violations = AcpSetupParameterValidator.Validate(template, parameterValues: null);
+
+        // Assert
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void Validate_WhenValueOutsideAllowedSet_ReportsViolation()
+    {
+        // Arrange
+        var template = CreateTemplate(new AcpSetupParameterDefinition
+        {
+            Key = "--mode",
+            DisplayName = "--mode",
+            AllowedValues = new[] { "fast", "thorough" }
+        });
+        var values = new Dictionary<string, string>(StringComparer.Ordinal) { ["--mode"] = "turbo" };
+
+        // Act
+        var violations = AcpSetupParameterValidator.Validate(template, values);
+
+        // Assert
+        Assert.Equal(AcpSetupParameterValidator.ValueNotAllowedKey, Assert.Single(violations).MessageKey);
+    }
+
+    [Fact]
+    public void Validate_WhenValueInsideAllowedSet_ReportsNothing()
+    {
+        // Arrange
+        var template = CreateTemplate(new AcpSetupParameterDefinition
+        {
+            Key = "--mode",
+            DisplayName = "--mode",
+            AllowedValues = new[] { "fast", "thorough" }
+        });
+        var values = new Dictionary<string, string>(StringComparer.Ordinal) { ["--mode"] = "thorough" };
+
+        // Act
+        var violations = AcpSetupParameterValidator.Validate(template, values);
+
+        // Assert
+        Assert.Empty(violations);
+    }
+
+    private static AcpLaunchTemplate CreateTemplate(params AcpSetupParameterDefinition[] parameters)
+        => new()
+        {
+            Command = "npx",
+            Parameters = parameters
+        };
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Probe stub that answers from pre-set values, so installer behaviour can be tested without touching
+/// PATH or launching package managers.
+/// </summary>
+internal sealed class StubAcpExecutableProbe : IAcpExecutableProbe
+{
+    private readonly Dictionary<string, string?> _resolvedPaths = new(StringComparer.Ordinal);
+
+    public bool SupportsProcessProbing { get; init; } = true;
+
+    public List<string> ResolveRequests { get; } = new();
+
+    public void SetResolvedPath(string command, string? path) => _resolvedPaths[command] = path;
+
+    public Task<string?> ResolveExecutablePathAsync(
+        string command,
+        CancellationToken cancellationToken = default)
+    {
+        ResolveRequests.Add(command);
+        return Task.FromResult(_resolvedPaths.TryGetValue(command, out var path) ? path : null);
+    }
+
+    public Task<string?> ReadVersionAsync(
+        string command,
+        IReadOnlyList<string> versionArguments,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>(null);
+
+    public Task<bool?> IsGlobalNodePackageInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(null);
+
+    public Task<bool?> IsGlobalUvToolInstalledAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(null);
+}
+
+/// <summary>
+/// Handshake stub recording whether the tester delegated, so the tester's own guards can be
+/// distinguished from the handshake's staged failures.
+/// </summary>
+internal sealed class StubAcpSetupHandshakeProbe : IAcpSetupHandshakeProbe
+{
+    private readonly AcpSetupTestResult _result;
+
+    public StubAcpSetupHandshakeProbe(AcpSetupTestResult result)
+    {
+        _result = result;
+    }
+
+    public int ProbeCount { get; private set; }
+
+    public AcpLaunchPlan? LastPlan { get; private set; }
+
+    public Task<AcpSetupTestResult> ProbeAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default)
+    {
+        ProbeCount++;
+        LastPlan = launchPlan;
+        return Task.FromResult(_result);
+    }
+}
+
+/// <summary>Shared builders for the descriptors and plans these tests exercise.</summary>
+internal static class AcpSetupFixtures
+{
+    public static AcpComponentDescriptor NpxComponent(string packageId = "@scope/adapter")
+        => new()
+        {
+            Id = "adapter.npx",
+            DisplayName = "Npx Adapter",
+            Distribution = AcpDistributionKind.Npx,
+            DetectionMode = AcpComponentDetectionMode.GlobalNodePackage,
+            ProbeCommand = "npx",
+            PackageId = packageId
+        };
+
+    public static AcpComponentDescriptor UvxComponent(string packageId = "adapter-tool")
+        => new()
+        {
+            Id = "adapter.uvx",
+            DisplayName = "Uvx Adapter",
+            Distribution = AcpDistributionKind.Uvx,
+            DetectionMode = AcpComponentDetectionMode.GlobalUvTool,
+            ProbeCommand = "uvx",
+            PackageId = packageId
+        };
+
+    public static AcpComponentDescriptor BinaryComponent()
+        => new()
+        {
+            Id = "adapter.binary",
+            DisplayName = "Binary Adapter",
+            Distribution = AcpDistributionKind.Binary,
+            DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+            ProbeCommand = "binary-adapter"
+        };
+
+    public static AcpLaunchPlan Plan(string command = "npx", params string[] arguments)
+        => new() { Command = command, Arguments = arguments };
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the installer's decisions before any package manager runs: which distributions it will
+/// install at all, which launcher each one maps to, and that an unavailable launcher is reported as a
+/// failure instead of a silent no-op.
+/// </summary>
+public sealed class DesktopAcpComponentInstallerTests
+{
+    [Fact]
+    public void Constructor_WithNullProbe_ShouldThrow()
+        => Assert.Throws<ArgumentNullException>(() => new DesktopAcpComponentInstaller(null!));
+
+    [Fact]
+    public async Task InstallAsync_WithNullComponent_ShouldThrow()
+    {
+        var installer = new DesktopAcpComponentInstaller(new StubAcpExecutableProbe());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => installer.InstallAsync(null!));
+    }
+
+    [Fact]
+    public async Task InstallAsync_ForBinaryDistribution_ShouldFailWithoutRunningAnything()
+    {
+        var probe = new StubAcpExecutableProbe();
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.BinaryComponent());
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.ExitCode);
+        Assert.Contains("manually", result.ErrorDetail);
+        Assert.Empty(probe.ResolveRequests);
+    }
+
+    [Fact]
+    public async Task InstallAsync_WhenLauncherMissingFromPath_ShouldFailWithLauncherName()
+    {
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath("npm", null);
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent());
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.ExitCode);
+        Assert.Contains("npm", result.ErrorDetail);
+        Assert.Contains("PATH", result.ErrorDetail);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ForNpxDistribution_ShouldResolveNpmLauncher()
+    {
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath("npm", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent());
+
+        Assert.Equal(new[] { "npm" }, probe.ResolveRequests);
+        // The resolved path does not exist, so the attempt fails at start rather than reporting success.
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.ErrorDetail);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ForUvxDistribution_ShouldResolveUvLauncher()
+    {
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath("uv", null);
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.UvxComponent());
+
+        Assert.Equal(new[] { "uv" }, probe.ResolveRequests);
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ForComponentWithoutPackageId_ShouldFailAsManual()
+    {
+        var component = new AcpComponentDescriptor
+        {
+            Id = "adapter.no-package",
+            DisplayName = "No Package",
+            Distribution = AcpDistributionKind.Npx,
+            PackageId = string.Empty
+        };
+        var probe = new StubAcpExecutableProbe();
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(component);
+
+        Assert.False(result.IsSuccess);
+        Assert.Empty(probe.ResolveRequests);
+    }
+
+    [Fact]
+    public void SupportsAutomaticInstall_OnDesktop_ShouldBeTrue()
+        => Assert.True(new DesktopAcpComponentInstaller(new StubAcpExecutableProbe()).SupportsAutomaticInstall);
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the probe's two load-bearing behaviours: resolving a command the way a shell would, and
+/// answering "unknown" rather than "absent" when it could not actually look.
+/// </summary>
+public sealed class DesktopAcpExecutableProbeTests
+{
+    [Fact]
+    public void SupportsProcessProbing_OnDesktop_ShouldBeTrue()
+        => Assert.True(new DesktopAcpExecutableProbe().SupportsProcessProbing);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ResolveExecutablePathAsync_WithBlankCommand_ShouldReturnNull(string command)
+    {
+        var resolved = await new DesktopAcpExecutableProbe().ResolveExecutablePathAsync(command);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task ResolveExecutablePathAsync_WithExistingExplicitPath_ShouldReturnFullPath()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"acp-probe-{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(file, "#!/bin/sh\n");
+        try
+        {
+            var resolved = await new DesktopAcpExecutableProbe().ResolveExecutablePathAsync(file);
+
+            Assert.Equal(Path.GetFullPath(file), resolved);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveExecutablePathAsync_WithMissingExplicitPath_ShouldReturnNull()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"acp-absent-{Guid.NewGuid():N}");
+
+        var resolved = await new DesktopAcpExecutableProbe().ResolveExecutablePathAsync(missing);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task ResolveExecutablePathAsync_WithNameNotOnPath_ShouldReturnNull()
+    {
+        var resolved = await new DesktopAcpExecutableProbe()
+            .ResolveExecutablePathAsync($"acp-nonexistent-{Guid.NewGuid():N}");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task ResolveExecutablePathAsync_WhenCancelled_ShouldThrow()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => new DesktopAcpExecutableProbe().ResolveExecutablePathAsync("npm", cts.Token));
+    }
+
+    [Fact]
+    public async Task ReadVersionAsync_WithUnresolvableCommand_ShouldReturnNull()
+    {
+        var version = await new DesktopAcpExecutableProbe()
+            .ReadVersionAsync($"acp-nonexistent-{Guid.NewGuid():N}", new[] { "--version" });
+
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public async Task ReadVersionAsync_WithNullArguments_ShouldReturnNull()
+    {
+        var version = await new DesktopAcpExecutableProbe().ReadVersionAsync("npm", null!);
+
+        Assert.Null(version);
+    }
+
+    /// <summary>
+    /// A blank package coordinate is unanswerable, not absent: reporting false here would make the
+    /// wizard advertise an install for a component it never asked about.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task IsGlobalNodePackageInstalledAsync_WithBlankPackageId_ShouldReturnNull(string packageId)
+    {
+        var installed = await new DesktopAcpExecutableProbe().IsGlobalNodePackageInstalledAsync(packageId);
+
+        Assert.Null(installed);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task IsGlobalUvToolInstalledAsync_WithBlankPackageId_ShouldReturnNull(string packageId)
+    {
+        var installed = await new DesktopAcpExecutableProbe().IsGlobalUvToolInstalledAsync(packageId);
+
+        Assert.Null(installed);
+    }
+
+    [Theory]
+    [InlineData("@agentclientprotocol/codex-acp@1.6.2", "@agentclientprotocol/codex-acp")]
+    [InlineData("@scope/pkg", "@scope/pkg")]
+    [InlineData("plain-package@1.2.3", "plain-package")]
+    [InlineData("plain-package", "plain-package")]
+    [InlineData("  spaced@0.1.0  ", "spaced")]
+    public void StripVersionSuffix_ShouldDropVersionAndKeepScope(string packageId, string expected)
+        => Assert.Equal(expected, DesktopAcpExecutableProbe.StripVersionSuffix(packageId));
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpSetupConnectivityTesterTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpSetupConnectivityTesterTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the tester's own responsibility: reject a plan that cannot possibly start before spending a
+/// process on it, and otherwise hand the plan to the handshake unchanged.
+/// </summary>
+public sealed class DesktopAcpSetupConnectivityTesterTests
+{
+    [Fact]
+    public void Constructor_WithNullProbe_ShouldThrow()
+        => Assert.Throws<ArgumentNullException>(() => new DesktopAcpSetupConnectivityTester(null!));
+
+    [Fact]
+    public async Task TestAsync_WithNullPlan_ShouldThrow()
+    {
+        var tester = new DesktopAcpSetupConnectivityTester(
+            new StubAcpSetupHandshakeProbe(AcpSetupTestResult.Success(1, "agent")));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => tester.TestAsync(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task TestAsync_WithBlankCommand_ShouldFailAtValidationWithoutProbing(string command)
+    {
+        var handshake = new StubAcpSetupHandshakeProbe(AcpSetupTestResult.Success(1, "agent"));
+        var tester = new DesktopAcpSetupConnectivityTester(handshake);
+
+        var result = await tester.TestAsync(AcpSetupFixtures.Plan(command));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AcpSetupTestStage.Validation, result.Stage);
+        Assert.Equal(0, handshake.ProbeCount);
+    }
+
+    [Fact]
+    public async Task TestAsync_WithRunnablePlan_ShouldForwardPlanToHandshake()
+    {
+        var handshake = new StubAcpSetupHandshakeProbe(AcpSetupTestResult.Success(1, "Test Agent"));
+        var tester = new DesktopAcpSetupConnectivityTester(handshake);
+        var plan = AcpSetupFixtures.Plan("npx", "@scope/adapter", "--acp");
+
+        var result = await tester.TestAsync(plan);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(AcpSetupTestStage.Completed, result.Stage);
+        Assert.Equal("Test Agent", result.AgentName);
+        Assert.Equal(1, handshake.ProbeCount);
+        Assert.Same(plan, handshake.LastPlan);
+    }
+
+    [Fact]
+    public async Task TestAsync_WhenHandshakeFails_ShouldSurfaceItsStage()
+    {
+        var handshake = new StubAcpSetupHandshakeProbe(
+            AcpSetupTestResult.Failure(AcpSetupTestStage.AdapterStartup, "boom", "hint"));
+        var tester = new DesktopAcpSetupConnectivityTester(handshake);
+
+        var result = await tester.TestAsync(AcpSetupFixtures.Plan());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AcpSetupTestStage.AdapterStartup, result.Stage);
+        Assert.Equal("boom", result.ErrorDetail);
+        Assert.Equal("hint", result.RemediationKey);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/UnsupportedAcpSetupTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/UnsupportedAcpSetupTests.cs
@@ -1,0 +1,64 @@
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the degradation contract for platforms with no child-process host: every seam must report
+/// "cannot answer" or "cannot do", and never a value the wizard would mistake for a real finding.
+/// </summary>
+public sealed class UnsupportedAcpSetupTests
+{
+    [Fact]
+    public void Probe_ShouldReportProcessProbingUnsupported()
+        => Assert.False(new UnsupportedAcpExecutableProbe().SupportsProcessProbing);
+
+    /// <summary>
+    /// Null, not false: a false here would make the wizard tell the user to install a component it
+    /// never looked for.
+    /// </summary>
+    [Fact]
+    public async Task Probe_ShouldAnswerEveryQueryAsUnknown()
+    {
+        var probe = new UnsupportedAcpExecutableProbe();
+
+        Assert.Null(await probe.ResolveExecutablePathAsync("npx"));
+        Assert.Null(await probe.ReadVersionAsync("npx", new[] { "--version" }));
+        Assert.Null(await probe.IsGlobalNodePackageInstalledAsync("@scope/pkg"));
+        Assert.Null(await probe.IsGlobalUvToolInstalledAsync("tool"));
+    }
+
+    [Fact]
+    public void Installer_ShouldReportAutomaticInstallUnsupported()
+        => Assert.False(new UnsupportedAcpComponentInstaller().SupportsAutomaticInstall);
+
+    [Fact]
+    public async Task Installer_WhenCalledAnyway_ShouldFailInsteadOfReportingSuccess()
+    {
+        var component = AcpSetupFixtures.NpxComponent();
+
+        var result = await new UnsupportedAcpComponentInstaller().InstallAsync(component);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(component.Id, result.ComponentId);
+        Assert.Null(result.ExitCode);
+        Assert.Contains("not supported", result.ErrorDetail);
+    }
+
+    /// <summary>
+    /// Fails at command resolution rather than validation: the plan itself is well-formed, it is this
+    /// platform that cannot run it, and a green test would let the wizard save an unusable profile.
+    /// </summary>
+    [Fact]
+    public async Task ConnectivityTester_ShouldFailAtCommandResolution()
+    {
+        var result = await new UnsupportedAcpSetupConnectivityTester()
+            .TestAsync(AcpSetupFixtures.Plan("npx", "@scope/adapter"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AcpSetupTestStage.CommandResolution, result.Stage);
+        Assert.Contains("not supported", result.ErrorDetail);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
@@ -185,6 +185,91 @@ public sealed class ConfigurationManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveConfigurationAsync_WithStdioEnvironment_PersistsBlockStyleAndLoadsBack()
+    {
+        var config = new ServerConfiguration
+        {
+            Id = "stdio-env-001",
+            Name = "Env Overlay",
+            Transport = TransportType.Stdio,
+            StdioCommand = "npx",
+            StdioArguments = ["@scope/adapter", "--acp"],
+            StdioEnvironment = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["AGENT_DISABLE_AUTO_UPDATE"] = "1"
+            },
+            ConnectionTimeout = 10
+        };
+
+        await _configManager.SaveConfigurationAsync(config);
+
+        var yaml = await File.ReadAllTextAsync(GetServerYamlPath(config.Id), TestContext.Current.CancellationToken);
+        // Block style, one entry per indented line: the persistence spec requires the file stay
+        // readable and mergeable, which a flow-style map would break.
+        Assert.Contains(
+            "stdio_environment:" + Environment.NewLine + "  AGENT_DISABLE_AUTO_UPDATE: 1",
+            yaml.ReplaceLineEndings(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("{", yaml, StringComparison.Ordinal);
+
+        var loaded = await _configManager.LoadConfigurationAsync(config.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal("1", Assert.Contains("AGENT_DISABLE_AUTO_UPDATE", loaded!.StdioEnvironment));
+    }
+
+    [Fact]
+    public async Task SaveConfigurationAsync_WithoutStdioEnvironment_OmitsTheKeyEntirely()
+    {
+        var config = new ServerConfiguration
+        {
+            Id = "stdio-env-absent-001",
+            Name = "No Env",
+            Transport = TransportType.Stdio,
+            StdioCommand = "agent",
+            ConnectionTimeout = 10
+        };
+
+        await _configManager.SaveConfigurationAsync(config);
+
+        var yaml = await File.ReadAllTextAsync(GetServerYamlPath(config.Id), TestContext.Current.CancellationToken);
+        Assert.DoesNotContain("stdio_environment", yaml, StringComparison.Ordinal);
+
+        var loaded = await _configManager.LoadConfigurationAsync(config.Id);
+        Assert.NotNull(loaded);
+        Assert.Empty(loaded!.StdioEnvironment);
+    }
+
+    [Fact]
+    public async Task LoadConfigurationAsync_WithSchemaVersion2File_HydratesEmptyEnvironmentWithoutMigration()
+    {
+        var configId = "schema-v2-no-env-001";
+        var path = GetServerYamlPath(configId);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(
+            path,
+            """
+            schema_version: 2
+            id: schema-v2-no-env-001
+            name: Legacy Stdio
+            transport: stdio
+            stdio_command: agent
+            stdio_arguments:
+            - --acp
+            connection_timeout_seconds: 10
+            authentication:
+              mode: none
+            proxy:
+              mode: system
+            """, TestContext.Current.CancellationToken);
+
+        var loaded = await _configManager.LoadConfigurationAsync(configId);
+
+        Assert.NotNull(loaded);
+        Assert.Equal("agent", loaded!.StdioCommand);
+        Assert.Empty(loaded.StdioEnvironment);
+    }
+
+    [Fact]
     public async Task TransportPersistence_WritesAndReadsCanonicalStreamableHttp()
     {
         var config = CreateTestConfiguration("streamable-http-001");

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Domain.Services.AcpSetup;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+/// <summary>
+/// Catalog stub serving descriptors the test declares, so wizard behaviour is exercised against
+/// deliberately shaped agents rather than the shipping catalog's real contents.
+/// </summary>
+internal sealed class StubAgentCatalog : IAcpAgentCatalog
+{
+    public StubAgentCatalog(params AcpAgentDescriptor[] agents)
+    {
+        Agents = agents;
+    }
+
+    public IReadOnlyList<AcpAgentDescriptor> Agents { get; }
+
+    public AcpAgentDescriptor? FindAgent(string? agentId)
+    {
+        foreach (var agent in Agents)
+        {
+            if (string.Equals(agent.Id, agentId, StringComparison.Ordinal))
+            {
+                return agent;
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Probe stub answering from per-command values, including the tri-state package answers, so the
+/// wizard's handling of "unknown" can be tested apart from "absent".
+/// </summary>
+internal sealed class StubExecutableProbe : IAcpExecutableProbe
+{
+    private readonly Dictionary<string, string?> _paths = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string?> _versions = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool?> _nodePackages = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool?> _uvTools = new(StringComparer.Ordinal);
+
+    public bool SupportsProcessProbing { get; set; } = true;
+
+    public void SetExecutable(string command, string? path, string? version = null)
+    {
+        _paths[command] = path;
+        _versions[command] = version;
+    }
+
+    public void SetNodePackage(string packageId, bool? installed) => _nodePackages[packageId] = installed;
+
+    public void SetUvTool(string packageId, bool? installed) => _uvTools[packageId] = installed;
+
+    public Task<string?> ResolveExecutablePathAsync(string command, CancellationToken cancellationToken = default)
+        => Task.FromResult(_paths.TryGetValue(command, out var path) ? path : null);
+
+    public Task<string?> ReadVersionAsync(
+        string command,
+        IReadOnlyList<string> versionArguments,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(_versions.TryGetValue(command, out var version) ? version : null);
+
+    public Task<bool?> IsGlobalNodePackageInstalledAsync(string packageId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_nodePackages.TryGetValue(packageId, out var installed) ? installed : null);
+
+    public Task<bool?> IsGlobalUvToolInstalledAsync(string packageId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_uvTools.TryGetValue(packageId, out var installed) ? installed : null);
+}
+
+/// <summary>
+/// Installer stub that records attempts and can emit output lines, so the wizard's progress plumbing
+/// and its post-install re-probe can both be observed.
+/// </summary>
+internal sealed class StubComponentInstaller : IAcpComponentInstaller
+{
+    private readonly Func<AcpComponentDescriptor, AcpComponentInstallResult> _resultFactory;
+
+    public StubComponentInstaller(
+        Func<AcpComponentDescriptor, AcpComponentInstallResult>? resultFactory = null,
+        bool supportsAutomaticInstall = true)
+    {
+        _resultFactory = resultFactory
+            ?? (component => AcpComponentInstallResult.Success(component.Id, output: null));
+        SupportsAutomaticInstall = supportsAutomaticInstall;
+    }
+
+    public bool SupportsAutomaticInstall { get; }
+
+    /// <summary>
+    /// Invoked before the canned result is produced, so a test can flip the probe's answer and the
+    /// orchestrator's post-install re-probe sees the component as installed.
+    /// </summary>
+    public Action<AcpComponentDescriptor>? OnInstall { get; set; }
+
+    public List<string> InstalledComponentIds { get; } = new();
+
+    public List<string> OutputLines { get; } = new();
+
+    public Task<AcpComponentInstallResult> InstallAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        InstalledComponentIds.Add(component.Id);
+        foreach (var line in OutputLines)
+        {
+            onOutput?.Invoke(line);
+        }
+
+        OnInstall?.Invoke(component);
+        return Task.FromResult(_resultFactory(component));
+    }
+}
+
+/// <summary>Connectivity stub returning a canned result and recording the plan it was handed.</summary>
+internal sealed class StubConnectivityTester : IAcpSetupConnectivityTester
+{
+    private Func<AcpLaunchPlan, AcpSetupTestResult> _resultFactory;
+
+    public StubConnectivityTester(AcpSetupTestResult result)
+        : this(_ => result)
+    {
+    }
+
+    public StubConnectivityTester(Func<AcpLaunchPlan, AcpSetupTestResult> resultFactory)
+    {
+        _resultFactory = resultFactory;
+    }
+
+    /// <summary>Replaces the canned outcome so a test can model re-testing after a fix.</summary>
+    public void SetResult(AcpSetupTestResult result) => _resultFactory = _ => result;
+
+    /// <summary>The shared healthy-handshake answer most tests walk against.</summary>
+    public static AcpSetupTestResult SuccessfulHandshake()
+        => AcpSetupTestResult.Success(protocolVersion: 1, agentName: "test-agent");
+
+    public int TestCount { get; private set; }
+
+    public AcpLaunchPlan? LastPlan { get; private set; }
+
+    public Task<AcpSetupTestResult> TestAsync(
+        AcpLaunchPlan launchPlan,
+        CancellationToken cancellationToken = default)
+    {
+        TestCount++;
+        LastPlan = launchPlan;
+        return Task.FromResult(_resultFactory(launchPlan));
+    }
+}
+
+/// <summary>Configuration stub capturing saves so the persisted shape can be asserted.</summary>
+internal sealed class RecordingConfigurationService : IConfigurationService
+{
+    public List<ServerConfiguration> Saved { get; } = new();
+
+    public Exception? SaveException { get; set; }
+
+    public Task SaveConfigurationAsync(ServerConfiguration config)
+    {
+        if (SaveException is not null)
+        {
+            return Task.FromException(SaveException);
+        }
+
+        Saved.Add(config);
+        return Task.CompletedTask;
+    }
+
+    public Task<ServerConfiguration?> LoadConfigurationAsync(string id)
+        => Task.FromResult<ServerConfiguration?>(null);
+
+    public Task<IEnumerable<ServerConfiguration>> ListConfigurationsAsync()
+        => Task.FromResult<IEnumerable<ServerConfiguration>>(Saved);
+
+    public Task DeleteConfigurationAsync(string id, string? expectedRevision = null)
+        => Task.CompletedTask;
+}
+
+/// <summary>Shared descriptor builders and a wizard factory for these tests.</summary>
+internal static class AcpSetupWizardFixtures
+{
+    public const string RuntimeCommand = "test-agent";
+    public const string AdapterPackage = "@scope/test-adapter";
+
+    public static AcpComponentDescriptor Runtime(string id = "runtime.test")
+        => new()
+        {
+            Id = id,
+            DisplayName = "Test Agent CLI",
+            Distribution = AcpDistributionKind.Npx,
+            DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+            ProbeCommand = RuntimeCommand,
+            ProbeVersionArguments = new[] { "--version" },
+            PackageId = "@scope/test-agent"
+        };
+
+    public static AcpAdapterDescriptor BuiltInAdapter(
+        string id = "adapter.builtin",
+        params AcpSetupParameterDefinition[] parameters)
+        => new()
+        {
+            Component = new AcpComponentDescriptor
+            {
+                Id = id,
+                DisplayName = "Built-in ACP",
+                Distribution = AcpDistributionKind.BuiltIn,
+                DetectionMode = AcpComponentDetectionMode.None
+            },
+            LaunchTemplate = new AcpLaunchTemplate
+            {
+                Command = RuntimeCommand,
+                FixedArguments = new[] { "--acp" },
+                Parameters = parameters
+            }
+        };
+
+    public static AcpAdapterDescriptor PackagedAdapter(
+        string id = "adapter.packaged",
+        params AcpSetupParameterDefinition[] parameters)
+        => new()
+        {
+            Component = new AcpComponentDescriptor
+            {
+                Id = id,
+                DisplayName = "Packaged ACP Adapter",
+                Distribution = AcpDistributionKind.Npx,
+                DetectionMode = AcpComponentDetectionMode.GlobalNodePackage,
+                ProbeCommand = "npx",
+                PackageId = AdapterPackage
+            },
+            LaunchTemplate = new AcpLaunchTemplate
+            {
+                Command = "npx",
+                FixedArguments = new[] { AdapterPackage },
+                Parameters = parameters
+            }
+        };
+
+    public static AcpAgentDescriptor Agent(
+        string id = "agent.test",
+        AcpComponentDescriptor? runtime = null,
+        params AcpAdapterDescriptor[] adapters)
+        => new()
+        {
+            Id = id,
+            DisplayName = "Test Agent",
+            Description = "AcpSetup_Agent_Test_Description",
+            Runtime = runtime ?? Runtime(),
+            Adapters = adapters.Length > 0 ? adapters : new[] { BuiltInAdapter() },
+            RecommendedAdapterId = adapters.Length > 0 ? adapters[0].Component.Id : "adapter.builtin"
+        };
+
+    public static AcpSetupParameterDefinition Parameter(
+        string key = "--model",
+        bool isRequired = false,
+        string defaultValue = "",
+        params string[] allowedValues)
+        => new()
+        {
+            Key = key,
+            DisplayName = key,
+            DefaultValue = defaultValue,
+            IsRequired = isRequired,
+            AllowedValues = allowedValues
+        };
+
+    public static AcpSetupWizardViewModel CreateWizard(
+        IAcpAgentCatalog catalog,
+        IAcpExecutableProbe probe,
+        IAcpComponentInstaller installer,
+        IAcpSetupConnectivityTester connectivityTester,
+        IConfigurationService configurationService,
+        IStringLocalizer<CoreStrings>? localizer = null)
+        => new(
+            new AcpSetupWizardOrchestrator(
+                catalog,
+                probe,
+                installer,
+                connectivityTester,
+                configurationService),
+            new ImmediateUiDispatcher(),
+            NullLogger<AcpSetupWizardViewModel>.Instance,
+            localizer);
+
+    /// <summary>The healthy-machine answer most tests walk against.</summary>
+    public static class WellKnownResults
+    {
+        public static AcpSetupTestResult Success()
+            => AcpSetupTestResult.Success(protocolVersion: 1, agentName: "test-agent");
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+public sealed class AcpSetupWizardViewModelTests
+{
+    private const string HandshakeRemediationKey = "AcpSetup_Remediation_Handshake";
+    private const string StageHandshakeKey = "AcpSetup_Stage_Handshake";
+
+    [Fact]
+    public void Constructor_SeedsCatalogRows_AsUndeterminedOnFirstStep()
+    {
+        var wizard = CreateWizard();
+
+        Assert.Single(wizard.Agents);
+        Assert.Equal(AcpComponentAvailability.Undetermined, wizard.Agents[0].Availability);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        Assert.True(wizard.IsOnAgentSelection);
+        Assert.False(wizard.GoBackCommand.CanExecute(null));
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DetectAgents_AppliesProbeResults_WithVersion()
+    {
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.2.3");
+        var wizard = CreateWizard(probe);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Equal(AcpComponentAvailability.Installed, wizard.Agents[0].Availability);
+        Assert.True(wizard.Agents[0].HasVersion);
+        Assert.Equal("1.2.3", wizard.Agents[0].Version);
+    }
+
+    [Fact]
+    public async Task DetectAgents_MissingRuntime_BlocksAdvancementUntilSelected()
+    {
+        var wizard = CreateWizard(new StubExecutableProbe());
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Equal(AcpComponentAvailability.Missing, wizard.Agents[0].Availability);
+        // Agent absence must not be reported as adapter absence: the adapter was never probed.
+        Assert.False(wizard.IsAdapterMissing);
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DetectAgents_UndeterminedProbe_DoesNotBlockAdvancement()
+    {
+        // No process probing on this platform: the runtime is unknown, not absent.
+        var probe = new StubExecutableProbe { SupportsProcessProbing = false };
+        var wizard = CreateWizard(probe);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Equal(AcpComponentAvailability.Undetermined, wizard.Agents[0].Availability);
+        wizard.SelectedAgent = wizard.Agents[0];
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task GoNext_FromAgentSelection_PreselectsRecommendedAdapter_AndProbesIt()
+    {
+        var (wizard, _, _) = await WalkToComponentSetupAsync(
+            configureProbe: probe =>
+            {
+                probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, true);
+                return probe;
+            });
+
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        Assert.Equal(2, wizard.Adapters.Count);
+        // The built-in adapter ships with the agent, so the recommendation lands there first.
+        Assert.Equal("adapter.builtin", wizard.SelectedAdapter?.Component.Id);
+        Assert.NotNull(wizard.AdapterProbe);
+        Assert.True(wizard.IsAdapterUsable);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task ComponentSetup_MissingAdapterBlocksWalk_InstallReprobesAndReopens()
+    {
+        // The runtime is healthy; only the packaged adapter is absent, so its absence is what
+        // blocks the walk. Package probing gates on its launcher being present too.
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable("npx", "/usr/bin/npx");
+        var adapter = AcpSetupWizardFixtures.PackagedAdapter();
+        var agent = AcpSetupWizardFixtures.Agent(adapters: adapter);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizardFor(agent, probe, installer, localizer: null);
+        probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, false);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[0];
+        await wizard.GoNextCommand.ExecuteAsync(null); // → ComponentSetup + auto adapter probe
+
+        Assert.True(wizard.IsAdapterMissing);
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+
+        // Installing flips the package answer; the orchestrator re-probes after the install.
+        installer.OnInstall = _ => probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, true);
+
+        await wizard.InstallAdapterCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsAdapterUsable);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Parameters_BuildsRowsFromTemplate_PreviewsCommandLine()
+    {
+        var parameter = AcpSetupWizardFixtures.Parameter("--model", defaultValue: "sonnet");
+        var (wizard, _, _) = await WalkToParametersAsync(parameters: new[] { parameter });
+
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
+        var row = Assert.Single(wizard.Parameters);
+        Assert.Equal("--model", row.Key);
+        Assert.Equal("sonnet", row.Value);
+
+        Assert.Contains("--model", wizard.LaunchCommandPreview, StringComparison.Ordinal);
+        Assert.Contains("sonnet", wizard.LaunchCommandPreview, StringComparison.Ordinal);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Parameters_MissingRequiredValue_StaysOnStepWithoutTesting()
+    {
+        var parameter = AcpSetupWizardFixtures.Parameter("--model", isRequired: true);
+        var (wizard, tester, _) = await WalkToParametersAsync(parameters: new[] { parameter });
+        var row = Assert.Single(wizard.Parameters);
+        Assert.Empty(row.Value);
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
+        Assert.True(row.HasValidationMessage);
+        Assert.Equal(0, tester.TestCount);
+    }
+
+    [Fact]
+    public async Task GoBack_RewindsOneStepAtATime_AndClearsErrorSurface()
+    {
+        var (wizard, tester, configuration) = await WalkToTestAsync();
+
+        wizard.ErrorMessage = "boom";
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
+        Assert.False(wizard.HasErrorMessage);
+
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        Assert.False(wizard.GoBackCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Test_SuccessfulHandshake_UnlocksSaveAndCarriesPlan()
+    {
+        var (wizard, tester, configuration) = await WalkToTestStepAsync();
+
+        await wizard.TestCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsTestSuccessful);
+        Assert.Equal(1, tester.TestCount);
+        // The walk adapter is npx-packaged, so the plan launches through npx.
+        Assert.NotNull(tester.LastPlan);
+        Assert.Equal("npx", tester.LastPlan!.Command);
+        Assert.Contains(AcpSetupWizardFixtures.AdapterPackage, tester.LastPlan!.Arguments, StringComparer.Ordinal);
+        // The name is still empty at this point, so save stays locked until the user names it.
+        Assert.False(wizard.SaveCommand.CanExecute(null));
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Test_HandshakeFailure_ShowsLocalizedStageAndRemediation_ThenRetestSucceeds()
+    {
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", StageHandshakeKey, "握手阶段");
+        localizer.Set("zh-Hans", HandshakeRemediationKey, "请确认 agent 支持 ACP 协议");
+        var (wizard, tester, _) = await WalkToTestAsync(localizer: localizer);
+        tester.SetResult(AcpSetupTestResult.Failure(
+            AcpSetupTestStage.Handshake,
+            errorDetail: "agent closed the stream",
+            remediationKey: HandshakeRemediationKey));
+
+        await wizard.TestCommand.ExecuteAsync(null);
+
+        Assert.False(wizard.IsTestSuccessful);
+        Assert.Equal("握手阶段", wizard.TestFailureStageText);
+        Assert.Equal("请确认 agent 支持 ACP 协议", wizard.TestRemediationText);
+        Assert.False(wizard.SaveCommand.CanExecute(null));
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+
+        // Re-testing after a fix succeeds and clears the failure surface.
+        tester.SetResult(AcpSetupWizardFixtures.WellKnownResults.Success());
+        await wizard.TestCommand.ExecuteAsync(null);
+        Assert.True(wizard.IsTestSuccessful);
+        Assert.Equal(string.Empty, wizard.TestFailureStageText);
+    }
+
+    [Fact]
+    public async Task Test_ValidationStageFailure_MirrorsOntoParameterRow()
+    {
+        var required = AcpSetupWizardFixtures.Parameter("--model", isRequired: true);
+        var (wizard, tester, _) = await WalkToParametersAsync(parameters: new[] { required });
+        var row = Assert.Single(wizard.Parameters);
+        Assert.Empty(row.Value);
+
+        // Testing straight from the form: the orchestrator validates before any process starts,
+        // and the failure is mirrored onto the offending row instead of the test panel alone.
+        await wizard.TestCommand.ExecuteAsync(null);
+
+        Assert.False(wizard.IsTestSuccessful);
+        Assert.True(row.HasValidationMessage);
+        Assert.Equal(0, tester.TestCount);
+    }
+
+    [Fact]
+    public async Task Save_AfterSuccessfulTest_PersistsStdioProfileShape()
+    {
+        var (wizard, tester, configuration) = await WalkToTestAsync();
+
+        await wizard.GoNextCommand.ExecuteAsync(null); // → Save; name prefilled from the agent
+        Assert.Equal("Test Agent", wizard.ProfileName);
+
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        var saved = Assert.Single(configuration.Saved);
+        Assert.Same(saved, wizard.SavedProfile);
+        Assert.Equal("Test Agent", saved.Name);
+        Assert.Equal(TransportType.Stdio, saved.Transport);
+        Assert.Equal("npx", saved.StdioCommand);
+        Assert.Contains(AcpSetupWizardFixtures.AdapterPackage, saved.StdioArguments!, StringComparer.Ordinal);
+        Assert.True(wizard.IsOnSave);
+    }
+
+    [Fact]
+    public async Task Save_RequiresSuccessfulTest_EvenWhenInvokedDirectly()
+    {
+        var (wizard, tester, configuration) = await WalkToTestStepAsync();
+
+        Assert.False(wizard.SaveCommand.CanExecute(null), "an untested draft must not be savable");
+
+        // Direct invocation bypasses CanExecute, so the handler itself must hold the line too.
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        Assert.Empty(configuration.Saved);
+        Assert.Equal(0, tester.TestCount);
+    }
+
+    [Fact]
+    public async Task Save_TrimsUserProvidedProfileName()
+    {
+        var (wizard, tester, configuration) = await WalkToTestAsync();
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        wizard.ProfileName = "  我的工作台  ";
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        Assert.Equal("我的工作台", Assert.Single(configuration.Saved).Name);
+    }
+
+    [Fact]
+    public async Task InstallRuntime_FailedInstall_SurfacesInstallerDetail()
+    {
+        var installer = new StubComponentInstaller(component =>
+            AcpComponentInstallResult.Failure(component.Id, 1, output: null, "network down"));
+        var wizard = CreateWizard(ProbeForInstalledRuntime(), installer);
+        wizard.SelectedAgent = wizard.Agents[0];
+
+        await wizard.InstallRuntimeCommand.ExecuteAsync(null);
+
+        Assert.Equal(
+            new[] { AcpSetupWizardFixtures.Runtime().Id },
+            installer.InstalledComponentIds.ToArray());
+        Assert.True(wizard.HasErrorMessage);
+        Assert.Equal("network down", wizard.ErrorMessage);
+    }
+
+    // ── Shared walk helpers ─────────────────────────────────────────────────
+
+    /// <summary>Detects the runtime, selects it, and walks to ComponentSetup with the adapter probed.</summary>
+    private static Task<(AcpSetupWizardViewModel Wizard, StubComponentInstaller Installer, RecordingConfigurationService Configuration)> WalkToComponentSetupAsync(
+        Func<StubExecutableProbe, StubExecutableProbe>? configureProbe = null,
+        MutableTestCoreStringLocalizer? localizer = null)
+    {
+        var probe = ProbeForInstalledRuntime();
+        if (configureProbe is not null)
+        {
+            configureProbe(probe);
+        }
+
+        return WalkWith(probe, localizer);
+    }
+
+    private static async Task<(AcpSetupWizardViewModel Wizard, StubComponentInstaller Installer, RecordingConfigurationService Configuration)> WalkWith(
+        StubExecutableProbe probe,
+        MutableTestCoreStringLocalizer? localizer)
+    {
+        var agent = AcpSetupWizardFixtures.Agent(
+            adapters: new[] { AcpSetupWizardFixtures.BuiltInAdapter(), AcpSetupWizardFixtures.PackagedAdapter() });
+        var installer = new StubComponentInstaller();
+        var configuration = new RecordingConfigurationService();
+        var wizard = CreateWizardFor(agent, probe, installer, localizer, configuration: configuration);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[0];
+        await wizard.GoNextCommand.ExecuteAsync(null); // → ComponentSetup + auto adapter probe
+        return (wizard, installer, configuration);
+    }
+
+    private static Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToParametersAsync(
+        AcpSetupParameterDefinition[]? parameters = null,
+        MutableTestCoreStringLocalizer? localizer = null)
+    {
+        var probe = ProbeForInstalledRuntime();
+        var packagedAdapter = AcpSetupWizardFixtures.PackagedAdapter(
+            parameters: parameters ?? Array.Empty<AcpSetupParameterDefinition>());
+        return WalkToParametersAsync(probe, packagedAdapter, localizer);
+    }
+
+    private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToParametersAsync(
+        StubExecutableProbe probe,
+        AcpAdapterDescriptor adapter,
+        MutableTestCoreStringLocalizer? localizer)
+    {
+        var agent = AcpSetupWizardFixtures.Agent(adapters: adapter);
+        var tester = new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success());
+        var configuration = new RecordingConfigurationService();
+        var wizard = CreateWizardFor(
+            agent, probe, new StubComponentInstaller(), localizer, tester, configuration);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[0];
+        await wizard.GoNextCommand.ExecuteAsync(null); // → ComponentSetup
+        await wizard.GoNextCommand.ExecuteAsync(null); // → Parameters
+        return (wizard, tester, configuration);
+    }
+
+    /// <summary>Walks to the Test step without running the test.</summary>
+    private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToTestStepAsync(
+        AcpSetupParameterDefinition[]? parameters = null,
+        MutableTestCoreStringLocalizer? localizer = null)
+    {
+        var (wizard, tester, configuration) = await WalkToParametersAsync(parameters, localizer);
+        await wizard.GoNextCommand.ExecuteAsync(null); // → Test
+        return (wizard, tester, configuration);
+    }
+
+    /// <summary>
+    /// Walks to the Test step and completes one successful handshake, so save-step tests start from
+    /// a verified configuration.
+    /// </summary>
+    private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToTestAsync(
+        AcpSetupParameterDefinition[]? parameters = null,
+        MutableTestCoreStringLocalizer? localizer = null)
+    {
+        var walked = await WalkToTestStepAsync(parameters, localizer);
+        await walked.Wizard.TestCommand.ExecuteAsync(null);
+        return walked;
+    }
+
+    private static StubExecutableProbe ProbeForInstalledRuntime()
+    {
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+        return probe;
+    }
+
+    private static AcpSetupWizardViewModel CreateWizard(
+        StubExecutableProbe? probe = null,
+        StubComponentInstaller? installer = null,
+        MutableTestCoreStringLocalizer? localizer = null)
+        => CreateWizardFor(AcpSetupWizardFixtures.Agent(), probe ?? ProbeForInstalledRuntime(), installer ?? new StubComponentInstaller(), localizer);
+
+    private static AcpSetupWizardViewModel CreateWizardFor(
+        AcpAgentDescriptor agent,
+        StubExecutableProbe probe,
+        StubComponentInstaller installer,
+        MutableTestCoreStringLocalizer? localizer,
+        StubConnectivityTester? tester = null,
+        RecordingConfigurationService? configuration = null)
+        => AcpSetupWizardFixtures.CreateWizard(
+            new StubAgentCatalog(agent),
+            probe,
+            installer,
+            tester ?? new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success()),
+            configuration ?? new RecordingConfigurationService(),
+            localizer);
+}


### PR DESCRIPTION
## 概要

五步向导：**Agent 选择 → 组件配置 → 启动参数 → 连通性测试 → 保存**，把用户从零带到一条验证过的 Stdio ACP 配置。

Closes #95

## 验收对照

| Issue 条目 | 实现 |
|---|---|
| 4.1 设置中心入口 | ACP 设置页「打开配置向导」→ `AcpSetupWizardPage`，不影响既有手动/JSON 配置路径 |
| 4.2 Agent 检测+一键安装 | 探测命令/版本；支持安装的分发走 `IAcpComponentInstaller`，装完自动重探 |
| 4.3 Agent↔Adapter 映射+推荐 | 目录数据声明映射与推荐 Adapter，进入组件步自动选中 |
| 4.4 选中即检测 Adapter | 进入组件步自动探测推荐 Adapter |
| 4.5 参数表单自动生成 | 模板驱动行 ViewModel：默认值/必填校验/枚举下拉/示例占位；配置含 Agent、Adapter、launch command、args、**环境变量**（新增 `StdioEnvironment`，schema v3） |
| 4.6 测试+失败阶段+补救建议 | stdio 握手分阶段报告（spawn/handshake…），失败带本地化阶段名 + remediation key，可重测 |
| 4.7 测试通过才可保存 | CanExecute 与 ExecuteAsync 双保险（RelayCommand 不查 CanExecute），成功后写入既有配置列表 |

## 架构分层

- **Domain**：目录描述符、三态可用性（Missing ≠ Undetermined）、参数定义含 `IsSecret` 契约
- **Application**：编排状态机、启动计划构建器（secret 参数硬拒持久化）、参数校验
- **Infrastructure(.Desktop)**：可执行探测、一键安装（输出流式）、stdio 握手测试；WASM/android/ios 落 Unsupported 回退，报「未确定」而非崩溃
- **Presentation.Core**：步骤门禁 —— Agent 缺失阻断前进、Undetermined 不阻断，端到端测试兜底
- **UI**：仅展示与绑定；合规门禁全过（本地化 uid、游戏手柄焦点、Symbol 字体）

## 安全边界

- 向导**不收集密钥/API key**——收集即意味着 YAML 明文持久化，违反配置持久化规范。`IsSecret` 参数在计划构建层被硬拒。
- 凭据仍走既有 Authentication 安全存储。

## 测试

- Application 98 / Infrastructure 603 / Presentation.Core **3174 全绿**
- 新增 65 个针对性用例（编排、计划构建、校验、探测、安装、握手、VM 状态机、Unsupported 回退）
- net10.0-desktop 编译零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)