### PR TITLE
fix(acp-setup): stop the setup wizard from fail-fasting on open

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -44,7 +44,7 @@
 
                         <!-- ── Step 1: agent selection ─────────────────────── -->
                         <StackPanel x:Name="AgentSelectionPanel"
-                                    Visibility="{x:Bind ViewModel.IsOnAgentSelection, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.IsOnAgentSelection, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Spacing="12">
                             <Grid ColumnDefinitions="*,Auto">
                                 <TextBlock x:Uid="AcpSetup_AgentsTitle"
@@ -96,7 +96,7 @@
                                                         Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                 <HyperlinkButton NavigateUri="{x:Bind InstallDocumentation}"
                                                                  x:Uid="AcpSetup_InstallDocs"
-                                                                 Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource InverseBooleanConverter}}"/>
+                                                                 Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"/>
                                             </StackPanel>
                                         </StackPanel>
                                     </DataTemplate>
@@ -106,7 +106,7 @@
 
                         <!-- ── Step 2: components (runtime + adapter) ──────── -->
                         <StackPanel x:Name="ComponentSetupPanel"
-                                    Visibility="{x:Bind ViewModel.IsOnComponentSetup, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.IsOnComponentSetup, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Spacing="12">
                             <TextBlock x:Uid="AcpSetup_ComponentsTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>
@@ -144,7 +144,7 @@
 
                         <!-- ── Step 3: launch parameters ───────────────────── -->
                         <StackPanel x:Name="ParametersPanel"
-                                    Visibility="{x:Bind ViewModel.IsOnParameters, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.IsOnParameters, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Spacing="12">
                             <TextBlock x:Uid="AcpSetup_ParametersTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>
@@ -172,7 +172,7 @@
                                                 <TextBox Grid.Column="1"
                                                          Text="{x:Bind Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                          PlaceholderText="{x:Bind Example}"
-                                                         Visibility="{x:Bind HasAllowedValues, Converter={StaticResource InverseBooleanConverter}}"/>
+                                                         Visibility="{x:Bind HasAllowedValues, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"/>
                                             </Grid>
                                             <TextBlock Text="{x:Bind Description}"
                                                        Style="{StaticResource CaptionTextBlockStyle}"
@@ -189,7 +189,7 @@
 
                         <!-- ── Step 4: test ────────────────────────────────── -->
                         <StackPanel x:Name="TestPanel"
-                                    Visibility="{x:Bind ViewModel.IsOnTest, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.IsOnTest, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Spacing="12">
                             <TextBlock x:Uid="AcpSetup_TestTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>
@@ -211,7 +211,7 @@
 
                         <!-- ── Step 5: save ────────────────────────────────── -->
                         <StackPanel x:Name="SavePanel"
-                                    Visibility="{x:Bind ViewModel.IsOnSave, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.IsOnSave, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Spacing="12">
                             <TextBlock x:Uid="AcpSetup_SaveTitle"
                                        Style="{StaticResource SettingsSectionTitleTextStyle}"/>

