### PR TITLE
docs(config): align migration spec with additive-only reality

### DIFF
--- a/docs/SPEC-CONFIG-PERSISTENCE-YAML.md
+++ b/docs/SPEC-CONFIG-PERSISTENCE-YAML.md
@@ -37,15 +37,12 @@ SalmonEgg/
     app.yaml
     servers/
       <id>.yaml
-  config-migrations/
-    migrations.log
   logs/
     ...
 ```
 
 - `app.yaml`：全局设置（UI 偏好、默认选项、最近使用的 server id 等）。
 - `servers/<id>.yaml`：每个 ServerConfiguration 一个文件，便于 diff/merge。
-- `config-migrations/migrations.log`：记录迁移过程（便于诊断）。
 
 ---
 
@@ -154,11 +151,24 @@ authentication:
 - 客户端必须支持读取 `schema_version <= 当前版本`
 - 高版本：必须拒绝写回（防止降级破坏），但允许只读并提示用户升级
 
-### 6.2 迁移机制
-提供 `IConfigMigration`：
-- `FromVersion` / `ToVersion`
-- `Task MigrateAsync(...)`
+### 6.2 附加式升级与写入防护（无迁移机制）
 
-启动时检测版本并按序迁移，记录到 `config-migrations/migrations.log`。
+版本演进采用**附加式（additive-only）契约**：每次升 `schema_version` 只新增字段或枚举值，
+不重命名、不删除、不改语义。旧版本写入的文件天然是当前版本的合法子集，因此**不需要迁移
+机制**——`IConfigMigration` 曾在早期设计中规划但从未实现，现已放弃；仓库中不保留迁移目录
+或迁移日志。
+
+真正的保护在**写入路径**而非读取路径：
+
+- **读取**宽松：`schema_version <= 0` 视为"不是我们的文件"予以忽略（返回默认值/空），
+  `schema_version > 当前版本` 的文件**仍可读**（附加式契约保证未知字段被忽略、枚举未知值
+  回退默认），`ConfigurationDiagnosticsService` 会对其报告 `SchemaTooNew` 诊断提示用户升级。
+- **写入**严格：发现磁盘上文件的 `schema_version > 当前版本` 时直接拒绝写回
+  （`SchemaVersionTooNew`），防止旧版本构建覆盖新版本文件而丢字段。这是云同步场景的关键
+  防线——两台版本不同的机器可能拉到对方写的更高版本文件，写入防护确保旧版本不会静默降级它。
+
+不保留迁移机制的理由：无历史遗留的破坏性 schema 变更，且旧版本 APP 几乎无存量用户，
+"装新版 → 回滚旧版"场景不构成需要支持的前向兼容路径。若未来确需破坏性变更，再以此节
+为锚点重新引入显式迁移。
 
 ---

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -1,13 +1,26 @@
 export async function waitForBodyText(page, pattern, label, timeoutMs = 30_000) {
-  await page.waitForFunction(
-    source => new RegExp(source).test(document.body?.innerText ?? ""),
-    pattern.source,
-    { timeout: timeoutMs });
+  // `waitForFunction` confirms the pattern is in body text, then a *separate*
+  // `locator().innerText()` re-reads. Those two reads straddle the LoadAsync
+  // Clear-then-refill window (ObservableCollection Reset momentarily empties
+  // the body), so the re-read can come back empty despite the poll just
+  // succeeding. Retry the whole poll+read cycle until the re-read is stable.
+  const deadline = Date.now() + timeoutMs;
+  let lastBodyText = "";
+  while (Date.now() < deadline) {
+    await page.waitForFunction(
+      source => new RegExp(source).test(document.body?.innerText ?? ""),
+      pattern.source,
+      { timeout: Math.min(5_000, Math.max(250, deadline - Date.now())) });
 
-  const bodyText = await page.locator("body").innerText();
-  if (!pattern.test(bodyText)) {
-    throw new Error(`Expected ${label} text was not visible.`);
+    lastBodyText = await page.locator("body").innerText();
+    if (pattern.test(lastBodyText)) {
+      return;
+    }
+
+    await page.waitForTimeout(100);
   }
+
+  throw new Error(`Expected ${label} text was not visible. Last body: ${lastBodyText.slice(0, 500)}`);
 }
 
 export async function clickVisibleNavigationTargetUntilBodyText(page, options, pattern, label, activationOptions = {}) {

--- a/src/SalmonEgg.Infrastructure/Storage/InstallationIdentityService.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/InstallationIdentityService.cs
@@ -17,7 +17,7 @@ namespace SalmonEgg.Infrastructure.Storage;
 /// <c>EnumerateFiles(ConfigRootPath, "*", AllDirectories)</c> 通配打包。装机标识一旦落在
 /// 那里，用户开启同步后第二台设备会恢复出同一个值，两台机器从此上报相同标识——装机数与
 /// DAU 永久偏低，且数据侧完全看不出异常（无报错、无缺口）。因此本文件放在 app data **根**
-/// 目录下，与 <c>config-migrations</c> 同级，天然在同步范围之外。
+/// 目录下（与 <c>logs</c> 同级），天然在同步范围之外。
 ///
 /// 不复用 <c>AppSettings</c> 同理：那是 app.yaml 的内容，属于可携带配置。
 ///

--- a/src/SalmonEgg.Infrastructure/Storage/SalmonEggPaths.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/SalmonEggPaths.cs
@@ -41,10 +41,4 @@ public static class SalmonEggPaths
     public static string GetServersDirectoryPath() => Path.Combine(GetConfigRootPath(), "servers");
 
     public static string GetAppYamlPath() => Path.Combine(GetConfigRootPath(), "app.yaml");
-
-    public static string GetConfigMigrationsDirectoryPath() =>
-        Path.Combine(GetAppDataRootPath(), "config-migrations");
-
-    public static string GetMigrationsLogPath() =>
-        Path.Combine(GetConfigMigrationsDirectoryPath(), "migrations.log");
 }


### PR DESCRIPTION
## What

Two unrelated cleanups that both came out of a "is develop CI green?" audit.

### 1. Config migration spec → reality (`docs` + dead code)

`docs/SPEC-CONFIG-PERSISTENCE-YAML.md` §6.2 documented an `IConfigMigration` mechanism (`FromVersion`/`ToVersion`/`MigrateAsync`, `config-migrations/migrations.log`) that **was never implemented** — only two dead helper methods (`GetConfigMigrationsDirectoryPath` / `GetMigrationsLogPath`) existed in `SalmonEggPaths.cs`, with zero callers.

The schema evolves **additive-only**: every `schema_version` bump only adds fields/enum values, never renames/deletes/reinterprets. An older build's file is a legal subset of the current schema, so no migration code is needed.

- **§6.2 rewritten** to state the actual contract:
  - **Read path** lenient — `schema_version <= 0` ignored as "not our file"; `> current` still readable (additive guarantee), surfaced as `SchemaTooNew` by `ConfigurationDiagnosticsService`.
  - **Write path** is the real guard — `SchemaVersionTooNew` refuses to overwrite a file whose version exceeds the running build. The cloud-sync safety line: two machines on different versions can pull each other's higher-version file; the write guard prevents silent downgrade.
  - Rationale: no legacy breaking changes, negligible old-version install base.
- **§2.2 layout** — removed `config-migrations/` directory and `migrations.log` bullet.
- **`SalmonEggPaths.cs`** — deleted the two uncalled helpers.
- **`InstallationIdentityService.cs`** — updated the dangling comment referencing `config-migrations` as a sibling (now references `logs`).

### 2. WASM smoke `waitForBodyText` race fix (`scripts`)

`Browser WASM Smoke Gates` was flaky on develop (failed on this PR's first run despite my changes being docs-only). Root cause: `waitForBodyText` did a non-atomic check-then-read — `page.waitForFunction` confirmed the pattern in body text, then a *separate* `locator().innerText()` call re-read and asserted again. Those two reads straddle the `LoadAsync` Clear-then-refill window (`ObservableCollection` Reset momentarily empties the body), so the re-read can come back empty even though the poll just succeeded. The previous fix (7694875e) added a `waitForControlState` guard at the call site, but the race lives inside `waitForBodyText` itself, so it only reduced frequency. Fix: retry the whole poll+read cycle within the deadline.

## Verification

- `dotnet build` — 0 errors, 0 warnings.
- `ConfigSchemaVersionContractTests` — 2/2 pass.
- `ConfigurationManagerTests` — 39/39 pass.
- `node --check` on the edited `.mjs` — syntax OK.
- grep confirms zero `cs` references to the deleted helpers.

## Out of scope

A separate, pre-existing bug in `ConfigurationEditorViewModel.cs` (load-returns-null → blank editor, no `HasProfileLoadError`/`SetError`, asymmetric with the adjacent catch — saving could clobber the original). That should be its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)