### PR TITLE
feat(acp-sdk): prepare SalmonEgg.Acp for standalone NuGet release

### DIFF
--- a/.github/workflows/ci-acp-sdk.yml
+++ b/.github/workflows/ci-acp-sdk.yml
@@ -9,6 +9,8 @@ on:
       - "tests/SalmonEgg.Acp.Tests/**"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
+      - "scripts/gates/run-acp-sdk-tag-version-gate.sh"
+      - "scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh"
       - ".github/workflows/ci-acp-sdk.yml"
       - "Directory.Build.props"
       - "NuGet.config"
@@ -21,6 +23,8 @@ on:
       - "tests/SalmonEgg.Acp.Tests/**"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
+      - "scripts/gates/run-acp-sdk-tag-version-gate.sh"
+      - "scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh"
       - ".github/workflows/ci-acp-sdk.yml"
       - "Directory.Build.props"
       - "NuGet.config"
@@ -60,6 +64,9 @@ jobs:
         env:
           DOTNET_BIN: dotnet
         run: ./scripts/gates/run-acp-sdk-gates.sh "${{ env.CONFIGURATION }}" "${{ env.PACKAGE_OUTPUT }}"
+
+      - name: Verify release tag/version gate rules
+        run: ./scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
 
       - name: Upload ACP SDK package
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/release-acp-sdk.yml
+++ b/.github/workflows/release-acp-sdk.yml
@@ -1,0 +1,137 @@
+name: Release ACP SDK
+
+# The ACP SDK ships on its own cadence, so it gets its own tag namespace: `acp-sdk-v*`.
+# release-packaging.yml owns `v*` (the GUI/CLI release line). Sharing one prefix would make every SDK
+# release rebuild the desktop installers, and every app release look like an SDK release.
+on:
+  push:
+    tags: ["acp-sdk-v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel a publish in flight: a push to nuget.org is irreversible, and a half-published release
+# (package without symbols) cannot be fixed by re-running.
+concurrency:
+  group: release-acp-sdk-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_VERSION: "10.0.3xx"
+  CONFIGURATION: "Release"
+  PACKAGE_OUTPUT: "artifacts/acp-sdk-pack"
+
+jobs:
+  pack:
+    name: Pack ACP SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # The same gates that guard every PR guard the release: format, analyzers, contract tests, pack.
+      # A release must not have a weaker bar than a pull request.
+      - name: Run ACP SDK gate script
+        env:
+          DOTNET_BIN: dotnet
+        run: ./scripts/gates/run-acp-sdk-gates.sh "${{ env.CONFIGURATION }}" "${{ env.PACKAGE_OUTPUT }}"
+
+      # Verify the rule itself before trusting it on an irreversible publish.
+      - name: Verify release tag/version gate rules
+        run: ./scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
+
+      - name: Verify tag matches packed version
+        if: startsWith(github.ref, 'refs/tags/acp-sdk-v')
+        run: ./scripts/gates/run-acp-sdk-tag-version-gate.sh "${{ github.ref_name }}" "${{ env.PACKAGE_OUTPUT }}"
+
+      - name: Upload ACP SDK package
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: acp-sdk-release-package
+          path: |
+            ${{ env.PACKAGE_OUTPUT }}/*.nupkg
+            ${{ env.PACKAGE_OUTPUT }}/*.snupkg
+
+  consumer-integration:
+    name: ACP Consumer Integration
+    needs: pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Download ACP SDK package
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: acp-sdk-release-package
+          path: artifacts/acp-sdk-package
+
+      # Publishing an unconsumable package is the failure this prevents: restore, build and run against
+      # the real nupkg before it reaches nuget.org, not after.
+      - name: Run package consumer smoke
+        env:
+          DOTNET_BIN: dotnet
+        run: ./scripts/gates/run-acp-consumer-package-smoke.sh artifacts/acp-sdk-package "${{ env.CONFIGURATION }}"
+
+  publish-nuget:
+    name: Publish to NuGet
+    needs: [pack, consumer-integration]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Only a real tag publishes. workflow_dispatch stays available to rehearse pack + consumer smoke
+    # without pushing anything to nuget.org.
+    if: startsWith(github.ref, 'refs/tags/acp-sdk-v')
+    environment: nuget-publish
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Download ACP SDK package
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: acp-sdk-release-package
+          path: artifacts/acp-sdk-package
+
+      - name: Push package and symbols
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "NUGET_API_KEY secret is not configured; refusing to attempt a publish." >&2
+            exit 1
+          fi
+
+          # Push the .nupkg explicitly rather than globbing *.nupkg: the glob also matches .snupkg on
+          # some shells, and pushing symbols as a package is not something nuget.org lets you undo.
+          nupkg="$(find artifacts/acp-sdk-package -maxdepth 1 -type f -name 'SalmonEgg.Acp.*.nupkg' ! -name '*.snupkg')"
+          snupkg="$(find artifacts/acp-sdk-package -maxdepth 1 -type f -name 'SalmonEgg.Acp.*.snupkg')"
+
+          echo "Publishing $(basename "$nupkg")"
+          dotnet nuget push "$nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "$NUGET_API_KEY" \
+            --skip-duplicate
+
+          echo "Publishing $(basename "$snupkg")"
+          dotnet nuget push "$snupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "$NUGET_API_KEY" \
+            --skip-duplicate

--- a/.github/workflows/release-acp-sdk.yml
+++ b/.github/workflows/release-acp-sdk.yml
@@ -94,7 +94,16 @@ jobs:
     # Only a real tag publishes. workflow_dispatch stays available to rehearse pack + consumer smoke
     # without pushing anything to nuget.org.
     if: startsWith(github.ref, 'refs/tags/acp-sdk-v')
+    # The trusted publishing policy on nuget.org names this environment. Keeping it here is not
+    # decoration: if the policy is scoped to `nuget-publish`, a job running outside that environment
+    # cannot exchange its OIDC token, so the environment is part of the auth boundary.
     environment: nuget-publish
+    permissions:
+      contents: read
+      # Trusted publishing needs GitHub to mint an OIDC token for this job. Without this the
+      # NuGet/login step has no token to exchange. Scoped to this job only - no other job here
+      # should be able to request an identity token.
+      id-token: write
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -107,15 +116,54 @@ jobs:
           name: acp-sdk-release-package
           path: artifacts/acp-sdk-package
 
-      - name: Push package and symbols
+      # The nuget.org profile name that owns the trusted publishing policy. It is not a secret, but
+      # it is a repository variable rather than a literal: a fork inherits this workflow, and a
+      # hardcoded account name there would point a fork's publish attempts at this account.
+      #
+      # Check it here instead of letting NuGet/login receive an empty user. An empty `user` fails
+      # inside the action with a token-exchange error that reads like a policy mismatch, which sends
+      # you auditing the nuget.org policy for a problem that is actually a missing variable.
+      - name: Verify the trusted publishing account is configured
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_USER: ${{ vars.NUGET_USER }}
         run: |
           set -euo pipefail
 
+          if [ -z "${NUGET_USER:-}" ]; then
+            echo "The repository variable NUGET_USER is not set." >&2
+            echo "Set it to the nuget.org profile name (not an email) that owns the" >&2
+            echo "SalmonEgg.Acp trusted publishing policy:" >&2
+            echo "  Settings -> Secrets and variables -> Actions -> Variables" >&2
+            exit 1
+          fi
+
+          echo "Publishing as nuget.org account: ${NUGET_USER}"
+
+      # Trusted publishing: exchange the job's short-lived GitHub OIDC token for a temporary
+      # nuget.org API key. Nothing long-lived is stored in this repository. The key nuget.org
+      # returns is valid for one hour, so this step sits immediately before the push rather than
+      # at the top of the job.
+      - name: NuGet login (OIDC to temporary API key)
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push package and symbols
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          # Fail closed. A missing key here means the OIDC exchange silently produced nothing, and
+          # `dotnet nuget push` with an empty --api-key would report a confusing 401 instead of the
+          # real cause. Do not turn this into a warning: a publish that half-happens cannot be undone.
           if [ -z "${NUGET_API_KEY:-}" ]; then
-            echo "NUGET_API_KEY secret is not configured; refusing to attempt a publish." >&2
+            echo "Trusted publishing did not yield an API key." >&2
+            echo "Check that the nuget.org policy matches this repository, workflow file name," >&2
+            echo "and the '${GITHUB_JOB}' job's environment, and that the NUGET_USER variable is set." >&2
             exit 1
           fi
 

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -415,3 +415,72 @@ dotnet publish SalmonEgg/SalmonEgg/SalmonEgg.csproj -f net10.0-browserwasm -c Re
 - [Uno Platform 文档](https://platform.uno/docs/)
 - [.NET 发布指南](https://docs.microsoft.com/dotnet/core/deploying/)
 - [GitHub Issues](https://github.com/salmonloop/salmon-egg/issues)
+
+---
+
+## ACP SDK（`SalmonEgg.Acp`）发布
+
+SDK 与应用是两条独立的发布线，各有自己的 tag 命名空间与版本号：
+
+| | tag | 版本来源 | workflow |
+|---|---|---|---|
+| GUI / CLI | `v*` | 根 `Directory.Build.props` 的 `SalmonEggDisplayVersion` | `release-packaging.yml` |
+| ACP SDK | `acp-sdk-v*` | `src/SalmonEgg.Acp/SalmonEgg.Acp.csproj` 的 `<Version>` | `release-acp-sdk.yml` |
+
+两者必须保持分离：共用 `v*` 会让每次 SDK 发布都重建桌面安装包，也会让应用发版误触发 NuGet 推送。
+
+### 一次性准备
+
+1. 在 nuget.org 生成 API key，作用域限定为推送 `SalmonEgg.Acp`。
+2. 在仓库中创建名为 `NUGET_API_KEY` 的 secret。
+3. 创建名为 `nuget-publish` 的 GitHub Environment；`publish-nuget` job 绑定该环境，可在此挂必要的审批人。
+
+未配置 `NUGET_API_KEY` 时 `publish-nuget` 会显式失败而非静默跳过 —— 一次"绿灯但什么都没发布"的运行比失败更难发现。
+
+### 发布步骤
+
+```bash
+# 1. 更新 SDK 版本（首发之后必须同时提供上一个已发布版本作为兼容性基线）
+#    src/SalmonEgg.Acp/SalmonEgg.Acp.csproj: <Version>1.0.1</Version>
+
+# 2. 本地跑完整门禁 + 真实包消费验证
+./scripts/gates/run-acp-sdk-gates.sh Release artifacts/acp-sdk-pack
+./scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
+./scripts/gates/run-acp-sdk-tag-version-gate.sh acp-sdk-v1.0.1 artifacts/acp-sdk-pack
+./scripts/gates/run-acp-consumer-package-smoke.sh artifacts/acp-sdk-pack Release
+
+# 3. 打 tag 推送，workflow 接管 pack -> consumer smoke -> nuget push
+git tag acp-sdk-v1.0.1
+git push origin acp-sdk-v1.0.1
+```
+
+### 兼容性基线
+
+`EnablePackageValidation` 需要一个已发布版本作为对比基线才有意义。首发版本（`AcpPackageFirstReleasedVersion`，当前 `1.0.0`）在 nuget.org 上没有前身，写死基线会导致 restore 报 `NU1101`，因此该版本不启用基线比对。
+
+`<Version>` 一旦超过首发版本，构建就要求显式传入基线，否则 `AcpBaselineRequired` 直接报错：
+
+```bash
+dotnet pack src/SalmonEgg.Acp/SalmonEgg.Acp.csproj -c Release -p:AcpPackageBaselineVersion=1.0.0
+```
+
+这条门禁是 fail-closed 的：忘记传基线会构建失败，而不是让包验证退化成"什么都不比"的假绿。
+
+### 不可逆性
+
+nuget.org 的推送无法撤回，也无法覆盖同版本号。因此：
+
+- `run-acp-sdk-tag-version-gate.sh` 在推送前校验 tag 版本与产物版本一致、`.nupkg` 与 `.snupkg` 各恰好一个；
+- `concurrency` 不取消进行中的发布，避免出现"包已推、符号未推"的半成品；
+- `.snupkg` 与 `.nupkg` 分别显式推送，不用通配符（glob 会连带匹配 `.snupkg`）。
+
+### SDK 发布清单
+
+- [ ] `<Version>` 已更新，且非首发版本时已确定 `AcpPackageBaselineVersion`
+- [ ] `run-acp-sdk-gates.sh` 全绿（format / analyzer / 契约测试 / pack）
+- [ ] `run-acp-sdk-tag-version-gate-selftest.sh` 通过（门禁规则本身的正反例）
+- [ ] `run-acp-sdk-tag-version-gate.sh` 通过
+- [ ] `run-acp-consumer-package-smoke.sh` 通过（真实 nupkg restore + build + run）
+- [ ] tag 使用 `acp-sdk-v` 前缀，且与 `<Version>` 一致
+- [ ] `NUGET_API_KEY` secret 与 `nuget-publish` environment 已就绪
+- [ ] 发布后在 nuget.org 确认包与符号均已上架

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -429,13 +429,35 @@ SDK 与应用是两条独立的发布线，各有自己的 tag 命名空间与�
 
 两者必须保持分离：共用 `v*` 会让每次 SDK 发布都重建桌面安装包，也会让应用发版误触发 NuGet 推送。
 
-### 一次性准备
+### 一次性准备（受信任发布 / Trusted Publishing）
 
-1. 在 nuget.org 生成 API key，作用域限定为推送 `SalmonEgg.Acp`。
-2. 在仓库中创建名为 `NUGET_API_KEY` 的 secret。
-3. 创建名为 `nuget-publish` 的 GitHub Environment；`publish-nuget` job 绑定该环境，可在此挂必要的审批人。
+通道不存长期 API key。`publish-nuget` job 用 GitHub OIDC 向 nuget.org 换一枚有效期 1 小时的临时 key，用完即弃。
 
-未配置 `NUGET_API_KEY` 时 `publish-nuget` 会显式失败而非静默跳过 —— 一次"绿灯但什么都没发布"的运行比失败更难发现。
+1. 登录 nuget.org → 点用户名 → **Trusted Publishing** → 新建策略：
+
+    | 字段 | 值 |
+    |---|---|
+    | Package owner | `Salmon` |
+    | Scopes | Push new packages and package versions |
+    | Glob Patterns and Packages | `SalmonEgg.Acp` |
+    | Repository Owner | `salmonloop` |
+    | Repository | `salmon-egg` |
+    | Workflow File | `release-acp-sdk.yml` |
+    | Environment | `nuget-publish` |
+
+    Workflow File 只填文件名，**不要带** `.github/workflows/` 路径。Environment 必须与 workflow 里的 `environment:` 完全一致，否则令牌交换会被拒。Scopes 必须包含 "new packages"：首发时包还不存在，只给 "new versions" 会推不上去。
+
+    填表时请关闭浏览器页面翻译。`salmon-egg` 被译成中文后写入策略，与 GitHub 令牌里的原始仓库名不匹配，交换同样会失败。
+
+2. 策略的 **Package owner** 决定它归谁名下，并对该 owner 名下**所有**包生效，因此不要求 `SalmonEgg.Acp` 事先存在。选个人比选组织稳：策略归组织名下时，创建者若离开该组织，策略会失效。
+
+3. 创建名为 `nuget-publish` 的 GitHub Environment；`publish-nuget` job 绑定该环境，可在此挂必要的审批人。策略若限定了 environment，该环境就是鉴权边界的一部分，不是装饰。
+
+4. 在 `Settings → Secrets and variables → Actions → Variables` 添加变量 `NUGET_USER`，值为 nuget.org 的**用户名（profile name），不是邮箱**。它不是机密，但也不该硬编码进 workflow：fork 会连同用户名一起继承。
+
+新建策略会先带一个 7 天临时有效期，即使仓库是公开的也会看到。nuget.org 需要 GitHub 仓库与所有者的**数字 ID** 才能把策略永久锁定到本仓库（防止有人删库、重建同名仓库后冒名发布），而这些 ID 只随一次成功发布的 OIDC 令牌送达。7 天内未发布则转为 inactive，可随时重启该窗口。
+
+OIDC 交换未产出 key 时 `publish-nuget` 会显式失败而非静默跳过 —— 一次"绿灯但什么都没发布"的运行比失败更难发现。
 
 ### 发布步骤
 
@@ -482,5 +504,5 @@ nuget.org 的推送无法撤回，也无法覆盖同版本号。因此：
 - [ ] `run-acp-sdk-tag-version-gate.sh` 通过
 - [ ] `run-acp-consumer-package-smoke.sh` 通过（真实 nupkg restore + build + run）
 - [ ] tag 使用 `acp-sdk-v` 前缀，且与 `<Version>` 一致
-- [ ] `NUGET_API_KEY` secret 与 `nuget-publish` environment 已就绪
+- [ ] nuget.org 受信任发布策略、`NUGET_USER` 变量与 `nuget-publish` environment 均已就绪
 - [ ] 发布后在 nuget.org 确认包与符号均已上架

--- a/scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
+++ b/scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Exercises run-acp-sdk-tag-version-gate.sh with positive and negative cases so the rule is verified on
+# every PR instead of only when a release tag is pushed. A guard that is never exercised against a
+# failing case cannot be trusted to fail when it matters.
+set -euo pipefail
+
+gate="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-acp-sdk-tag-version-gate.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+expect() {
+  local expected="$1" tag="$2" dir="$3" label="$4"
+  local actual
+  if bash "$gate" "$tag" "$dir" >/dev/null 2>&1; then actual="pass"; else actual="fail"; fi
+  if [ "$actual" = "$expected" ]; then
+    echo "  ok    ${label} (${actual})"
+  else
+    echo "  FAIL  ${label}: expected ${expected}, got ${actual}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+mkdir -p "$work/match" && touch "$work/match/SalmonEgg.Acp.1.2.3.nupkg" "$work/match/SalmonEgg.Acp.1.2.3.snupkg"
+mkdir -p "$work/version-mismatch" \
+  && touch "$work/version-mismatch/SalmonEgg.Acp.1.2.4.nupkg" \
+           "$work/version-mismatch/SalmonEgg.Acp.1.2.3.snupkg"
+mkdir -p "$work/symbols-mismatch" \
+  && touch "$work/symbols-mismatch/SalmonEgg.Acp.1.2.3.nupkg" \
+           "$work/symbols-mismatch/SalmonEgg.Acp.1.2.4.snupkg"
+mkdir -p "$work/no-symbols" && touch "$work/no-symbols/SalmonEgg.Acp.1.2.3.nupkg"
+mkdir -p "$work/extra-nupkg" \
+  && touch "$work/extra-nupkg/SalmonEgg.Acp.1.2.3.nupkg" \
+           "$work/extra-nupkg/SalmonEgg.Acp.1.2.9.nupkg" \
+           "$work/extra-nupkg/SalmonEgg.Acp.1.2.3.snupkg"
+mkdir -p "$work/extra-snupkg" \
+  && touch "$work/extra-snupkg/SalmonEgg.Acp.1.2.3.nupkg" \
+           "$work/extra-snupkg/SalmonEgg.Acp.1.2.3.snupkg" \
+           "$work/extra-snupkg/SalmonEgg.Acp.1.2.9.snupkg"
+mkdir -p "$work/empty"
+mkdir -p "$work/bare-version" \
+  && touch "$work/bare-version/SalmonEgg.Acp.v1.2.3.nupkg" \
+           "$work/bare-version/SalmonEgg.Acp.v1.2.3.snupkg"
+
+echo "[selftest] ACP SDK tag/version gate"
+expect pass "acp-sdk-v1.2.3" "$work/match"        "matching tag and package"
+expect fail "acp-sdk-v1.2.3" "$work/version-mismatch" "packed version disagrees with tag"
+expect fail "acp-sdk-v1.2.3" "$work/symbols-mismatch" "symbols version disagrees with tag"
+expect fail "acp-sdk-v1.2.3" "$work/no-symbols"   "missing symbols package"
+expect fail "acp-sdk-v1.2.3" "$work/extra-nupkg"      "second package leaked into output"
+expect fail "acp-sdk-v1.2.3" "$work/extra-snupkg"     "second symbols package leaked into output"
+expect fail "acp-sdk-v1.2.3" "$work/empty"        "no packages at all"
+expect fail "v1.2.3"         "$work/match"        "app release tag rejected for SDK"
+expect fail "v1.2.3"         "$work/bare-version" "app tag rejected by prefix, not by name match"
+expect fail "acp-sdk-v"      "$work/match"        "tag without a version"
+expect fail "acp-sdk-v1.2.3" "$work/missing-dir"  "nonexistent package directory"
+
+if [ "$failures" -ne 0 ]; then
+  echo "[selftest] ${failures} case(s) failed" >&2
+  exit 1
+fi
+
+echo "[selftest] all cases passed"

--- a/scripts/gates/run-acp-sdk-tag-version-gate.sh
+++ b/scripts/gates/run-acp-sdk-tag-version-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Guards the one irreversible step in ACP SDK publishing: a push to nuget.org cannot be undone or
+# overwritten. If the release tag and the packed version disagree, the wrong version ships forever
+# under the right tag. This rule is kept out of the workflow so it can be exercised with positive and
+# negative cases on any machine instead of only being discovered by pushing a tag.
+set -euo pipefail
+
+RELEASE_TAG="${1:?Release tag is required (acp-sdk-v<version>)}"
+PACKAGE_DIR="${2:?Package directory is required}"
+
+tag_prefix="acp-sdk-v"
+case "$RELEASE_TAG" in
+  "$tag_prefix"*) ;;
+  *)
+    echo "ACP SDK release tags must start with '${tag_prefix}', got: ${RELEASE_TAG}" >&2
+    exit 1
+    ;;
+esac
+
+tag_version="${RELEASE_TAG#"$tag_prefix"}"
+# The next two checks (empty version, missing directory) are diagnostics, not independent safety
+# properties: removing either still leaves the run rejected by the package name/count rules below.
+# They exist to name the actual problem instead of reporting a confusing downstream mismatch, so
+# the selftest deliberately does not claim mutation coverage for them.
+if [ -z "$tag_version" ]; then
+  echo "ACP SDK release tag carries no version: ${RELEASE_TAG}" >&2
+  exit 1
+fi
+
+if [ ! -d "$PACKAGE_DIR" ]; then
+  echo "ACP SDK package directory not found: ${PACKAGE_DIR}" >&2
+  exit 1
+fi
+
+# Exactly one .nupkg and one .snupkg. Two packages in the same directory means an earlier build leaked
+# in, and `nuget push *.nupkg` would publish both.
+mapfile -t nupkgs < <(find "$PACKAGE_DIR" -maxdepth 1 -type f -name 'SalmonEgg.Acp.*.nupkg' ! -name '*.snupkg' -print | sort)
+mapfile -t snupkgs < <(find "$PACKAGE_DIR" -maxdepth 1 -type f -name 'SalmonEgg.Acp.*.snupkg' -print | sort)
+
+if [ "${#nupkgs[@]}" -ne 1 ]; then
+  echo "Expected exactly one SalmonEgg.Acp .nupkg in ${PACKAGE_DIR}, found ${#nupkgs[@]}:" >&2
+  printf '  %s\n' "${nupkgs[@]:-<none>}" >&2
+  exit 1
+fi
+
+# Symbols are part of the published contract: PublishRepositoryUrl/EmbedUntrackedSources only pay off
+# if the snupkg reaches nuget.org alongside the package.
+if [ "${#snupkgs[@]}" -ne 1 ]; then
+  echo "Expected exactly one SalmonEgg.Acp .snupkg in ${PACKAGE_DIR}, found ${#snupkgs[@]}:" >&2
+  printf '  %s\n' "${snupkgs[@]:-<none>}" >&2
+  exit 1
+fi
+
+package_file="$(basename "${nupkgs[0]}")"
+package_version="${package_file#SalmonEgg.Acp.}"
+package_version="${package_version%.nupkg}"
+
+if [ "$package_version" != "$tag_version" ]; then
+  echo "ACP SDK release tag and package version disagree." >&2
+  echo "  tag:     ${RELEASE_TAG} (version ${tag_version})" >&2
+  echo "  package: ${package_file} (version ${package_version})" >&2
+  echo "Bump <Version> in src/SalmonEgg.Acp/SalmonEgg.Acp.csproj to match the tag, or retag." >&2
+  exit 1
+fi
+
+symbols_file="$(basename "${snupkgs[0]}")"
+if [ "$symbols_file" != "SalmonEgg.Acp.${tag_version}.snupkg" ]; then
+  echo "ACP SDK symbols package does not match the release tag." >&2
+  echo "  tag:     ${RELEASE_TAG} (version ${tag_version})" >&2
+  echo "  symbols: ${symbols_file}" >&2
+  exit 1
+fi
+
+echo "[gate] ACP SDK tag/version contract satisfied: ${RELEASE_TAG} -> ${package_file} + ${symbols_file}"

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -160,6 +160,9 @@ namespace SalmonEgg.Acp.Client
         /// Creates a new <see cref="AcpClient"/> instance.
         /// </summary>
         /// <param name="transport">The transport used to exchange messages with the agent.</param>
+        /// <param name="logger">Optional logger for client diagnostics.</param>
+        /// <param name="sessionStore">Optional store consulted for session state.</param>
+        /// <param name="terminalSessionManager">Optional manager that services terminal requests.</param>
         public AcpClient(
             IAcpTransport transport,
             IAcpClientLogger? logger = null,

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -17,8 +17,8 @@ using SalmonEgg.Acp.Tool;
 namespace SalmonEgg.Acp.Client
 {
     /// <summary>
-    /// ACP 客户端核心实现。
-    /// 整合了消息层、协议层、传输层和安全层，提供完整的 ACP 客户端功能。
+    /// Core ACP client implementation.
+    /// Combines the message, protocol, transport, and security layers into a complete ACP client.
     /// </summary>
     public sealed class AcpClient : IAcpClient, IDisposable
     {
@@ -97,69 +97,69 @@ namespace SalmonEgg.Acp.Client
                 : _agentCapabilities?.SupportsLogout == true;
 
         /// <summary>
-        /// 初始化事件。
+        /// Raised when initialization completes.
         /// </summary>
         public event EventHandler<InitializeResponse>? Initialized;
 
         /// <summary>
-        /// 会话更新事件。
+        /// Raised when a session update is received.
         /// </summary>
         public event EventHandler<SessionUpdateEventArgs>? SessionUpdateReceived;
 
         /// <summary>
-        /// 权限请求事件。
+        /// Raised when a permission request is received.
         /// </summary>
         public event EventHandler<PermissionRequestEventArgs>? PermissionRequestReceived;
 
         /// <summary>
-        /// 文件系统请求事件。
+        /// Raised when a file system request is received.
         /// </summary>
         public event EventHandler<FileSystemRequestEventArgs>? FileSystemRequestReceived;
 
         /// <summary>
-        /// 终端请求事件。
+        /// Raised when a terminal request is received.
         /// </summary>
         public event EventHandler<TerminalRequestEventArgs>? TerminalRequestReceived;
 
         /// <summary>
-        /// 终端状态事件。
+        /// Raised when terminal state changes.
         /// </summary>
         public event EventHandler<TerminalStateChangedEventArgs>? TerminalStateChangedReceived;
 
         /// <summary>
-        /// Ask-user 请求事件。
+        /// Raised when an ask-user request is received.
         /// </summary>
         public event EventHandler<AskUserRequestEventArgs>? AskUserRequestReceived;
 
         /// <summary>
-        /// 连接错误事件。
+        /// Raised when a connection error occurs.
         /// </summary>
         public event EventHandler<string>? ErrorOccurred;
 
         /// <summary>
-        /// 判断客户端是否已初始化。
+        /// Gets a value indicating whether the client has been initialized.
         /// </summary>
         public bool IsInitialized => _isInitialized;
 
         /// <summary>
-        /// 判断是否已连接到 Agent。
+        /// Gets a value indicating whether the client is connected to the agent.
         /// </summary>
         public bool IsConnected => _transport.IsConnected;
 
         /// <summary>
-        /// 获取当前的 Agent 信息。
+        /// Gets the current agent information.
         /// </summary>
         public AgentInfo? AgentInfo => _agentInfo;
 
         /// <summary>
-        /// 获取当前的 Agent 能力。
+        /// Gets the current agent capabilities.
         /// </summary>
         public AgentCapabilities? AgentCapabilities => _agentCapabilities;
 
         /// <summary>
-        /// 创建新的 AcpClient 实例。
+        /// Creates a new <see cref="AcpClient"/> instance.
         /// </summary>
-        /// <param name="transport">传输层对象</param>
+        /// <param name="transport">The transport used to exchange messages with the agent.</param>
         public AcpClient(
             IAcpTransport transport,
             IAcpClientLogger? logger = null,
@@ -173,13 +173,13 @@ namespace SalmonEgg.Acp.Client
             _terminalSessionManager = terminalSessionManager ?? new UnsupportedAcpTerminalSessionManager();
             _logger = logger ?? new NullAcpClientLogger();
 
-            // 注册传输层事件
+            // Subscribe to transport events.
             _transport.MessageReceived += OnMessageReceived;
             _transport.ErrorOccurred += OnTransportError;
         }
 
         /// <summary>
-        /// 初始化与 Agent 的连接。
+        /// Initializes the connection to the agent.
         /// </summary>
         public async Task<InitializeResponse> InitializeAsync(InitializeParams @params, CancellationToken cancellationToken = default)
         {
@@ -199,7 +199,7 @@ namespace SalmonEgg.Acp.Client
                 throw new InvalidOperationException("ACP client is already initialized.");
             }
 
-            // 确保传输层已连接
+            // Make sure the transport is connected.
             if (!_transport.IsConnected)
             {
                 ClearLastTransportError();
@@ -210,14 +210,14 @@ namespace SalmonEgg.Acp.Client
                 }
             }
 
-            // 发送 initialize 请求
+            // Send the initialize request.
             var request = new JsonRpcRequest(
                 Interlocked.Increment(ref _nextMessageId),
                 "initialize",
                 ToElement(@params, AcpJsonContext.Default.InitializeParams));
             var response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
-            // 验证响应
+            // Validate the response.
             var validationResult = _validator.ValidateResponse(response);
             if (!validationResult.IsValid)
             {
@@ -229,7 +229,7 @@ namespace SalmonEgg.Acp.Client
                 throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
             }
 
-            // 解析响应
+            // Parse the response.
             var initializeResponse = FromElement(response.Result!.Value, AcpJsonContext.Default.InitializeResponse);
             if (initializeResponse == null)
             {
@@ -246,7 +246,7 @@ namespace SalmonEgg.Acp.Client
                     $"Protocol version mismatch. Expected by client: {clientVersion}, Server: {serverVersion}");
             }
 
-            // 存储 Agent 信息
+            // Store the agent information.
             _protocolVersion = serverVersion;
             _agentInfo = initializeResponse.AgentInfo;
             _agentCapabilities = initializeResponse.AgentCapabilities;
@@ -254,18 +254,18 @@ namespace SalmonEgg.Acp.Client
             _clientCapabilities = @params.ClientCapabilities;
             _isInitialized = true;
 
-            // 启动传输断连看门狗
+            // Start the transport disconnect watchdog.
             _messageLoopCts = new CancellationTokenSource();
             _ = MonitorTransportConnectionAsync(_messageLoopCts.Token);
 
-            // 触发事件
+            // Raise the event.
             Initialized?.Invoke(this, initializeResponse);
 
             return initializeResponse;
         }
 
         /// <summary>
-        /// 创建新的会话。
+        /// Creates a new session.
         /// </summary>
         public async Task<SessionNewResponse> CreateSessionAsync(SessionNewParams @params, CancellationToken cancellationToken = default)
         {
@@ -304,7 +304,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 加载已有的会话。
+        /// Loads an existing session.
         /// </summary>
         public async Task<SessionLoadResponse> LoadSessionAsync(SessionLoadParams @params, CancellationToken cancellationToken = default)
         {
@@ -336,8 +336,9 @@ namespace SalmonEgg.Acp.Client
                 throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
             }
 
-            // session/load 成功即代表 Agent 已确认该会话;注册进本地 store,否则后续
-            // session/prompt 的存在性快速失败会把官方 load→prompt 主流程本地拦截为 SessionNotFound。
+            // A successful session/load means the agent has acknowledged the session, so register it in
+            // the local store. Otherwise the existence fast-fail in session/prompt would locally reject
+            // the official load -> prompt flow as SessionNotFound.
             await RegisterSessionAsync(@params.SessionId, @params.Cwd).ConfigureAwait(false);
 
             if (!response.Result.HasValue ||
@@ -352,8 +353,8 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 恢复已有会话。省略 <see cref="SessionResumeParams.ReplayFrom"/> 时不要求重放历史；
-        /// 设置 <c>replayFrom: { type: "start" }</c> 时请求完整历史重放（V2）。
+        /// Resumes an existing session. Omitting <see cref="SessionResumeParams.ReplayFrom"/> requests no
+        /// history replay; setting <c>replayFrom: { type: "start" }</c> requests a full history replay (V2).
         /// </summary>
         public async Task<SessionResumeResponse> ResumeSessionAsync(SessionResumeParams @params, CancellationToken cancellationToken = default)
         {
@@ -393,8 +394,9 @@ namespace SalmonEgg.Acp.Client
                 throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
             }
 
-            // Agent 已确认恢复该会话:注册本地追踪条目,使后续 session/prompt 的存在性
-            // 快速失败门(SendPromptAsync)不会把 resume→prompt 官方主流程误判为 SessionNotFound。
+            // The agent has acknowledged the resumed session, so register the local tracking entry. This
+            // keeps the existence fast-fail gate in SendPromptAsync from misreporting the official
+            // resume -> prompt flow as SessionNotFound.
             await RegisterSessionAsync(@params.SessionId, @params.Cwd).ConfigureAwait(false);
 
             if (!response.Result.HasValue ||
@@ -409,7 +411,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 关闭已有会话并释放 Agent 侧资源。
+        /// Closes an existing session and releases the resources held on the agent side.
         /// </summary>
         public async Task<SessionCloseResponse> CloseSessionAsync(SessionCloseParams @params, CancellationToken cancellationToken = default)
         {
@@ -453,7 +455,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 删除远端 Agent 会话。
+        /// Deletes a session on the remote agent.
         /// </summary>
         public async Task<SessionDeleteResponse> DeleteSessionAsync(SessionDeleteParams @params, CancellationToken cancellationToken = default)
         {
@@ -496,7 +498,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 列出远端 Agent 支持的会话列表
+        /// Lists the sessions reported by the remote agent.
         /// </summary>
         public async Task<SessionListResponse> ListSessionsAsync(SessionListParams @params, CancellationToken cancellationToken = default)
         {
@@ -537,13 +539,13 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 向会话发送提示。
+        /// Sends a prompt to a session.
         /// </summary>
         public async Task<SessionPromptResponse> SendPromptAsync(SessionPromptParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
 
-            // 检查会话是否存在
+            // Check whether the session exists.
             if (!_sessionStore.ContainsSession(@params.SessionId))
             {
                 throw new AcpException(JsonRpcErrorCode.SessionNotFound, $"Session '{@params.SessionId}' not found");
@@ -574,10 +576,12 @@ namespace SalmonEgg.Acp.Client
             return promptResponse;
         }
 
-        // spec MUST:client 须按 initialize 协商的 promptCapabilities 限制发送的 content 类型
-        // (image→SupportsImage、audio→SupportsAudio、resource→SupportsEmbeddedContext)。
-        // text 与 resource_link 是无条件基线,始终允许;未知判别值走 passthrough 由 Agent 裁决,
-        // 不在此反向收紧。发送前快速失败,避免把 Agent 明确不支持的内容打到线上。
+        // spec MUST: the client must restrict the content types it sends to the promptCapabilities
+        // negotiated during initialize (image -> SupportsImage, audio -> SupportsAudio,
+        // resource -> SupportsEmbeddedContext). text and resource_link are the unconditional baseline and
+        // are always allowed; unknown discriminator values pass through for the agent to decide and are
+        // not tightened here. Failing fast before sending avoids putting content the agent explicitly
+        // does not support on the wire.
         private void EnsurePromptContentAllowed(SessionPromptParams @params)
         {
             var prompt = @params.Prompt;
@@ -607,7 +611,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 设置会话模式。
+        /// Sets the session mode.
         /// </summary>
         public async Task<SessionSetModeResponse> SetSessionModeAsync(SessionSetModeParams @params, CancellationToken cancellationToken = default)
         {
@@ -631,14 +635,14 @@ namespace SalmonEgg.Acp.Client
                 throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse session/set_mode response");
             }
 
-            // 更新会话模式
+            // Update the cached session mode.
             _sessionStore.UpdateCurrentMode(@params.SessionId, @params.ModeId);
 
             return setModeResponse;
         }
 
         /// <summary>
-        /// 设置会话配置选项。
+        /// Sets a session configuration option.
         /// </summary>
         public async Task<SessionSetConfigOptionResponse> SetSessionConfigOptionAsync(SessionSetConfigOptionParams @params, CancellationToken cancellationToken = default)
         {
@@ -666,7 +670,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 取消会话。
+        /// Cancels a session.
         /// </summary>
         public async Task CancelSessionAsync(SessionCancelParams @params, CancellationToken cancellationToken = default)
         {
@@ -696,7 +700,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 执行认证。
+        /// Performs authentication.
         /// </summary>
         public async Task<AuthenticateResponse> AuthenticateAsync(AuthenticateParams @params, CancellationToken cancellationToken = default)
         {
@@ -733,7 +737,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 登出当前认证状态。
+        /// Logs out of the current authenticated state.
         /// </summary>
         public async Task<LogoutResponse> LogoutAsync(LogoutParams @params, CancellationToken cancellationToken = default)
         {
@@ -771,7 +775,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 响应权限请求。
+        /// Responds to a permission request.
         /// </summary>
         public async Task<bool> RespondToPermissionRequestAsync(object messageId, string outcome, string? optionId = null)
         {
@@ -779,7 +783,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 响应文件系统请求。
+        /// Responds to a file system request.
         /// </summary>
         public async Task<bool> RespondToFileSystemRequestAsync(object messageId, bool success, string? content = null, string? message = null)
         {
@@ -787,7 +791,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 响应 ask-user 请求。
+        /// Responds to an ask-user request.
         /// </summary>
         public async Task<bool> RespondToAskUserRequestAsync(object messageId, IReadOnlyDictionary<string, string> answers)
         {
@@ -907,7 +911,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 断开与 Agent 的连接。
+        /// Disconnects from the agent.
         /// </summary>
         public async Task<bool> DisconnectAsync()
         {
@@ -919,7 +923,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 发送请求并等待响应。
+        /// Sends a request and awaits its response.
         /// </summary>
 
         private async Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken)
@@ -989,9 +993,11 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 幂等注册本地会话追踪条目。session/new 与 session/load、session/resume 成功后都要登记,
-        /// 使 SendPromptAsync 的存在性快速失败门不会误拦官方 load/resume→prompt 主流程。
-        /// 本地条目只是可选的快速失败优化,存在性事实源仍在 Agent(未声明能力时不收紧)。
+        /// Idempotently registers the local session tracking entry. It is recorded after a successful
+        /// session/new, session/load, or session/resume so the existence fast-fail gate in
+        /// SendPromptAsync does not reject the official load/resume -> prompt flow.
+        /// The local entry is only an optional fast-fail optimization; the agent remains the source of
+        /// truth for session existence, and nothing is tightened when a capability is not advertised.
         /// </summary>
         private async Task RegisterSessionAsync(string sessionId, string cwd)
         {
@@ -1023,7 +1029,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 发送响应（用于通知请求的响应）。
+        /// Sends a response (used to answer inbound requests).
         /// </summary>
         private async Task<bool> SendResponseAsync(JsonRpcResponse response)
         {
@@ -1041,7 +1047,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理消息接收事件。
+        /// Handles the transport message-received event.
         /// </summary>
         private void OnMessageReceived(object? sender, AcpTransportMessageReceivedEventArgs e)
         {
@@ -1072,7 +1078,7 @@ namespace SalmonEgg.Acp.Client
                 if (message is JsonRpcResponse response)
                 {
                     var responseIdStr = response.Id?.ToString() ?? string.Empty;
-                    // 匹配 pending 请求
+                    // Match the pending request.
                     if (_pendingRequests.TryRemove(responseIdStr, out var tcs))
                     {
                         tcs.TrySetResult(response);
@@ -1086,7 +1092,7 @@ namespace SalmonEgg.Acp.Client
                 }
                 else if (message is JsonRpcNotification notification)
                 {
-                    // 处理通知
+                    // Handle the notification.
                     HandleNotification(notification);
                 }
             }
@@ -1129,7 +1135,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理通知消息。
+        /// Handles an inbound notification message.
         /// </summary>
         private void HandleNotification(JsonRpcNotification notification)
         {
@@ -1139,13 +1145,13 @@ namespace SalmonEgg.Acp.Client
                     HandleSessionUpdate(notification);
                     break;
                 default:
-                    // 未知通知类型
+                    // Unknown notification type.
                     break;
             }
         }
 
         /// <summary>
-        /// 处理请求消息（Agent -> Client，需要返回响应）。
+        /// Handles an inbound request message (agent -> client, a response is required).
         /// </summary>
         private void HandleRequest(JsonRpcRequest request)
         {
@@ -1255,7 +1261,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理会话更新通知。
+        /// Handles the session/update notification.
         /// </summary>
         private void HandleSessionUpdate(JsonRpcNotification notification)
         {
@@ -1280,7 +1286,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理权限请求通知。
+        /// Handles an inbound permission request.
         /// </summary>
         private void HandlePermissionRequest(JsonRpcRequest request)
         {
@@ -1395,7 +1401,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理文件系统请求通知。
+        /// Handles an inbound file system request.
         /// </summary>
         private void HandleFileSystemRequest(JsonRpcRequest request)
         {
@@ -1474,7 +1480,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理 ask-user 请求。
+        /// Handles an inbound ask-user request.
         /// </summary>
         private void HandleAskUserRequest(JsonRpcRequest request)
         {
@@ -1543,7 +1549,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理终端请求。
+        /// Handles an inbound terminal request.
         /// </summary>
         private async Task HandleTerminalRequestAsync(JsonRpcRequest request)
         {
@@ -1879,7 +1885,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 处理传输错误事件。
+        /// Handles the transport error event.
         /// </summary>
         private void OnTransportError(object? sender, AcpTransportErrorEventArgs e)
         {
@@ -1916,7 +1922,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 触发错误事件。
+        /// Raises the error event.
         /// </summary>
         private void OnErrorOccurred(string errorMessage)
         {
@@ -1980,9 +1986,10 @@ namespace SalmonEgg.Acp.Client
             => "ACP request failed because the transport disconnected: " + transportErrorMessage;
 
         /// <summary>
-        /// 监视传输连接状态。传输可能在不触发 ErrorOccurred 的情况下静默断开
-        /// (或在错误事件时刻仍短暂报告已连接),此看门狗兜底 fault 所有挂起请求,
-        /// 避免调用方在 <see cref="SendRequestAsync"/> 上永久悬挂。
+        /// Monitors the transport connection state. A transport can drop silently without raising
+        /// ErrorOccurred (or still briefly report itself as connected at the moment of the error event),
+        /// so this watchdog faults every pending request as a backstop and keeps callers from hanging
+        /// forever on <see cref="SendRequestAsync"/>.
         /// </summary>
         private async Task MonitorTransportConnectionAsync(CancellationToken cancellationToken)
         {
@@ -1995,7 +2002,7 @@ namespace SalmonEgg.Acp.Client
             }
             catch (OperationCanceledException)
             {
-                // 显式 DisconnectAsync 已负责取消挂起请求。
+                // An explicit DisconnectAsync already cancels the pending requests.
                 return;
             }
 
@@ -2006,7 +2013,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 确保客户端已初始化。
+        /// Ensures the client has been initialized.
         /// </summary>
         private void EnsureInitialized()
         {
@@ -2094,8 +2101,9 @@ namespace SalmonEgg.Acp.Client
 
         private JsonElement ToElement<T>(T value, JsonTypeInfo<T> typeInfo)
         {
-            // 沿调用流把协商后的协议版本传给内部 converter（如 McpServer 的版本分流写入）。
-            // set→SerializeToElement→restore 同步闭合，中间无 await，并发请求不会串版本。
+            // Carry the negotiated protocol version along the call flow to the internal converters (for
+            // example the version-specific McpServer write path). set -> SerializeToElement -> restore
+            // closes synchronously with no await in between, so concurrent requests cannot mix versions.
             using (AcpProtocolWriteContext.Enter(_protocolVersion))
             {
                 return JsonSerializer.SerializeToElement(value, typeInfo);
@@ -2112,7 +2120,7 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// 释放资源。
+        /// Releases the resources held by this client.
         /// </summary>
         public void Dispose()
         {
@@ -2124,23 +2132,27 @@ namespace SalmonEgg.Acp.Client
             _disposed = true;
             _messageLoopCts?.Cancel();
 
-            // 先解绑传输事件,避免 teardown 期间的回调重入已释放的处理器;
-            // 再 fault 所有挂起请求,否则正在 await tcs.Task 的调用方在 Dispose 路径
-            // 永久悬挂(看门狗的取消只覆盖显式 DisconnectAsync,Dispose 无人负责)。
+            // Detach the transport events first so callbacks during teardown cannot re-enter disposed
+            // handlers, then fault every pending request. Otherwise callers awaiting tcs.Task would hang
+            // forever on the Dispose path, because the watchdog's cancellation only covers an explicit
+            // DisconnectAsync and nothing covers Dispose.
             _transport.MessageReceived -= OnMessageReceived;
             _transport.ErrorOccurred -= OnTransportError;
             CancelPendingRequests(_lastTransportErrorMessage ?? "The ACP client was disposed.");
 
-            // 传输是本客户端独占的资源(进程/套接字/HttpClient/Rx subject),Dispose 是其
-            // 权威释放路径(优雅的协议级断连由显式 DisconnectAsync 负责,已在调用方先行 await)。
-            // 终端会话管理器是跨连接共享的单例,由 DI 容器拥有,本客户端不得释放它。
+            // The transport is owned exclusively by this client (process / socket / HttpClient / Rx
+            // subject), and Dispose is its authoritative release path; a graceful protocol-level
+            // disconnect is the job of an explicit DisconnectAsync, awaited by the caller beforehand.
+            // The terminal session manager is a singleton shared across connections and owned by the DI
+            // container, so this client must not dispose it.
             try
             {
                 _transport.Dispose();
             }
             catch (Exception ex)
             {
-                // 清理路径的释放失败不得逃逸,否则会顶替真正的业务异常并挂死调用栈。
+                // A disposal failure on the cleanup path must not escape, or it would replace the real
+                // business exception and wedge the call stack.
                 _logger.Log(
                     AcpClientLogLevel.Warning,
                     "TRANSPORT_DISPOSE_FAILED",

--- a/src/SalmonEgg.Acp/Client/IAcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/IAcpClient.cs
@@ -8,162 +8,163 @@ using SalmonEgg.Acp.Client;
 namespace SalmonEgg.Acp.Client
 {
     /// <summary>
-    /// ACP 客户端接口。
-    /// 定义了与 Agent 通信的核心方法。
-    /// 客户端独占其传输（进程/套接字/HttpClient）与消息循环 CTS，生命周期由持有者
-    /// （ChatService）拥有，故契约包含 <see cref="IDisposable"/>：断连只停止流量，
-    /// 释放才归还底层资源。
+    /// ACP client interface.
+    /// Defines the core methods for communicating with an Agent.
+    /// The client exclusively owns its transport (process/socket/HttpClient) and the message-loop CTS;
+    /// its lifetime is owned by the holder (ChatService), so the contract includes
+    /// <see cref="IDisposable"/>: disconnecting only stops traffic, whereas disposing returns the
+    /// underlying resources.
     /// </summary>
     public interface IAcpClient : IDisposable
     {
         /// <summary>
-        /// 初始化事件。当初始化完成时触发。
+        /// Initialization event. Raised when initialization completes.
         /// </summary>
         event EventHandler<InitializeResponse>? Initialized;
 
         /// <summary>
-        /// 会话更新事件。当收到会话更新通知时触发。
+        /// Session update event. Raised when a session update notification is received.
         /// </summary>
         event EventHandler<SessionUpdateEventArgs>? SessionUpdateReceived;
 
         /// <summary>
-        /// 权限请求事件。当收到权限请求时触发。
+        /// Permission request event. Raised when a permission request is received.
         /// </summary>
         event EventHandler<PermissionRequestEventArgs>? PermissionRequestReceived;
 
         /// <summary>
-        /// 文件系统请求事件。当收到文件系统操作请求时触发。
+        /// File system request event. Raised when a file system operation request is received.
         /// </summary>
         event EventHandler<FileSystemRequestEventArgs>? FileSystemRequestReceived;
 
         /// <summary>
-        /// 终端请求事件。当收到终端操作请求时触发。
+        /// Terminal request event. Raised when a terminal operation request is received.
         /// </summary>
         event EventHandler<TerminalRequestEventArgs>? TerminalRequestReceived;
 
         /// <summary>
-        /// 终端状态事件。当客户端执行 ACP terminal 请求并获得状态快照时触发。
+        /// Terminal state event. Raised when the client executes an ACP terminal request and obtains a state snapshot.
         /// </summary>
         event EventHandler<TerminalStateChangedEventArgs>? TerminalStateChangedReceived;
 
         /// <summary>
-        /// Ask-user 请求事件。当 Agent 需要用户结构化回答时触发。
+        /// Ask-user request event. Raised when the Agent needs a structured answer from the user.
         /// </summary>
         event EventHandler<AskUserRequestEventArgs>? AskUserRequestReceived;
 
         /// <summary>
-        /// 连接错误事件。当发生连接错误时触发。
+        /// Connection error event. Raised when a connection error occurs.
         /// </summary>
         event EventHandler<string>? ErrorOccurred;
 
         /// <summary>
-        /// 判断客户端是否已初始化。
+        /// Gets a value indicating whether the client has been initialized.
         /// </summary>
         bool IsInitialized { get; }
 
         /// <summary>
-        /// 判断是否已连接到 Agent。
+        /// Gets a value indicating whether the client is connected to the Agent.
         /// </summary>
         bool IsConnected { get; }
 
         /// <summary>
-        /// 获取当前的 Agent 信息。
+        /// Gets the current Agent information.
         /// </summary>
         AgentInfo? AgentInfo { get; }
 
         /// <summary>
-        /// 获取当前的 Agent 能力。
+        /// Gets the current Agent capabilities.
         /// </summary>
         AgentCapabilities? AgentCapabilities { get; }
 
         /// <summary>
-        /// 初始化与 Agent 的连接。
-        /// 发送 initialize 请求并等待 Agent 响应。
+        /// Initializes the connection to the Agent.
+        /// Sends an initialize request and waits for the Agent's response.
         /// </summary>
-        /// <param name="params">初始化参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>初始化响应</returns>
+        /// <param name="params">The initialization parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The initialization response</returns>
         Task<InitializeResponse> InitializeAsync(InitializeParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 创建新的会话。
-        /// 发送 session/new 请求并等待 Agent 响应。
+        /// Creates a new session.
+        /// Sends a session/new request and waits for the Agent's response.
         /// </summary>
-        /// <param name="params">创建会话参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>创建会话响应</returns>
+        /// <param name="params">The create-session parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The create-session response</returns>
         Task<SessionNewResponse> CreateSessionAsync(SessionNewParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 加载已有的会话。
-        /// 发送 session/load 请求并等待 Agent 通过 session/update 通知重放历史。
+        /// Loads an existing session.
+        /// Sends a session/load request and waits for the Agent to replay history through session/update notifications.
         /// </summary>
-        /// <param name="params">加载会话参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>加载会话响应</returns>
+        /// <param name="params">The load-session parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The load-session response</returns>
         Task<SessionLoadResponse> LoadSessionAsync(SessionLoadParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 恢复已有会话但不要求 Agent 重放历史。
-        /// 发送 session/resume 请求并等待 Agent 恢复运行上下文。
+        /// Resumes an existing session without requiring the Agent to replay history.
+        /// Sends a session/resume request and waits for the Agent to restore the run context.
         /// </summary>
-        /// <param name="params">恢复会话参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>恢复会话响应</returns>
+        /// <param name="params">The resume-session parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The resume-session response</returns>
         Task<SessionResumeResponse> ResumeSessionAsync(SessionResumeParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 关闭已有会话并释放 Agent 侧资源。
-        /// 发送 session/close 请求。
+        /// Closes an existing session and releases the Agent-side resources.
+        /// Sends a session/close request.
         /// </summary>
-        /// <param name="params">关闭会话参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>关闭会话响应</returns>
+        /// <param name="params">The close-session parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The close-session response</returns>
         Task<SessionCloseResponse> CloseSessionAsync(SessionCloseParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 删除远端 Agent 会话。
-        /// 发送 session/delete 请求。
+        /// Deletes a remote Agent session.
+        /// Sends a session/delete request.
         /// </summary>
-        /// <param name="params">删除会话参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>删除会话响应</returns>
+        /// <param name="params">The delete-session parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The delete-session response</returns>
         Task<SessionDeleteResponse> DeleteSessionAsync(SessionDeleteParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 列出远端 Agent 支持的会话列表。
-        /// 发送 session/list 请求并等待 Agent 响应。
+        /// Lists the sessions supported by the remote Agent.
+        /// Sends a session/list request and waits for the Agent's response.
         /// </summary>
-        /// <param name="params">列表参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>会话列表响应</returns>
+        /// <param name="params">The list parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The session list response</returns>
         Task<SessionListResponse> ListSessionsAsync(SessionListParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 向会话发送提示。
-        /// 发送 session/prompt 请求并等待 Agent 响应。
+        /// Sends a prompt to the session.
+        /// Sends a session/prompt request and waits for the Agent's response.
         /// </summary>
-        /// <param name="params">发送提示参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>发送提示响应</returns>
+        /// <param name="params">The send-prompt parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The send-prompt response</returns>
         Task<SessionPromptResponse> SendPromptAsync(SessionPromptParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 设置会话模式。
-        /// 发送 session/set_mode 请求。
+        /// Sets the session mode.
+        /// Sends a session/set_mode request.
         /// </summary>
-        /// <param name="params">设置模式参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>设置模式响应</returns>
+        /// <param name="params">The set-mode parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The set-mode response</returns>
         Task<SessionSetModeResponse> SetSessionModeAsync(SessionSetModeParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 设置会话配置选项。
-        /// 发送 session/set_config_option 请求。
+        /// Sets a session configuration option.
+        /// Sends a session/set_config_option request.
         /// </summary>
-        /// <param name="params">设置配置参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>设置配置响应</returns>
+        /// <param name="params">The set-config parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The set-config response</returns>
         Task<SessionSetConfigOptionResponse> SetSessionConfigOptionAsync(SessionSetConfigOptionParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -172,80 +173,80 @@ namespace SalmonEgg.Acp.Client
         Task CancelSessionAsync(SessionCancelParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 执行认证。
-        /// 发送 authenticate 请求。
+        /// Performs authentication.
+        /// Sends an authenticate request.
         /// </summary>
-        /// <param name="params">认证参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>认证响应</returns>
+        /// <param name="params">The authentication parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The authentication response</returns>
         Task<AuthenticateResponse> AuthenticateAsync(AuthenticateParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 登出当前认证状态。
-        /// 发送 logout 请求。
+        /// Logs out of the current authentication state.
+        /// Sends a logout request.
         /// </summary>
-        /// <param name="params">登出参数</param>
-        /// <param name="cancellationToken">取消令牌</param>
-        /// <returns>登出响应</returns>
+        /// <param name="params">The logout parameters</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The logout response</returns>
         Task<LogoutResponse> LogoutAsync(LogoutParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// 响应权限请求。
-        /// 发送对之前权限请求的响应。
+        /// Responds to a permission request.
+        /// Sends the response to a previously received permission request.
         /// </summary>
-        /// <param name="messageId">原始请求的消息 ID</param>
-        /// <param name="outcome">结果（`selected` 或 `cancelled`）</param>
-        /// <param name="optionId">选中的选项 ID（可选）</param>
-        /// <returns>是否成功发送响应</returns>
+        /// <param name="messageId">The message ID of the original request</param>
+        /// <param name="outcome">The outcome (`selected` or `cancelled`)</param>
+        /// <param name="optionId">The ID of the selected option (optional)</param>
+        /// <returns>Whether the response was sent successfully</returns>
         Task<bool> RespondToPermissionRequestAsync(object messageId, string outcome, string? optionId = null);
 
         /// <summary>
-        /// 响应文件系统请求。
-        /// 发送对之前文件系统请求的响应。
+        /// Responds to a file system request.
+        /// Sends the response to a previously received file system request.
         /// </summary>
-        /// <param name="messageId">原始请求的消息 ID</param>
-        /// <param name="success">是否成功</param>
-        /// <param name="content">文件内容（读取操作）</param>
-        /// <param name="message">错误消息（如果失败）</param>
-        /// <returns>是否成功发送响应</returns>
+        /// <param name="messageId">The message ID of the original request</param>
+        /// <param name="success">Whether the operation succeeded</param>
+        /// <param name="content">The file content (read operations)</param>
+        /// <param name="message">The error message (when the operation failed)</param>
+        /// <returns>Whether the response was sent successfully</returns>
         Task<bool> RespondToFileSystemRequestAsync(object messageId, bool success, string? content = null, string? message = null);
 
         /// <summary>
-        /// 响应 ask-user 请求。
-        /// 发送对之前交互式提问请求的结构化答案。
+        /// Responds to an ask-user request.
+        /// Sends the structured answers for a previously received interactive question request.
         /// </summary>
-        /// <param name="messageId">原始请求的消息 ID</param>
-        /// <param name="answers">问题到答案的映射。</param>
-        /// <returns>是否成功发送响应</returns>
+        /// <param name="messageId">The message ID of the original request</param>
+        /// <param name="answers">A mapping from question to answer.</param>
+        /// <returns>Whether the response was sent successfully</returns>
         Task<bool> RespondToAskUserRequestAsync(object messageId, IReadOnlyDictionary<string, string> answers);
 
         /// <summary>
-        /// 断开与 Agent 的连接。
+        /// Disconnects from the Agent.
         /// </summary>
-        /// <returns>是否成功断开</returns>
+        /// <returns>Whether the disconnect succeeded</returns>
         Task<bool> DisconnectAsync();
     }
 
     /// <summary>
-    /// 会话更新事件参数。
+    /// Session update event arguments.
     /// </summary>
     public sealed class SessionUpdateEventArgs : EventArgs
     {
         /// <summary>
-        /// 会话 ID。
+        /// The session ID.
         /// </summary>
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 更新内容。
+        /// The update payload.
         /// </summary>
         public SessionUpdate? Update { get; init; }
 
         /// <summary>
-        /// 创建新的会话更新事件参数。
+        /// Creates new session update event arguments.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="update">更新内容</param>
+        /// <param name="sessionId">The session ID</param>
+        /// <param name="update">The update payload</param>
         public SessionUpdateEventArgs(string sessionId, SessionUpdate? update)
         {
             SessionId = sessionId;
@@ -254,43 +255,43 @@ namespace SalmonEgg.Acp.Client
     }
 
     /// <summary>
-    /// 权限请求事件参数。
+    /// Permission request event arguments.
     /// </summary>
     public sealed class PermissionRequestEventArgs : EventArgs
     {
         /// <summary>
-        /// 原始请求的消息 ID。
+        /// The message ID of the original request.
         /// </summary>
         public object MessageId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 会话 ID。
+        /// The session ID.
         /// </summary>
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 工具调用数据。
+        /// The tool call data.
         /// </summary>
         public object? ToolCall { get; init; }
 
         /// <summary>
-        /// 可用的权限选项列表。
+        /// The list of available permission options.
         /// </summary>
         public List<PermissionOption> Options { get; init; } = new List<PermissionOption>();
 
         /// <summary>
-        /// 响应回调。
+        /// The response callback.
         /// </summary>
         public Func<string, string?, Task> Respond { get; init; } = null!;
 
         /// <summary>
-        /// 创建新的权限请求事件参数。
+        /// Creates new permission request event arguments.
         /// </summary>
-        /// <param name="messageId">消息 ID</param>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="toolCall">工具调用</param>
-        /// <param name="options">权限选项</param>
-        /// <param name="respond">响应回调</param>
+        /// <param name="messageId">The message ID</param>
+        /// <param name="sessionId">The session ID</param>
+        /// <param name="toolCall">The tool call</param>
+        /// <param name="options">The permission options</param>
+        /// <param name="respond">The response callback</param>
         public PermissionRequestEventArgs(
             object messageId,
             string sessionId,
@@ -313,61 +314,61 @@ namespace SalmonEgg.Acp.Client
     }
 
     /// <summary>
-    /// 文件系统请求事件参数。
+    /// File system request event arguments.
     /// </summary>
     public sealed class FileSystemRequestEventArgs : EventArgs
     {
         /// <summary>
-        /// 原始请求的消息 ID。
+        /// The message ID of the original request.
         /// </summary>
         public object MessageId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 会话 ID。
+        /// The session ID.
         /// </summary>
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// ACP 文件系统请求方法。
+        /// The ACP file system request method.
         /// </summary>
         public string Method { get; init; } = string.Empty;
 
         /// <summary>
-        /// 文件系统请求类型。
+        /// The file system request kind.
         /// </summary>
         public FileSystemRequestKind Kind { get; init; }
 
         /// <summary>
-        /// 文件路径。
+        /// The file path.
         /// </summary>
         public string Path { get; init; } = string.Empty;
 
         /// <summary>
-        /// 文件编码（读取操作）。
+        /// The file encoding (read operations).
         /// </summary>
         public string? Encoding { get; init; }
 
         /// <summary>
-        /// 文件内容（写入操作）。
+        /// The file content (write operations).
         /// </summary>
         public string? Content { get; init; }
 
         /// <summary>
-        /// 响应回调。
+        /// The response callback.
         /// </summary>
         public Func<bool, string?, string?, Task> Respond { get; init; } = null!;
 
         /// <summary>
-        /// 创建新的文件系统请求事件参数。
+        /// Creates new file system request event arguments.
         /// </summary>
-        /// <param name="messageId">消息 ID</param>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="method">ACP 方法名</param>
-        /// <param name="kind">请求类型</param>
-        /// <param name="path">文件路径</param>
-        /// <param name="encoding">编码</param>
-        /// <param name="content">内容</param>
-        /// <param name="respond">响应回调</param>
+        /// <param name="messageId">The message ID</param>
+        /// <param name="sessionId">The session ID</param>
+        /// <param name="method">The ACP method name</param>
+        /// <param name="kind">The request kind</param>
+        /// <param name="path">The file path</param>
+        /// <param name="encoding">The encoding</param>
+        /// <param name="content">The content</param>
+        /// <param name="respond">The response callback</param>
         public FileSystemRequestEventArgs(
             object messageId,
             string sessionId,

--- a/src/SalmonEgg.Acp/Client/IAcpTransport.cs
+++ b/src/SalmonEgg.Acp/Client/IAcpTransport.cs
@@ -5,8 +5,9 @@ using System.Threading.Tasks;
 namespace SalmonEgg.Acp.Client
 {
     /// <summary>
-    /// ACP 传输契约。持有底层传输独占的进程/套接字/HttpClient 资源，
-    /// 生命周期由 <see cref="AcpClient"/> 拥有，故继承 <see cref="IDisposable"/>。
+    /// Transport contract for ACP. Holds the process, socket, or HttpClient resources owned exclusively by the
+    /// underlying transport; its lifetime belongs to <see cref="AcpClient"/>, hence it derives from
+    /// <see cref="IDisposable"/>.
     /// </summary>
     public interface IAcpTransport : IDisposable
     {

--- a/src/SalmonEgg.Acp/Content/AudioContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/AudioContentBlock.cs
@@ -3,42 +3,43 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 音频内容块。
-    /// 用于表示 Base64 编码的音频数据。
+    /// An audio content block.
+    /// Represents Base64-encoded audio data.
     /// </summary>
     public sealed record AudioContentBlock : ContentBlock
     {
         /// <summary>
-        /// 内容块类型标识符，固定为 "audio"。
-        /// 此属性被 [JsonIgnore] 忽略；wire 判别值由 ContentBlockJsonConverter 手写读写（保留未知类型 RawPayload 透传）。
+        /// The content block type identifier; always "audio".
+        /// This property is ignored via [JsonIgnore]; the wire discriminator is read and written by hand in
+        /// ContentBlockJsonConverter (which preserves RawPayload pass-through for unknown types).
         /// </summary>
         [JsonIgnore]
         public override string Type => "audio";
 
         /// <summary>
-        /// Base64 编码的音频数据。
+        /// The Base64-encoded audio data.
         /// </summary>
         [JsonPropertyName("data")]
         public string Data { get; init; } = string.Empty;
 
         /// <summary>
-        /// 音频的 MIME 类型（例如 "audio/wav", "audio/mp3"）。
+        /// The MIME type of the audio (for example "audio/wav" or "audio/mp3").
         /// </summary>
         [JsonPropertyName("mimeType")]
         public string MimeType { get; init; } = "audio/wav";
 
         /// <summary>
-        /// 创建新的音频内容块实例。
+        /// Creates a new audio content block instance.
         /// </summary>
         public AudioContentBlock()
         {
         }
 
         /// <summary>
-        /// 创建新的音频内容块实例。
+        /// Creates a new audio content block instance.
         /// </summary>
-        /// <param name="data">Base64 编码的音频数据</param>
-        /// <param name="mimeType">音频的 MIME 类型</param>
+        /// <param name="data">The Base64-encoded audio data.</param>
+        /// <param name="mimeType">The MIME type of the audio.</param>
         public AudioContentBlock(string data, string mimeType = "audio/wav")
         {
             Data = data;

--- a/src/SalmonEgg.Acp/Content/ContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ContentBlock.cs
@@ -7,8 +7,8 @@ using SalmonEgg.Acp.Protocol;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 内容块的基类。
-    /// 用于表示会话中的各种类型的内容（文本、图片、音频、资源等）。
+    /// Base type for content blocks.
+    /// Represents the various kinds of content exchanged in a session (text, image, audio, resource, and so on).
     /// ContentBlock uses a dedicated converter so protocol fields retain their wire shape.
     /// </summary>
     [JsonConverter(typeof(ContentBlockJsonConverter))]
@@ -24,17 +24,18 @@ namespace SalmonEgg.Acp.Content
         internal string? UnknownTypeDiscriminator { get; init; }
 
         /// <summary>
-        /// 未知判别值内容块的原始 payload，原样保留以供无损透传。
-        /// spec 要求 client 对未知 content 类型保留原始形态，由 Agent 而非 client 决定接受或拒绝；
-        /// 已知类型（text/image/audio/resource/resource_link）不使用此字段。
-        /// 由 <see cref="ContentBlockJsonConverter"/> 手动读写，不经默认序列化。
+        /// Raw payload of a content block with an unknown type discriminator, kept verbatim for lossless passthrough.
+        /// The spec requires a client to preserve the original shape of unknown content types, leaving the decision
+        /// to accept or reject them to the Agent rather than the client; the known types
+        /// (text/image/audio/resource/resource_link) do not use this field.
+        /// Read and written manually by <see cref="ContentBlockJsonConverter"/>, bypassing default serialization.
         /// </summary>
         [JsonIgnore]
         internal JsonElement? RawPayload { get; init; }
 
         /// <summary>
-        /// 内容块的类型标识符。
-        /// 用于多态序列化和反序列化。
+        /// Type discriminator of the content block.
+        /// Used for polymorphic serialization and deserialization.
         /// </summary>
         [JsonIgnore]
         public virtual string Type => UnknownTypeDiscriminator ?? string.Empty;
@@ -190,9 +191,11 @@ namespace SalmonEgg.Acp.Content
 
         private static ContentBlock ReadUnknown(JsonElement root, string discriminator)
         {
-            // 未知判别值走 passthrough:spec 要求 receiver 对不认识的 content 类型保留 raw payload,
-            // 由 Agent 而非 client 决定接受或拒绝。原样保留整个 block object 以供无损 round-trip,
-            // 不丢弃 type/annotations/_meta 之外的字段(对照 McpServerJsonConverter 的 RawPayload 范式)。
+            // Unknown discriminators take the passthrough path: the spec requires a receiver to preserve the raw
+            // payload of content types it does not recognize, leaving the decision to accept or reject them to the
+            // Agent rather than the client. The whole block object is kept verbatim so the round-trip is lossless
+            // and fields beyond type/annotations/_meta are not dropped (mirrors the RawPayload pattern in
+            // McpServerJsonConverter).
             return new ContentBlock
             {
                 UnknownTypeDiscriminator = discriminator,
@@ -468,10 +471,12 @@ namespace SalmonEgg.Acp.Content
                 throw new JsonException("Unknown ContentBlock instances must preserve their original type discriminator.");
             }
 
-            // 无损透传:原样写回读入时保留的 raw payload,不重排字段、不丢弃未知属性。
-            // RawPayload 是未知 block 的唯一权威事实源(含其 annotations/_meta),故不叠加另写,
-            // 避免第二套状态 owner。用 WriteRawValue(GetRawText()) 保证字节级保真(对照 CustomMcpServer)。
-            // 若 RawPayload 为空(如手工构造的未知 block),退化为按已知字段最小写出,仍携带原始 type。
+            // Lossless passthrough: write back the raw payload captured on read, without reordering fields or
+            // dropping unknown properties. RawPayload is the single authoritative source of truth for an unknown
+            // block (including its annotations/_meta), so nothing else is written alongside it, which avoids a
+            // second state owner. WriteRawValue(GetRawText()) guarantees byte-level fidelity (mirrors
+            // CustomMcpServer). When RawPayload is absent (for example a hand-constructed unknown block), fall back
+            // to a minimal write of the known fields, still carrying the original type.
             if (value.RawPayload is { ValueKind: JsonValueKind.Object } rawPayload)
             {
                 writer.WriteRawValue(rawPayload.GetRawText());

--- a/src/SalmonEgg.Acp/Content/EmbeddedResource.cs
+++ b/src/SalmonEgg.Acp/Content/EmbeddedResource.cs
@@ -4,50 +4,50 @@ using SalmonEgg.Acp.Protocol;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 嵌入的资源对象。
-    /// 用于 ResourceContentBlock 中包含的实际资源数据。
+    /// An embedded resource object.
+    /// Carries the actual resource data contained in a ResourceContentBlock.
     /// </summary>
     public sealed record EmbeddedResource : AcpProtocolObject
     {
         /// <summary>
-        /// 资源的 URI 标识符。
+        /// The URI identifier of the resource.
         /// </summary>
         [JsonPropertyName("uri")]
         public string Uri { get; init; } = string.Empty;
 
         /// <summary>
-        /// 资源的 MIME 类型（例如 "text/plain", "application/json"）。
+        /// The MIME type of the resource (for example "text/plain", "application/json").
         /// </summary>
         [JsonPropertyName("mimeType")]
         public string MimeType { get; init; } = "text/plain";
 
         /// <summary>
-        /// 资源的文本内容（如果资源是文本类型）。
-        /// 与 Blob 互斥。
+        /// The textual content of the resource, when the resource is text.
+        /// Mutually exclusive with Blob.
         /// </summary>
         [JsonPropertyName("text")]
         public string? Text { get; init; }
 
         /// <summary>
-        /// 资源的二进制数据（Base64 编码，如果资源是二进制类型）。
-        /// 与 Text 互斥。
+        /// The binary data of the resource (Base64 encoded), when the resource is binary.
+        /// Mutually exclusive with Text.
         /// </summary>
         [JsonPropertyName("blob")]
         public string? Blob { get; init; }
 
         /// <summary>
-        /// 创建新的 EmbeddedResource 实例。
+        /// Creates a new EmbeddedResource instance.
         /// </summary>
         public EmbeddedResource()
         {
         }
 
         /// <summary>
-        /// 创建新的文本资源实例。
+        /// Creates a new text resource instance.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="text">文本内容</param>
-        /// <param name="mimeType">MIME 类型</param>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="text">The textual content</param>
+        /// <param name="mimeType">The MIME type</param>
         public EmbeddedResource(string uri, string text, string mimeType = "text/plain")
         {
             Uri = uri;
@@ -56,11 +56,11 @@ namespace SalmonEgg.Acp.Content
         }
 
         /// <summary>
-        /// 创建新的二进制资源实例。
+        /// Creates a new binary resource instance.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="blob">Base64 编码的二进制数据</param>
-        /// <param name="mimeType">MIME 类型</param>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="blob">The Base64 encoded binary data</param>
+        /// <param name="mimeType">The MIME type</param>
         public EmbeddedResource(string uri, string blob, string mimeType, bool isBinary)
         {
             Uri = uri;
@@ -69,36 +69,36 @@ namespace SalmonEgg.Acp.Content
         }
 
         /// <summary>
-        /// 静态辅助方法：创建文本资源。
+        /// Static helper method: creates a text resource.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="text">文本内容</param>
-        /// <param name="mimeType">MIME 类型</param>
-        /// <returns>EmbeddedResource 实例</returns>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="text">The textual content</param>
+        /// <param name="mimeType">The MIME type</param>
+        /// <returns>An EmbeddedResource instance</returns>
         public static EmbeddedResource CreateText(string uri, string text, string mimeType = "text/plain")
         {
             return new EmbeddedResource(uri, text, mimeType);
         }
 
         /// <summary>
-        /// 静态辅助方法：创建二进制资源。
+        /// Static helper method: creates a binary resource.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="blob">Base64 编码的二进制数据</param>
-        /// <param name="mimeType">MIME 类型</param>
-        /// <returns>EmbeddedResource 实例</returns>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="blob">The Base64 encoded binary data</param>
+        /// <param name="mimeType">The MIME type</param>
+        /// <returns>An EmbeddedResource instance</returns>
         public static EmbeddedResource CreateBinary(string uri, string blob, string mimeType)
         {
             return new EmbeddedResource(uri, blob, mimeType, true);
         }
 
         /// <summary>
-        /// 判断资源是否为文本类型。
+        /// Indicates whether the resource is a text resource.
         /// </summary>
         public bool IsText => !string.IsNullOrEmpty(Text);
 
         /// <summary>
-        /// 判断资源是否为二进制类型。
+        /// Indicates whether the resource is a binary resource.
         /// </summary>
         public bool IsBinary => !string.IsNullOrEmpty(Blob);
     }

--- a/src/SalmonEgg.Acp/Content/EmbeddedResource.cs
+++ b/src/SalmonEgg.Acp/Content/EmbeddedResource.cs
@@ -61,6 +61,7 @@ namespace SalmonEgg.Acp.Content
         /// <param name="uri">The resource URI</param>
         /// <param name="blob">The Base64 encoded binary data</param>
         /// <param name="mimeType">The MIME type</param>
+        /// <param name="isBinary">Unused; distinguishes this overload from the text constructor</param>
         public EmbeddedResource(string uri, string blob, string mimeType, bool isBinary)
         {
             Uri = uri;

--- a/src/SalmonEgg.Acp/Content/ImageContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ImageContentBlock.cs
@@ -3,20 +3,21 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 图片内容块。
-    /// 用于表示 Base64 编码的图片数据。
+    /// An image content block.
+    /// Represents Base64-encoded image data.
     /// </summary>
     public sealed record ImageContentBlock : ContentBlock
     {
         /// <summary>
-        /// 内容块类型标识符，固定为 "image"。
-        /// 此属性被 [JsonIgnore] 忽略；wire 判别值由 ContentBlockJsonConverter 手写读写（保留未知类型 RawPayload 透传）。
+        /// The content block type identifier; always "image".
+        /// This property is excluded by [JsonIgnore]; the wire discriminator is read and written by hand in
+        /// ContentBlockJsonConverter (which also passes unknown types through via RawPayload).
         /// </summary>
         [JsonIgnore]
         public override string Type => "image";
 
         /// <summary>
-        /// Base64 编码的图片数据。
+        /// The Base64-encoded image data.
         /// </summary>
         [JsonPropertyName("data")]
         public string Data { get; init; } = string.Empty;
@@ -28,23 +29,23 @@ namespace SalmonEgg.Acp.Content
         public string? Uri { get; init; }
 
         /// <summary>
-        /// 图片的 MIME 类型（例如 "image/png", "image/jpeg"）。
+        /// The MIME type of the image (for example "image/png", "image/jpeg").
         /// </summary>
         [JsonPropertyName("mimeType")]
         public string MimeType { get; init; } = "image/png";
 
         /// <summary>
-        /// 创建新的图片内容块实例。
+        /// Creates a new image content block instance.
         /// </summary>
         public ImageContentBlock()
         {
         }
 
         /// <summary>
-        /// 创建新的图片内容块实例。
+        /// Creates a new image content block instance.
         /// </summary>
-        /// <param name="data">Base64 编码的图片数据</param>
-        /// <param name="mimeType">图片的 MIME 类型</param>
+        /// <param name="data">The Base64-encoded image data</param>
+        /// <param name="mimeType">The MIME type of the image</param>
         /// <param name="uri">Optional URI reference for the image source</param>
         public ImageContentBlock(string data, string mimeType = "image/png", string? uri = null)
         {

--- a/src/SalmonEgg.Acp/Content/ResourceContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ResourceContentBlock.cs
@@ -4,58 +4,59 @@ using SalmonEgg.Acp.Content;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 资源内容块。
-    /// 用于表示嵌入的实际资源数据（文本或二进制）。
+    /// A resource content block.
+    /// Represents embedded resource data (either text or binary).
     /// </summary>
     public sealed record ResourceContentBlock : ContentBlock
     {
         /// <summary>
-        /// 内容块类型标识符，固定为 "resource"。
-        /// 此属性被 [JsonIgnore] 忽略；wire 判别值由 ContentBlockJsonConverter 手写读写（保留未知类型 RawPayload 透传）。
+        /// The content block type identifier, always "resource".
+        /// This property is excluded by [JsonIgnore]; the wire discriminator is read and written by hand in
+        /// ContentBlockJsonConverter (which preserves RawPayload pass-through for unknown types).
         /// </summary>
         [JsonIgnore]
         public override string Type => "resource";
 
         /// <summary>
-        /// 嵌入的资源对象。
-        /// 包含资源的实际数据（uri, mimeType, text 或 blob）。
+        /// The embedded resource object.
+        /// Holds the resource's actual data (uri, mimeType, text or blob).
         /// </summary>
         [JsonPropertyName("resource")]
         public EmbeddedResource Resource { get; init; } = null!;
 
         /// <summary>
-        /// 创建新的资源内容块实例。
+        /// Creates a new resource content block instance.
         /// </summary>
         public ResourceContentBlock()
         {
         }
 
         /// <summary>
-        /// 创建新的资源内容块实例。
+        /// Creates a new resource content block instance.
         /// </summary>
-        /// <param name="resource">嵌入的资源对象</param>
+        /// <param name="resource">The embedded resource object</param>
         public ResourceContentBlock(EmbeddedResource resource)
         {
             Resource = resource;
         }
 
         /// <summary>
-        /// 创建新的文本资源内容块实例。
+        /// Creates a new text resource content block instance.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="text">文本内容</param>
-        /// <param name="mimeType">MIME 类型</param>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="text">The text content</param>
+        /// <param name="mimeType">The MIME type</param>
         public static ResourceContentBlock CreateText(string uri, string text, string mimeType = "text/plain")
         {
             return new ResourceContentBlock(EmbeddedResource.CreateText(uri, text, mimeType));
         }
 
         /// <summary>
-        /// 创建新的二进制资源内容块实例。
+        /// Creates a new binary resource content block instance.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="blob">Base64 编码的二进制数据</param>
-        /// <param name="mimeType">MIME 类型</param>
+        /// <param name="uri">The resource URI</param>
+        /// <param name="blob">The Base64-encoded binary data</param>
+        /// <param name="mimeType">The MIME type</param>
         public static ResourceContentBlock CreateBinary(string uri, string blob, string mimeType)
         {
             return new ResourceContentBlock(EmbeddedResource.CreateBinary(uri, blob, mimeType));

--- a/src/SalmonEgg.Acp/Content/ResourceLinkContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ResourceLinkContentBlock.cs
@@ -3,70 +3,71 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 资源链接内容块。
-    /// 用于表示对外部资源的引用（URI 链接）。
+    /// Resource link content block.
+    /// Represents a reference to an external resource (a URI link).
     /// </summary>
     public sealed record ResourceLinkContentBlock : ContentBlock
     {
         /// <summary>
-        /// 内容块类型标识符，固定为 "resource_link"。
-        /// 此属性被 [JsonIgnore] 忽略；wire 判别值由 ContentBlockJsonConverter 手写读写（保留未知类型 RawPayload 透传）。
+        /// Content block type identifier, always "resource_link".
+        /// This property is excluded by [JsonIgnore]; the wire discriminator is read and written by hand in
+        /// ContentBlockJsonConverter (which preserves RawPayload passthrough for unknown types).
         /// </summary>
         [JsonIgnore]
         public override string Type => "resource_link";
 
         /// <summary>
-        /// 资源的 URI 标识符。
+        /// URI identifying the resource.
         /// </summary>
         [JsonPropertyName("uri")]
         public string Uri { get; init; } = string.Empty;
 
         /// <summary>
-        /// 资源的名称（可选）。
+        /// Name of the resource (optional).
         /// </summary>
         [JsonPropertyName("name")]
         public string? Name { get; init; }
 
         /// <summary>
-        /// 资源的 MIME 类型（可选）。
+        /// MIME type of the resource (optional).
         /// </summary>
         [JsonPropertyName("mimeType")]
         public string? MimeType { get; init; }
 
         /// <summary>
-        /// 资源的标题（可选）。
+        /// Title of the resource (optional).
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; init; }
 
         /// <summary>
-        /// 资源的描述（可选）。
+        /// Description of the resource (optional).
         /// </summary>
         [JsonPropertyName("description")]
         public string? Description { get; init; }
 
         /// <summary>
-        /// 资源的大小（字节，可选）。
+        /// Size of the resource, in bytes (optional).
         /// </summary>
         [JsonPropertyName("size")]
         public long? Size { get; init; }
 
         /// <summary>
-        /// 创建新的资源链接内容块实例。
+        /// Creates a new resource link content block instance.
         /// </summary>
         public ResourceLinkContentBlock()
         {
         }
 
         /// <summary>
-        /// 创建新的资源链接内容块实例。
+        /// Creates a new resource link content block instance.
         /// </summary>
-        /// <param name="uri">资源 URI</param>
-        /// <param name="name">资源名称</param>
-        /// <param name="mimeType">MIME 类型</param>
-        /// <param name="title">标题</param>
-        /// <param name="description">描述</param>
-        /// <param name="size">大小（字节）</param>
+        /// <param name="uri">Resource URI</param>
+        /// <param name="name">Resource name</param>
+        /// <param name="mimeType">MIME type</param>
+        /// <param name="title">Title</param>
+        /// <param name="description">Description</param>
+        /// <param name="size">Size, in bytes</param>
         public ResourceLinkContentBlock(
             string uri,
             string? name = null,

--- a/src/SalmonEgg.Acp/Content/TextContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/TextContentBlock.cs
@@ -3,35 +3,36 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.Content
 {
     /// <summary>
-    /// 文本内容块。
-    /// 用于表示纯文本内容。
+    /// A text content block.
+    /// Represents plain text content.
     /// </summary>
     public sealed record TextContentBlock : ContentBlock
     {
         /// <summary>
-        /// 内容块类型标识符，固定为 "text"。
-        /// 此属性被 [JsonIgnore] 忽略；wire 判别值由 ContentBlockJsonConverter 手写读写（保留未知类型 RawPayload 透传）。
+        /// The content block type identifier, always "text".
+        /// This property is marked [JsonIgnore]; the wire discriminator is read and written by hand in
+        /// ContentBlockJsonConverter (which keeps RawPayload pass-through for unknown types).
         /// </summary>
         [JsonIgnore]
         public override string Type => "text";
 
         /// <summary>
-        /// 文本内容。
+        /// The text content.
         /// </summary>
         [JsonPropertyName("text")]
         public string Text { get; init; } = string.Empty;
 
         /// <summary>
-        /// 创建新的文本内容块实例。
+        /// Creates a new text content block instance.
         /// </summary>
         public TextContentBlock()
         {
         }
 
         /// <summary>
-        /// 创建新的文本内容块实例。
+        /// Creates a new text content block instance.
         /// </summary>
-        /// <param name="text">文本内容</param>
+        /// <param name="text">The text content.</param>
         public TextContentBlock(string text)
         {
             Text = text;

--- a/src/SalmonEgg.Acp/JsonRpc/AcpException.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/AcpException.cs
@@ -4,27 +4,27 @@ using System.Text.Json;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// ACP 协议异常类。
-    /// 用于表示 JSON-RPC 2.0 协议级别的错误。
+    /// ACP protocol exception.
+    /// Represents an error at the JSON-RPC 2.0 protocol level.
     /// </summary>
     public sealed class AcpException : Exception
     {
         /// <summary>
-        /// JSON-RPC 2.0 错误码。
+        /// The JSON-RPC 2.0 error code.
         /// </summary>
         public int ErrorCode { get; }
 
         /// <summary>
-        /// 可选的附加错误数据。
+        /// Optional additional error data.
         /// </summary>
         public object? ErrorData { get; }
 
         /// <summary>
-        /// 创建新的 AcpException 实例。
+        /// Creates a new <see cref="AcpException"/> instance.
         /// </summary>
-        /// <param name="errorCode">JSON-RPC 2.0 错误码</param>
-        /// <param name="message">异常消息</param>
-        /// <param name="errorData">可选的附加数据</param>
+        /// <param name="errorCode">The JSON-RPC 2.0 error code.</param>
+        /// <param name="message">The exception message.</param>
+        /// <param name="errorData">Optional additional data.</param>
         public AcpException(int errorCode, string message, object? errorData = null)
             : base(FormatMessage(message, errorData))
         {
@@ -33,12 +33,12 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建新的 AcpException 实例。
+        /// Creates a new <see cref="AcpException"/> instance.
         /// </summary>
-        /// <param name="errorCode">JSON-RPC 2.0 错误码</param>
-        /// <param name="message">异常消息</param>
-        /// <param name="innerException">内部异常</param>
-        /// <param name="errorData">可选的附加数据</param>
+        /// <param name="errorCode">The JSON-RPC 2.0 error code.</param>
+        /// <param name="message">The exception message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="errorData">Optional additional data.</param>
         public AcpException(int errorCode, string message, Exception innerException, object? errorData = null)
             : base(FormatMessage(message, errorData), innerException)
         {
@@ -47,10 +47,10 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个解析错误的异常。
+        /// Creates an exception representing a parse error.
         /// </summary>
-        /// <param name="innerException">解析异常</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="innerException">The parse exception.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateParseError(Exception innerException)
         {
             return new AcpException(
@@ -60,11 +60,11 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个无效请求的异常。
+        /// Creates an exception representing an invalid request.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <param name="data">可选的附加数据</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <param name="data">Optional additional data.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInvalidRequest(string message, object? errorData = null)
         {
             return new AcpException(
@@ -74,10 +74,10 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个方法未找到的异常。
+        /// Creates an exception representing a method that was not found.
         /// </summary>
-        /// <param name="methodName">方法名</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="methodName">The method name.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateMethodNotFound(string methodName)
         {
             return new AcpException(
@@ -86,11 +86,11 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个参数无效的异常。
+        /// Creates an exception representing invalid parameters.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <param name="data">可选的附加数据</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <param name="data">Optional additional data.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInvalidParams(string message, object? errorData = null)
         {
             return new AcpException(
@@ -100,12 +100,12 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个内部错误的异常。
+        /// Creates an exception representing an internal error.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <param name="innerException">内部异常</param>
-        /// <param name="data">可选的附加数据</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="data">Optional additional data.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInternalError(string message, Exception? innerException = null, object? errorData = null)
         {
             if (innerException != null)
@@ -124,9 +124,9 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个未初始化的异常（客户端本地状态）。
+        /// Creates an exception representing an uninitialized state (client-side local state).
         /// </summary>
-        /// <returns>AcpException 实例</returns>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateNotInitialized()
         {
             return new AcpException(
@@ -135,10 +135,10 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个会话未找到的异常。
+        /// Creates an exception representing a session that was not found.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="sessionId">The session ID.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateSessionNotFound(string sessionId)
         {
             return new AcpException(
@@ -147,11 +147,11 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个权限被拒绝的异常。
+        /// Creates an exception representing a denied permission.
         /// </summary>
-        /// <param name="operation">操作名称</param>
-        /// <param name="path">可选的路径</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="operation">The operation name.</param>
+        /// <param name="path">An optional path.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreatePermissionDenied(string operation, string? path = null)
         {
             var message = path != null
@@ -164,11 +164,11 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个协议版本不匹配的异常。
+        /// Creates an exception representing a protocol version mismatch.
         /// </summary>
-        /// <param name="expected">期望的版本</param>
-        /// <param name="actual">实际的版本</param>
-        /// <returns>AcpException 实例</returns>
+        /// <param name="expected">The expected version.</param>
+        /// <param name="actual">The actual version.</param>
+        /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateProtocolVersionMismatch(string expected, string actual)
         {
             return new AcpException(

--- a/src/SalmonEgg.Acp/JsonRpc/AcpException.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/AcpException.cs
@@ -63,7 +63,7 @@ namespace SalmonEgg.Acp.JsonRpc
         /// Creates an exception representing an invalid request.
         /// </summary>
         /// <param name="message">The error message.</param>
-        /// <param name="data">Optional additional data.</param>
+        /// <param name="errorData">Optional additional data.</param>
         /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInvalidRequest(string message, object? errorData = null)
         {
@@ -89,7 +89,7 @@ namespace SalmonEgg.Acp.JsonRpc
         /// Creates an exception representing invalid parameters.
         /// </summary>
         /// <param name="message">The error message.</param>
-        /// <param name="data">Optional additional data.</param>
+        /// <param name="errorData">Optional additional data.</param>
         /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInvalidParams(string message, object? errorData = null)
         {
@@ -104,7 +104,7 @@ namespace SalmonEgg.Acp.JsonRpc
         /// </summary>
         /// <param name="message">The error message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <param name="data">Optional additional data.</param>
+        /// <param name="errorData">Optional additional data.</param>
         /// <returns>An <see cref="AcpException"/> instance.</returns>
         public static AcpException CreateInternalError(string message, Exception? innerException = null, object? errorData = null)
         {

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcError.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcError.cs
@@ -4,44 +4,44 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 错误对象。
-    /// 当发生错误或异常时，error 对象被包含在响应中。
+    /// JSON-RPC 2.0 error object.
+    /// The error object is included in a response when an error or exception occurs.
     /// </summary>
     internal sealed class JsonRpcError
     {
         /// <summary>
-        /// 错误类型标识。根据 JSON-RPC 2.0 规范，这是一个数字。
-        /// 预定义的错误码范围是 -32768 到 -32000。
+        /// Identifies the error type. Per the JSON-RPC 2.0 specification, this is a number.
+        /// The range reserved for predefined error codes is -32768 to -32000.
         /// </summary>
         [JsonPropertyName("code")]
         public int Code { get; set; }
 
         /// <summary>
-        /// 简短的描述性消息，适合于显示给用户。
+        /// A short, descriptive message suitable for display to the user.
         /// </summary>
         [JsonPropertyName("message")]
         public string Message { get; set; } = string.Empty;
 
         /// <summary>
-        /// 包含错误详细信息的对象。
-        /// 可以是任何类型，用于提供关于错误的额外信息。
+        /// An object carrying detailed information about the error.
+        /// May be of any type, and is used to provide additional information about the error.
         /// </summary>
         [JsonPropertyName("data")]
         public object? Data { get; set; }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcError 实例。
+        /// Creates a new <see cref="JsonRpcError"/> instance.
         /// </summary>
         public JsonRpcError()
         {
         }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcError 实例。
+        /// Creates a new <see cref="JsonRpcError"/> instance.
         /// </summary>
-        /// <param name="code">错误码</param>
-        /// <param name="message">错误消息</param>
-        /// <param name="data">可选的附加数据</param>
+        /// <param name="code">The error code.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="data">Optional additional data.</param>
         public JsonRpcError(int code, string message, object? data = null)
         {
             Code = code;
@@ -50,68 +50,68 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个解析错误的错误对象。
+        /// Creates an error object representing a parse error.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <returns>JsonRpcError 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <returns>A <see cref="JsonRpcError"/> instance.</returns>
         public static JsonRpcError CreateParseError(string message = "Invalid JSON")
         {
             return new JsonRpcError(JsonRpcErrorCode.ParseError, message);
         }
 
         /// <summary>
-        /// 创建一个无效请求的错误对象。
+        /// Creates an error object representing an invalid request.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <returns>JsonRpcError 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <returns>A <see cref="JsonRpcError"/> instance.</returns>
         public static JsonRpcError CreateInvalidRequest(string message = "Invalid Request")
         {
             return new JsonRpcError(JsonRpcErrorCode.InvalidRequest, message);
         }
 
         /// <summary>
-        /// 创建一个方法未找到的错误对象。
+        /// Creates an error object representing a method that was not found.
         /// </summary>
-        /// <param name="methodName">方法名</param>
-        /// <returns>JsonRpcError 实例</returns>
+        /// <param name="methodName">The method name.</param>
+        /// <returns>A <see cref="JsonRpcError"/> instance.</returns>
         public static JsonRpcError CreateMethodNotFound(string methodName)
         {
             return new JsonRpcError(JsonRpcErrorCode.MethodNotFound, $"Method '{methodName}' not found");
         }
 
         /// <summary>
-        /// 创建一个参数无效的错误对象。
+        /// Creates an error object representing invalid parameters.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <returns>JsonRpcError 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <returns>A <see cref="JsonRpcError"/> instance.</returns>
         public static JsonRpcError CreateInvalidParams(string message = "Invalid params")
         {
             return new JsonRpcError(JsonRpcErrorCode.InvalidParams, message);
         }
 
         /// <summary>
-        /// 创建一个内部错误的错误对象。
+        /// Creates an error object representing an internal error.
         /// </summary>
-        /// <param name="message">错误消息</param>
-        /// <returns>JsonRpcError 实例</returns>
+        /// <param name="message">The error message.</param>
+        /// <returns>A <see cref="JsonRpcError"/> instance.</returns>
         public static JsonRpcError CreateInternalError(string message = "Internal error")
         {
             return new JsonRpcError(JsonRpcErrorCode.InternalError, message);
         }
 
         /// <summary>
-        /// 判断错误码是否为标准错误码。
+        /// Determines whether the error code is a standard error code.
         /// </summary>
-        /// <returns>如果是标准错误码返回 true</returns>
+        /// <returns><c>true</c> if the error code is a standard error code.</returns>
         public bool IsStandardError()
         {
             return JsonRpcErrorCode.IsStandardErrorCode(Code);
         }
 
         /// <summary>
-        /// 判断错误码是否为 ACP 扩展错误码。
+        /// Determines whether the error code is an ACP extension error code.
         /// </summary>
-        /// <returns>如果是 ACP 扩展错误码返回 true</returns>
+        /// <returns><c>true</c> if the error code is an ACP extension error code.</returns>
         public bool IsAcpError()
         {
             return JsonRpcErrorCode.IsAcpErrorCode(Code);

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcErrorCode.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcErrorCode.cs
@@ -1,115 +1,117 @@
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 标准错误码常量。
-    /// 根据 JSON-RPC 2.0 规范定义的标准错误码。
+    /// Standard JSON-RPC 2.0 error code constants.
+    /// The error codes defined by the JSON-RPC 2.0 specification.
     /// </summary>
     public static class JsonRpcErrorCode
     {
-        #region JSON-RPC 2.0 标准错误码
+        #region Standard JSON-RPC 2.0 error codes
 
         /// <summary>
         /// -32700: Parse error
-        /// 无效的 JSON 或 JSON 解析错误。
+        /// Invalid JSON, or a JSON parsing failure.
         /// </summary>
         public const int ParseError = -32700;
 
         /// <summary>
         /// -32600: Invalid Request
-        /// 请求消息格式无效（缺少必需字段、字段类型错误等）。
+        /// The request message is malformed (a required field is missing, a field has the wrong type, and so on).
         /// </summary>
         public const int InvalidRequest = -32600;
 
         /// <summary>
         /// -32601: Method not found
-        /// 请求的方法不存在。
+        /// The requested method does not exist.
         /// </summary>
         public const int MethodNotFound = -32601;
 
         /// <summary>
         /// -32602: Invalid params
-        /// 方法参数无效（缺少必需参数、参数类型错误等）。
+        /// The method parameters are invalid (a required parameter is missing, a parameter has the wrong type,
+        /// and so on).
         /// </summary>
         public const int InvalidParams = -32602;
 
         /// <summary>
         /// -32603: Internal error
-        /// 服务器内部错误。
+        /// An internal server error.
         /// </summary>
         public const int InternalError = -32603;
 
         #endregion
 
-        #region ACP 扩展错误码
+        #region ACP extension error codes
 
         /// <summary>
         /// -32000: Authentication required
-        /// ACP：需要先进行认证（例如调用 authenticate 或完成外部登录流程）。
+        /// ACP: authentication is required first (for example, calling authenticate or completing an external
+        /// sign-in flow).
         /// </summary>
         public const int AuthenticationRequired = -32000;
 
         /// <summary>
         /// -32001: Permission denied
-        /// ACP：权限被拒绝。
+        /// ACP: permission was denied.
         /// </summary>
         public const int PermissionDenied = -32001;
 
         /// <summary>
         /// -32002: Resource not found
-        /// ACP：资源未找到（例如会话、文件等）。
+        /// ACP: the resource was not found (a session, a file, and so on).
         /// </summary>
         public const int ResourceNotFound = -32002;
 
         /// <summary>
-        /// 兼容别名：会话未找到（ACP schema 中归类为 Resource not found）。
+        /// Compatibility alias: session not found (classified as Resource not found in the ACP schema).
         /// </summary>
         public const int SessionNotFound = ResourceNotFound;
 
         /// <summary>
         /// -32003: Method not allowed
-        /// 方法不被允许（例如在未初始化的会话中调用）。
+        /// The method is not allowed (for example, calling it on a session that has not been initialized).
         /// </summary>
         public const int MethodNotAllowed = -32003;
 
         /// <summary>
         /// -32004: Protocol version mismatch
-        /// 协议版本不匹配。
+        /// The protocol version does not match.
         /// </summary>
         public const int ProtocolVersionMismatch = -32004;
 
         /// <summary>
         /// -32005: Capability not supported
-        /// 不支持的功能。
+        /// The capability is not supported.
         /// </summary>
         public const int CapabilityNotSupported = -32005;
 
         #endregion
 
         /// <summary>
-        /// 判断错误码是否为 JSON-RPC 2.0 标准错误码。
+        /// Determines whether an error code is a standard JSON-RPC 2.0 error code.
         /// </summary>
-        /// <param name="code">错误码</param>
-        /// <returns>如果是标准错误码返回 true</returns>
+        /// <param name="code">The error code.</param>
+        /// <returns>true if it is a standard error code.</returns>
         public static bool IsStandardErrorCode(int code)
         {
             return code >= -32700 && code <= -32603;
         }
 
         /// <summary>
-        /// 判断错误码是否为 ACP 扩展错误码。
+        /// Determines whether an error code is an ACP extension error code.
         /// </summary>
-        /// <param name="code">错误码</param>
-        /// <returns>如果是 ACP 扩展错误码返回 true</returns>
+        /// <param name="code">The error code.</param>
+        /// <returns>true if it is an ACP extension error code.</returns>
         public static bool IsAcpErrorCode(int code)
         {
             return code >= -32099 && code <= -32000;
         }
 
         /// <summary>
-        /// 获取错误码对应的标准错误消息。
+        /// Gets the standard error message for an error code.
         /// </summary>
-        /// <param name="code">错误码</param>
-        /// <returns>错误消息</returns>
+        /// <param name="code">The error code.</param>
+        /// <returns>The error message.</returns>
         public static string GetErrorMessage(int code)
         {
             return code switch

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcMessage.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcMessage.cs
@@ -3,14 +3,14 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 消息的抽象基类。
-    /// 所有 JSON-RPC 消息都必须包含 jsonrpc 字段，其值固定为 "2.0"。
+    /// Abstract base class for JSON-RPC 2.0 messages.
+    /// Every JSON-RPC message must carry a jsonrpc field whose value is always "2.0".
     /// </summary>
     internal abstract class JsonRpcMessage
     {
         /// <summary>
-        /// JSON-RPC 协议版本，固定为 "2.0"。
-        /// 所有 JSON-RPC 2.0 消息都必须包含此字段。
+        /// The JSON-RPC protocol version, always "2.0".
+        /// Every JSON-RPC 2.0 message must include this field.
         /// </summary>
         [JsonPropertyName("jsonrpc")]
         public string JsonRpc { get; set; } = "2.0";

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcNotification.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcNotification.cs
@@ -4,38 +4,38 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 通知消息。
-    /// 通知是一种特殊类型的请求，它没有响应，并且接收方不返回任何东西。
-    /// 通知消息不包含 id 字段。
+    /// A JSON-RPC 2.0 notification message.
+    /// A notification is a special kind of request that has no response, and the receiver returns nothing.
+    /// Notification messages do not carry an id field.
     /// </summary>
     internal sealed class JsonRpcNotification : JsonRpcMessage
     {
         /// <summary>
-        /// 要调用的方法名。
+        /// The name of the method to invoke.
         /// </summary>
         [JsonPropertyName("method")]
         public string Method { get; set; } = string.Empty;
 
         /// <summary>
-        /// 方法的参数。
-        /// 可以是对象、数组、原始值或省略。
+        /// The parameters for the method.
+        /// May be an object, an array, a primitive value, or omitted.
         /// </summary>
         [JsonPropertyName("params")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public JsonElement? Params { get; set; }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcNotification 实例。
+        /// Creates a new JsonRpcNotification instance.
         /// </summary>
         public JsonRpcNotification()
         {
         }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcNotification 实例。
+        /// Creates a new JsonRpcNotification instance.
         /// </summary>
-        /// <param name="method">方法名</param>
-        /// <param name="params">方法参数</param>
+        /// <param name="method">The method name.</param>
+        /// <param name="params">The method parameters.</param>
         public JsonRpcNotification(string method, JsonElement? @params = null)
         {
             Method = method;

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcRequest.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcRequest.cs
@@ -4,45 +4,45 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 请求消息。
-    /// 用于从客户端向服务器发送请求。
+    /// A JSON-RPC 2.0 request message.
+    /// Used to send a request from the client to the server.
     /// </summary>
     internal sealed class JsonRpcRequest : JsonRpcMessage
     {
         /// <summary>
-        /// 请求的唯一标识符。
-        /// 可以是字符串、数字、null，但不能是布尔值。
-        /// 服务器必须在响应中包含相同的 id。
+        /// The unique identifier of the request.
+        /// May be a string, a number, or null, but never a boolean.
+        /// The server must echo the same id back in its response.
         /// </summary>
         [JsonPropertyName("id")]
         public object Id { get; set; } = string.Empty;
 
         /// <summary>
-        /// 要调用的方法名。
+        /// The name of the method to invoke.
         /// </summary>
         [JsonPropertyName("method")]
         public string Method { get; set; } = string.Empty;
 
         /// <summary>
-        /// 方法的参数。
-        /// 可以是对象、数组、原始值或省略。
+        /// The parameters of the method.
+        /// May be an object, an array, a primitive value, or omitted entirely.
         /// </summary>
         [JsonPropertyName("params")]
         public JsonElement? Params { get; set; }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcRequest 实例。
+        /// Creates a new JsonRpcRequest instance.
         /// </summary>
         public JsonRpcRequest()
         {
         }
 
         /// <summary>
-        /// 创建一个新的 JsonRpcRequest 实例。
+        /// Creates a new JsonRpcRequest instance.
         /// </summary>
-        /// <param name="id">请求 ID</param>
-        /// <param name="method">方法名</param>
-        /// <param name="params">方法参数</param>
+        /// <param name="id">The request id.</param>
+        /// <param name="method">The method name.</param>
+        /// <param name="params">The method parameters.</param>
         public JsonRpcRequest(object id, string method, JsonElement? @params = null)
         {
             Id = id;

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcResponse.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcResponse.cs
@@ -4,14 +4,14 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 响应消息。
-    /// 用于服务器对请求的响应。响应消息恰好包含 result 或 error 之一。
+    /// JSON-RPC 2.0 response message.
+    /// Sent by the server in reply to a request. A response carries exactly one of result or error.
     /// </summary>
     internal sealed class JsonRpcResponse : JsonRpcMessage
     {
         /// <summary>
-        /// 对应请求的唯一标识符。
-        /// 必须与请求消息中的 id 值相同。
+        /// The unique identifier of the request being answered.
+        /// Must match the id value carried by the request message.
         /// </summary>
         /// <remarks>
         /// Always serialized, overriding the envelope-wide WhenWritingNull policy. JSON-RPC 2.0
@@ -24,33 +24,33 @@ namespace SalmonEgg.Acp.JsonRpc
         public object? Id { get; set; }
 
         /// <summary>
-        /// 方法调用的结果。
-        /// 在成功时存在，error 为 null。
-        /// 可以是任何 JSON 值。
+        /// The result of the method invocation.
+        /// Present on success, in which case error is null.
+        /// May be any JSON value.
         /// </summary>
         [JsonPropertyName("result")]
         public JsonElement? Result { get; set; }
 
         /// <summary>
-        /// 错误信息。
-        /// 在失败时存在，result 为 null。
-        /// 如果响应成功，则为 null。
+        /// The error information.
+        /// Present on failure, in which case result is null.
+        /// Null when the response is successful.
         /// </summary>
         [JsonPropertyName("error")]
         public JsonRpcError? Error { get; set; }
 
         /// <summary>
-        /// 创建一个新的成功响应实例。
+        /// Creates a new successful response instance.
         /// </summary>
         public JsonRpcResponse()
         {
         }
 
         /// <summary>
-        /// 创建一个新的成功响应实例。
+        /// Creates a new successful response instance.
         /// </summary>
-        /// <param name="id">对应的请求 ID</param>
-        /// <param name="result">响应结果</param>
+        /// <param name="id">The ID of the corresponding request</param>
+        /// <param name="result">The response result</param>
         public JsonRpcResponse(object? id, JsonElement? result)
         {
             Id = id;
@@ -59,10 +59,10 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 创建一个新的错误响应实例。
+        /// Creates a new error response instance.
         /// </summary>
-        /// <param name="id">对应的请求 ID</param>
-        /// <param name="error">错误信息</param>
+        /// <param name="id">The ID of the corresponding request</param>
+        /// <param name="error">The error information</param>
         public JsonRpcResponse(object? id, JsonRpcError error)
         {
             Id = id;
@@ -71,7 +71,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 判断响应是否成功。
+        /// Gets a value indicating whether the response is successful.
         /// </summary>
         /// <remarks>
         /// Local convenience only. A JSON-RPC 2.0 Response carries exactly jsonrpc/id/result/error,
@@ -81,7 +81,7 @@ namespace SalmonEgg.Acp.JsonRpc
         public bool IsSuccess => Error == null && Result.HasValue;
 
         /// <summary>
-        /// 判断响应是否失败。
+        /// Gets a value indicating whether the response is an error.
         /// </summary>
         /// <remarks>
         /// Local convenience only; see <see cref="IsSuccess"/>. Not part of the JSON-RPC envelope.

--- a/src/SalmonEgg.Acp/JsonRpc/MessageParser.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/MessageParser.cs
@@ -7,20 +7,20 @@ using SalmonEgg.Acp.Serialization;
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 消息解析器实现。
-    /// 使用 System.Text.Json 进行消息的解析和序列化。
+    /// JSON-RPC 2.0 message parser implementation.
+    /// Uses System.Text.Json to parse and serialize messages.
     /// </summary>
     internal sealed class MessageParser
     {
         private readonly JsonSerializerOptions _options;
 
         /// <summary>
-        /// 获取 JsonSerializerOptions 实例供外部使用。
+        /// Gets the JsonSerializerOptions instance for external use.
         /// </summary>
         public JsonSerializerOptions Options => _options;
 
         /// <summary>
-        /// 创建新的 MessageParser 实例。
+        /// Creates a new MessageParser instance.
         /// </summary>
         public MessageParser()
         {
@@ -44,7 +44,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 解析 JSON 字符串为 JSON-RPC 消息。
+        /// Parses a JSON string into a JSON-RPC message.
         /// </summary>
         public JsonRpcMessage ParseMessage(string json)
         {
@@ -57,30 +57,30 @@ namespace SalmonEgg.Acp.JsonRpc
 
             try
             {
-                // 首先尝试作为基础对象解析以检测类型
+                // First parse as a plain document in order to detect the message type
                 using var doc = JsonDocument.Parse(json);
                 var root = doc.RootElement;
 
-                // 检测消息类型
+                // Detect the message type
                 var hasId = root.TryGetProperty("id", out _);
                 var hasResult = root.TryGetProperty("result", out _);
                 var hasError = root.TryGetProperty("error", out _);
 
                 if (hasResult || hasError)
                 {
-                    // 响应消息
+                    // Response message
                     return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcResponse>())
                         ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse response");
                 }
                 else if (hasId)
                 {
-                    // 请求消息
+                    // Request message
                     return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcRequest>())
                         ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse request");
                 }
                 else
                 {
-                    // 通知消息（无 id）
+                    // Notification message (no id)
                     return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcNotification>())
                         ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse notification");
                 }
@@ -106,7 +106,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 解析 JSON 字符串为请求消息。
+        /// Parses a JSON string into a request message.
         /// </summary>
         public JsonRpcRequest ParseRequest(string json)
         {
@@ -123,7 +123,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 解析 JSON 字符串为通知消息。
+        /// Parses a JSON string into a notification message.
         /// </summary>
         public JsonRpcNotification ParseNotification(string json)
         {
@@ -140,7 +140,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 解析 JSON 字符串为响应消息。
+        /// Parses a JSON string into a response message.
         /// </summary>
         public JsonRpcResponse ParseResponse(string json)
         {
@@ -157,7 +157,7 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 将 JSON-RPC 消息序列化为 JSON 字符串。
+        /// Serializes a JSON-RPC message into a JSON string.
         /// </summary>
         public string SerializeMessage(JsonRpcMessage message)
         {

--- a/src/SalmonEgg.Acp/JsonRpc/MessageValidator.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/MessageValidator.cs
@@ -1,14 +1,14 @@
 namespace SalmonEgg.Acp.JsonRpc
 {
     /// <summary>
-    /// JSON-RPC 2.0 消息验证器实现。
-    /// 验证消息格式和必需字段的完整性。
+    /// JSON-RPC 2.0 message validator implementation.
+    /// Validates message shape and the presence of required fields.
     /// </summary>
     internal sealed class MessageValidator
     {
         /// <summary>
-        /// 验证请求消息的格式和必需字段。
-        /// 请求消息必须包含：jsonrpc, method, id
+        /// Validates the shape and required fields of a request message.
+        /// A request message must contain: jsonrpc, method, id
         /// </summary>
         public ValidationResult ValidateRequest(JsonRpcRequest request)
         {
@@ -21,22 +21,22 @@ namespace SalmonEgg.Acp.JsonRpc
 
             var errors = new System.Collections.Generic.List<string>();
 
-            // 验证 jsonrpc 字段
+            // Validate the jsonrpc field
             if (string.IsNullOrWhiteSpace(request.JsonRpc) || request.JsonRpc != "2.0")
             {
                 errors.Add("Invalid or missing 'jsonrpc' field. Must be '2.0'");
             }
 
-            // 验证 method 字段
+            // Validate the method field
             if (string.IsNullOrWhiteSpace(request.Method))
             {
                 errors.Add("Missing or empty 'method' field");
             }
 
-            // 验证 id 字段
+            // Validate the id field
             if (request.Id == null || request.Id.Equals(false))
             {
-                // id 可以是 null，但不能是布尔值 false
+                // id may be null, but it must not be the boolean value false
                 if (request.Id is bool)
                 {
                     errors.Add("Invalid 'id' field. Cannot be a boolean value");
@@ -58,9 +58,9 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 验证通知消息的格式和必需字段。
-        /// 通知消息必须包含：jsonrpc, method
-        /// 通知消息不能包含：id
+        /// Validates the shape and required fields of a notification message.
+        /// A notification message must contain: jsonrpc, method
+        /// A notification message must not contain: id
         /// </summary>
         public ValidationResult ValidateNotification(JsonRpcNotification notification)
         {
@@ -73,22 +73,22 @@ namespace SalmonEgg.Acp.JsonRpc
 
             var errors = new System.Collections.Generic.List<string>();
 
-            // 验证 jsonrpc 字段
+            // Validate the jsonrpc field
             if (string.IsNullOrWhiteSpace(notification.JsonRpc) || notification.JsonRpc != "2.0")
             {
                 errors.Add("Invalid or missing 'jsonrpc' field. Must be '2.0'");
             }
 
-            // 验证 method 字段
+            // Validate the method field
             if (string.IsNullOrWhiteSpace(notification.Method))
             {
                 errors.Add("Missing or empty 'method' field");
             }
 
-            // 验证没有 id 字段（通知不应有 id）
-            // 注意：在 C# 对象中我们无法直接检查 JSON 中是否存在某个字段，
-            // 这里假设如果 Id 被设置为默认值，则没有设置 id
-            // 实际验证需要在 JSON 层面进行
+            // Validate the absence of an id field (a notification should not carry an id)
+            // Note: in a C# object we cannot directly check whether a given field is present in the JSON,
+            // so here we assume that an Id left at its default value means no id was set.
+            // Real validation has to happen at the JSON level.
 
             if (errors.Count > 0)
             {
@@ -101,9 +101,9 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
-        /// 验证响应消息的格式和必需字段。
-        /// 响应消息必须包含：jsonrpc, id
-        /// 响应消息必须恰好包含 result 或 error 之一
+        /// Validates the shape and required fields of a response message.
+        /// A response message must contain: jsonrpc, id
+        /// A response message must contain exactly one of result or error
         /// </summary>
         public ValidationResult ValidateResponse(JsonRpcResponse response)
         {
@@ -116,13 +116,13 @@ namespace SalmonEgg.Acp.JsonRpc
 
             var errors = new System.Collections.Generic.List<string>();
 
-            // 验证 jsonrpc 字段
+            // Validate the jsonrpc field
             if (string.IsNullOrWhiteSpace(response.JsonRpc) || response.JsonRpc != "2.0")
             {
                 errors.Add("Invalid or missing 'jsonrpc' field. Must be '2.0'");
             }
 
-            // 验证 id 字段
+            // Validate the id field
             if (response.Id == null || response.Id.Equals(false))
             {
                 if (response.Id is bool)
@@ -135,7 +135,7 @@ namespace SalmonEgg.Acp.JsonRpc
                 }
             }
 
-            // 验证恰好有 result 或 error 之一
+            // Validate that exactly one of result or error is present
             var hasResult = response.Result.HasValue;
             var hasError = response.Error != null;
 
@@ -148,23 +148,24 @@ namespace SalmonEgg.Acp.JsonRpc
                 errors.Add("Response must have either 'result' or 'error'");
             }
 
-            // 如果有 error，验证 error 对象的格式
+            // When an error is present, validate the shape of the error object
             if (hasError && response.Error != null)
             {
                 var error = response.Error;
 
-                // 验证 error.code 是数字
-                // 在 C# 中 Code 是 int 属性，所以总是数字
+                // Validate that error.code is a number
+                // In C#, Code is an int property, so it is always a number
 
-                // 验证 error.message 是非空字符串
+                // Validate that error.message is a non-empty string
                 if (string.IsNullOrWhiteSpace(error.Message))
                 {
                     errors.Add("Error 'message' field cannot be empty");
                 }
 
-                // 不校验错误码取值:JSON-RPC 2.0 只是把 -32768..-32000 保留给预定义语义,
-                // 应用可用范围外任意整数码;保留区间内未知码属未来规范由 Agent 决定,
-                // client 按码值拒绝响应即协议外反向收紧。
+                // Error code values are not validated: JSON-RPC 2.0 merely reserves -32768..-32000 for
+                // predefined semantics, and applications may use any integer code outside that range; unknown
+                // codes inside the reserved range belong to future spec revisions and are the Agent's call, so
+                // having the client reject a response based on its code would tighten the protocol from outside.
             }
 
             if (errors.Count > 0)
@@ -179,39 +180,39 @@ namespace SalmonEgg.Acp.JsonRpc
     }
 
     /// <summary>
-    /// JSON-RPC 消息验证结果。仅供 SDK 内部消息校验使用。
+    /// JSON-RPC message validation result. For SDK-internal message validation only.
     /// </summary>
     internal sealed class ValidationResult
     {
         /// <summary>
-        /// 验证是否通过。
+        /// Whether validation succeeded.
         /// </summary>
         public bool IsValid { get; init; }
 
         /// <summary>
-        /// 错误消息列表（当 <see cref="IsValid"/> 为 false 时包含错误）。
+        /// The list of error messages (populated when <see cref="IsValid"/> is false).
         /// </summary>
         public System.Collections.Generic.IReadOnlyList<string> Errors { get; init; }
             = System.Array.Empty<string>();
 
         /// <summary>
-        /// 错误码（如果验证失败）。
+        /// The error code (when validation failed).
         /// </summary>
         public int? ErrorCode { get; init; }
 
         /// <summary>
-        /// 创建成功的验证结果。
+        /// Creates a successful validation result.
         /// </summary>
         public static ValidationResult Success() => new() { IsValid = true };
 
         /// <summary>
-        /// 创建失败的验证结果。
+        /// Creates a failed validation result.
         /// </summary>
         public static ValidationResult Failure(int errorCode, System.Collections.Generic.IReadOnlyList<string> errors)
             => new() { IsValid = false, ErrorCode = errorCode, Errors = errors };
 
         /// <summary>
-        /// 创建失败的验证结果（单个错误）。
+        /// Creates a failed validation result (single error).
         /// </summary>
         public static ValidationResult Failure(int errorCode, string error)
             => new() { IsValid = false, ErrorCode = errorCode, Errors = new[] { error } };

--- a/src/SalmonEgg.Acp/Mcp/McpServerConfig.cs
+++ b/src/SalmonEgg.Acp/Mcp/McpServerConfig.cs
@@ -7,14 +7,14 @@ using SalmonEgg.Acp.Protocol;
 namespace SalmonEgg.Acp.Mcp
 {
     /// <summary>
-    /// MCP 服务器配置类。
-    /// 支持多种传输类型（stdio、http、sse）的配置。
+    /// MCP server configuration.
+    /// Supports configuration for multiple transport types (stdio, http, sse).
     /// </summary>
     [JsonConverter(typeof(McpServerJsonConverter))]
     public abstract record McpServer : AcpProtocolObject
     {
         /// <summary>
-        /// 服务器的显示名称。
+        /// The display name of the server.
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
@@ -30,43 +30,43 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// Stdio 类型的 MCP 服务器配置。
-    /// 通过标准输入/输出与服务器通信。
+    /// Configuration for a stdio MCP server.
+    /// Communicates with the server over standard input/output.
     /// </summary>
     public sealed record StdioMcpServer : McpServer
     {
         /// <summary>
-        /// 服务器可执行文件的命令。
+        /// The command that launches the server executable.
         /// </summary>
         [JsonPropertyName("command")]
         public string Command { get; init; } = string.Empty;
 
         /// <summary>
-        /// 命令行参数列表。
+        /// The command-line argument list.
         /// </summary>
         [JsonPropertyName("args")]
         public List<string>? Args { get; init; }
 
         /// <summary>
-        /// 环境变量配置。
+        /// The environment variable configuration.
         /// </summary>
         [JsonPropertyName("env")]
         public List<McpEnvVariable>? Env { get; init; }
 
         /// <summary>
-        /// 创建新的 StdioMcpServer 实例。
+        /// Creates a new StdioMcpServer instance.
         /// </summary>
         public StdioMcpServer()
         {
         }
 
         /// <summary>
-        /// 创建新的 StdioMcpServer 实例。
+        /// Creates a new StdioMcpServer instance.
         /// </summary>
-        /// <param name="name">服务器名称</param>
-        /// <param name="command">命令</param>
-        /// <param name="args">参数列表</param>
-        /// <param name="env">环境变量</param>
+        /// <param name="name">The server name</param>
+        /// <param name="command">The command</param>
+        /// <param name="args">The argument list</param>
+        /// <param name="env">The environment variables</param>
         public StdioMcpServer(
             string name,
             string command,
@@ -81,36 +81,36 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// HTTP 类型的 MCP 服务器配置。
-    /// 通过 HTTP 请求与服务器通信。
+    /// Configuration for an HTTP MCP server.
+    /// Communicates with the server over HTTP requests.
     /// </summary>
     public sealed record HttpMcpServer : McpServer
     {
         /// <summary>
-        /// 服务器的 URL 地址。
+        /// The URL of the server.
         /// </summary>
         [JsonPropertyName("url")]
         public string Url { get; init; } = string.Empty;
 
         /// <summary>
-        /// HTTP 请求头配置。
+        /// The HTTP header configuration.
         /// </summary>
         [JsonPropertyName("headers")]
         public List<McpHttpHeader>? Headers { get; init; }
 
         /// <summary>
-        /// 创建新的 HttpMcpServer 实例。
+        /// Creates a new HttpMcpServer instance.
         /// </summary>
         public HttpMcpServer()
         {
         }
 
         /// <summary>
-        /// 创建新的 HttpMcpServer 实例。
+        /// Creates a new HttpMcpServer instance.
         /// </summary>
-        /// <param name="name">服务器名称</param>
-        /// <param name="url">URL 地址</param>
-        /// <param name="headers">HTTP 请求头</param>
+        /// <param name="name">The server name</param>
+        /// <param name="url">The URL</param>
+        /// <param name="headers">The HTTP headers</param>
         public HttpMcpServer(string name, string url, List<McpHttpHeader>? headers = null)
         {
             Name = name;
@@ -120,36 +120,36 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// SSE (Server-Sent Events) 类型的 MCP 服务器配置。
-    /// 通过 SSE 流与服务器通信。
+    /// Configuration for an SSE (Server-Sent Events) MCP server.
+    /// Communicates with the server over an SSE stream.
     /// </summary>
     public sealed record SseMcpServer : McpServer
     {
         /// <summary>
-        /// SSE 端点的 URL 地址。
+        /// The URL of the SSE endpoint.
         /// </summary>
         [JsonPropertyName("url")]
         public string Url { get; init; } = string.Empty;
 
         /// <summary>
-        /// HTTP 请求头配置。
+        /// The HTTP header configuration.
         /// </summary>
         [JsonPropertyName("headers")]
         public List<McpHttpHeader>? Headers { get; init; }
 
         /// <summary>
-        /// 创建新的 SseMcpServer 实例。
+        /// Creates a new SseMcpServer instance.
         /// </summary>
         public SseMcpServer()
         {
         }
 
         /// <summary>
-        /// 创建新的 SseMcpServer 实例。
+        /// Creates a new SseMcpServer instance.
         /// </summary>
-        /// <param name="name">服务器名称</param>
-        /// <param name="url">URL 地址</param>
-        /// <param name="headers">HTTP 请求头</param>
+        /// <param name="name">The server name</param>
+        /// <param name="url">The URL</param>
+        /// <param name="headers">The HTTP headers</param>
         public SseMcpServer(string name, string url, List<McpHttpHeader>? headers = null)
         {
             Name = name;
@@ -159,38 +159,38 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// 自定义 / 未来的 MCP transport 配置。
-    /// 承载 V2 schema "other" 分支（<c>type</c> 值非 stdio/http/sse）的前向兼容透传：
-    /// spec 要求 receiver 对不认识的 transport「preserve the raw payload」，
-    /// 由 Agent 而非 client 决定接受或拒绝。
+    /// Configuration for a custom / future MCP transport.
+    /// Carries the forward-compatible passthrough for the V2 schema "other" branch (a <c>type</c> value other than
+    /// stdio/http/sse): the spec requires a receiver to "preserve the raw payload" for a transport it does not
+    /// recognize, leaving it to the Agent rather than the client to accept or reject it.
     /// </summary>
     public sealed record CustomMcpServer : McpServer
     {
         /// <summary>
-        /// 原始 <c>type</c> transport 值（如 <c>_custom</c> 扩展或未来 ACP 变体值）。
+        /// The raw <c>type</c> transport value (such as a <c>_custom</c> extension or a future ACP variant value).
         /// </summary>
         [JsonPropertyName("type")]
         public string Transport { get; init; } = string.Empty;
 
         /// <summary>
-        /// 原始 server object payload，原样保留以供透传。
-        /// 由 <see cref="McpServerJsonConverter"/> 手动读写，不经默认序列化。
+        /// The raw server object payload, preserved verbatim for passthrough.
+        /// Read and written manually by <see cref="McpServerJsonConverter"/>, bypassing default serialization.
         /// </summary>
         public JsonElement RawPayload { get; init; }
 
         /// <summary>
-        /// 创建新的 CustomMcpServer 实例。
+        /// Creates a new CustomMcpServer instance.
         /// </summary>
         public CustomMcpServer()
         {
         }
 
         /// <summary>
-        /// 创建新的 CustomMcpServer 实例。
+        /// Creates a new CustomMcpServer instance.
         /// </summary>
-        /// <param name="name">服务器名称</param>
-        /// <param name="transport">原始 transport 值</param>
-        /// <param name="rawPayload">原始 server object payload</param>
+        /// <param name="name">The server name</param>
+        /// <param name="transport">The raw transport value</param>
+        /// <param name="rawPayload">The raw server object payload</param>
         public CustomMcpServer(string name, string transport, JsonElement rawPayload)
         {
             Name = name;
@@ -200,34 +200,34 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// MCP 环境变量配置类。
+    /// MCP environment variable configuration.
     /// </summary>
     public sealed record McpEnvVariable : AcpProtocolObject
     {
         /// <summary>
-        /// 环境变量名称。
+        /// The environment variable name.
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
 
         /// <summary>
-        /// 环境变量值。
+        /// The environment variable value.
         /// </summary>
         [JsonPropertyName("value")]
         public string Value { get; init; } = string.Empty;
 
         /// <summary>
-        /// 创建新的 McpEnvVariable 实例。
+        /// Creates a new McpEnvVariable instance.
         /// </summary>
         public McpEnvVariable()
         {
         }
 
         /// <summary>
-        /// 创建新的 McpEnvVariable 实例。
+        /// Creates a new McpEnvVariable instance.
         /// </summary>
-        /// <param name="name">变量名</param>
-        /// <param name="value">变量值</param>
+        /// <param name="name">The variable name</param>
+        /// <param name="value">The variable value</param>
         public McpEnvVariable(string name, string value)
         {
             Name = name;
@@ -236,34 +236,34 @@ namespace SalmonEgg.Acp.Mcp
     }
 
     /// <summary>
-    /// MCP HTTP 请求头配置类。
+    /// MCP HTTP header configuration.
     /// </summary>
     public sealed record McpHttpHeader : AcpProtocolObject
     {
         /// <summary>
-        /// 请求头名称。
+        /// The header name.
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
 
         /// <summary>
-        /// 请求头值。
+        /// The header value.
         /// </summary>
         [JsonPropertyName("value")]
         public string Value { get; init; } = string.Empty;
 
         /// <summary>
-        /// 创建新的 McpHttpHeader 实例。
+        /// Creates a new McpHttpHeader instance.
         /// </summary>
         public McpHttpHeader()
         {
         }
 
         /// <summary>
-        /// 创建新的 McpHttpHeader 实例。
+        /// Creates a new McpHttpHeader instance.
         /// </summary>
-        /// <param name="name">请求头名称</param>
-        /// <param name="value">请求头值</param>
+        /// <param name="name">The header name</param>
+        /// <param name="value">The header value</param>
         public McpHttpHeader(string name, string value)
         {
             Name = name;
@@ -441,8 +441,9 @@ namespace SalmonEgg.Acp.Mcp
                 "stdio" => McpServerTransport.Stdio,
                 "http" => McpServerTransport.Http,
                 "sse" => McpServerTransport.Sse,
-                // V2 schema "other" 分支：任何非 stdio/http/sse 的 type 值（含 `_` 扩展与未来 ACP 变体）
-                // 均须 preserve raw payload 前向透传，由 Agent 而非 client 收紧。Read 纯容错，不按版本区分。
+                // V2 schema "other" branch: any type value other than stdio/http/sse (including `_` extensions and
+                // future ACP variants) must preserve the raw payload for forward passthrough, leaving it to the Agent
+                // rather than the client to tighten. Read is purely tolerant and does not branch on version.
                 _ => McpServerTransport.Custom
             };
         }
@@ -468,9 +469,10 @@ namespace SalmonEgg.Acp.Mcp
             {
                 Name = ReadRequiredString(root, "name"),
                 Url = ReadRequiredString(root, "url"),
-                // headers 在 schema 中为可选（V2 required 仅 [name,url]，Rust 标注
-                // skip_serializing_if=Vec::is_empty）：缺省不再抛，读为空列表。
-                // 但类型契约不放宽——一旦提供却非数组 / 条目缺 name|value 仍抛。
+                // headers is optional in the schema (V2 requires only [name,url], and Rust annotates it with
+                // skip_serializing_if=Vec::is_empty): its absence no longer throws and reads as an empty list.
+                // The type contract is not relaxed, though - if it is provided but is not an array, or an entry is
+                // missing name|value, it still throws.
                 Headers = ReadOptionalNameValueArray<McpHttpHeader>(
                     root,
                     "headers",
@@ -485,7 +487,8 @@ namespace SalmonEgg.Acp.Mcp
             {
                 Name = ReadRequiredString(root, "name"),
                 Url = ReadRequiredString(root, "url"),
-                // headers 同 http：schema 可选，缺省读为空列表而非抛；类型契约不放宽。
+                // headers behaves as for http: optional in the schema, absence reads as an empty list instead of
+                // throwing; the type contract is not relaxed.
                 Headers = ReadOptionalNameValueArray<McpHttpHeader>(
                     root,
                     "headers",
@@ -495,21 +498,22 @@ namespace SalmonEgg.Acp.Mcp
         }
 
         /// <summary>
-        /// 读取 V2 schema "other" 分支：非 stdio/http/sse 的 transport。
-        /// 按 spec「preserve the raw payload」原样保留整个 server object，
-        /// 由 Agent 而非 client 决定接受或拒绝，client 层不做任何字段收紧。
+        /// Reads the V2 schema "other" branch: a transport other than stdio/http/sse.
+        /// Per the spec's "preserve the raw payload" rule the entire server object is kept verbatim, leaving it to the
+        /// Agent rather than the client to accept or reject it; the client layer tightens no field.
         /// </summary>
         private static CustomMcpServer ReadOther(JsonElement root)
         {
-            // type 一定存在且为字符串（ResolveTransport 已保证进入本分支的前提），
-            // 但仍防御性取值，缺省回退空串而非抛出，贯彻纯透传语义。
+            // type is guaranteed to be present and a string (ResolveTransport is the precondition for reaching this
+            // branch), but the value is still read defensively, falling back to an empty string instead of throwing,
+            // which upholds the pure passthrough semantics.
             var transport = root.TryGetProperty("type", out var typeElement)
                 && typeElement.ValueKind == JsonValueKind.String
                     ? typeElement.GetString() ?? string.Empty
                     : string.Empty;
 
-            // name 是所有 transport 共有的必需字段，读取以供上层展示；
-            // 其余未知字段全部保存在 RawPayload 中透传，不做解释。
+            // name is the required field common to every transport and is read so upper layers can display it;
+            // all remaining unknown fields are kept in RawPayload for passthrough and are not interpreted.
             var name = root.TryGetProperty("name", out var nameElement)
                 && nameElement.ValueKind == JsonValueKind.String
                     ? nameElement.GetString() ?? string.Empty
@@ -535,14 +539,16 @@ namespace SalmonEgg.Acp.Mcp
 
         private static List<string>? ReadOptionalStringArray(JsonElement root, string propertyName)
         {
-            // V2 将 args 放宽为可选：缺省时返回 null（忠实表达「未提供」，区别于「显式空数组」）。
+            // V2 relaxes args to optional: return null when it is absent (faithfully expressing "not provided", as
+            // distinct from "an explicit empty array").
             if (!root.TryGetProperty(propertyName, out var values))
             {
                 return null;
             }
 
-            // 但类型契约不放宽：一旦提供，非数组 / 非字符串条目仍视为协议违规而抛出，
-            // 不做反向的过度容忍（args 未标注 x-deserialize-default-on-error）。
+            // The type contract is not relaxed, though: once provided, a non-array or a non-string entry is still
+            // treated as a protocol violation and throws - no over-tolerance in the other direction (args is not
+            // annotated with x-deserialize-default-on-error).
             if (values.ValueKind != JsonValueKind.Array)
             {
                 throw new JsonException($"MCP server '{propertyName}' must be an array.");
@@ -623,8 +629,9 @@ namespace SalmonEgg.Acp.Mcp
         private static void WriteStdio(Utf8JsonWriter writer, StdioMcpServer stdio)
         {
             writer.WriteStartObject();
-            // V2 schema 以 `type` 判别式区分 stdio/http/sse；V1 stdio 无 type 字段，
-            // 靠缺省 type 隐式判定。仅在协商为 V2 时写出 type，避免向 V1 Agent 发送其不认识的字段。
+            // The V2 schema discriminates stdio/http/sse via the `type` field; V1 stdio has no type field and is
+            // identified implicitly by its absence. Write type only when the negotiated version is V2, so a V1 Agent
+            // is never sent a field it does not recognize.
             if (AcpProtocolWriteContext.Current >= AcpProtocolVersion.V2)
             {
                 writer.WriteString("type", "stdio");
@@ -664,12 +671,15 @@ namespace SalmonEgg.Acp.Mcp
 
         private static void WriteCustom(Utf8JsonWriter writer, CustomMcpServer custom)
         {
-            // 前向兼容透传：原样写回读入时保留的 raw payload，不重排字段、不丢弃未知属性，
-            // 由 Agent 而非 client 决定接受或拒绝该 transport。RawPayload 是 Custom transport 的
-            // 唯一权威事实源（含其 _meta），故此处不叠加写出 custom.Meta，避免第二套状态 owner。
-            // 用 WriteRawValue(GetRawText()) 而非 WriteTo：与 AcpProtocolObject 一致，
-            // 避免 WriteTo 对转义/数字 token 形态的 re-encode，实现字节级保真。
-            // 若 RawPayload 为空（如手工构造），退化为按已知字段最小写出，仍携带原始 type 值。
+            // Forward-compatible passthrough: write back the raw payload preserved at read time verbatim, without
+            // reordering fields or dropping unknown properties, leaving it to the Agent rather than the client to
+            // accept or reject the transport. RawPayload is the single authoritative source of truth for a Custom
+            // transport (including its _meta), so custom.Meta is not written on top of it here, which avoids a second
+            // state owner.
+            // Uses WriteRawValue(GetRawText()) rather than WriteTo: consistent with AcpProtocolObject, this avoids
+            // WriteTo re-encoding escape sequences and numeric token shapes, achieving byte-level fidelity.
+            // If RawPayload is empty (for example when hand-constructed), fall back to a minimal write of the known
+            // fields, still carrying the original type value.
             if (custom.RawPayload.ValueKind == JsonValueKind.Object)
             {
                 writer.WriteRawValue(custom.RawPayload.GetRawText());

--- a/src/SalmonEgg.Acp/Mcp/McpServerSupportPolicy.cs
+++ b/src/SalmonEgg.Acp/Mcp/McpServerSupportPolicy.cs
@@ -64,8 +64,10 @@ namespace SalmonEgg.Acp.Mcp
                 SseMcpServer sse when agentCapabilities?.SupportsSse == true => ValidateSse(sse),
                 SseMcpServer sse => McpServerSupportResult.Unsupported(
                     $"Agent does not advertise mcpCapabilities.sse for MCP server '{ResolveName(sse)}'."),
-                // V2 前向兼容 transport：client 不做任何收紧，原样透传交由 Agent 决定接受或拒绝。
-                // 这是 spec「preserve the raw payload」的直接体现，client 层不越权 gating 未知 transport。
+                // V2 forward-compatible transport: the client applies no tightening and passes the
+                // payload through as-is, leaving acceptance or rejection to the Agent. This is the
+                // spec's "preserve the raw payload" rule applied directly; the client layer does not
+                // overstep by gating transports it does not recognise.
                 CustomMcpServer => McpServerSupportResult.Supported,
                 _ => McpServerSupportResult.Unsupported(
                     $"Unsupported MCP server type '{server.GetType().Name}'.")

--- a/src/SalmonEgg.Acp/Plan/Plan.cs
+++ b/src/SalmonEgg.Acp/Plan/Plan.cs
@@ -7,15 +7,15 @@ using SalmonEgg.Acp.Protocol;
 namespace SalmonEgg.Acp.Plan
 {
     /// <summary>
-    /// 计划类。
-    /// 表示 Agent 的行动计划，包含一系列计划条目。
+    /// Plan.
+    /// Represents an agent's action plan, containing a sequence of plan entries.
     /// </summary>
     public sealed record Plan : AcpProtocolObject
     {
         private readonly List<PlanEntry> _entries = new();
 
         /// <summary>
-        /// 计划条目列表。
+        /// The list of plan entries.
         /// </summary>
         [JsonRequired]
         [JsonPropertyName("entries")]
@@ -26,23 +26,23 @@ namespace SalmonEgg.Acp.Plan
         }
 
         /// <summary>
-        /// 创建新的计划实例。
+        /// Creates a new plan instance.
         /// </summary>
         public Plan()
         {
         }
 
         /// <summary>
-        /// 创建新的计划实例。
+        /// Creates a new plan instance.
         /// </summary>
-        /// <param name="entries">计划条目列表</param>
+        /// <param name="entries">The list of plan entries</param>
         public Plan(List<PlanEntry> entries)
         {
             Entries = ValidateEntries(entries);
         }
 
         /// <summary>
-        /// 返回追加一条新计划条目后的计划快照（不修改当前实例）。
+        /// Returns a snapshot of the plan with one new entry appended (the current instance is not modified).
         /// </summary>
         public Plan WithEntry(string content, PlanEntryStatus? status = null, PlanEntryPriority? priority = null)
         {
@@ -57,19 +57,19 @@ namespace SalmonEgg.Acp.Plan
         }
 
         /// <summary>
-        /// 获取所有待处理的条目。
+        /// Gets all pending entries.
         /// </summary>
         public List<PlanEntry> GetPendingEntries()
             => Entries.FindAll(e => e.Status == PlanEntryStatus.Pending);
 
         /// <summary>
-        /// 获取所有进行中的条目。
+        /// Gets all in-progress entries.
         /// </summary>
         public List<PlanEntry> GetInProgressEntries()
             => Entries.FindAll(e => e.Status == PlanEntryStatus.InProgress);
 
         /// <summary>
-        /// 获取所有已完成的条目。
+        /// Gets all completed entries.
         /// </summary>
         public List<PlanEntry> GetCompletedEntries()
             => Entries.FindAll(e => e.Status == PlanEntryStatus.Completed);
@@ -94,15 +94,15 @@ namespace SalmonEgg.Acp.Plan
     }
 
     /// <summary>
-    /// 计划条目类。
-    /// 表示计划中的一个具体任务或步骤。
+    /// Plan entry.
+    /// Represents a specific task or step within a plan.
     /// </summary>
     public sealed record PlanEntry : AcpProtocolObject
     {
         private readonly string _content = string.Empty;
 
         /// <summary>
-        /// 条目的内容描述。
+        /// The content description of the entry.
         /// </summary>
         [JsonRequired]
         [JsonPropertyName("content")]
@@ -113,32 +113,32 @@ namespace SalmonEgg.Acp.Plan
         }
 
         /// <summary>
-        /// 条目的当前状态。
+        /// The current status of the entry.
         /// </summary>
         [JsonRequired]
         [JsonPropertyName("status")]
         public PlanEntryStatus Status { get; init; } = PlanEntryStatus.Pending;
 
         /// <summary>
-        /// 条目的优先级。
+        /// The priority of the entry.
         /// </summary>
         [JsonRequired]
         [JsonPropertyName("priority")]
         public PlanEntryPriority Priority { get; init; } = PlanEntryPriority.Medium;
 
         /// <summary>
-        /// 创建新的计划条目实例。
+        /// Creates a new plan entry instance.
         /// </summary>
         public PlanEntry()
         {
         }
 
         /// <summary>
-        /// 创建新的计划条目实例。
+        /// Creates a new plan entry instance.
         /// </summary>
-        /// <param name="content">条目内容</param>
-        /// <param name="status">条目状态</param>
-        /// <param name="priority">条目优先级</param>
+        /// <param name="content">The entry content</param>
+        /// <param name="status">The entry status</param>
+        /// <param name="priority">The entry priority</param>
         public PlanEntry(string content, PlanEntryStatus? status = null, PlanEntryPriority? priority = null)
         {
             Content = content ?? throw new JsonException("Plan entry content must not be null.");
@@ -147,13 +147,13 @@ namespace SalmonEgg.Acp.Plan
         }
 
         /// <summary>
-        /// 返回标记为进行中的条目快照（不修改当前实例）。
+        /// Returns a snapshot of the entry marked as in progress (the current instance is not modified).
         /// </summary>
         public PlanEntry Started()
             => this with { Status = PlanEntryStatus.InProgress };
 
         /// <summary>
-        /// 返回标记为已完成的条目快照（不修改当前实例）。
+        /// Returns a snapshot of the entry marked as completed (the current instance is not modified).
         /// </summary>
         public PlanEntry Completed()
             => this with { Status = PlanEntryStatus.Completed };
@@ -161,13 +161,14 @@ namespace SalmonEgg.Acp.Plan
 
 
     /// <summary>
-    /// 计划条目状态。
+    /// The status of a plan entry.
     /// </summary>
     /// <remarks>
-    /// 建模为可扩展值类型而非封闭枚举，以便无损保留并 round-trip 未知的 wire 值，对齐权威
-    /// ACP schema（<c>PlanEntryStatus</c> 为 <c>#[non_exhaustive]</c> 且带 untagged
-    /// <c>Other(String)</c> 兜底）。依据 ACP 扩展契约，不以 <c>_</c> 开头的未知值保留给未来
-    /// ACP variant，client 不得拒绝。
+    /// Modeled as an extensible value type rather than a closed enum, so that unknown wire values are
+    /// preserved losslessly and round-trip intact, matching the authoritative ACP schema
+    /// (<c>PlanEntryStatus</c> is <c>#[non_exhaustive]</c> with an untagged <c>Other(String)</c> fallback).
+    /// Per the ACP extension contract, unknown values that do not start with <c>_</c> are reserved for future
+    /// ACP variants and must not be rejected by a client.
     /// </remarks>
     [JsonConverter(typeof(PlanEntryStatusJsonConverter))]
     public readonly struct PlanEntryStatus : IEquatable<PlanEntryStatus>
@@ -175,36 +176,36 @@ namespace SalmonEgg.Acp.Plan
         private readonly string? _value;
 
         /// <summary>
-        /// 以给定 wire 值创建计划条目状态。
+        /// Creates a plan entry status carrying the given wire value.
         /// </summary>
-        /// <param name="value">协议字符串值。</param>
+        /// <param name="value">The protocol string value.</param>
         public PlanEntryStatus(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
-        /// 条目已创建但尚未开始。
+        /// The entry has been created but has not started yet.
         /// </summary>
         public static PlanEntryStatus Pending { get; } = new("pending");
 
         /// <summary>
-        /// 条目正在执行中。
+        /// The entry is currently in progress.
         /// </summary>
         public static PlanEntryStatus InProgress { get; } = new("in_progress");
 
         /// <summary>
-        /// 条目已成功完成。
+        /// The entry completed successfully.
         /// </summary>
         public static PlanEntryStatus Completed { get; } = new("completed");
 
         /// <summary>
-        /// 条目在完成前被取消。
+        /// The entry was cancelled before completion.
         /// </summary>
         public static PlanEntryStatus Cancelled { get; } = new("cancelled");
 
         /// <summary>
-        /// 此状态承载的 wire 值。
+        /// The wire value carried by this status.
         /// </summary>
         public string Value => _value ?? string.Empty;
 
@@ -218,12 +219,12 @@ namespace SalmonEgg.Acp.Plan
         public override int GetHashCode() => _value is null ? 0 : StringComparer.Ordinal.GetHashCode(_value);
 
         /// <summary>
-        /// 判断两个状态是否承载相同 wire 值。
+        /// Determines whether two statuses carry the same wire value.
         /// </summary>
         public static bool operator ==(PlanEntryStatus left, PlanEntryStatus right) => left.Equals(right);
 
         /// <summary>
-        /// 判断两个状态是否承载不同 wire 值。
+        /// Determines whether two statuses carry different wire values.
         /// </summary>
         public static bool operator !=(PlanEntryStatus left, PlanEntryStatus right) => !left.Equals(right);
 
@@ -232,13 +233,14 @@ namespace SalmonEgg.Acp.Plan
     }
 
     /// <summary>
-    /// 计划条目优先级。
+    /// The priority of a plan entry.
     /// </summary>
     /// <remarks>
-    /// 建模为可扩展值类型而非封闭枚举，以便无损保留并 round-trip 未知的 wire 值，对齐权威
-    /// ACP schema（<c>PlanEntryPriority</c> 为 <c>#[non_exhaustive]</c> 且带 untagged
-    /// <c>Other(String)</c> 兜底）。依据 ACP 扩展契约，不以 <c>_</c> 开头的未知值保留给未来
-    /// ACP variant，client 不得拒绝。
+    /// Modeled as an extensible value type rather than a closed enum, so that unknown wire values are
+    /// preserved losslessly and round-trip intact, matching the authoritative ACP schema
+    /// (<c>PlanEntryPriority</c> is <c>#[non_exhaustive]</c> with an untagged <c>Other(String)</c> fallback).
+    /// Per the ACP extension contract, unknown values that do not start with <c>_</c> are reserved for future
+    /// ACP variants and must not be rejected by a client.
     /// </remarks>
     [JsonConverter(typeof(PlanEntryPriorityJsonConverter))]
     public readonly struct PlanEntryPriority : IEquatable<PlanEntryPriority>
@@ -246,31 +248,31 @@ namespace SalmonEgg.Acp.Plan
         private readonly string? _value;
 
         /// <summary>
-        /// 以给定 wire 值创建计划条目优先级。
+        /// Creates a plan entry priority carrying the given wire value.
         /// </summary>
-        /// <param name="value">协议字符串值。</param>
+        /// <param name="value">The protocol string value.</param>
         public PlanEntryPriority(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
-        /// 低优先级。
+        /// Low priority.
         /// </summary>
         public static PlanEntryPriority Low { get; } = new("low");
 
         /// <summary>
-        /// 中等优先级。
+        /// Medium priority.
         /// </summary>
         public static PlanEntryPriority Medium { get; } = new("medium");
 
         /// <summary>
-        /// 高优先级。
+        /// High priority.
         /// </summary>
         public static PlanEntryPriority High { get; } = new("high");
 
         /// <summary>
-        /// 此优先级承载的 wire 值。
+        /// The wire value carried by this priority.
         /// </summary>
         public string Value => _value ?? string.Empty;
 
@@ -284,12 +286,12 @@ namespace SalmonEgg.Acp.Plan
         public override int GetHashCode() => _value is null ? 0 : StringComparer.Ordinal.GetHashCode(_value);
 
         /// <summary>
-        /// 判断两个优先级是否承载相同 wire 值。
+        /// Determines whether two priorities carry the same wire value.
         /// </summary>
         public static bool operator ==(PlanEntryPriority left, PlanEntryPriority right) => left.Equals(right);
 
         /// <summary>
-        /// 判断两个优先级是否承载不同 wire 值。
+        /// Determines whether two priorities carry different wire values.
         /// </summary>
         public static bool operator !=(PlanEntryPriority left, PlanEntryPriority right) => !left.Equals(right);
 

--- a/src/SalmonEgg.Acp/Protocol/AcpProtocolWriteContext.cs
+++ b/src/SalmonEgg.Acp/Protocol/AcpProtocolWriteContext.cs
@@ -4,28 +4,33 @@ using System.Threading;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// 承载当前序列化调用流的协商协议版本，供无版本的类型 converter
-    /// （如 <c>McpServerJsonConverter</c>）在 Write 时按版本分流 wire 形态。
-    /// 未显式指定时使用稳定的 <see cref="AcpProtocolVersion.Default"/>；草案 V2
-    /// 仅由显式 wire 测试通过 <see cref="Enter"/> 进入。
+    /// Carries the negotiated protocol version for the current serialization call flow, so that
+    /// converters for version-agnostic types (such as <c>McpServerJsonConverter</c>) can branch on the
+    /// wire shape while writing. When no version is specified explicitly, the stable
+    /// <see cref="AcpProtocolVersion.Default"/> is used; draft V2 is entered only by explicit wire
+    /// tests via <see cref="Enter"/>.
     /// </summary>
     /// <remarks>
-    /// 版本沿同步序列化调用流（<c>JsonSerializer.SerializeToElement</c>）自然传递：
-    /// <c>Enter</c> 与序列化之间无 <c>await</c>，同步闭合，并发请求不会串版本。
+    /// The version propagates naturally along the synchronous serialization call flow
+    /// (<c>JsonSerializer.SerializeToElement</c>): there is no <c>await</c> between <c>Enter</c> and
+    /// serialization, so the scope closes synchronously and concurrent requests cannot interleave
+    /// versions.
     /// </remarks>
     internal static class AcpProtocolWriteContext
     {
         private static readonly AsyncLocal<int?> s_protocolVersion = new();
 
         /// <summary>
-        /// 当前调用流的协议版本；未显式进入时默认 <see cref="AcpProtocolVersion.Default"/>。
+        /// The protocol version for the current call flow; defaults to
+        /// <see cref="AcpProtocolVersion.Default"/> when no version has been entered explicitly.
         /// </summary>
         public static int Current => s_protocolVersion.Value ?? AcpProtocolVersion.Default;
 
         /// <summary>
-        /// 进入指定协议版本的写入上下文，返回的 <see cref="IDisposable"/> 在 Dispose 时恢复上一层版本。
+        /// Enters a write context for the specified protocol version. Disposing the returned
+        /// <see cref="IDisposable"/> restores the version of the enclosing scope.
         /// </summary>
-        /// <param name="version">协商后的协议版本。</param>
+        /// <param name="version">The negotiated protocol version.</param>
         public static IDisposable Enter(int version)
         {
             var previous = s_protocolVersion.Value;

--- a/src/SalmonEgg.Acp/Protocol/AuthenticateTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/AuthenticateTypes.cs
@@ -4,8 +4,8 @@ using System.Text.Json.Serialization;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Authenticate 方法的请求参数。
-    /// 用于向 Agent 发起认证请求。
+    /// Request parameters for the <c>authenticate</c> method.
+    /// Used to initiate an authentication request against the Agent.
     /// </summary>
     public sealed record AuthenticateParams : AcpProtocolObject
     {
@@ -29,21 +29,21 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Authenticate 方法的响应。
+    /// Response for the <c>authenticate</c> method.
     /// </summary>
     public sealed record AuthenticateResponse : AcpProtocolObject
     {
     }
 
     /// <summary>
-    /// Logout 方法的请求参数。
+    /// Request parameters for the <c>logout</c> method.
     /// </summary>
     public sealed record LogoutParams : AcpProtocolObject
     {
     }
 
     /// <summary>
-    /// Logout 方法的响应。
+    /// Response for the <c>logout</c> method.
     /// </summary>
     public sealed record LogoutResponse : AcpProtocolObject
     {
@@ -51,22 +51,22 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 认证方法枚举。
+    /// Authentication methods.
     /// </summary>
     public enum AuthMethod
     {
         /// <summary>
-        /// Bearer Token 认证。
+        /// Bearer token authentication.
         /// </summary>
         Bearer,
 
         /// <summary>
-        /// API Key 认证。
+        /// API key authentication.
         /// </summary>
         ApiKey,
 
         /// <summary>
-        /// 其他认证方法。
+        /// Any other authentication method.
         /// </summary>
         Other
     }

--- a/src/SalmonEgg.Acp/Protocol/InitializeTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/InitializeTypes.cs
@@ -8,45 +8,45 @@ using SalmonEgg.Acp.Serialization;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Initialize 方法的请求参数。
-    /// 用于客户端向 Agent 发起初始化请求。
+    /// Request parameters for the Initialize method.
+    /// Used by the client to send an initialization request to the Agent.
     /// </summary>
     [JsonConverter(typeof(InitializeParamsJsonConverter))]
     public sealed record InitializeParams : AcpProtocolObject
     {
         /// <summary>
-        /// 协议版本号。必须是整数。
+        /// The protocol version number. Must be an integer.
         /// </summary>
         [JsonPropertyName("protocolVersion")]
         public int ProtocolVersion { get; init; } = AcpProtocolVersion.Default;
 
         /// <summary>
-        /// 客户端信息。
+        /// Client information.
         /// </summary>
         [JsonPropertyName("clientInfo")]
         public ClientInfo ClientInfo { get; init; } = new ClientInfo();
 
         /// <summary>
-        /// 客户端能力声明。
+        /// Client capability declaration.
         /// </summary>
         [JsonPropertyName("clientCapabilities")]
         public ClientCapabilities ClientCapabilities { get; init; } = new ClientCapabilities();
 
         /// <summary>
-        /// 扩展字段（_meta），用于协议可扩展性。
+        /// Extension field (_meta) used for protocol extensibility.
         /// </summary>
         /// <summary>
-        /// 创建新的 InitializeParams 实例。
+        /// Creates a new InitializeParams instance.
         /// </summary>
         public InitializeParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 InitializeParams 实例。
+        /// Creates a new InitializeParams instance.
         /// </summary>
-        /// <param name="clientInfo">客户端信息</param>
-        /// <param name="clientCapabilities">客户端能力</param>
+        /// <param name="clientInfo">Client information</param>
+        /// <param name="clientCapabilities">Client capabilities</param>
         public InitializeParams(ClientInfo clientInfo, ClientCapabilities clientCapabilities)
         {
             ClientInfo = clientInfo;
@@ -55,42 +55,42 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 客户端信息类。
-    /// 包含客户端的名称、标题和版本信息。
+    /// Client information class.
+    /// Contains the name, title, and version information of the client.
     /// </summary>
     public sealed record ClientInfo : AcpProtocolObject
     {
         /// <summary>
-        /// 客户端的名称（标识符）。
+        /// The client name (identifier).
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
 
         /// <summary>
-        /// 客户端的显示标题。
+        /// The client display title.
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; init; }
 
         /// <summary>
-        /// 客户端的版本号。
+        /// The client version.
         /// </summary>
         [JsonPropertyName("version")]
         public string Version { get; init; } = "1.0.0";
 
         /// <summary>
-        /// 创建新的 ClientInfo 实例。
+        /// Creates a new ClientInfo instance.
         /// </summary>
         public ClientInfo()
         {
         }
 
         /// <summary>
-        /// 创建新的 ClientInfo 实例。
+        /// Creates a new ClientInfo instance.
         /// </summary>
-        /// <param name="name">客户端名称</param>
-        /// <param name="version">版本号</param>
-        /// <param name="title">显示标题</param>
+        /// <param name="name">Client name</param>
+        /// <param name="version">Version</param>
+        /// <param name="title">Display title</param>
         [SetsRequiredMembers]
         public ClientInfo(string name, string version, string? title = null)
         {
@@ -101,46 +101,46 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 客户端能力声明类。
-    /// 声明客户端支持的功能。
+    /// Client capability declaration class.
+    /// Declares the features supported by the client.
     /// </summary>
     public sealed record ClientCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 文件系统能力。
+        /// File system capabilities.
         /// </summary>
         [JsonPropertyName("fs")]
         public FsCapability? Fs { get; init; }
 
         /// <summary>
-        /// 终端能力。
+        /// Terminal capability.
         /// </summary>
         [JsonPropertyName("terminal")]
         public bool? Terminal { get; init; }
 
         /// <summary>
-        /// 会话相关客户端能力。
+        /// Session-related client capabilities.
         /// </summary>
         [JsonPropertyName("session")]
         public ClientSessionCapabilities? Session { get; init; }
 
         /// <summary>
-        /// 扩展字段（_meta），用于声明自定义客户端能力。
+        /// Extension field (_meta) used to declare custom client capabilities.
         /// </summary>
         /// <summary>
-        /// 创建新的 ClientCapabilities 实例。
+        /// Creates a new ClientCapabilities instance.
         /// </summary>
         public ClientCapabilities()
         {
         }
 
         /// <summary>
-        /// 创建新的 ClientCapabilities 实例。
+        /// Creates a new ClientCapabilities instance.
         /// </summary>
-        /// <param name="fs">文件系统能力</param>
-        /// <param name="terminal">终端能力</param>
-        /// <param name="session">会话能力</param>
-        /// <param name="meta">扩展能力元数据</param>
+        /// <param name="fs">File system capabilities</param>
+        /// <param name="terminal">Terminal capability</param>
+        /// <param name="session">Session capabilities</param>
+        /// <param name="meta">Extension capability metadata</param>
         public ClientCapabilities(
             FsCapability? fs = null,
             bool? terminal = null,
@@ -154,10 +154,10 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 判断是否声明支持指定的扩展能力。
+        /// Determines whether support for the specified extension capability is declared.
         /// </summary>
-        /// <param name="extensionName">扩展能力名称</param>
-        /// <returns>如果声明支持返回 true，否则返回 false</returns>
+        /// <param name="extensionName">Extension capability name</param>
+        /// <returns>true if support is declared; otherwise false</returns>
         public bool SupportsExtension(string extensionName)
         {
             if (string.IsNullOrWhiteSpace(extensionName)
@@ -199,7 +199,7 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 客户端会话能力。
+    /// Client session capabilities.
     /// </summary>
     public sealed record ClientSessionCapabilities : AcpProtocolObject
     {
@@ -209,7 +209,7 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 客户端会话配置选项能力。
+    /// Client session configuration option capabilities.
     /// </summary>
     public sealed record SessionConfigOptionsCapabilities : AcpProtocolObject
     {
@@ -222,34 +222,34 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 文件系统能力类。
+    /// File system capability class.
     /// </summary>
     public sealed record FsCapability : AcpProtocolObject
     {
         /// <summary>
-        /// 是否支持读取文本文件。
+        /// Whether reading text files is supported.
         /// </summary>
         [JsonPropertyName("readTextFile")]
         public bool ReadTextFile { get; init; } = true;
 
         /// <summary>
-        /// 是否支持写入文本文件。
+        /// Whether writing text files is supported.
         /// </summary>
         [JsonPropertyName("writeTextFile")]
         public bool WriteTextFile { get; init; } = true;
 
         /// <summary>
-        /// 创建新的 FsCapability 实例。
+        /// Creates a new FsCapability instance.
         /// </summary>
         public FsCapability()
         {
         }
 
         /// <summary>
-        /// 创建新的 FsCapability 实例。
+        /// Creates a new FsCapability instance.
         /// </summary>
-        /// <param name="readTextFile">是否支持读取</param>
-        /// <param name="writeTextFile">是否支持写入</param>
+        /// <param name="readTextFile">Whether reading is supported</param>
+        /// <param name="writeTextFile">Whether writing is supported</param>
         public FsCapability(bool readTextFile = true, bool writeTextFile = true)
         {
             ReadTextFile = readTextFile;
@@ -285,50 +285,50 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Initialize 方法的响应。
-    /// Agent 对初始化请求的响应。
+    /// Response for the Initialize method.
+    /// The Agent response to the initialization request.
     /// </summary>
     [JsonConverter(typeof(InitializeResponseJsonConverter))]
     public sealed record InitializeResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 协议版本号。必须是整数。
+        /// The protocol version number. Must be an integer.
         /// </summary>
         [JsonPropertyName("protocolVersion")]
         public int ProtocolVersion { get; init; } = AcpProtocolVersion.Default;
 
         /// <summary>
-        /// Agent 信息。
+        /// Agent information.
         /// </summary>
         public AgentInfo AgentInfo { get; init; } = new AgentInfo();
 
         /// <summary>
-        /// Agent 能力声明。
+        /// Agent capability declaration.
         /// </summary>
         public AgentCapabilities AgentCapabilities { get; init; } = new AgentCapabilities();
 
         /// <summary>
-        /// 可选的认证方法列表（当 Agent 需要认证时提供）。
+        /// Optional list of authentication methods (provided when the Agent requires authentication).
         /// </summary>
         [JsonPropertyName("authMethods")]
         public List<AuthMethodDefinition>? AuthMethods { get; init; }
 
         /// <summary>
-        /// 扩展字段（_meta），用于协议可扩展性。
+        /// Extension field (_meta) used for protocol extensibility.
         /// </summary>
         /// <summary>
-        /// 创建新的 InitializeResponse 实例。
+        /// Creates a new InitializeResponse instance.
         /// </summary>
         public InitializeResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 InitializeResponse 实例。
+        /// Creates a new InitializeResponse instance.
         /// </summary>
-        /// <param name="protocolVersion">协议版本</param>
-        /// <param name="agentInfo">Agent 信息</param>
-        /// <param name="agentCapabilities">Agent 能力</param>
+        /// <param name="protocolVersion">Protocol version</param>
+        /// <param name="agentInfo">Agent information</param>
+        /// <param name="agentCapabilities">Agent capabilities</param>
         public InitializeResponse(int protocolVersion, AgentInfo agentInfo, AgentCapabilities agentCapabilities)
         {
             ProtocolVersion = protocolVersion;
@@ -338,42 +338,42 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Agent 信息类。
-    /// 包含 Agent 的名称、标题和版本信息。
+    /// Agent information class.
+    /// Contains the name, title, and version information of the Agent.
     /// </summary>
     public sealed record AgentInfo : AcpProtocolObject
     {
         /// <summary>
-        /// Agent 的名称（标识符）。
+        /// The Agent name (identifier).
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
 
         /// <summary>
-        /// Agent 的显示标题。
+        /// The Agent display title.
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; init; }
 
         /// <summary>
-        /// Agent 的版本号。
+        /// The Agent version.
         /// </summary>
         [JsonPropertyName("version")]
         public string Version { get; init; } = "1.0.0";
 
         /// <summary>
-        /// 创建新的 AgentInfo 实例。
+        /// Creates a new AgentInfo instance.
         /// </summary>
         public AgentInfo()
         {
         }
 
         /// <summary>
-        /// 创建新的 AgentInfo 实例。
+        /// Creates a new AgentInfo instance.
         /// </summary>
-        /// <param name="name">Agent 名称</param>
-        /// <param name="version">版本号</param>
-        /// <param name="title">显示标题</param>
+        /// <param name="name">Agent name</param>
+        /// <param name="version">Version</param>
+        /// <param name="title">Display title</param>
         [SetsRequiredMembers]
         public AgentInfo(string name, string version, string? title = null)
         {
@@ -384,56 +384,56 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Agent 能力声明类。
-    /// 声明 Agent 支持的功能。
+    /// Agent capability declaration class.
+    /// Declares the features supported by the Agent.
     /// </summary>
     public sealed record AgentCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 提示相关能力。
+        /// Prompt-related capabilities.
         /// </summary>
         [JsonPropertyName("promptCapabilities")]
         public PromptCapabilities? PromptCapabilities { get; init; }
 
         /// <summary>
-        /// 是否支持会话加载。
+        /// Whether session loading is supported.
         /// </summary>
         [JsonPropertyName("loadSession")]
         public bool? LoadSession { get; init; }
 
         /// <summary>
-        /// MCP 相关能力。
+        /// MCP-related capabilities.
         /// </summary>
         [JsonPropertyName("mcpCapabilities")]
         public McpCapabilities? McpCapabilities { get; init; }
 
         /// <summary>
-        /// 会话相关能力。
+        /// Session-related capabilities.
         /// </summary>
         [JsonPropertyName("sessionCapabilities")]
         public SessionCapabilities? SessionCapabilities { get; init; }
 
         /// <summary>
-        /// 认证相关能力。
+        /// Authentication-related capabilities.
         /// </summary>
         [JsonPropertyName("auth")]
         public AgentAuthCapabilities? Auth { get; init; }
 
         /// <summary>
-        /// 创建新的 AgentCapabilities 实例。
+        /// Creates a new AgentCapabilities instance.
         /// </summary>
         public AgentCapabilities()
         {
         }
 
         /// <summary>
-        /// 创建新的 AgentCapabilities 实例。
+        /// Creates a new AgentCapabilities instance.
         /// </summary>
-        /// <param name="promptCapabilities">提示能力</param>
-        /// <param name="loadSession">是否支持会话加载</param>
-        /// <param name="mcpCapabilities">MCP 能力</param>
-        /// <param name="sessionCapabilities">会话能力</param>
-        /// <param name="auth">认证能力</param>
+        /// <param name="promptCapabilities">Prompt capabilities</param>
+        /// <param name="loadSession">Whether session loading is supported</param>
+        /// <param name="mcpCapabilities">MCP capabilities</param>
+        /// <param name="sessionCapabilities">Session capabilities</param>
+        /// <param name="auth">Authentication capabilities</param>
         public AgentCapabilities(
             PromptCapabilities? promptCapabilities = null,
             bool? loadSession = null,
@@ -449,73 +449,73 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 判断是否支持图片内容。
+        /// Gets a value indicating whether image content is supported.
         /// </summary>
         public bool SupportsImage => PromptCapabilities?.Image == true || SessionCapabilities?.Prompt?.Image == true;
 
         /// <summary>
-        /// 判断是否支持音频内容。
+        /// Gets a value indicating whether audio content is supported.
         /// </summary>
         public bool SupportsAudio => PromptCapabilities?.Audio == true || SessionCapabilities?.Prompt?.Audio == true;
 
         /// <summary>
-        /// 判断是否支持嵌入上下文。
+        /// Gets a value indicating whether embedded context is supported.
         /// </summary>
         public bool SupportsEmbeddedContext => PromptCapabilities?.EmbeddedContext == true || SessionCapabilities?.Prompt?.EmbeddedContext == true;
 
         /// <summary>
-        /// 判断是否支持会话加载。
+        /// Gets a value indicating whether session loading is supported.
         /// </summary>
         public bool SupportsSessionLoading => LoadSession ?? false;
 
         /// <summary>
-        /// 判断是否支持会话恢复。
+        /// Gets a value indicating whether session resumption is supported.
         /// </summary>
         public bool SupportsSessionResume => SessionCapabilities?.Resume != null;
 
         /// <summary>
-        /// 判断是否支持会话关闭。
+        /// Gets a value indicating whether closing a session is supported.
         /// </summary>
         public bool SupportsSessionClose => SessionCapabilities?.Close != null;
 
         /// <summary>
-        /// 判断是否支持会话删除。
+        /// Gets a value indicating whether deleting a session is supported.
         /// </summary>
         public bool SupportsSessionDelete => SessionCapabilities?.Delete != null;
 
         /// <summary>
-        /// 判断是否支持 additionalDirectories。
+        /// Gets a value indicating whether additionalDirectories is supported.
         /// </summary>
         public bool SupportsSessionAdditionalDirectories => SessionCapabilities?.AdditionalDirectories != null;
 
         /// <summary>
-        /// 判断是否支持会话列表。
+        /// Gets a value indicating whether listing sessions is supported.
         /// </summary>
         public bool SupportsSessionList => SessionCapabilities?.List != null;
 
         /// <summary>
-        /// 判断是否支持登出。
+        /// Gets a value indicating whether logout is supported.
         /// </summary>
         public bool SupportsLogout => Auth?.Logout != null;
 
         /// <summary>
-        /// 判断是否支持 HTTP 传输。
+        /// Gets a value indicating whether the HTTP transport is supported.
         /// </summary>
         public bool SupportsHttp => McpCapabilities?.Http == true || SessionCapabilities?.Mcp?.Http == true;
 
         /// <summary>
-        /// 判断是否支持 SSE 传输。
+        /// Gets a value indicating whether the SSE transport is supported.
         /// </summary>
         public bool SupportsSse => McpCapabilities?.Sse == true || SessionCapabilities?.Mcp?.Sse == true;
 
         /// <summary>
-        /// 判断是否支持 stdio 传输。
+        /// Gets a value indicating whether the stdio transport is supported.
         /// </summary>
         public bool SupportsStdio => SessionCapabilities?.Mcp?.SupportsStdio == true;
     }
 
     /// <summary>
-    /// Agent 认证能力。
+    /// Agent authentication capabilities.
     /// </summary>
     public sealed record AgentAuthCapabilities : AcpProtocolObject
     {
@@ -525,48 +525,48 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Logout 方法能力。
+    /// Logout method capabilities.
     /// </summary>
     public sealed record LogoutCapabilities : AcpProtocolObject
     {
     }
 
     /// <summary>
-    /// 提示相关能力类。
+    /// Prompt-related capability class.
     /// </summary>
     public sealed record PromptCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 是否支持图片内容。
+        /// Whether image content is supported.
         /// </summary>
         [JsonPropertyName("image")]
         public bool Image { get; init; }
 
         /// <summary>
-        /// 是否支持音频内容。
+        /// Whether audio content is supported.
         /// </summary>
         [JsonPropertyName("audio")]
         public bool Audio { get; init; }
 
         /// <summary>
-        /// 是否支持嵌入上下文。
+        /// Whether embedded context is supported.
         /// </summary>
         [JsonPropertyName("embeddedContext")]
         public bool EmbeddedContext { get; init; }
 
         /// <summary>
-        /// 创建新的 PromptCapabilities 实例。
+        /// Creates a new PromptCapabilities instance.
         /// </summary>
         public PromptCapabilities()
         {
         }
 
         /// <summary>
-        /// 创建新的 PromptCapabilities 实例。
+        /// Creates a new PromptCapabilities instance.
         /// </summary>
-        /// <param name="image">是否支持图片</param>
-        /// <param name="audio">是否支持音频</param>
-        /// <param name="embeddedContext">是否支持嵌入上下文</param>
+        /// <param name="image">Whether images are supported</param>
+        /// <param name="audio">Whether audio is supported</param>
+        /// <param name="embeddedContext">Whether embedded context is supported</param>
         public PromptCapabilities(bool image = false, bool audio = false, bool embeddedContext = false)
         {
             Image = image;
@@ -576,38 +576,38 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// MCP 相关能力类。
+    /// MCP-related capability class.
     /// </summary>
     public sealed record McpCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 是否支持 HTTP 传输。
+        /// Whether the HTTP transport is supported.
         /// </summary>
         [JsonPropertyName("http")]
         public bool Http { get; init; }
 
         /// <summary>
-        /// 是否支持 SSE 传输。
+        /// Whether the SSE transport is supported.
         /// </summary>
         [JsonPropertyName("sse")]
         public bool Sse { get; init; }
 
         /// <summary>
-        /// ACP 保留的扩展元数据。
+        /// Extension metadata reserved by ACP.
         /// </summary>
         /// <summary>
-        /// 创建新的 McpCapabilities 实例。
+        /// Creates a new McpCapabilities instance.
         /// </summary>
         public McpCapabilities()
         {
         }
 
         /// <summary>
-        /// 创建新的 McpCapabilities 实例。
+        /// Creates a new McpCapabilities instance.
         /// </summary>
-        /// <param name="http">是否支持 HTTP</param>
-        /// <param name="sse">是否支持 SSE</param>
-        /// <param name="meta">扩展元数据</param>
+        /// <param name="http">Whether HTTP is supported</param>
+        /// <param name="sse">Whether SSE is supported</param>
+        /// <param name="meta">Extension metadata</param>
         public McpCapabilities(
             bool http = false,
             bool sse = false,
@@ -621,67 +621,67 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 是否支持 stdio 传输。
-        /// v1 wire 不公开该字段，v2 wire 通过 session.mcp.stdio 公开。
+        /// Whether the stdio transport is supported.
+        /// The v1 wire does not expose this field; the v2 wire exposes it through session.mcp.stdio.
         /// </summary>
         [JsonIgnore]
         public bool? Stdio { get; init; }
 
         /// <summary>
-        /// 判断是否支持 stdio 传输。
+        /// Gets a value indicating whether the stdio transport is supported.
         /// </summary>
         public bool SupportsStdio => Stdio ?? false;
     }
 
     /// <summary>
-    /// 会话相关能力类。
+    /// Session-related capability class.
     /// </summary>
     public sealed record SessionCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 是否支持 prompt 扩展。
+        /// Whether prompt extensions are supported.
         /// </summary>
         [JsonPropertyName("prompt")]
         public PromptCapabilities? Prompt { get; init; }
 
         /// <summary>
-        /// 是否支持 MCP 传输。
+        /// Whether MCP transports are supported.
         /// </summary>
         [JsonPropertyName("mcp")]
         public McpCapabilities? Mcp { get; init; }
 
         /// <summary>
-        /// 是否支持会话列表功能。
+        /// Whether the session listing feature is supported.
         /// </summary>
         [JsonPropertyName("list")]
         public SessionListCapabilities? List { get; init; }
 
         /// <summary>
-        /// 是否支持会话恢复功能。
+        /// Whether the session resume feature is supported.
         /// </summary>
         [JsonPropertyName("resume")]
         public SessionResumeCapabilities? Resume { get; init; }
 
         /// <summary>
-        /// 是否支持会话关闭功能。
+        /// Whether the session close feature is supported.
         /// </summary>
         [JsonPropertyName("close")]
         public SessionCloseCapabilities? Close { get; init; }
 
         /// <summary>
-        /// 是否支持会话删除功能。
+        /// Whether the session delete feature is supported.
         /// </summary>
         [JsonPropertyName("delete")]
         public SessionDeleteCapabilities? Delete { get; init; }
 
         /// <summary>
-        /// 是否支持 additionalDirectories。
+        /// Whether additionalDirectories is supported.
         /// </summary>
         [JsonPropertyName("additionalDirectories")]
         public SessionAdditionalDirectoriesCapabilities? AdditionalDirectories { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionCapabilities 实例。
+        /// Creates a new SessionCapabilities instance.
         /// </summary>
         public SessionCapabilities()
         {
@@ -689,12 +689,12 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话列表能力类。
+    /// Session listing capability class.
     /// </summary>
     public sealed record SessionListCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 创建新的 SessionListCapabilities 实例。
+        /// Creates a new SessionListCapabilities instance.
         /// </summary>
         public SessionListCapabilities()
         {
@@ -702,12 +702,12 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话恢复能力类。
+    /// Session resume capability class.
     /// </summary>
     public sealed record SessionResumeCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 创建新的 SessionResumeCapabilities 实例。
+        /// Creates a new SessionResumeCapabilities instance.
         /// </summary>
         public SessionResumeCapabilities()
         {
@@ -715,12 +715,12 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话关闭能力类。
+    /// Session close capability class.
     /// </summary>
     public sealed record SessionCloseCapabilities : AcpProtocolObject
     {
         /// <summary>
-        /// 创建新的 SessionCloseCapabilities 实例。
+        /// Creates a new SessionCloseCapabilities instance.
         /// </summary>
         public SessionCloseCapabilities()
         {
@@ -728,14 +728,14 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话删除能力类。
+    /// Session delete capability class.
     /// </summary>
     public sealed record SessionDeleteCapabilities : AcpProtocolObject
     {
     }
 
     /// <summary>
-    /// additionalDirectories 能力类。
+    /// additionalDirectories capability class.
     /// </summary>
     public sealed record SessionAdditionalDirectoriesCapabilities : AcpProtocolObject
     {

--- a/src/SalmonEgg.Acp/Protocol/InitializeTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/InitializeTypes.cs
@@ -608,6 +608,7 @@ namespace SalmonEgg.Acp.Protocol
         /// <param name="http">Whether HTTP is supported</param>
         /// <param name="sse">Whether SSE is supported</param>
         /// <param name="meta">Extension metadata</param>
+        /// <param name="stdio">Whether stdio is supported; null when the wire did not carry the field</param>
         public McpCapabilities(
             bool http = false,
             bool sse = false,

--- a/src/SalmonEgg.Acp/Protocol/OtherSessionTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/OtherSessionTypes.cs
@@ -7,35 +7,35 @@ using SalmonEgg.Acp.Mcp;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Session/Set_Mode 方法的请求参数。
-    /// 用于切换会话的工作模式。
+    /// Request parameters for the Session/Set_Mode method.
+    /// Switches the working mode of a session.
     /// </summary>
     public sealed record SessionSetModeParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 要切换到的目标模式 ID（必填）。
+        /// The target mode ID to switch to (required).
         /// </summary>
         [JsonPropertyName("modeId")]
         public string ModeId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 创建新的 SessionSetModeParams 实例。
+        /// Creates a new SessionSetModeParams instance.
         /// </summary>
         public SessionSetModeParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionSetModeParams 实例。
+        /// Creates a new SessionSetModeParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="modeId">目标模式 ID</param>
+        /// <param name="sessionId">Session ID</param>
+        /// <param name="modeId">Target mode ID</param>
         public SessionSetModeParams(string sessionId, string modeId)
         {
             SessionId = sessionId;
@@ -44,15 +44,15 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Set_Mode 方法的响应。
+    /// Response for the Session/Set_Mode method.
     /// </summary>
     public sealed record SessionSetModeResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 协议扩展字段（_meta）。
+        /// Protocol extension field (_meta).
         /// </summary>
         /// <summary>
-        /// 创建新的 SessionSetModeResponse 实例。
+        /// Creates a new SessionSetModeResponse instance.
         /// </summary>
         public SessionSetModeResponse()
         {
@@ -78,50 +78,51 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Load 方法的请求参数。
-    /// 用于加载已存在的会话历史。
+    /// Request parameters for the Session/Load method.
+    /// Loads the history of an existing session.
     /// </summary>
     public sealed record SessionLoadParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 会话的工作目录（必填）。
+        /// The working directory of the session (required).
         /// </summary>
         [JsonPropertyName("cwd")]
         public string Cwd { get; init; } = string.Empty;
 
         /// <summary>
-        /// MCP 服务器配置列表。
-        /// ACP session/load 要求该字段始终为数组，即使当前没有任何 MCP server 也必须发送 []。
+        /// List of MCP server configurations.
+        /// ACP session/load requires this field to always be an array; send [] even when there is no MCP server.
         /// </summary>
         [JsonPropertyName("mcpServers")]
         public List<McpServer> McpServers { get; init; } = new List<McpServer>();
 
         /// <summary>
-        /// 附加工作目录。非空时要求 Agent 声明 sessionCapabilities.additionalDirectories。
+        /// Additional working directories. When non-empty, requires the Agent to declare
+        /// sessionCapabilities.additionalDirectories.
         /// </summary>
         [JsonPropertyName("additionalDirectories")]
         public List<string>? AdditionalDirectories { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionLoadParams 实例。
+        /// Creates a new SessionLoadParams instance.
         /// </summary>
         public SessionLoadParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionLoadParams 实例。
+        /// Creates a new SessionLoadParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="cwd">工作目录</param>
-        /// <param name="mcpServers">MCP 服务器配置</param>
-        /// <param name="additionalDirectories">附加工作目录</param>
+        /// <param name="sessionId">Session ID</param>
+        /// <param name="cwd">Working directory</param>
+        /// <param name="mcpServers">MCP server configurations</param>
+        /// <param name="additionalDirectories">Additional working directories</param>
         public SessionLoadParams(
             string sessionId,
             string cwd,
@@ -136,36 +137,36 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Load 方法的响应。
-    /// 可能返回 null / 空对象，或返回模式与配置选项快照。
+    /// Response for the Session/Load method.
+    /// May be null / an empty object, or carry a snapshot of modes and configuration options.
     /// </summary>
     public sealed record SessionLoadResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 会话模式状态（可选，ACP 标准形态为 SessionModeState 对象）。
+        /// Session mode state (optional; the standard ACP form is a SessionModeState object).
         /// </summary>
         [JsonPropertyName("modes")]
         [JsonConverter(typeof(SessionModesStateJsonConverter))]
         public SessionModesState? Modes { get; init; }
 
         /// <summary>
-        /// 可用的配置选项列表（可选）。
+        /// List of available configuration options (optional).
         /// </summary>
         [JsonPropertyName("configOptions")]
         public List<ConfigOption>? ConfigOptions { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionLoadResponse 实例。
+        /// Creates a new SessionLoadResponse instance.
         /// </summary>
         public SessionLoadResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionLoadResponse 实例。
+        /// Creates a new SessionLoadResponse instance.
         /// </summary>
-        /// <param name="modes">模式状态</param>
-        /// <param name="configOptions">配置选项列表</param>
+        /// <param name="modes">Mode state</param>
+        /// <param name="configOptions">List of configuration options</param>
         public SessionLoadResponse(SessionModesState? modes, List<ConfigOption>? configOptions = null)
         {
             Modes = modes;
@@ -173,7 +174,7 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 表示加载完成的静态实例。
+        /// A static instance representing load completion.
         /// </summary>
         public static readonly SessionLoadResponse Completed = new SessionLoadResponse();
     }
@@ -297,33 +298,35 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Resume 方法的请求参数。
-    /// 用于恢复已存在的会话上下文；省略 <see cref="ReplayFrom"/> 时不要求 Agent 重放历史，
-    /// 设置 <c>replayFrom: { type: "start" }</c> 时请求完整历史重放（V2 对 session/load 的替代路径）。
+    /// Request parameters for the Session/Resume method.
+    /// Resumes the context of an existing session; omitting <see cref="ReplayFrom"/> does not require the Agent
+    /// to replay history, while <c>replayFrom: { type: "start" }</c> requests a full history replay (the V2
+    /// alternative to session/load).
     /// </summary>
     public sealed record SessionResumeParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 会话的工作目录（必填）。
+        /// The working directory of the session (required).
         /// </summary>
         [JsonPropertyName("cwd")]
         public string Cwd { get; init; } = string.Empty;
 
         /// <summary>
-        /// MCP 服务器配置列表。
-        /// ACP session/resume 要求该字段始终为数组，即使当前没有任何 MCP server 也必须发送 []。
+        /// List of MCP server configurations.
+        /// ACP session/resume requires this field to always be an array; send [] even when there is no MCP server.
         /// </summary>
         [JsonPropertyName("mcpServers")]
         public List<McpServer> McpServers { get; init; } = new List<McpServer>();
 
         /// <summary>
-        /// 附加工作目录。非空时要求 Agent 声明 sessionCapabilities.additionalDirectories。
+        /// Additional working directories. When non-empty, requires the Agent to declare
+        /// sessionCapabilities.additionalDirectories.
         /// </summary>
         [JsonPropertyName("additionalDirectories")]
         public List<string>? AdditionalDirectories { get; init; }
@@ -336,19 +339,19 @@ namespace SalmonEgg.Acp.Protocol
         public SessionReplayFrom? ReplayFrom { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionResumeParams 实例。
+        /// Creates a new SessionResumeParams instance.
         /// </summary>
         public SessionResumeParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionResumeParams 实例。
+        /// Creates a new SessionResumeParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="cwd">工作目录</param>
-        /// <param name="mcpServers">MCP 服务器配置</param>
-        /// <param name="additionalDirectories">附加工作目录</param>
+        /// <param name="sessionId">Session ID</param>
+        /// <param name="cwd">Working directory</param>
+        /// <param name="mcpServers">MCP server configurations</param>
+        /// <param name="additionalDirectories">Additional working directories</param>
         /// <param name="replayFrom">Optional V2 history replay cursor</param>
         public SessionResumeParams(
             string sessionId,
@@ -366,36 +369,36 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Resume 方法的响应。
-    /// 可能返回 null / 空对象，或返回模式与配置选项快照。
+    /// Response for the Session/Resume method.
+    /// May be null / an empty object, or carry a snapshot of modes and configuration options.
     /// </summary>
     public sealed record SessionResumeResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 会话模式状态（可选，ACP 标准形态为 SessionModeState 对象）。
+        /// Session mode state (optional; the standard ACP form is a SessionModeState object).
         /// </summary>
         [JsonPropertyName("modes")]
         [JsonConverter(typeof(SessionModesStateJsonConverter))]
         public SessionModesState? Modes { get; init; }
 
         /// <summary>
-        /// 可用的配置选项列表（可选）。
+        /// List of available configuration options (optional).
         /// </summary>
         [JsonPropertyName("configOptions")]
         public List<ConfigOption>? ConfigOptions { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionResumeResponse 实例。
+        /// Creates a new SessionResumeResponse instance.
         /// </summary>
         public SessionResumeResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionResumeResponse 实例。
+        /// Creates a new SessionResumeResponse instance.
         /// </summary>
-        /// <param name="modes">模式状态</param>
-        /// <param name="configOptions">配置选项列表</param>
+        /// <param name="modes">Mode state</param>
+        /// <param name="configOptions">List of configuration options</param>
         public SessionResumeResponse(SessionModesState? modes, List<ConfigOption>? configOptions = null)
         {
             Modes = modes;
@@ -403,34 +406,34 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 表示恢复完成的静态实例。
+        /// A static instance representing resume completion.
         /// </summary>
         public static readonly SessionResumeResponse Completed = new SessionResumeResponse();
     }
 
     /// <summary>
-    /// Session/Close 方法的请求参数。
-    /// 用于关闭已存在的会话并释放 Agent 侧资源。
+    /// Request parameters for the Session/Close method.
+    /// Closes an existing session and releases the Agent-side resources.
     /// </summary>
     public sealed record SessionCloseParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 创建新的 SessionCloseParams 实例。
+        /// Creates a new SessionCloseParams instance.
         /// </summary>
         public SessionCloseParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionCloseParams 实例。
+        /// Creates a new SessionCloseParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
+        /// <param name="sessionId">Session ID</param>
         public SessionCloseParams(string sessionId)
         {
             SessionId = sessionId;
@@ -438,31 +441,31 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Close 方法的响应。
+    /// Response for the Session/Close method.
     /// </summary>
     public sealed record SessionCloseResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 创建新的 SessionCloseResponse 实例。
+        /// Creates a new SessionCloseResponse instance.
         /// </summary>
         public SessionCloseResponse()
         {
         }
 
         /// <summary>
-        /// 表示关闭完成的静态实例。
+        /// A static instance representing close completion.
         /// </summary>
         public static readonly SessionCloseResponse Completed = new SessionCloseResponse();
     }
 
     /// <summary>
-    /// Session/Delete 方法的请求参数。
-    /// 用于删除 session/list 中的已有会话。
+    /// Request parameters for the Session/Delete method.
+    /// Deletes an existing session listed by session/list.
     /// </summary>
     public sealed record SessionDeleteParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
@@ -478,7 +481,7 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Delete 方法的响应。
+    /// Response for the Session/Delete method.
     /// </summary>
     public sealed record SessionDeleteResponse : AcpProtocolObject
     {
@@ -486,26 +489,26 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Set_Config_Option 方法的请求参数。
-    /// 用于设置会话的配置选项。
+    /// Request parameters for the Session/Set_Config_Option method.
+    /// Sets a configuration option of the session.
     /// </summary>
     [JsonConverter(typeof(SessionSetConfigOptionParamsJsonConverter))]
     public sealed record SessionSetConfigOptionParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 配置选项 ID（必填）。
+        /// Configuration option ID (required).
         /// </summary>
         [JsonPropertyName("configId")]
         public string ConfigId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 配置选项的值（必填）。
+        /// The value of the configuration option (required).
         /// </summary>
         [JsonIgnore]
         public string? Value { get; init; }
@@ -514,18 +517,18 @@ namespace SalmonEgg.Acp.Protocol
         public bool? BooleanValue { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionSetConfigOptionParams 实例。
+        /// Creates a new SessionSetConfigOptionParams instance.
         /// </summary>
         public SessionSetConfigOptionParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionSetConfigOptionParams 实例。
+        /// Creates a new SessionSetConfigOptionParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="configId">配置选项 ID</param>
-        /// <param name="value">配置选项的值</param>
+        /// <param name="sessionId">Session ID</param>
+        /// <param name="configId">Configuration option ID</param>
+        /// <param name="value">The value of the configuration option</param>
         public SessionSetConfigOptionParams(string sessionId, string configId, string value)
         {
             SessionId = sessionId;
@@ -636,27 +639,27 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Set_Config_Option 方法的响应。
+    /// Response for the Session/Set_Config_Option method.
     /// </summary>
     public sealed record SessionSetConfigOptionResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 更新后的配置选项列表（完整状态）。
+        /// The updated list of configuration options (complete state).
         /// </summary>
         [JsonPropertyName("configOptions")]
         public List<ConfigOption>? ConfigOptions { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionSetConfigOptionResponse 实例。
+        /// Creates a new SessionSetConfigOptionResponse instance.
         /// </summary>
         public SessionSetConfigOptionResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionSetConfigOptionResponse 实例。
+        /// Creates a new SessionSetConfigOptionResponse instance.
         /// </summary>
-        /// <param name="configOptions">配置选项列表</param>
+        /// <param name="configOptions">List of configuration options</param>
         public SessionSetConfigOptionResponse(List<ConfigOption>? configOptions = null)
         {
             ConfigOptions = configOptions;

--- a/src/SalmonEgg.Acp/Protocol/SessionNewTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionNewTypes.cs
@@ -7,42 +7,43 @@ using SalmonEgg.Acp.Mcp;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Session/New 方法的请求参数。
-    /// 用于创建新的会话。
+    /// Request parameters for the Session/New method.
+    /// Used to create a new session.
     /// </summary>
     public sealed record SessionNewParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话的工作目录（必填）。
+        /// The working directory for the session (required).
         /// </summary>
         [JsonPropertyName("cwd")]
         public string Cwd { get; init; } = string.Empty;
 
         /// <summary>
-        /// MCP 服务器配置列表（必填，根据协议要求为数组）。
+        /// List of MCP server configurations (required; the protocol requires this value to be an array).
         /// </summary>
         [JsonPropertyName("mcpServers")]
         public List<McpServer> McpServers { get; init; } = new List<McpServer>();
 
         /// <summary>
-        /// 附加工作目录。非空时要求 Agent 声明 sessionCapabilities.additionalDirectories。
+        /// Additional working directories. When non-empty, the Agent is required to declare
+        /// sessionCapabilities.additionalDirectories.
         /// </summary>
         [JsonPropertyName("additionalDirectories")]
         public List<string>? AdditionalDirectories { get; init; }
 
         /// <summary>
-        /// 创建新的 SessionNewParams 实例。
+        /// Creates a new SessionNewParams instance.
         /// </summary>
         public SessionNewParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionNewParams 实例。
+        /// Creates a new SessionNewParams instance.
         /// </summary>
-        /// <param name="cwd">工作目录</param>
-        /// <param name="mcpServers">MCP 服务器配置</param>
-        /// <param name="additionalDirectories">附加工作目录</param>
+        /// <param name="cwd">The working directory</param>
+        /// <param name="mcpServers">MCP server configurations</param>
+        /// <param name="additionalDirectories">Additional working directories</param>
         public SessionNewParams(
             string cwd,
             List<McpServer>? mcpServers = null,
@@ -55,19 +56,19 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/New 方法的响应。
-    /// Agent 对创建会话请求的响应。
+    /// Response for the Session/New method.
+    /// The Agent's response to a session creation request.
     /// </summary>
     public sealed record SessionNewResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 新创建的会话 ID。
+        /// The ID of the newly created session.
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 会话模式状态（可选，ACP 标准形态为 SessionModeState 对象）。
+        /// Session mode state (optional; the ACP standard shape is a SessionModeState object).
         /// </summary>
         [JsonPropertyName("modes")]
         [JsonConverter(typeof(SessionModesStateJsonConverter))]
@@ -75,25 +76,25 @@ namespace SalmonEgg.Acp.Protocol
 
 
         /// <summary>
-        /// 可用的配置选项列表（可选）。
+        /// List of available configuration options (optional).
         /// </summary>
         [JsonPropertyName("configOptions")]
         public List<ConfigOption>? ConfigOptions { get; init; }
 
 
         /// <summary>
-        /// 创建新的 SessionNewResponse 实例。
+        /// Creates a new SessionNewResponse instance.
         /// </summary>
         public SessionNewResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionNewResponse 实例。
+        /// Creates a new SessionNewResponse instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="modes">可用模式列表</param>
-        /// <param name="configOptions">配置选项</param>
+        /// <param name="sessionId">The session ID</param>
+        /// <param name="modes">The list of available modes</param>
+        /// <param name="configOptions">Configuration options</param>
         public SessionNewResponse(string sessionId, SessionModesState? modes = null, List<ConfigOption>? configOptions = null)
         {
             SessionId = sessionId;
@@ -103,19 +104,19 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话模式状态（用于 Session/New 响应）。
+    /// Session mode state (used in the Session/New response).
     /// https://agentclientprotocol.com/protocol/session-modes
     /// </summary>
     public sealed record SessionModesState : AcpProtocolObject
     {
         /// <summary>
-        /// 当前模式 ID。
+        /// The current mode ID.
         /// </summary>
         [JsonPropertyName("currentModeId")]
         public string CurrentModeId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 可用模式列表。
+        /// The list of available modes.
         /// </summary>
         [JsonPropertyName("availableModes")]
         public List<SessionMode> AvailableModes { get; init; } = new();

--- a/src/SalmonEgg.Acp/Protocol/SessionPromptTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionPromptTypes.cs
@@ -6,39 +6,39 @@ using SalmonEgg.Acp.Content;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Session/Prompt 方法的请求参数。
-    /// 用于向会话发送提示并请求 Agent 响应。
+    /// Request parameters for the <c>session/prompt</c> method.
+    /// Sends a prompt to a session and requests a response from the Agent.
     /// </summary>
     public sealed record SessionPromptParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// The session id. Required.
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 要发送的提示内容块列表（必填，根据协议要求为数组）。
+        /// The prompt content blocks to send. Required, and serialized as an array per the protocol.
         /// </summary>
         [JsonPropertyName("prompt")]
         public List<ContentBlock> Prompt { get; init; } = new List<ContentBlock>();
 
         /// <summary>
-        /// 协议扩展字段（_meta）。
+        /// Protocol extension field (<c>_meta</c>).
         /// </summary>
         /// <summary>
-        /// 创建新的 SessionPromptParams 实例。
+        /// Creates a new <see cref="SessionPromptParams"/> instance.
         /// </summary>
         public SessionPromptParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionPromptParams 实例。
+        /// Creates a new <see cref="SessionPromptParams"/> instance.
         /// </summary>
 
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="prompt">提示内容块数组</param>
+        /// <param name="sessionId">The session id.</param>
+        /// <param name="prompt">The prompt content blocks.</param>
         public SessionPromptParams(string sessionId, List<ContentBlock> prompt)
         {
             SessionId = sessionId;
@@ -47,32 +47,31 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Session/Prompt 方法的响应。
-    /// Agent 对提示请求的响应，仅包含停止原因。
+    /// Response for the <c>session/prompt</c> method.
+    /// The Agent's reply to a prompt request, carrying only the stop reason.
     /// </summary>
     public sealed record SessionPromptResponse : AcpProtocolObject
     {
         /// <summary>
-        /// 停止原因。
-        /// 指示 Agent 为什么停止生成响应。
+        /// The stop reason, indicating why the Agent stopped generating a response.
         /// </summary>
         [JsonPropertyName("stopReason")]
         public StopReason StopReason { get; init; } = StopReason.EndTurn;
 
         /// <summary>
-        /// 协议扩展字段（_meta）。
+        /// Protocol extension field (<c>_meta</c>).
         /// </summary>
         /// <summary>
-        /// 创建新的 SessionPromptResponse 实例。
+        /// Creates a new <see cref="SessionPromptResponse"/> instance.
         /// </summary>
         public SessionPromptResponse()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionPromptResponse 实例。
+        /// Creates a new <see cref="SessionPromptResponse"/> instance.
         /// </summary>
-        /// <param name="stopReason">停止原因</param>
+        /// <param name="stopReason">The stop reason.</param>
         public SessionPromptResponse(StopReason stopReason)
         {
             StopReason = stopReason;

--- a/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
@@ -10,37 +10,37 @@ using SalmonEgg.Acp.Tool;
 namespace SalmonEgg.Acp.Protocol
 {
     /// <summary>
-    /// Session/Update 通知的参数。
-    /// 用于 Agent 向客户端发送会话更新。
+    /// Parameters for the session/update notification.
+    /// Used by the agent to send session updates to the client.
     /// </summary>
     [JsonConverter(typeof(SessionUpdateParamsJsonConverter))]
     public record SessionUpdateParams : AcpProtocolObject
     {
         /// <summary>
-        /// 会话 ID（必填）。
+        /// Session ID (required).
         /// </summary>
         [JsonPropertyName("sessionId")]
         public string SessionId { get; init; } = string.Empty;
 
         /// <summary>
-        /// 更新内容（多态类型）。
-        /// 可以是文本、工具调用、计划、模式切换等。
+        /// The update payload (polymorphic type).
+        /// May be text, a tool call, a plan, a mode switch, and so on.
         /// </summary>
         [JsonPropertyName("update")]
         public SessionUpdate Update { get; init; } = null!;
 
         /// <summary>
-        /// 创建新的 SessionUpdateParams 实例。
+        /// Creates a new SessionUpdateParams instance.
         /// </summary>
         public SessionUpdateParams()
         {
         }
 
         /// <summary>
-        /// 创建新的 SessionUpdateParams 实例。
+        /// Creates a new SessionUpdateParams instance.
         /// </summary>
-        /// <param name="sessionId">会话 ID</param>
-        /// <param name="update">更新内容</param>
+        /// <param name="sessionId">Session ID.</param>
+        /// <param name="update">The update payload.</param>
         public SessionUpdateParams(string sessionId, SessionUpdate update)
         {
             SessionId = sessionId;
@@ -49,8 +49,8 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 会话更新的基类/多态类型。
-    /// 使用 JsonPolymorphic 特性支持不同类型的更新。
+    /// Base polymorphic type for session updates.
+    /// Uses the JsonPolymorphic attribute to support different kinds of updates.
     /// </summary>
     [JsonPolymorphic(
         TypeDiscriminatorPropertyName = "sessionUpdate",
@@ -70,9 +70,11 @@ namespace SalmonEgg.Acp.Protocol
     public record SessionUpdate : AcpProtocolObject
     {
         /// <summary>
-        /// 未绑定到已知契约的前向兼容字段(含未知 sessionUpdate 判别值的完整 payload)。
-        /// 协议要求未知更新原样保留并可 round-trip,client 不解释也不丢弃,
-        /// 语义由 Agent 决定(AGENTS.md「协议宽松度不得反向收紧」)。
+        /// Forward-compatible fields that are not bound to a known contract (including the complete payload of an
+        /// unknown sessionUpdate discriminator value).
+        /// The protocol requires unknown updates to be preserved verbatim and to round-trip; the client neither
+        /// interprets nor discards them, and their semantics are decided by the agent
+        /// (AGENTS.md: protocol leniency must never be tightened in reverse).
         /// </summary>
         // STJ requires JsonExtensionData binders to be settable (not init-only) when the
         // polymorphic record hierarchy uses a deserialization constructor. Keep mutation
@@ -82,7 +84,8 @@ namespace SalmonEgg.Acp.Protocol
         public Dictionary<string, JsonElement>? ExtensionData { get; set; }
 
         /// <summary>
-        /// 未知更新类型的原始判别值;仅当此实例是未识别判别值回落的基类实例时非空。
+        /// The raw discriminator value of an unknown update kind; non-null only when this instance is the base-type
+        /// fallback produced by an unrecognized discriminator value.
         /// </summary>
         [JsonIgnore]
         public string? UnknownUpdateKind =>
@@ -94,9 +97,11 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// session/update 参数的读写。已知更新完全委托多态契约;未知判别值回落基类时
-    /// STJ 会把判别值当多态元数据丢弃,这里把它补回 <see cref="SessionUpdate.ExtensionData"/>,
-    /// 保证未知更新原样 round-trip 而不是被 client 静默降级。
+    /// Reads and writes session/update parameters. Known updates are delegated entirely to the polymorphic
+    /// contract; when an unrecognized discriminator value falls back to the base type, STJ discards that
+    /// discriminator as polymorphic metadata, so it is restored here into
+    /// <see cref="SessionUpdate.ExtensionData"/> to guarantee that unknown updates round-trip verbatim instead of
+    /// being silently downgraded by the client.
     /// </summary>
     internal sealed class SessionUpdateParamsJsonConverter : JsonConverter<SessionUpdateParams>
     {
@@ -189,8 +194,8 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Agent 消息片段更新。
-    /// 用于流式传输 Agent 的文本响应。
+    /// Agent message chunk update.
+    /// Used to stream the agent's text response.
     /// </summary>
     public sealed record AgentMessageUpdate : ContentChunkUpdate
     {
@@ -198,16 +203,16 @@ namespace SalmonEgg.Acp.Protocol
         public ContentBlock? Content { get; init; }
 
         /// <summary>
-        /// 创建新的 AgentMessageUpdate 实例。
+        /// Creates a new AgentMessageUpdate instance.
         /// </summary>
         public AgentMessageUpdate()
         {
         }
 
         /// <summary>
-        /// 创建新的 AgentMessageUpdate 实例。
+        /// Creates a new AgentMessageUpdate instance.
         /// </summary>
-        /// <param name="content">内容块</param>
+        /// <param name="content">The content block.</param>
         public AgentMessageUpdate(ContentBlock? content)
         {
             Content = content;
@@ -215,7 +220,7 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 用户消息片段更新（用于 session/load 回放或多端同步）。
+    /// User message chunk update (used for session/load replay or multi-client synchronization).
     /// </summary>
     public sealed record UserMessageUpdate : ContentChunkUpdate
     {
@@ -233,89 +238,89 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// Agent 思考片段更新（通常不直接展示给用户，但必须可解析/可跳过）。
+    /// Agent thought chunk update (usually not shown to the user directly, but it must remain parsable/skippable).
     /// </summary>
     public sealed record AgentThoughtUpdate : ContentChunkUpdate
     {
         /// <summary>
-        /// 消息内容块。
+        /// The message content block.
         /// </summary>
         [JsonPropertyName("content")]
         public ContentBlock? Content { get; init; }
     }
 
     /// <summary>
-    /// 工具调用更新。
-    /// 用于通知客户端工具调用的状态变化。
+    /// Tool call update.
+    /// Used to notify the client that the state of a tool call has changed.
     /// </summary>
     public sealed record ToolCallUpdate : SessionUpdate
     {
         /// <summary>
-        /// 工具调用 ID。
+        /// Tool call ID.
         /// </summary>
         [JsonPropertyName("toolCallId")]
         public string? ToolCallId { get; init; }
 
         /// <summary>
-        /// 工具调用类型。
+        /// Tool call kind.
         /// </summary>
         [JsonPropertyName("kind")]
         public ToolCallKind? Kind { get; init; }
 
         /// <summary>
-        /// 工具调用状态。
+        /// Tool call status.
         /// </summary>
         [JsonPropertyName("status")]
         public ToolCallStatus? Status { get; init; }
 
         /// <summary>
-        /// 标题（可选）。
+        /// Title (optional).
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; init; }
 
         /// <summary>
-        /// 工具调用产生的内容。
+        /// Content produced by the tool call.
         /// </summary>
         [JsonPropertyName("content")]
         public List<ToolCallContent>? Content { get; init; }
 
         /// <summary>
-        /// 文件位置列表，表示工具调用影响的文件。
+        /// List of file locations, indicating the files affected by the tool call.
         /// </summary>
         [JsonPropertyName("locations")]
         public List<ToolCallLocation>? Locations { get; init; }
 
         /// <summary>
-        /// 原始输入参数。
+        /// Raw input parameters.
         /// </summary>
         [JsonPropertyName("rawInput")]
         public JsonElement? RawInput { get; init; }
 
         /// <summary>
-        /// 原始输出结果。
+        /// Raw output result.
         /// </summary>
         [JsonPropertyName("rawOutput")]
         public JsonElement? RawOutput { get; init; }
 
         /// <summary>
-        /// 创建新的 ToolCallUpdate 实例。
+        /// Creates a new ToolCallUpdate instance.
         /// </summary>
         public ToolCallUpdate()
         {
         }
 
         /// <summary>
-        /// 创建新的 ToolCallUpdate 实例。
+        /// Creates a new ToolCallUpdate instance.
         /// </summary>
-        /// <param name="toolCallId">工具调用 ID</param>
-        /// <param name="kind">工具调用类型</param>
-        /// <param name="status">工具调用状态</param>
-        /// <param name="title">标题</param>
-        /// <param name="content">工具调用产生的内容</param>
-        /// <param name="locations">文件位置列表</param>
-        /// <param name="rawInput">原始输入参数</param>
-        /// <param name="rawOutput">原始输出结果</param>
+        /// <param name="toolCallId">Tool call ID.</param>
+        /// <param name="kind">Tool call kind.</param>
+        /// <param name="status">Tool call status.</param>
+        /// <param name="title">Title.</param>
+        /// <param name="content">Content produced by the tool call.</param>
+        /// <param name="locations">List of file locations.</param>
+        /// <param name="rawInput">Raw input parameters.</param>
+        /// <param name="rawOutput">Raw output result.</param>
         public ToolCallUpdate(
             string? toolCallId = null,
             ToolCallKind? kind = null,
@@ -338,15 +343,15 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 计划更新。
-    /// 用于通知客户端 Agent 的行动计划变化。
+    /// Plan update.
+    /// Used to notify the client that the agent's action plan has changed.
     /// </summary>
     public sealed record PlanUpdate : SessionUpdate
     {
         private readonly List<PlanEntry> _entries = new();
 
         /// <summary>
-        /// 计划条目列表（用于 plan 类型的更新）。
+        /// List of plan entries (used by the plan update kind).
         /// </summary>
         [JsonRequired]
         [JsonPropertyName("entries")]
@@ -357,16 +362,16 @@ namespace SalmonEgg.Acp.Protocol
         }
 
         /// <summary>
-        /// 创建新的 PlanUpdate 实例。
+        /// Creates a new PlanUpdate instance.
         /// </summary>
         public PlanUpdate()
         {
         }
 
         /// <summary>
-        /// 创建新的 PlanUpdate 实例。
+        /// Creates a new PlanUpdate instance.
         /// </summary>
-        /// <param name="entries">计划条目列表</param>
+        /// <param name="entries">List of plan entries.</param>
         public PlanUpdate(List<PlanEntry> entries)
         {
             Entries = entries;
@@ -374,8 +379,8 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 当前模式更新（current_mode_update）。
-    /// ACP 会通过 session/update 通知发送当前模式的变化。
+    /// Current mode update (current_mode_update).
+    /// ACP sends changes to the current mode through the session/update notification.
     /// </summary>
     public sealed record CurrentModeUpdate : SessionUpdate
     {
@@ -393,74 +398,75 @@ namespace SalmonEgg.Acp.Protocol
     }
 
     /// <summary>
-    /// 工具调用状态更新（tool_call_update）。
-    /// 某些 Agent 不会在 tool_call update 中发送完整 toolCall 对象，只会推送状态与输出内容。
+    /// Tool call status update (tool_call_update).
+    /// Some agents do not send the complete toolCall object in a tool_call update and push only the status and the
+    /// output content.
     /// </summary>
     public sealed record ToolCallStatusUpdate : SessionUpdate
     {
         /// <summary>
-        /// 工具调用 ID。
+        /// Tool call ID.
         /// </summary>
         [JsonPropertyName("toolCallId")]
         public string? ToolCallId { get; init; }
 
         /// <summary>
-        /// 工具调用类型。
+        /// Tool call kind.
         /// </summary>
         [JsonPropertyName("kind")]
         public ToolCallKind? Kind { get; init; }
 
         /// <summary>
-        /// 标题（可选）。
+        /// Title (optional).
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; init; }
 
         /// <summary>
-        /// 工具调用状态。
+        /// Tool call status.
         /// </summary>
         [JsonPropertyName("status")]
         public ToolCallStatus? Status { get; init; }
 
         /// <summary>
-        /// 工具调用产生的内容。
+        /// Content produced by the tool call.
         /// </summary>
         [JsonPropertyName("content")]
         public List<ToolCallContent>? Content { get; init; }
 
         /// <summary>
-        /// 文件位置列表，表示工具调用影响的文件。
+        /// List of file locations, indicating the files affected by the tool call.
         /// </summary>
         [JsonPropertyName("locations")]
         public List<ToolCallLocation>? Locations { get; init; }
 
         /// <summary>
-        /// 原始输入参数。
+        /// Raw input parameters.
         /// </summary>
         [JsonPropertyName("rawInput")]
         public JsonElement? RawInput { get; init; }
 
         /// <summary>
-        /// 原始输出结果。
+        /// Raw output result.
         /// </summary>
         [JsonPropertyName("rawOutput")]
         public JsonElement? RawOutput { get; init; }
     }
 
     /// <summary>
-    /// 配置选项更新（config_option_update）。
+    /// Configuration option update (config_option_update).
     /// </summary>
     public sealed record ConfigOptionUpdate : SessionUpdate
     {
         /// <summary>
-        /// 配置选项列表。
+        /// List of configuration options.
         /// </summary>
         [JsonPropertyName("configOptions")]
         public List<ConfigOption>? ConfigOptions { get; init; }
     }
 
     /// <summary>
-    /// 会话信息更新（session_info_update）。
+    /// Session info update (session_info_update).
     /// </summary>
     public sealed record SessionInfoUpdate : SessionUpdate
     {
@@ -468,7 +474,7 @@ namespace SalmonEgg.Acp.Protocol
         private string? _updatedAt;
 
         /// <summary>
-        /// 会话标题（可选）。
+        /// Session title (optional).
         /// Setter tracks JSON presence so omitted vs explicit-null can be distinguished after deserialize.
         /// </summary>
         [JsonPropertyName("title")]
@@ -486,7 +492,7 @@ namespace SalmonEgg.Acp.Protocol
         public bool HasTitle { get; private set; }
 
         /// <summary>
-        /// 最近更新时间（UTC iso8601）。
+        /// Last updated timestamp (UTC iso8601).
         /// Setter tracks JSON presence so omitted vs explicit-null can be distinguished after deserialize.
         /// </summary>
         [JsonPropertyName("updatedAt")]

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -22,8 +22,10 @@
     <PackageTags>acp;agent-client-protocol;json-rpc;sdk;aot</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://agentclientprotocol.com/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/salmon-egg/salmon-egg</RepositoryUrl>
+    <!-- The package home is this repository. agentclientprotocol.com is the upstream spec, not
+         this project, and pointing ProjectUrl there would imply an official ACP package. -->
+    <PackageProjectUrl>https://github.com/salmonloop/salmon-egg</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/salmonloop/salmon-egg</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Public surface XML docs are mixed language today; keep missing-doc noise from blocking AOT/warn-as-error. -->

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -11,6 +11,14 @@
     <IsAotCompatible>true</IsAotCompatible>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- Baseline validation diffs the public surface against the last shipped package, so it can only
+         run once something has shipped. 1.0.0 is the first release and has no predecessor on
+         nuget.org; hardcoding a baseline there fails restore with NU1101. Deriving it from
+         AcpPackageBaselineVersion keeps the first release packable while forcing every later version
+         to diff against a real published package instead of silently validating nothing. The
+         AcpBaselineRequired target below turns a missing baseline into a build error. -->
+    <AcpPackageFirstReleasedVersion>1.0.0</AcpPackageFirstReleasedVersion>
+    <PackageValidationBaselineVersion Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)'">$(AcpPackageBaselineVersion)</PackageValidationBaselineVersion>
 
     <PackageId>SalmonEgg.Acp</PackageId>
     <Version>1.0.0</Version>
@@ -41,6 +49,14 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <!-- Fail closed on a missing baseline. Without this, bumping Version past the first release while
+       forgetting AcpPackageBaselineVersion leaves PackageValidationBaselineVersion empty, and package
+       validation silently degrades to comparing nothing - a green build that checks no compatibility. -->
+  <Target Name="AcpBaselineRequired" BeforeTargets="Build">
+    <Error Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)' AND '$(PackageValidationBaselineVersion)' == ''"
+           Text="SalmonEgg.Acp $(Version) is past the first release $(AcpPackageFirstReleasedVersion), so package validation needs a published baseline. Pass -p:AcpPackageBaselineVersion=&lt;last published version&gt;." />
+  </Target>
 
   <!-- Internals remain available to first-party contract tests. External consumers use the public surface. -->
   <ItemGroup>

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -36,10 +36,11 @@
     <RepositoryUrl>https://github.com/salmonloop/salmon-egg</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Public surface docs are English, but many members are still undocumented. Suppressing the
-         missing-doc family keeps that backlog from blocking AOT/warn-as-error; it is not a licence
-         to ship undocumented new public API. -->
-    <NoWarn>$(NoWarn);CS1591;CS1572;CS1573</NoWarn>
+    <!-- Public surface docs are English, but many members are still undocumented. CS1591 keeps that
+         backlog from blocking warn-as-error; it is not a licence to ship undocumented new public API.
+         CS1572/CS1573 stay enforced: a param tag naming a parameter that does not exist, or a
+         documented member that silently drops a parameter, is a defect in shipped documentation. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -36,7 +36,9 @@
     <RepositoryUrl>https://github.com/salmonloop/salmon-egg</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Public surface XML docs are mixed language today; keep missing-doc noise from blocking AOT/warn-as-error. -->
+    <!-- Public surface docs are English, but many members are still undocumented. Suppressing the
+         missing-doc family keeps that backlog from blocking AOT/warn-as-error; it is not a licence
+         to ship undocumented new public API. -->
     <NoWarn>$(NoWarn);CS1591;CS1572;CS1573</NoWarn>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/SalmonEgg.Acp/Tool/ToolCallContent.cs
+++ b/src/SalmonEgg.Acp/Tool/ToolCallContent.cs
@@ -10,12 +10,14 @@ namespace SalmonEgg.Acp.Tool
     /// <summary>
     /// Tool call content types.
     /// Represents different types of content that can be produced by a tool call.
-    /// 多态读写由 <see cref="ToolCallContentJsonConverter"/> 手动分发:已知 <c>type</c>
-    /// (content/diff/terminal) 映射到强类型子类;未知 <c>type</c> 按 spec「preserve the raw
-    /// payload」原样保留为 <see cref="CustomToolCallContent"/> 并可字节级 round-trip,由 Agent
-    /// 而非 client 决定语义(AGENTS.md「协议宽松度不得反向收紧」,与 McpServer 同一 RawPayload 范式)。
-    /// 不用 <see cref="JsonPolymorphicAttribute"/>+FallBackToBaseType:STJ 回落基类时会把判别值
-    /// <c>type</c> 当多态元数据消费掉,导致未知判别值无法 round-trip。
+    /// Polymorphic reading and writing is dispatched manually by <see cref="ToolCallContentJsonConverter"/>: a known
+    /// <c>type</c> (content/diff/terminal) maps to a strongly typed subtype; an unknown <c>type</c> is preserved
+    /// verbatim as <see cref="CustomToolCallContent"/> per the spec rule "preserve the raw payload" and can round-trip
+    /// byte for byte, leaving the semantics to the Agent rather than the client (AGENTS.md: protocol leniency must
+    /// never be tightened in reverse; the same RawPayload pattern as McpServer).
+    /// <see cref="JsonPolymorphicAttribute"/> plus FallBackToBaseType is not used: when STJ falls back to the base
+    /// type it consumes the <c>type</c> discriminator as polymorphic metadata, which makes unknown discriminator
+    /// values impossible to round-trip.
     /// </summary>
     [JsonConverter(typeof(ToolCallContentJsonConverter))]
     public abstract record ToolCallContent : AcpProtocolObject
@@ -123,21 +125,21 @@ namespace SalmonEgg.Acp.Tool
     }
 
     /// <summary>
-    /// 未知 <c>type</c> 的 tool call content 前向兼容载体。按 spec「preserve the raw payload」
-    /// 原样保留整个对象(含判别值与所有未知字段),由 Agent 而非 client 决定语义;client 不解释、
-    /// 不丢弃、不收紧。
+    /// Forward-compatible carrier for tool call content with an unknown <c>type</c>. Per the spec rule "preserve the
+    /// raw payload" the whole object is kept verbatim (including the discriminator and every unknown field), leaving
+    /// the semantics to the Agent rather than the client; the client does not interpret, discard, or tighten it.
     /// </summary>
     public sealed record CustomToolCallContent : ToolCallContent
     {
         /// <summary>
-        /// 原始 <c>type</c> 判别值。
+        /// The original <c>type</c> discriminator value.
         /// </summary>
         [JsonIgnore]
         public string Type { get; init; } = string.Empty;
 
         /// <summary>
-        /// 读入时保留的完整原始 payload,由 <see cref="ToolCallContentJsonConverter"/> 手动读写,
-        /// 是本载体的唯一权威事实源。
+        /// The complete raw payload preserved on read, read and written manually by
+        /// <see cref="ToolCallContentJsonConverter"/>; it is the single authoritative source of truth for this carrier.
         /// </summary>
         [JsonIgnore]
         public JsonElement RawPayload { get; init; }
@@ -152,8 +154,8 @@ namespace SalmonEgg.Acp.Tool
         /// <summary>
         /// Creates a new CustomToolCallContent instance.
         /// </summary>
-        /// <param name="type">原始 type 判别值</param>
-        /// <param name="rawPayload">完整原始 payload</param>
+        /// <param name="type">The original type discriminator value</param>
+        /// <param name="rawPayload">The complete raw payload</param>
         public CustomToolCallContent(string type, JsonElement rawPayload)
         {
             Type = type;
@@ -162,9 +164,10 @@ namespace SalmonEgg.Acp.Tool
     }
 
     /// <summary>
-    /// tool call content 的多态读写。已知 <c>type</c> 映射强类型子类;未知 <c>type</c> 保留
-    /// 完整 raw payload 到 <see cref="CustomToolCallContent"/> 并原样写回,保证未知判别值
-    /// 字节级 round-trip。缺失 <c>type</c> 按已知最宽松分支(content)处理,不抛错。
+    /// Polymorphic reading and writing for tool call content. A known <c>type</c> maps to a strongly typed subtype; an
+    /// unknown <c>type</c> keeps the complete raw payload in <see cref="CustomToolCallContent"/> and writes it back
+    /// verbatim, guaranteeing a byte-for-byte round-trip of unknown discriminator values. A missing <c>type</c> is
+    /// handled by the most lenient known branch (content) and does not throw.
     /// </summary>
     internal sealed class ToolCallContentJsonConverter : JsonConverter<ToolCallContent>
     {
@@ -187,7 +190,8 @@ namespace SalmonEgg.Acp.Tool
                 "content" => ReadContent(root, options),
                 "diff" => ReadDiff(root, options),
                 "terminal" => ReadTerminal(root, options),
-                // 未知或缺失判别值:保留 raw payload 前向透传,由 Agent 决定语义。
+                // Unknown or missing discriminator: keep the raw payload for forward passthrough and let the Agent
+                // decide the semantics.
                 _ => new CustomToolCallContent(type ?? string.Empty, root.Clone())
             };
         }
@@ -228,9 +232,11 @@ namespace SalmonEgg.Acp.Tool
                     writer.WriteEndObject();
                     break;
                 case CustomToolCallContent custom:
-                    // 前向兼容透传:原样写回读入时保留的 raw payload,不重排字段、不丢弃未知属性。
-                    // 用 WriteRawValue(GetRawText()) 实现字节级保真,与 McpServer 一致。
-                    // RawPayload 为空(手工构造)时退化为最小写出,仍携带原始 type 值。
+                    // Forward-compatible passthrough: write back the raw payload preserved on read verbatim, without
+                    // reordering fields or dropping unknown properties.
+                    // WriteRawValue(GetRawText()) is used for byte-for-byte fidelity, matching McpServer.
+                    // When RawPayload is empty (hand-constructed), fall back to a minimal write that still carries the
+                    // original type value.
                     if (custom.RawPayload.ValueKind == JsonValueKind.Object)
                     {
                         writer.WriteRawValue(custom.RawPayload.GetRawText());


### PR DESCRIPTION
## 摘要

把 ACP core 层准备成可独立发布到 nuget.org 的 SDK（`SalmonEgg.Acp`），并为它建立独立的发布通道。发布尚未执行 —— 本 PR 只落地"发布前必须做完"的部分。

分成 7 个提交，每个提交一件事：

| 提交 | 内容 |
|---|---|
| `53d472d1` | 包元数据指向真实仓库。原先 `RepositoryUrl` 指向一个不存在的地址（会让 nuget.org 上的 "source repository" 链接 404，且 Source Link 失效），`PackageProjectUrl` 指向上游规范站 agentclientprotocol.com（会让人误以为这是官方 ACP 包）。NuGet 版本不可变，发布后无法修正。 |
| `f9c547b2` | 包验证基线随版本条件生效。`PackageValidationBaselineVersion=1.0.0` 在首发时会以 NU1101 失败（nuget.org 上没有前驱可比）。改为从 `AcpPackageBaselineVersion` 推导，并加 fail-closed target：一旦版本越过首发而没传基线就报错，避免验证静默退化成"什么都不比"。 |
| `8e1372cb` | 新增 `release-acp-sdk.yml`，SDK 走自己的 tag 命名空间 `acp-sdk-v*`。三段：`pack` → `consumer-integration`（真实 nupkg restore + build + run）→ `publish-nuget`。同时新增 `run-acp-sdk-tag-version-gate.sh`（5 条安全规则）及其 selftest（11 例），selftest 接入 PR CI，让规则在每个 PR 上被跑到而不是只在 tag 时。 |
| `03406dd4` | release-guide 补 SDK 发布章节。 |
| `35fcd605` | 公开 API 文档改写成英文。原先 931 行中文 `///` 注释会随包发给外部使用者。 |
| `81236b45` | 修 11 处 `<param>` 名字与真实参数不符（`AcpException` 三个工厂方法把 `errorData` 写成 `data`，外部使用者看不到该参数的文档），并移除原本在掩盖它们的 `NoWarn` 条目 `CS1572;CS1573`。 |
| `dcf392a8` | 发布改用 nuget.org 受信任发布（OIDC），不再存长期 API key。 |

## tag 命名空间为什么要分开

`release-packaging.yml` 已经占用 `v*`（GUI/CLI 发布线）。共用一个前缀会让每次 SDK 发布都重建桌面安装包，也会让应用发版误触发 NuGet 推送。

## 验证

- 336 个契约测试通过，0 警告
- tag/版本门禁 selftest 11/11
- consumer smoke 在真实 nupkg 上通过
- 打出的 4879 行 XML 文档中 0 个 CJK 字符
- 文档翻译做了机械核对：剥掉注释行与 `#region` 折叠标签后，30 个文件的代码与 HEAD 逐字节一致 —— 协议线上字面量、JSON 属性名、方法签名均未被改动
- 两处 fail-closed 守卫都做了反向验证（破坏规则确认会失败）
- `.snupkg` 不会被当作主包推送
- `NuGet/login` 的 SHA `8d19675` 核对为上游真实提交且等于 v1.2.0，`action.yml` 的输入 `user` / 输出 `NUGET_API_KEY` 与用法一致

## 未验证 / 需要注意

`release-acp-sdk.yml` 从未在 GitHub Actions 上真正跑过。它只吃 `acp-sdk-v*` tag，而 `workflow_dispatch` 无法用于尚未进入默认分支的 workflow 文件（API 返回 404）。因此这条通道的实际可运行性，要等合入后创建第一个 tag 时才能确认。

本 PR 的 `ci-acp-sdk` 会跑 `sdk-gates` + `consumer-integration`，其步骤与 release workflow 的 `pack` + `consumer-integration` 相同，差别仅是 release 多一步 tag/版本一致性检查（该检查的 selftest 已在本 PR 中被执行）。

## 发布还差什么

合入后创建 `acp-sdk-v1.0.0` tag 即触发发布。nuget.org 侧已就绪：受信任发布策略、`NUGET_USER` 变量、`nuget-publish` environment 均已配置。注意新建策略带 7 天临时窗口，需在窗口内完成首次发布才会永久生效。

推送到 nuget.org 不可撤回，也不能覆盖同版本号。