--- a/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceSettingsTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceSettingsTests.cs
@@ -15,6 +15,45 @@ using static SalmonEgg.Presentation.Core.Tests.Ui.XamlComplianceTestHelpers;
 public sealed class XamlComplianceSettingsTests
 {
 
+    /// <summary>
+    /// A converter bound to <c>Visibility</c> must return <c>Visibility</c>. The compiled x:Bind setter
+    /// casts the converter's result straight to the target type, so returning <c>bool</c> throws
+    /// <see cref="InvalidCastException"/> from inside the native layout callback — which WinUI cannot
+    /// swallow, so it fail-fasts the process even though the app's UnhandledException handler ran.
+    /// The build cannot see it (the converter is resolved by key at runtime) and no ViewModel test can
+    /// either, so the type contract is asserted here.
+    /// </summary>
+    [Fact]
+    public void VisibilityBindings_DoNotUseConvertersThatReturnBoolean()
+    {
+        var root = Path.Combine(FindRepoRoot(), "SalmonEgg", "SalmonEgg");
+        var offender = new Regex(
+            @"Visibility\s*=\s*""\{[^}]*Converter\s*=\s*\{StaticResource\s+InverseBooleanConverter\}",
+            RegexOptions.Singleline);
+        var failures = new List<string>();
+
+        foreach (var xamlFile in Directory.EnumerateFiles(root, "*.xaml", SearchOption.AllDirectories))
+        {
+            if (xamlFile.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                || xamlFile.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(xamlFile);
+            foreach (var match in offender.Matches(text).Cast<Match>())
+            {
+                var line = text.Take(match.Index).Count(character => character == '\n') + 1;
+                failures.Add(
+                    $"{Path.GetRelativePath(FindRepoRoot(), xamlFile)}:{line}"
+                    + " binds Visibility through InverseBooleanConverter, which returns bool."
+                    + " Use BoolToVisibilityConverter with ConverterParameter=Invert.");
+            }
+        }
+
+        Assert.True(failures.Count == 0, string.Join(Environment.NewLine, failures));
+    }
+
     [Fact]
     public void AcpEditors_ExposeStableAutomationIdsForEditableFields()
     {

--- a/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceSettingsTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceSettingsTests.cs
@@ -23,12 +23,22 @@ public sealed class XamlComplianceSettingsTests
     /// The build cannot see it (the converter is resolved by key at runtime) and no ViewModel test can
     /// either, so the type contract is asserted here.
     /// </summary>
+    /// <remarks>
+    /// The offending converters are discovered from their own source rather than listed, so a new
+    /// bool-returning converter is covered the day it is written instead of the day someone remembers
+    /// to extend this test.
+    /// </remarks>
     [Fact]
     public void VisibilityBindings_DoNotUseConvertersThatReturnBoolean()
     {
         var root = Path.Combine(FindRepoRoot(), "SalmonEgg", "SalmonEgg");
+        var booleanConverters = FindBooleanReturningConverters(root);
+        Assert.NotEmpty(booleanConverters);
+
         var offender = new Regex(
-            @"Visibility\s*=\s*""\{[^}]*Converter\s*=\s*\{StaticResource\s+InverseBooleanConverter\}",
+            @"Visibility\s*=\s*""\{[^}]*Converter\s*=\s*\{StaticResource\s+("
+            + string.Join("|", booleanConverters.Select(Regex.Escape))
+            + @")\}",
             RegexOptions.Singleline);
         var failures = new List<string>();
 
@@ -46,12 +56,45 @@ public sealed class XamlComplianceSettingsTests
                 var line = text.Take(match.Index).Count(character => character == '\n') + 1;
                 failures.Add(
                     $"{Path.GetRelativePath(FindRepoRoot(), xamlFile)}:{line}"
-                    + " binds Visibility through InverseBooleanConverter, which returns bool."
-                    + " Use BoolToVisibilityConverter with ConverterParameter=Invert.");
+                    + $" binds Visibility through {match.Groups[1].Value}, which returns bool."
+                    + " Use BoolToVisibilityConverter (ConverterParameter=Invert to negate)"
+                    + " or InverseBoolToVisibilityConverter.");
             }
         }
 
         Assert.True(failures.Count == 0, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>
+    /// Names the converters whose <c>Convert</c> only ever returns <c>bool</c>, read from their source.
+    /// A converter that returns a <see cref="Visibility"/> on any path is out of scope: the cast in the
+    /// generated binding setter is what fails, and that only happens for a value that is never one.
+    /// </summary>
+    private static string[] FindBooleanReturningConverters(string root)
+    {
+        var convertersRoot = Path.Combine(root, "Presentation", "Converters");
+        var convertBody = new Regex(
+            @"public object Convert\([^)]*\)(?<body>.*?)\n    \}",
+            RegexOptions.Singleline);
+
+        return Directory
+            .EnumerateFiles(convertersRoot, "*.cs", SearchOption.TopDirectoryOnly)
+            .Select(path => (Name: Path.GetFileNameWithoutExtension(path), Text: File.ReadAllText(path)))
+            .Where(converter =>
+            {
+                var body = convertBody.Match(converter.Text);
+                if (!body.Success)
+                {
+                    return false;
+                }
+
+                var convert = body.Groups["body"].Value;
+                return !convert.Contains("Visibility.", StringComparison.Ordinal)
+                       && Regex.IsMatch(convert, @"return\s+(!|true|false)");
+            })
+            .Select(converter => converter.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Opening the ACP setup wizard killed the process. Two `Visibility` bindings went through `InverseBooleanConverter`, which returns `bool` by contract — it exists for `IsEnabled`. The compiled `x:Bind` setter casts a converter's result straight to the target type:

```csharp
Set_..._Visibility(this.obj39,
    (Visibility)this.LookupConverter("InverseBooleanConverter").Convert(obj, typeof(Visibility), null, null));
```

That cast threw `InvalidCastException` from inside the native layout callback. WinUI cannot swallow an exception thrown back across the ABI from `MeasureOverride`, so it fail-fasted with a stowed exception (`0xC000027B`) — which is why the app's `UnhandledException` handler logged the fault (`ShellFirstFrameReady=true`, `e.Handled=true`) and the process still died.

The wizard's ViewModel constructor fills the agent list eagerly, so the first offending binding was realized as soon as the `ListView` laid out. No interaction was needed: opening the wizard was enough.

Introduced by 6d4783cb (#95).

## Changes

- **`AcpSetupWizardPage.xaml:99`** (`HyperlinkButton`, agent row) and **`:175`** (`TextBox`, parameters step) now use `BoolToVisibilityConverter` with `ConverterParameter=Invert`, which that converter already supports. Only the first one appeared in the crash stack because it realizes first; the second would have crashed again at the parameters step.
- The five step panels bound `bool` to `Visibility` with **no converter at all**. Uno coerces that, WinUI does not guarantee it — made explicit alongside.
- **New XAML compliance test** fails on any `Visibility` binding routed through `InverseBooleanConverter`, repo-wide.

## Why a compliance test

Neither the build nor a ViewModel test can see this defect. The converter is resolved by key at runtime, and the fault only occurs during layout on WinUI's binding codegen — so the type contract needs its own guard. This is the `AGENTS.md` §5.6 case: a form-level assertion that prevents a specific architectural regression rather than covering a line of implementation.

## Verification

- `XamlComplianceSettingsTests` — 32/32 pass
- Full `Ui.*` compliance suite — 208/208 pass
- Skia Desktop build (`net10.0-desktop`, Debug) — 0 warnings, 0 errors
- **Reverse-verified**: restoring either bad binding fails the new test, naming the offending file and line

## Not verified here

The crash reproduces on WinUI only. A Linux Skia runtime probe I built first walked the whole wizard (open → detect 8 agents → advance two steps) and passed **identically with and without the fix** — Uno's codegen coerces `bool` to `Visibility` where WinUI's hard cast does not. That probe was removed rather than kept: it would have been false safety for this defect. Windows validation needs a repackaged MSIX; the installed 1.2.0.0 build predates the fix and will not self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)