### PR TITLE
fix(acp-setup): find the toolchains a GUI session cannot see

### DIFF
--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -521,9 +522,13 @@ public static class DependencyInjection
         services.AddSingleton<IAcpComponentInstaller, UnsupportedAcpComponentInstaller>();
         services.AddSingleton<IAcpSetupConnectivityTester, UnsupportedAcpSetupConnectivityTester>();
 #else
+        // Widens what the probe can find beyond the PATH this process inherited. A GUI-launched app gets
+        // the session PATH, not the one a shell profile builds, so a version-manager toolchain is
+        // invisible to it and every component would otherwise report as missing. The composition — which
+        // sources this installation can use, and in what order — belongs to AcpSearchPathSources.
         services.AddSingleton<IAcpExecutableProbe>(sp =>
             sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
-                ? new DesktopAcpExecutableProbe()
+                ? new DesktopAcpExecutableProbe(AcpSearchPathSources.Create())
                 : new UnsupportedAcpExecutableProbe());
         services.AddSingleton<IAcpComponentInstaller>(sp =>
             sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
@@ -54,18 +54,8 @@ public sealed class AcpComponentDetector
         {
             AcpComponentDetectionMode.ExecutableOnPath
                 => await DetectExecutableAsync(component, effectiveOverrides, cancellationToken).ConfigureAwait(false),
-            AcpComponentDetectionMode.GlobalNodePackage
-                => await DetectPackageAsync(
-                    component,
-                    effectiveOverrides,
-                    _probe.LocateGlobalNodePackageAsync,
-                    cancellationToken).ConfigureAwait(false),
-            AcpComponentDetectionMode.GlobalUvTool
-                => await DetectPackageAsync(
-                    component,
-                    effectiveOverrides,
-                    _probe.LocateGlobalUvToolAsync,
-                    cancellationToken).ConfigureAwait(false),
+            AcpComponentDetectionMode.GlobalNodePackage or AcpComponentDetectionMode.GlobalUvTool
+                => await DetectPackageAsync(component, effectiveOverrides, cancellationToken).ConfigureAwait(false),
             _ => AcpComponentProbeResult.Undetermined(component.Id)
         };
     }
@@ -99,13 +89,19 @@ public sealed class AcpComponentDetector
 
     /// <summary>
     /// A package-manager component is only usable when its launcher exists too: <c>npx @scope/pkg</c>
-    /// cannot run without <c>npx</c> on PATH, however the package query answers. The query is passed as
-    /// a factory so it is never started — and never left unawaited — when the launcher is absent.
+    /// cannot run without <c>npx</c> on PATH, however the package query answers — so the launcher is
+    /// resolved first and the query is never started when it is absent.
     /// </summary>
+    /// <remarks>
+    /// The manager asked is the one belonging to the launcher that was just resolved, not a bare name the
+    /// inherited PATH resolves independently. Those differ exactly when the user overrode the launcher to
+    /// escape a PATH that cannot see their toolchain — which is the case this whole path exists for, and
+    /// where asking the wrong manager answers about a toolchain the user did not choose. See
+    /// <see cref="AcpPackageManagerCommand"/>.
+    /// </remarks>
     private async Task<AcpComponentProbeResult> DetectPackageAsync(
         AcpComponentDescriptor component,
         AcpCommandOverrides overrides,
-        Func<string, CancellationToken, Task<AcpPackageQueryResult>> queryPackageAsync,
         CancellationToken cancellationToken)
     {
         var launcher = overrides.Resolve(component.ProbeCommand);
@@ -118,7 +114,16 @@ public sealed class AcpComponentDetector
             return AcpComponentProbeResult.Missing(component.Id, LauncherMissingDetail(launcher));
         }
 
-        var packageQuery = await queryPackageAsync(component.PackageId, cancellationToken).ConfigureAwait(false);
+        // Derived from the resolved path rather than from the override text: an override may name a
+        // launcher by bare name or relative path, and the sibling lookup needs the real directory.
+        var packageManager = AcpPackageManagerCommand.Resolve(
+            component.Distribution,
+            launcherPath,
+            overrides);
+
+        var packageQuery = await _probe
+            .LocateGlobalPackageAsync(component.Distribution, component.PackageId, packageManager, cancellationToken)
+            .ConfigureAwait(false);
         return packageQuery.IsInstalled switch
         {
             true => AcpComponentProbeResult.Installed(

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -80,8 +80,10 @@ public sealed class AcpSetupWizardOrchestrator
     {
         ArgumentNullException.ThrowIfNull(component);
 
+        // The same overrides govern the install and the re-probe, so the install lands in the toolchain
+        // the probe then asks about.
         var install = await _installer
-            .InstallAsync(component, onOutput, cancellationToken)
+            .InstallAsync(component, onOutput, overrides, cancellationToken)
             .ConfigureAwait(false);
         var probe = await _detector
             .DetectAsync(component, overrides, cancellationToken)

--- a/src/SalmonEgg.Cli/CliApplication.cs
+++ b/src/SalmonEgg.Cli/CliApplication.cs
@@ -116,6 +116,24 @@ public static class CliApplication
 
         var output = outputOverride ?? new TextCliOutput(stdout, stderr);
 
+        // Handled before the container exists and before startup recovery runs. This mode is invoked by
+        // the user's own login shell while the app is starting, purely to report the environment that
+        // shell produced; building the container or recovering transactions would turn an environment
+        // probe into a source of configuration side effects. See CliPrintEnvironment.
+        if (CliPrintEnvironment.TryGetMarker(args, out var environmentMarker))
+        {
+            try
+            {
+                return await CliPrintEnvironment
+                    .WriteAsync(environmentMarker, stdout, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return CliExitCodes.Failure;
+            }
+        }
+
         try
         {
             var fallbackWarningState = new CliFallbackSecureStorageWarningState();

--- a/src/SalmonEgg.Cli/Hosting/CliPrintEnvironment.cs
+++ b/src/SalmonEgg.Cli/Hosting/CliPrintEnvironment.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Cli.Hosting;
+
+/// <summary>
+/// Prints this process's environment as one JSON object, wrapped in a caller-supplied marker.
+/// </summary>
+/// <remarks>
+/// This exists to be run <em>by the user's own shell</em>. A GUI-launched desktop process inherits the
+/// session environment rather than the one a shell profile builds, so a version-manager toolchain (nvm,
+/// fnm, volta, asdf, mise) is invisible to it. The app recovers the real environment by asking the user's
+/// login shell to run this, then reading what the shell handed the child.
+///
+/// Every editor that solves this does the same thing — run its own executable inside the shell rather
+/// than parse the shell's <c>env</c> output — because rc files print banners, colour codes, and warnings
+/// onto the same stream. VS Code runs <c>code -p</c>, Zed runs <c>zed --printenv</c>, JetBrains runs a
+/// bundled <c>printenv</c> helper. Emitting JSON from inside the child makes the payload
+/// self-delimiting and immune to whatever text surrounds it.
+///
+/// The marker handles the surrounding noise. The caller generates a fresh random one per invocation and
+/// extracts what lies between the two occurrences, so a chatty rc file cannot be mistaken for payload.
+/// It must be random rather than fixed: a fixed marker could appear in a variable's value — this process
+/// prints its own environment, which includes anything the shell exported — and turn an honest value into
+/// a false delimiter.
+///
+/// This path deliberately runs before the CLI builds its service container or performs startup recovery.
+/// It reads nothing and writes nothing but stdout, and it is invoked while the app is starting, so
+/// touching user data here would make an environment probe a source of configuration side effects.
+/// </remarks>
+internal static class CliPrintEnvironment
+{
+    /// <summary>The option that selects this mode. Undocumented: it is an app-internal protocol.</summary>
+    internal const string OptionName = "--printenv";
+
+    /// <summary>
+    /// True when <paramref name="args"/> requests environment printing, yielding the marker to wrap the
+    /// payload in.
+    /// </summary>
+    /// <remarks>
+    /// Matched against raw arguments rather than through the command tree because the container must not
+    /// be built for this invocation, and the parser needs it.
+    ///
+    /// The marker is required, and only <c>--printenv=&lt;marker&gt;</c> is accepted rather than a
+    /// separate argument, so a bare <c>--printenv</c> cannot silently produce unwrapped output that the
+    /// caller would then fail to locate.
+    /// </remarks>
+    internal static bool TryGetMarker(IReadOnlyList<string> args, out string marker)
+    {
+        marker = string.Empty;
+        if (args is null)
+        {
+            return false;
+        }
+
+        const string prefix = OptionName + "=";
+        foreach (var argument in args)
+        {
+            if (argument is null || !argument.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var candidate = argument[prefix.Length..];
+            if (candidate.Length == 0)
+            {
+                continue;
+            }
+
+            marker = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Writes <c>&lt;marker&gt;{...}&lt;marker&gt;</c> to <paramref name="stdout"/> and flushes it.
+    /// </summary>
+    /// <remarks>
+    /// Flushed explicitly because the caller reads this from a pipe and the process may be killed on a
+    /// timeout: an unflushed buffer would read as a shell that produced nothing.
+    /// </remarks>
+    internal static async Task<int> WriteAsync(
+        string marker,
+        TextWriter stdout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stdout);
+
+        var variables = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && key.Length > 0)
+            {
+                variables[key] = entry.Value as string ?? string.Empty;
+            }
+        }
+
+        var payload = JsonSerializer.Serialize(variables, CliPrintEnvironmentJson.Default.DictionaryStringString);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await stdout.WriteAsync(marker).ConfigureAwait(false);
+        await stdout.WriteAsync(payload).ConfigureAwait(false);
+        await stdout.WriteAsync(marker).ConfigureAwait(false);
+        await stdout.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        return CliExitCodes.Success;
+    }
+}

--- a/src/SalmonEgg.Cli/Hosting/CliPrintEnvironmentJson.cs
+++ b/src/SalmonEgg.Cli/Hosting/CliPrintEnvironmentJson.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace SalmonEgg.Cli.Hosting;
+
+/// <summary>
+/// Source-generated serializer for the environment payload printed by <see cref="CliPrintEnvironment"/>.
+/// </summary>
+/// <remarks>
+/// Not indented: the payload is machine-read from a pipe, and keeping it on one line means a shell that
+/// interleaves its own output cannot split the JSON across the marker boundary.
+///
+/// Names are emitted verbatim. These are environment variable names, not model properties — a naming
+/// policy would rewrite <c>PATH</c> into something the reader does not expect.
+/// </remarks>
+[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class CliPrintEnvironmentJson : JsonSerializerContext
+{
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpPackageManagerCandidates.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpPackageManagerCandidates.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The package-manager commands to try, in order, for one component.
+/// </summary>
+/// <remarks>
+/// More than one is needed because a derived manager path is a preference rather than a fact. Deriving
+/// <c>npm</c> from a user-named <c>npx</c> is right whenever the two are siblings — which is how npm and
+/// uv install them — but a launcher can be a lone shim with no manager beside it. Without a fallback that
+/// case would turn a query PATH could still have answered into a hard "manager missing", which reads to
+/// the user as a component they must install.
+///
+/// Ordering carries the intent: the toolchain the user named is asked first, and the bare name is only a
+/// last resort. A command the user supplied explicitly has no fallback at all, since falling back from it
+/// would answer about a toolchain they did not choose.
+/// </remarks>
+public sealed class AcpPackageManagerCandidates
+{
+    private readonly string[] _commands;
+
+    private AcpPackageManagerCandidates(string[] commands)
+    {
+        _commands = commands;
+    }
+
+    /// <summary>The commands to try, most preferred first.</summary>
+    public IReadOnlyList<string> Commands => _commands;
+
+    /// <summary>The command tried first; what diagnostics should name.</summary>
+    public string Preferred => _commands.Length > 0 ? _commands[0] : string.Empty;
+
+    /// <summary>Exactly one command, with no fallback.</summary>
+    public static AcpPackageManagerCandidates Exact(string command)
+        => new(new[] { command ?? string.Empty });
+
+    /// <summary>
+    /// A derived <paramref name="preferred"/> command, falling back to <paramref name="fallback"/> when
+    /// the derivation does not exist on this machine.
+    /// </summary>
+    public static AcpPackageManagerCandidates PreferredWithFallback(string preferred, string fallback)
+        => string.Equals(preferred, fallback, StringComparison.Ordinal)
+            ? Exact(preferred)
+            : new(new[] { preferred, fallback });
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpPackageManagerCommand.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpPackageManagerCommand.cs
@@ -1,0 +1,114 @@
+using System;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Decides which package-manager executable answers for a component: the one belonging to the toolchain
+/// the user named, rather than whatever the inherited PATH happens to resolve.
+/// </summary>
+/// <remarks>
+/// A package manager only ever answers for its own toolchain. Asking a different one is not a degraded
+/// answer but a wrong one: a package installed under the toolchain the user named reads as absent, and a
+/// package absent there can read as installed. Both mislead — the first makes the wizard offer an install
+/// the user already did, the second makes it skip the install and fail at launch.
+///
+/// The manager needs no separate answer from the user because it is the launcher's sibling. npm publishes
+/// <c>npm</c> and <c>npx</c> from one package into one bin directory, and the uv installer lays down
+/// <c>uv</c> beside <c>uvx</c>; the Windows shims (<c>npm.cmd</c>, <c>npx.cmd</c>) sit there too. So an
+/// override for the launcher already identifies the manager, and asking twice for one toolchain would be
+/// a question the wizard can answer itself.
+///
+/// Derivation is a fallback, not a rule: an explicit override for the manager's own name wins, because
+/// the derivation exists to spare the user a second answer rather than to overrule one they gave.
+///
+/// This type decides <em>which</em> command to use and performs no IO; whether the derived path exists is
+/// the platform probe's question, since only it knows how this machine resolves executables.
+/// </remarks>
+public static class AcpPackageManagerCommand
+{
+    /// <summary>
+    /// Resolves the package-manager command for <paramref name="distribution"/>, honouring
+    /// <paramref name="overrides"/> for the manager itself and otherwise deriving it from the launcher.
+    /// </summary>
+    /// <param name="launcherCommand">
+    /// The launcher the component is detected and started through, already resolved through
+    /// <paramref name="overrides"/>. An absolute path names a toolchain; a bare name does not.
+    /// </param>
+    /// <returns>
+    /// The manager's bare name when no toolchain is identified — so PATH resolution answers as before —
+    /// and a toolchain-qualified candidate otherwise. A derived candidate is a preference the probe may
+    /// fall back from; see <see cref="AcpPackageManagerCandidates"/>.
+    /// </returns>
+    public static AcpPackageManagerCandidates Resolve(
+        AcpDistributionKind distribution,
+        string? launcherCommand,
+        AcpCommandOverrides? overrides)
+    {
+        var managerName = ResolveName(distribution);
+        if (managerName.Length == 0)
+        {
+            return AcpPackageManagerCandidates.Exact(managerName);
+        }
+
+        // An answer the user gave outranks one derived on their behalf, so it is used as given.
+        var overridden = (overrides ?? AcpCommandOverrides.Empty).Resolve(managerName);
+        if (!string.Equals(overridden, managerName, StringComparison.Ordinal))
+        {
+            return AcpPackageManagerCandidates.Exact(overridden);
+        }
+
+        return ResolveSibling(launcherCommand, managerName) is { } sibling
+            ? AcpPackageManagerCandidates.PreferredWithFallback(sibling, managerName)
+            : AcpPackageManagerCandidates.Exact(managerName);
+    }
+
+    /// <summary>The command that lists global installs for <paramref name="distribution"/>.</summary>
+    public static string ResolveName(AcpDistributionKind distribution)
+        => distribution switch
+        {
+            AcpDistributionKind.Npx => "npm",
+            AcpDistributionKind.Uvx => "uv",
+            _ => string.Empty
+        };
+
+    /// <summary>
+    /// Returns the manager path sitting next to <paramref name="launcherCommand"/>, or null when the
+    /// launcher names no directory.
+    /// </summary>
+    /// <remarks>
+    /// The launcher's own extension is carried over, which is what makes this work on Windows: npm
+    /// installs its launchers as <c>.cmd</c> shims, so the sibling of <c>npx.cmd</c> is <c>npm.cmd</c>
+    /// and not an extensionless <c>npm</c> that CreateProcess cannot start.
+    ///
+    /// Directory and extension are split by hand rather than through <c>System.IO.Path</c>: this decision
+    /// belongs to the domain, which stays free of filesystem types, and the separators it must understand
+    /// are exactly the two below on every platform the app targets.
+    /// </remarks>
+    private static string? ResolveSibling(string? launcherCommand, string managerName)
+    {
+        if (string.IsNullOrWhiteSpace(launcherCommand))
+        {
+            return null;
+        }
+
+        var launcher = launcherCommand.Trim();
+        var separator = launcher.LastIndexOfAny(new[] { '/', '\\' });
+        if (separator < 0)
+        {
+            // A bare name: PATH resolution is the only route, and it applies to the manager too.
+            return null;
+        }
+
+        var directory = launcher[..(separator + 1)];
+        var fileName = launcher[(separator + 1)..];
+        if (fileName.Length == 0)
+        {
+            // A trailing separator names a directory, not a launcher.
+            return null;
+        }
+
+        var dot = fileName.LastIndexOf('.');
+        var extension = dot > 0 ? fileName[dot..] : string.Empty;
+        return directory + managerName + extension;
+    }
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpShellInvocation.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpShellInvocation.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// How to ask one shell to run a command such that the shell's own startup files have been applied.
+/// </summary>
+/// <remarks>
+/// The app captures the user's real environment by having their shell run the app's own
+/// environment-printing mode. Which arguments achieve that differs per shell family, and getting it wrong
+/// fails in two distinct ways: the shell refuses the flags outright, or it accepts them and silently
+/// applies fewer startup files than the user's terminal does — the second being worse, since it yields a
+/// plausible environment that is missing exactly the toolchain the probe was looking for.
+///
+/// This type decides the argument list and performs no IO. Running the shell, enforcing a timeout, and
+/// extracting the payload belong to the platform layer.
+/// </remarks>
+public sealed class AcpShellInvocation
+{
+    /// <summary>
+    /// Set for the child so a user's startup files can skip work that is pointless or harmful during a
+    /// capture.
+    /// </summary>
+    /// <remarks>
+    /// Startup files routinely do things that make a capture hang or fail: attaching to tmux, starting a
+    /// pager, prompting for input. VS Code and Zed both ship an equivalent flag
+    /// (<c>VSCODE_RESOLVING_ENVIRONMENT</c>, and a Zed request for the same) precisely because users need
+    /// a way to guard those blocks. Publishing one here means a user who hits the problem has a fix that
+    /// does not involve giving up their shell configuration.
+    /// </remarks>
+    public const string GuardVariableName = "SALMONEGG_RESOLVING_ENVIRONMENT";
+
+    private AcpShellInvocation(AcpShellKind kind, IReadOnlyList<string> arguments)
+    {
+        Kind = kind;
+        Arguments = arguments;
+    }
+
+    public AcpShellKind Kind { get; }
+
+    /// <summary>The complete argument list, ending with the command to run.</summary>
+    public IReadOnlyList<string> Arguments { get; }
+
+    /// <summary>
+    /// Builds the invocation that runs <paramref name="command"/> through the shell at
+    /// <paramref name="shellPath"/>.
+    /// </summary>
+    /// <remarks>
+    /// Login <em>and</em> interactive is deliberate. A login shell alone reads only profile files, and the
+    /// most common toolchain setup on Linux puts its PATH mutation in an interactive-only file: nvm's own
+    /// installer appends to <c>~/.bashrc</c>, which Debian's stock <c>~/.bashrc</c> guards with an
+    /// interactivity check that returns early. Verified on this machine: <c>bash -l -c</c> cannot find
+    /// npm, while <c>bash -l -i -c</c> resolves it under ~/.nvm. VS Code and Zed both pay the same cost —
+    /// interactive shells are slower and noisier — for the same reason.
+    /// </remarks>
+    public static AcpShellInvocation Create(string shellPath, string command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var kind = ClassifyShell(shellPath);
+        return new AcpShellInvocation(kind, BuildArguments(kind, command));
+    }
+
+    private static IReadOnlyList<string> BuildArguments(AcpShellKind kind, string command)
+        => kind switch
+        {
+            // csh and tcsh reject -l together with -c, so interactivity is the only lever available.
+            AcpShellKind.Csh => new[] { "-ic", command },
+
+            // fish applies its config file, but asdf, direnv, and friends attach to the fish_prompt event
+            // rather than to config.fish — so a capture that never prompts never sees their PATH.
+            AcpShellKind.Fish => new[] { "-l", "-i", "-c", "emit fish_prompt; " + command },
+
+            // nushell refuses a login shell that is not interactive, and refuses -i with -c.
+            AcpShellKind.Nushell => new[] { "-l", "-c", command },
+
+            // PowerShell profiles are the equivalent of rc files here, so -Login runs them. Word flags,
+            // and -Command must come last.
+            AcpShellKind.PowerShell => new[] { "-Login", "-Command", command },
+
+            _ => new[] { "-l", "-i", "-c", command }
+        };
+
+    /// <summary>
+    /// Identifies the shell family from its executable name.
+    /// </summary>
+    /// <remarks>
+    /// Matched on the file name rather than the full path, since the same shell lives in different places
+    /// per platform and package manager (<c>/bin/zsh</c>, <c>/opt/homebrew/bin/fish</c>). An unknown name
+    /// is treated as POSIX: that is what an unrecognized shell most likely is, and the alternative —
+    /// refusing to capture — gives up the user's environment over a name this code has not heard of.
+    /// </remarks>
+    private static AcpShellKind ClassifyShell(string? shellPath)
+    {
+        if (string.IsNullOrWhiteSpace(shellPath))
+        {
+            return AcpShellKind.Posix;
+        }
+
+        var name = ExtractFileName(shellPath.Trim());
+
+        // Windows shells carry an extension the family name does not include.
+        if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            name = name[..^4];
+        }
+
+        return name.ToLowerInvariant() switch
+        {
+            "fish" => AcpShellKind.Fish,
+            "csh" or "tcsh" => AcpShellKind.Csh,
+            "nu" or "nushell" => AcpShellKind.Nushell,
+            "pwsh" or "powershell" or "pwsh-preview" => AcpShellKind.PowerShell,
+            _ => AcpShellKind.Posix
+        };
+    }
+
+    /// <summary>
+    /// Returns the last path segment. Split by hand so the domain stays free of filesystem types; the two
+    /// separators below are the only ones the app's platforms use.
+    /// </summary>
+    private static string ExtractFileName(string path)
+    {
+        var separator = path.LastIndexOfAny(new[] { '/', '\\' });
+        return separator < 0 ? path : path[(separator + 1)..];
+    }
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpShellKind.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpShellKind.cs
@@ -1,0 +1,26 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The shell families whose environment the app can capture. Distinguished only where the invocation has
+/// to differ; every shell that accepts <c>-l -i -c</c> is <see cref="Posix"/>.
+/// </summary>
+public enum AcpShellKind
+{
+    /// <summary>Any shell driven with <c>-l -i -c</c>: sh, bash, zsh, dash, ksh.</summary>
+    Posix,
+
+    /// <summary>
+    /// fish. Needs an explicit prompt event, because tools that mutate PATH hook the prompt rather than
+    /// the config file.
+    /// </summary>
+    Fish,
+
+    /// <summary>csh and tcsh. Reject <c>-l</c> combined with <c>-c</c>; take <c>-ic</c> instead.</summary>
+    Csh,
+
+    /// <summary>nushell. Rejects a non-interactive login shell; driven with <c>-l -c</c>.</summary>
+    Nushell,
+
+    /// <summary>PowerShell and pwsh. Uses word flags rather than single letters.</summary>
+    PowerShell
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayout.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayout.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Where one toolchain installer places the executables it manages, expressed relative to a base
+/// directory with at most one wildcard segment standing for a version.
+/// </summary>
+/// <remarks>
+/// Scanning these is what makes <em>several</em> installed versions visible. A version manager puts only
+/// the version it has activated on PATH, so asking the user's shell — which is the only way to learn what
+/// nvm activated — reports exactly one node however many are installed. The wizard needs the rest to tell
+/// a user their agent exists under a version they are not currently using, which is otherwise
+/// indistinguishable from not having it at all.
+///
+/// It is also the only route on Windows, where there is no profile-built PATH to capture.
+///
+/// Layouts are declared as data rather than probed for, because the alternative is walking a user's home
+/// directory looking for anything that resembles a toolchain — unbounded IO for a question that a fixed,
+/// documented list answers. A layout naming a directory that does not exist simply contributes nothing.
+/// </remarks>
+public sealed class AcpToolchainLayout
+{
+    /// <summary>The wildcard segment standing for a version directory.</summary>
+    public const string VersionWildcard = "*";
+
+    private AcpToolchainLayout(AcpToolchainLayoutRoot root, IReadOnlyList<string> segments)
+    {
+        Root = root;
+        Segments = segments;
+    }
+
+    /// <summary>Which base directory <see cref="Segments"/> is relative to.</summary>
+    public AcpToolchainLayoutRoot Root { get; }
+
+    /// <summary>
+    /// Path segments below <see cref="Root"/>, at most one of which is <see cref="VersionWildcard"/>.
+    /// </summary>
+    public IReadOnlyList<string> Segments { get; }
+
+    /// <summary>True when this layout expands to one directory per installed version.</summary>
+    public bool IsVersioned
+    {
+        get
+        {
+            foreach (var segment in Segments)
+            {
+                if (string.Equals(segment, VersionWildcard, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Declares a layout: <paramref name="segments"/> below <paramref name="root"/>, at most one of them
+    /// being <see cref="VersionWildcard"/>.
+    /// </summary>
+    /// <remarks>
+    /// Public because the set of layouts is configuration rather than a closed rule — a deployment that
+    /// standardizes on a toolchain location this list does not know can supply its own — and because
+    /// <see cref="Known"/> is then just the shipped default rather than a privileged code path.
+    /// </remarks>
+    public static AcpToolchainLayout Create(AcpToolchainLayoutRoot root, params string[] segments)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+
+        var wildcards = 0;
+        foreach (var segment in segments)
+        {
+            if (string.Equals(segment, VersionWildcard, StringComparison.Ordinal))
+            {
+                wildcards++;
+            }
+        }
+
+        if (wildcards > 1)
+        {
+            // Expansion resolves exactly one version directory. Rejecting this here turns a layout the
+            // scan cannot honour into an authoring error rather than silently-missing directories.
+            throw new ArgumentException(
+                $"A layout may declare at most one '{VersionWildcard}' segment.",
+                nameof(segments));
+        }
+
+        return new AcpToolchainLayout(root, segments);
+    }
+
+    /// <summary>
+    /// The layouts the wizard scans, in the order they are searched.
+    /// </summary>
+    /// <remarks>
+    /// Ordered so a version manager outranks a system-wide directory. That mirrors what a user's own shell
+    /// does — a manager prepends its directory to PATH — so the wizard's first candidate matches the one
+    /// their terminal would run.
+    ///
+    /// Only managers that publish a stable, documented layout are listed. asdf and mise are represented by
+    /// their shim directories rather than per-version paths: both resolve versions through a shim that
+    /// reads configuration at invocation time, so the shim is the honest entry point and enumerating
+    /// versions behind it would name executables that refuse to run outside a configured directory.
+    /// </remarks>
+    public static IReadOnlyList<AcpToolchainLayout> Known { get; } = new[]
+    {
+        // Node version managers, per-version bin directories.
+        Create(AcpToolchainLayoutRoot.UserHome, ".nvm", "versions", "node", VersionWildcard, "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".fnm", "node-versions", VersionWildcard, "installation", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".local", "share", "fnm", "node-versions", VersionWildcard, "installation", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".nodenv", "versions", VersionWildcard, "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".n", "n", "versions", "node", VersionWildcard, "bin"),
+
+        // Managers that front every version behind one shim directory.
+        Create(AcpToolchainLayoutRoot.UserHome, ".volta", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".asdf", "shims"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".local", "share", "mise", "shims"),
+
+        // Per-user install directories that a GUI session commonly lacks.
+        Create(AcpToolchainLayoutRoot.UserHome, ".local", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".bun", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".deno", "bin"),
+        Create(AcpToolchainLayoutRoot.UserHome, ".cargo", "bin"),
+
+        // npm's own global prefix on Windows, which its installer does not always add to PATH.
+        Create(AcpToolchainLayoutRoot.WindowsRoamingAppData, "npm"),
+
+        // Homebrew, whose prefix differs by architecture and is absent from a Finder-launched PATH.
+        Create(AcpToolchainLayoutRoot.Absolute, "/opt/homebrew/bin"),
+        Create(AcpToolchainLayoutRoot.Absolute, "/usr/local/bin")
+    };
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayoutRoot.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayoutRoot.cs
@@ -1,0 +1,17 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The base directory a <see cref="AcpToolchainLayout"/>'s segments hang off. Named rather than resolved
+/// here so the domain stays free of filesystem and platform lookups.
+/// </summary>
+public enum AcpToolchainLayoutRoot
+{
+    /// <summary>The current user's home directory.</summary>
+    UserHome,
+
+    /// <summary>The Windows roaming application data directory; contributes nothing elsewhere.</summary>
+    WindowsRoamingAppData,
+
+    /// <summary>The single segment is already an absolute path.</summary>
+    Absolute
+}

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
@@ -21,8 +21,14 @@ public interface IAcpComponentInstaller
     /// Installs <paramref name="component"/>, reporting installer output lines through
     /// <paramref name="onOutput"/> as they arrive so the UI can show progress.
     /// </summary>
+    /// <param name="overrides">
+    /// Paths the user supplied for commands the catalog names by bare name. Applied so the install runs
+    /// through the same toolchain detection asked about — installing into a different one leaves the
+    /// component invisible to the next probe and absent at launch.
+    /// </param>
     Task<AcpComponentInstallResult> InstallAsync(
         AcpComponentDescriptor component,
         Action<string>? onOutput = null,
+        AcpCommandOverrides? overrides = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
@@ -54,21 +54,22 @@ public interface IAcpExecutableProbe
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Asks whether <paramref name="packageId"/> is installed as a Node global package, and where.
+    /// Asks whether <paramref name="packageId"/> is installed globally for
+    /// <paramref name="distribution"/>, and where.
     /// </summary>
+    /// <param name="packageManager">
+    /// The package-manager commands to try, in order — see <see cref="AcpPackageManagerCandidates"/>.
+    /// Supplied by the caller rather than chosen here, because which manager is the right one depends on
+    /// which toolchain the user selected, and only the caller knows that.
+    /// </param>
     /// <remarks>
-    /// Answers where rather than only whether, because a package manager answers for the toolchain
-    /// currently on PATH: the location is what lets the wizard say which one it asked. An unanswerable
-    /// query reports unknown, which callers must not read as absent.
+    /// Answers where rather than only whether, because a package manager answers for one toolchain: the
+    /// location is what lets the wizard say which one it asked. An unanswerable query reports unknown,
+    /// which callers must not read as absent.
     /// </remarks>
-    Task<AcpPackageQueryResult> LocateGlobalNodePackageAsync(
+    Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+        AcpDistributionKind distribution,
         string packageId,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Asks whether <paramref name="packageId"/> is installed as a uv tool, and where.
-    /// </summary>
-    Task<AcpPackageQueryResult> LocateGlobalUvToolAsync(
-        string packageId,
+        AcpPackageManagerCandidates packageManager,
         CancellationToken cancellationToken = default);
 }

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSearchPathSource.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSearchPathSource.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>
+/// Supplies the directories an executable may be found in, which is broader than the PATH this process
+/// inherited.
+/// </summary>
+/// <remarks>
+/// A GUI-launched desktop process inherits the session environment rather than the one a shell profile
+/// builds, so a version-manager toolchain (nvm, fnm, volta, asdf, mise) is invisible to it and every
+/// catalog component probes as missing. The inherited PATH is therefore a floor, not the answer.
+///
+/// This is a seam rather than a single implementation because the two ways of widening the search answer
+/// different questions and neither subsumes the other:
+/// <list type="bullet">
+/// <item>Asking the user's login shell yields the toolchain they have <em>activated</em> — the one their
+/// terminal would use. It is the only route to a version manager implemented as a shell function, since
+/// such a manager has no executable on disk to find.</item>
+/// <item>Scanning a version manager's on-disk layout yields <em>every</em> version installed, which the
+/// shell cannot report because a manager puts only the current one on PATH.</item>
+/// </list>
+///
+/// Order is meaningful: sources are consulted in registration order and their directories keep that
+/// order, so the first match stays the one a shell would run.
+/// </remarks>
+public interface IAcpSearchPathSource
+{
+    /// <summary>
+    /// Returns additional directories to search, most preferred first.
+    /// </summary>
+    /// <remarks>
+    /// Empty rather than throwing when this source has nothing to contribute or could not answer. A
+    /// source that fails must not deny the search the directories other sources found, and must never
+    /// prevent the inherited PATH from being used.
+    /// </remarks>
+    Task<IReadOnlyList<string>> GetSearchDirectoriesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSearchPathSources.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSearchPathSources.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Assembles the search-path sources this installation can actually use, in search order.
+/// </summary>
+/// <remarks>
+/// The two ways of widening the search answer different questions and neither subsumes the other, so the
+/// order matters and is fixed here rather than left to registration:
+/// <list type="number">
+/// <item>The login shell reports the toolchain the user has <em>activated</em>. It leads because that is
+/// what their own terminal would run, and it is the only route to a version manager implemented as a shell
+/// function — nvm ships no executable, so nothing on disk reveals the node it selected.</item>
+/// <item>The on-disk scan reports <em>every</em> installed version, which the shell cannot, because a
+/// manager puts only the current one on PATH.</item>
+/// </list>
+///
+/// Whether the shell source is available is a deployment question, which is why this type exists rather
+/// than each source self-registering: the capture needs an executable that implements the printing mode,
+/// and that is the CLI, which ships as its own package installed independently of the desktop app. When it
+/// is absent the scan alone still widens the search, so the wizard degrades rather than failing.
+/// </remarks>
+public static class AcpSearchPathSources
+{
+    /// <summary>The CLI's executable name, which is what an installation puts on PATH.</summary>
+    private const string CliExecutableName = "salmon-egg";
+
+    /// <summary>
+    /// Creates the sources for this machine.
+    /// </summary>
+    /// <param name="resolveCliPath">
+    /// Locates the CLI executable, or returns null when none is installed. Injectable so the composition
+    /// can be tested without depending on what the host machine happens to have installed.
+    /// </param>
+    public static IReadOnlyList<IAcpSearchPathSource> Create(Func<string?>? resolveCliPath = null)
+    {
+        var sources = new List<IAcpSearchPathSource>(2);
+
+        // Windows is not captured: its per-user PATH lives in the registry and the session already holds
+        // it, so there is no profile-built PATH to recover and the scan is the whole answer there.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var cliPath = (resolveCliPath ?? ResolveInstalledCliPath)();
+            if (PrintEnvironmentCommandFactory.TryCreate(cliPath) is { } printEnvironmentCommand)
+            {
+                sources.Add(new LoginShellSearchPathSource(printEnvironmentCommand));
+            }
+        }
+
+        sources.Add(new ToolchainScanSearchPathSource());
+        return sources;
+    }
+
+    /// <summary>
+    /// Finds the installed CLI, preferring one that sits beside this process.
+    /// </summary>
+    /// <remarks>
+    /// The sibling is checked first because a build tree and a portable extraction both put the two
+    /// together, and that copy is certain to match this app's version. Falling back to PATH covers the
+    /// packaged case, where the CLI installs to a system directory (a .deb owns
+    /// <c>/usr/bin/salmon-egg</c>) that this process's own directory says nothing about.
+    /// </remarks>
+    private static string? ResolveInstalledCliPath()
+    {
+        var processDirectory = Path.GetDirectoryName(Environment.ProcessPath);
+        if (!string.IsNullOrEmpty(processDirectory))
+        {
+            var sibling = Path.Combine(processDirectory, CliExecutableName);
+            if (File.Exists(sibling))
+            {
+                return sibling;
+            }
+        }
+
+        foreach (var directory in (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                 .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string candidate;
+            try
+            {
+                candidate = Path.Combine(directory, CliExecutableName);
+            }
+            catch (ArgumentException)
+            {
+                // PATH entries can hold characters that are invalid in a path on this platform.
+                continue;
+            }
+
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSetupProcessRunner.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSetupProcessRunner.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Transport;
 
 namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 
@@ -58,20 +59,7 @@ internal static class AcpSetupProcessRunner
             return NotStarted("Executable name was empty.");
         }
 
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = fileName,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            RedirectStandardInput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        foreach (var argument in arguments)
-        {
-            startInfo.ArgumentList.Add(argument);
-        }
+        var startInfo = CreateProcessStartInfo(fileName, arguments);
 
         using var process = new Process { StartInfo = startInfo };
         var standardOutput = new OutputAccumulator(onOutputLine);
@@ -130,6 +118,32 @@ internal static class AcpSetupProcessRunner
             standardOutput.ToString(),
             standardError.ToString(),
             FailureDetail: null);
+    }
+
+    /// <summary>
+    /// Builds the start info for one helper invocation: stdio redirected, and the command normalized
+    /// through <see cref="LauncherInvocation"/> so a batch shim is wrapped and the launcher's own
+    /// directory reaches the child's PATH.
+    /// </summary>
+    /// <remarks>
+    /// The PATH entry is what makes an absolute-path launcher usable at all. The wizard's answer to a GUI
+    /// process that cannot see the user's toolchain is to let them name the executable, but naming
+    /// <c>npm</c> alone leaves its sibling <c>node</c> unreachable and the probe dies at exit 127 — so the
+    /// override would resolve a command that still cannot run. See <see cref="LauncherInvocation"/>.
+    /// </remarks>
+    internal static ProcessStartInfo CreateProcessStartInfo(string fileName, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        LauncherInvocation.Create(fileName, arguments).ApplyTo(startInfo);
+        return startInfo;
     }
 
     private static AcpSetupProcessResult NotStarted(string detail)

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
@@ -33,6 +33,7 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
     public async Task<AcpComponentInstallResult> InstallAsync(
         AcpComponentDescriptor component,
         Action<string>? onOutput = null,
+        AcpCommandOverrides? overrides = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(component);
@@ -46,7 +47,17 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
                 errorDetail: $"'{component.DisplayName}' must be installed manually.");
         }
 
-        var (launcher, arguments) = ResolveInstallCommand(component);
+        // The component's own launcher is resolved first so the manager can be derived from a real
+        // directory: an override may name it by bare name or relative path, which no sibling lookup can
+        // use. A launcher that does not resolve is not fatal here — the manager may still be on PATH —
+        // so this only sharpens the derivation.
+        var resolvedLauncher = await _probe
+            .ResolveExecutablePathAsync(
+                (overrides ?? AcpCommandOverrides.Empty).Resolve(component.ProbeCommand),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var (launcher, arguments) = ResolveInstallCommand(component, resolvedLauncher, overrides);
         var launcherPath = await _probe
             .ResolveExecutablePathAsync(launcher, cancellationToken)
             .ConfigureAwait(false);
@@ -83,14 +94,28 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
     /// The package coordinate is passed verbatim, including any pinned version: the catalog decides
     /// which version the wizard installs, and rewriting it here would silently disagree with what the
     /// launch command later resolves.
+    ///
+    /// The package manager is resolved through the same rule detection uses, so an install lands in the
+    /// toolchain the wizard asked about. Installing into a different one would report success and leave
+    /// the next probe — and the launch — looking at a toolchain that still does not have the package.
+    /// Only the preferred candidate is used: an install has to choose one toolchain, and falling back to
+    /// a bare name would write into whichever one PATH happens to resolve.
     /// </remarks>
     private static (string Launcher, IReadOnlyList<string> Arguments) ResolveInstallCommand(
-        AcpComponentDescriptor component)
-        => component.Distribution switch
+        AcpComponentDescriptor component,
+        string? resolvedLauncherPath,
+        AcpCommandOverrides? overrides)
+    {
+        var launcher = AcpPackageManagerCommand
+            .Resolve(component.Distribution, resolvedLauncherPath, overrides)
+            .Preferred;
+
+        return component.Distribution switch
         {
-            AcpDistributionKind.Npx => ("npm", new[] { "install", "--global", component.PackageId }),
-            AcpDistributionKind.Uvx => ("uv", new[] { "tool", "install", component.PackageId }),
+            AcpDistributionKind.Npx => (launcher, new[] { "install", "--global", component.PackageId }),
+            AcpDistributionKind.Uvx => (launcher, new[] { "tool", "install", component.PackageId }),
             _ => throw new NotSupportedException(
                 $"Distribution '{component.Distribution}' has no automatic install path.")
         };
+    }
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
@@ -23,22 +23,84 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
     private static readonly TimeSpan VersionProbeTimeout = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan PackageQueryTimeout = TimeSpan.FromSeconds(60);
 
-    public bool SupportsProcessProbing => true;
+    private readonly IReadOnlyList<IAcpSearchPathSource> _searchPathSources;
 
-    public Task<string?> ResolveExecutablePathAsync(
-        string command,
-        CancellationToken cancellationToken = default)
+    /// <param name="searchPathSources">
+    /// Sources of directories beyond the inherited PATH, consulted in order. None means PATH alone, which
+    /// is the correct behaviour for a process that already has the user's real environment.
+    /// </param>
+    public DesktopAcpExecutableProbe(IReadOnlyList<IAcpSearchPathSource>? searchPathSources = null)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(ResolveExecutablePath(command));
+        _searchPathSources = searchPathSources ?? Array.Empty<IAcpSearchPathSource>();
     }
 
-    public Task<IReadOnlyList<string>> ResolveExecutableCandidatesAsync(
+    public bool SupportsProcessProbing => true;
+
+    public async Task<string?> ResolveExecutablePathAsync(
+        string command,
+        CancellationToken cancellationToken = default)
+    {
+        var candidates = await ResolveExecutableCandidatesAsync(command, cancellationToken)
+            .ConfigureAwait(false);
+        return candidates.Count == 0 ? null : candidates[0];
+    }
+
+    public async Task<IReadOnlyList<string>> ResolveExecutableCandidatesAsync(
         string command,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(ResolveExecutableCandidates(command));
+
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return Array.Empty<string>();
+        }
+
+        var trimmed = command.Trim();
+        if (trimmed.IndexOfAny(new[] { '/', '\\' }) >= 0)
+        {
+            // An explicit path names one file; there is no search to widen.
+            return File.Exists(trimmed) ? new[] { Path.GetFullPath(trimmed) } : Array.Empty<string>();
+        }
+
+        var directories = await ResolveSearchDirectoriesAsync(cancellationToken).ConfigureAwait(false);
+        return FindCandidates(trimmed, directories);
+    }
+
+    /// <summary>
+    /// The directories to search: the inherited PATH first, then whatever the sources add.
+    /// </summary>
+    /// <remarks>
+    /// PATH leads because a command it can already resolve is the one this process — and anything it
+    /// starts — will actually run. The sources exist to find what PATH cannot see, not to displace it.
+    ///
+    /// A source that throws is skipped rather than failing the resolution: it is a widening, and losing it
+    /// leaves the probe exactly as capable as it was before the source existed.
+    /// </remarks>
+    private async Task<IReadOnlyList<string>> ResolveSearchDirectoriesAsync(CancellationToken cancellationToken)
+    {
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var directories = new List<string>(
+            (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                .Split(
+                    isWindows ? ';' : ':',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        foreach (var source in _searchPathSources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                directories.AddRange(
+                    await source.GetSearchDirectoriesAsync(cancellationToken).ConfigureAwait(false));
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                // A source is additive; a broken one must not deny the search what PATH already offers.
+            }
+        }
+
+        return directories;
     }
 
     public async Task<string?> ReadVersionAsync(
@@ -232,9 +294,59 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
     }
 
     /// <summary>
-    /// Resolves <paramref name="command"/> the way a shell would: an explicit path is used as given,
-    /// otherwise PATH is searched, applying PATHEXT on Windows so <c>npm</c> finds <c>npm.cmd</c>.
+    /// Finds every distinct executable named <paramref name="command"/> under
+    /// <paramref name="directories"/>, in order.
     /// </summary>
+    /// <remarks>
+    /// Deduplicated by resolved target rather than by candidate string: PATH commonly lists the same
+    /// directory more than once, and per-user bin directories are often symlink farms pointing at one real
+    /// file. Without that, a machine with one install reports several identical candidates and the UI
+    /// offers a choice between a path and itself.
+    ///
+    /// Extensions are the outer loop on Windows so PATHEXT precedence holds across the whole search, which
+    /// is how the shell resolves a bare name: an <c>.exe</c> late on PATH wins over a <c>.cmd</c> early on
+    /// it.
+    /// </remarks>
+    private static IReadOnlyList<string> FindCandidates(string command, IReadOnlyList<string> directories)
+    {
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var candidates = new List<string>();
+        var seenTargets = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var extension in ResolveExtensions(isWindows))
+        {
+            var candidateName = command + extension;
+            foreach (var directory in directories)
+            {
+                string candidate;
+                try
+                {
+                    candidate = Path.Combine(directory, candidateName);
+                }
+                catch (ArgumentException)
+                {
+                    // PATH entries can contain characters that are invalid for this platform's paths.
+                    continue;
+                }
+
+                if (File.Exists(candidate) && seenTargets.Add(ResolveDeduplicationKey(candidate)))
+                {
+                    candidates.Add(candidate);
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="command"/> against the inherited PATH only.
+    /// </summary>
+    /// <remarks>
+    /// Used by the paths that run a process they have already decided on. It stays synchronous and
+    /// PATH-only because those callers were handed a command that a source already resolved, or a bare name
+    /// whose own resolution is the caller's question rather than this method's.
+    /// </remarks>
     private static string? ResolveExecutablePath(string command)
     {
         if (string.IsNullOrWhiteSpace(command))
@@ -249,103 +361,18 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
         }
 
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        var pathSeparator = isWindows ? ';' : ':';
         var directories = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
-            .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(
+                isWindows ? ';' : ':',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        foreach (var extension in ResolveExtensions(isWindows))
-        {
-            var candidateName = trimmed + extension;
-            foreach (var directory in directories)
-            {
-                string candidate;
-                try
-                {
-                    candidate = Path.Combine(directory, candidateName);
-                }
-                catch (ArgumentException)
-                {
-                    // PATH entries can contain characters that are invalid for this platform's paths.
-                    continue;
-                }
-
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-        }
-
-        return null;
+        var candidates = FindCandidates(trimmed, directories);
+        return candidates.Count == 0 ? null : candidates[0];
     }
 
     /// <summary>
-    /// Enumerates every distinct executable <paramref name="command"/> matches, in PATH order.
-    /// </summary>
-    /// <remarks>
-    /// Deduplicated by resolved target rather than by candidate string: PATH commonly lists the same
-    /// directory more than once, and per-user bin directories are often symlink farms pointing at one
-    /// real file. Without that, a machine with one install reports several identical candidates and the
-    /// UI offers a choice between a path and itself.
-    ///
-    /// An explicit path is returned as its single candidate, matching the single-path overload — there is
-    /// no PATH search to enumerate.
-    /// </remarks>
-    private static IReadOnlyList<string> ResolveExecutableCandidates(string command)
-    {
-        if (string.IsNullOrWhiteSpace(command))
-        {
-            return Array.Empty<string>();
-        }
-
-        var trimmed = command.Trim();
-        if (trimmed.IndexOfAny(new[] { '/', '\\' }) >= 0)
-        {
-            var explicitPath = ResolveExecutablePath(trimmed);
-            return explicitPath is null ? Array.Empty<string>() : new[] { explicitPath };
-        }
-
-        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        var pathSeparator = isWindows ? ';' : ':';
-        var directories = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
-            .Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        var candidates = new List<string>();
-        var seenTargets = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var extension in ResolveExtensions(isWindows))
-        {
-            var candidateName = trimmed + extension;
-            foreach (var directory in directories)
-            {
-                string candidate;
-                try
-                {
-                    candidate = Path.Combine(directory, candidateName);
-                }
-                catch (ArgumentException)
-                {
-                    continue;
-                }
-
-                if (!File.Exists(candidate))
-                {
-                    continue;
-                }
-
-                if (seenTargets.Add(ResolveDeduplicationKey(candidate)))
-                {
-                    candidates.Add(candidate);
-                }
-            }
-        }
-
-        return candidates;
-    }
-
-    /// <summary>
-    /// The identity two candidate paths are compared on: the symlink target when one can be read, the
-    /// full path otherwise.
+    /// The identity two candidate paths are compared on: the symlink target when one can be read, the full
+    /// path otherwise.
     /// </summary>
     private static string ResolveDeduplicationKey(string candidate)
     {

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
@@ -65,55 +65,72 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
     }
 
     /// <summary>
-    /// Asks npm for the global package list. <c>--depth 0</c> keeps the walk to top-level packages, and
-    /// <c>--parseable</c> yields one path per line, which is stable across npm versions.
+    /// Asks the caller-chosen package manager for its global list.
     /// </summary>
-    public Task<AcpPackageQueryResult> LocateGlobalNodePackageAsync(
+    /// <remarks>
+    /// For npm, <c>--depth 0</c> keeps the walk to top-level packages and <c>--parseable</c> yields one
+    /// path per line, which is stable across npm versions.
+    ///
+    /// Candidates are tried in order and the first one that resolves is asked. Only resolution is retried,
+    /// never a manager's answer: a manager that ran and said "no" has answered for the toolchain the
+    /// caller chose, and trying the next candidate would replace that answer with one about a different
+    /// toolchain.
+    /// </remarks>
+    public async Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+        AcpDistributionKind distribution,
         string packageId,
+        AcpPackageManagerCandidates packageManager,
         CancellationToken cancellationToken = default)
-        => QueryPackageListAsync(
-            launcher: "npm",
-            arguments: new[] { "ls", "--global", "--depth", "0", "--parseable" },
-            packageId,
-            cancellationToken);
+    {
+        ArgumentNullException.ThrowIfNull(packageManager);
 
-    public Task<AcpPackageQueryResult> LocateGlobalUvToolAsync(
-        string packageId,
-        CancellationToken cancellationToken = default)
-        => QueryPackageListAsync(
-            launcher: "uv",
-            arguments: new[] { "tool", "list" },
-            packageId,
-            cancellationToken);
+        if (string.IsNullOrWhiteSpace(packageId) || ResolveListArguments(distribution) is not { } arguments)
+        {
+            return AcpPackageQueryResult.Unknown();
+        }
+
+        foreach (var candidate in packageManager.Commands)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ResolveExecutablePath(candidate) is { } executable)
+            {
+                return await QueryPackageListAsync(executable, arguments, packageId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return AcpPackageQueryResult.Unknown();
+    }
+
+    /// <summary>
+    /// The list-installed invocation for <paramref name="distribution"/>, or null when it has no package
+    /// manager to ask.
+    /// </summary>
+    private static IReadOnlyList<string>? ResolveListArguments(AcpDistributionKind distribution)
+        => distribution switch
+        {
+            AcpDistributionKind.Npx => new[] { "ls", "--global", "--depth", "0", "--parseable" },
+            AcpDistributionKind.Uvx => new[] { "tool", "list" },
+            _ => null
+        };
 
     /// <summary>
     /// Runs a package-list command and looks for the package name in its output.
     /// </summary>
     /// <remarks>
-    /// Returns null — not false — when the launcher is missing or the command fails, because an
-    /// unanswerable query must not be reported as a definitive absence.
+    /// Returns null — not false — when the command fails to run at all, because an unanswerable query
+    /// must not be reported as a definitive absence.
     ///
     /// npm exits non-zero for unrelated reasons (peer-dependency complaints in the global root, for
     /// instance) while still printing a usable list, so output that contains the package is trusted even
     /// on a non-zero exit. The reverse is not true: a failed run with no match stays unknown.
     /// </remarks>
     private static async Task<AcpPackageQueryResult> QueryPackageListAsync(
-        string launcher,
+        string executable,
         IReadOnlyList<string> arguments,
         string packageId,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(packageId))
-        {
-            return AcpPackageQueryResult.Unknown();
-        }
-
-        var executable = ResolveExecutablePath(launcher);
-        if (executable is null)
-        {
-            return AcpPackageQueryResult.Unknown();
-        }
-
         var result = await AcpSetupProcessRunner
             .RunAsync(executable, arguments, PackageQueryTimeout, onOutputLine: null, cancellationToken)
             .ConfigureAwait(false);

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/LoginShellSearchPathSource.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/LoginShellSearchPathSource.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Contributes the PATH the user's own login shell produces.
+/// </summary>
+/// <remarks>
+/// This is the only route to a version manager implemented as a shell function. nvm is the common case:
+/// it ships no executable — <c>command -v nvm</c> finds nothing, only <c>nvm.sh</c> exists on disk — and
+/// mutates PATH inside the shell that sources it. No amount of directory scanning can discover the node
+/// it activated; asking the shell is the whole mechanism.
+///
+/// Captured once and reused. A capture spawns an interactive login shell, which runs the user's startup
+/// files and routinely takes seconds; repeating that per probe would multiply the cost across every
+/// component the wizard inspects, for an answer that does not change while the app runs.
+/// </remarks>
+public sealed class LoginShellSearchPathSource : IAcpSearchPathSource
+{
+    private readonly Func<string?> _resolveShellPath;
+    private readonly Func<string, string> _printEnvironmentCommand;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private IReadOnlyList<string>? _cached;
+
+    /// <param name="printEnvironmentCommand">
+    /// Builds a shell-ready command that prints the environment wrapped in the supplied marker.
+    /// </param>
+    /// <param name="resolveShellPath">
+    /// Yields the user's shell, or null when none can be determined. Injectable so the capture can be
+    /// tested without depending on the host's own shell configuration.
+    /// </param>
+    public LoginShellSearchPathSource(
+        Func<string, string> printEnvironmentCommand,
+        Func<string?>? resolveShellPath = null)
+    {
+        _printEnvironmentCommand = printEnvironmentCommand
+            ?? throw new ArgumentNullException(nameof(printEnvironmentCommand));
+        _resolveShellPath = resolveShellPath ?? ResolveDefaultShellPath;
+    }
+
+    public async Task<IReadOnlyList<string>> GetSearchDirectoriesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (_cached is { } cached)
+        {
+            return cached;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Re-checked inside the gate: several components are probed in sequence and a concurrent
+            // caller must reuse the first capture rather than start a second interactive shell.
+            if (_cached is { } existing)
+            {
+                return existing;
+            }
+
+            _cached = await CaptureDirectoriesAsync(cancellationToken).ConfigureAwait(false);
+            return _cached;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<string>> CaptureDirectoriesAsync(CancellationToken cancellationToken)
+    {
+        var shellPath = _resolveShellPath();
+        if (string.IsNullOrWhiteSpace(shellPath))
+        {
+            return Array.Empty<string>();
+        }
+
+        var environment = await ShellEnvironmentCapture
+            .CaptureAsync(shellPath, _printEnvironmentCommand, timeout: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (environment is null || !environment.TryGetValue("PATH", out var path) || string.IsNullOrWhiteSpace(path))
+        {
+            return Array.Empty<string>();
+        }
+
+        return SplitPath(path);
+    }
+
+    /// <summary>
+    /// Splits a captured PATH into directories, preserving order.
+    /// </summary>
+    /// <remarks>
+    /// Order is the shell's answer about precedence, so it is kept: the first entry is what the user's own
+    /// terminal would run. Duplicates are left for the consumer to collapse, which it must do anyway
+    /// because it merges several sources.
+    /// </remarks>
+    private static IReadOnlyList<string> SplitPath(string path)
+        => path.Split(
+            Path.PathSeparator,
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// The user's shell, preferring <c>SHELL</c> and falling back to the platform default.
+    /// </summary>
+    /// <remarks>
+    /// <c>SHELL</c> is what the user's terminal exports and what every editor reads, but a GUI process may
+    /// not have inherited it — which is the same reason this whole feature exists. The fallback keeps the
+    /// capture possible in that case rather than abandoning it: <c>/bin/sh</c> still sources a profile, so
+    /// it recovers a login PATH even though it misses interactive-only configuration.
+    ///
+    /// Windows is not captured at all. Its per-user PATH lives in the registry and the session already
+    /// holds it, so there is no profile-built PATH to recover: <c>cmd.exe</c> has no login or interactive
+    /// startup files, and capturing through it would spend a process to be told what this process already
+    /// knows. A Windows user whose toolchain is invisible needs the on-disk scan instead.
+    /// </remarks>
+    private static string? ResolveDefaultShellPath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        var shell = Environment.GetEnvironmentVariable("SHELL");
+        return string.IsNullOrWhiteSpace(shell) ? "/bin/sh" : shell;
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/PrintEnvironmentCommandFactory.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/PrintEnvironmentCommandFactory.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Builds the shell-ready command that makes an executable report the environment its shell handed it.
+/// </summary>
+/// <remarks>
+/// The capture works by having the user's shell start a program that prints its own environment. Which
+/// program that is belongs to the host rather than to this type: the CLI implements the printing mode, and
+/// it ships as its own package installed independently of the desktop app, so whether one is present is a
+/// deployment fact the caller establishes.
+///
+/// The result is one string because the shell is invoked as <c>-c &lt;command&gt;</c> and parses it itself.
+/// Paths routinely contain spaces — "Program Files", "Application Support" — so each is quoted; an
+/// unquoted path would be read as several arguments.
+/// </remarks>
+internal static class PrintEnvironmentCommandFactory
+{
+    /// <summary>The option that selects environment printing. Must match the CLI's own spelling.</summary>
+    /// <remarks>
+    /// Held as a constant rather than referenced from the CLI assembly, because the two are separate
+    /// executables that meet only across a process boundary and neither references the other. A test pins
+    /// the two spellings together so they cannot drift apart silently.
+    /// </remarks>
+    internal const string OptionName = "--printenv";
+
+    /// <summary>
+    /// Returns a factory turning a marker into the command that runs
+    /// <paramref name="printEnvironmentExecutable"/>, or null when that executable is unusable.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than a best guess: a command built around a path that is not there produces a shell
+    /// failure indistinguishable from a user's broken rc file, so the caller should skip the capture and
+    /// keep the inherited PATH instead of reporting one that never had a chance.
+    /// </remarks>
+    internal static Func<string, string>? TryCreate(string? printEnvironmentExecutable)
+    {
+        if (string.IsNullOrWhiteSpace(printEnvironmentExecutable)
+            || !File.Exists(printEnvironmentExecutable))
+        {
+            return null;
+        }
+
+        var invocation = Quote(printEnvironmentExecutable);
+        return marker => invocation + " " + Quote(OptionName + "=" + marker);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> in single quotes for a POSIX shell.
+    /// </summary>
+    /// <remarks>
+    /// Single quotes because they suppress every expansion a shell would otherwise apply to a path: no
+    /// variable substitution, no globbing, no backslash escapes. An embedded single quote is closed,
+    /// escaped, and reopened — the only sequence POSIX defines for it.
+    ///
+    /// POSIX only, because only POSIX shells are captured: Windows has no profile-built PATH to recover, so
+    /// no command is ever built for it.
+    /// </remarks>
+    private static string Quote(string value)
+        => "'" + value.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ShellEnvironmentCapture.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ShellEnvironmentCapture.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Runs the user's login shell so it reports the environment that shell produces.
+/// </summary>
+/// <remarks>
+/// A GUI-launched process inherits the session environment, not the one a shell profile builds, so a
+/// version-manager toolchain is invisible to it. This recovers the real environment the way every editor
+/// that solves the problem does: run our own executable inside the user's shell and read structured
+/// output back, rather than parse the shell's own <c>env</c> text.
+///
+/// The hazards here are the reason this is its own type. A user's startup files are arbitrary code that
+/// this app does not control, and in the wild they hang (tmux attach, pagers, prompts for input), write
+/// banners and colour codes onto the same stdout, and exit non-zero while still having produced a usable
+/// environment. Every guard below answers one of those:
+/// <list type="bullet">
+/// <item>stdin is closed, so a startup file that reads input gets EOF instead of blocking. Verified: a
+/// capture against an rc file containing a bare <c>read</c> hangs indefinitely without this and returns
+/// immediately with it.</item>
+/// <item>A timeout kills the shell, because a startup file can block on something that is not stdin.</item>
+/// <item>A random per-invocation marker delimits the payload, so surrounding noise cannot be mistaken for
+/// it.</item>
+/// <item>A non-zero exit is not fatal when the payload parsed, since rc-file failures are common and
+/// unrelated to whether the environment was reported.</item>
+/// <item>Failure yields null rather than throwing. Losing the captured environment means falling back to
+/// the inherited PATH, which is the status quo; blocking the wizard on a shell misconfiguration would be
+/// worse than the problem being solved.</item>
+/// </list>
+/// </remarks>
+internal static class ShellEnvironmentCapture
+{
+    /// <summary>
+    /// How long the user's shell gets to report its environment.
+    /// </summary>
+    /// <remarks>
+    /// Startup files that initialize version managers routinely take seconds, and an interactive shell
+    /// pays that cost on every capture, so a short timeout would abandon exactly the setups this feature
+    /// exists for. VS Code defaults to the same 10 seconds after years of user reports.
+    /// </remarks>
+    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Captures the environment produced by <paramref name="shellPath"/>, or null when it could not be
+    /// captured.
+    /// </summary>
+    /// <param name="shellPath">The user's shell. Its file name selects the invocation rules.</param>
+    /// <param name="printEnvironmentCommand">
+    /// A shell-ready command that prints <c>&lt;marker&gt;{json}&lt;marker&gt;</c>, given the marker this
+    /// method generates. Supplied by the caller because only it knows how to invoke this app.
+    /// </param>
+    internal static async Task<IReadOnlyDictionary<string, string>?> CaptureAsync(
+        string shellPath,
+        Func<string, string> printEnvironmentCommand,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(printEnvironmentCommand);
+
+        if (string.IsNullOrWhiteSpace(shellPath))
+        {
+            return null;
+        }
+
+        var marker = CreateMarker();
+        var invocation = AcpShellInvocation.Create(shellPath, printEnvironmentCommand(marker));
+        var startInfo = CreateStartInfo(shellPath, invocation);
+
+        var output = await ReadShellOutputAsync(
+                startInfo,
+                timeout ?? DefaultTimeout,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return output is null ? null : ExtractEnvironment(output, marker);
+    }
+
+    /// <summary>
+    /// A fresh random marker per invocation.
+    /// </summary>
+    /// <remarks>
+    /// Random rather than fixed because the payload is the shell's own environment: a fixed marker could
+    /// appear inside an exported value and turn an honest value into a false delimiter. Hex so it survives
+    /// every shell's quoting rules without escaping.
+    /// </remarks>
+    private static string CreateMarker()
+        => Convert.ToHexString(RandomNumberGenerator.GetBytes(12)).ToLowerInvariant();
+
+    private static ProcessStartInfo CreateStartInfo(string shellPath, AcpShellInvocation invocation)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = shellPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            // Redirected and closed immediately after start: a startup file that reads from stdin then
+            // sees EOF rather than blocking forever on a terminal that is not there.
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in invocation.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        // Lets a user's startup files skip work that would hang or pollute a capture.
+        startInfo.Environment[AcpShellInvocation.GuardVariableName] = "1";
+
+        // Startup files localize their own messages and colourize prompts. Neither affects the payload,
+        // which is delimited JSON, but a predictable locale keeps diagnostics readable when it fails.
+        startInfo.Environment["LC_ALL"] = "C";
+
+        return startInfo;
+    }
+
+    /// <summary>
+    /// Runs the shell to completion and returns its stdout, or null when it could not be run.
+    /// </summary>
+    /// <remarks>
+    /// Output is read concurrently with the wait rather than after it: a shell whose startup files write
+    /// more than the pipe buffer holds would block writing while this blocked waiting.
+    ///
+    /// On timeout the whole process tree is killed. A login shell starts children — that is the point —
+    /// and killing only the shell would leave them holding the pipe.
+    /// </remarks>
+    private static async Task<string?> ReadShellOutputAsync(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            if (!process.Start())
+            {
+                return null;
+            }
+        }
+        catch (Exception exception) when (exception is System.ComponentModel.Win32Exception or System.IO.IOException or InvalidOperationException)
+        {
+            // $SHELL can name a file that no longer exists or is not executable.
+            return null;
+        }
+
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (Exception exception) when (exception is System.IO.IOException or ObjectDisposedException or InvalidOperationException)
+        {
+            // The shell already closed its end; the wait below still governs the outcome.
+        }
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillTree(process);
+            cancellationToken.ThrowIfCancellationRequested();
+            return null;
+        }
+
+        try
+        {
+            // Awaited after exit so a shell that produced output before failing is still read. The reads
+            // complete once the pipes close, which exiting guarantees.
+            _ = await standardError.ConfigureAwait(false);
+            return await standardOutput.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is System.IO.IOException or ObjectDisposedException)
+        {
+            return null;
+        }
+    }
+
+    private static void TryKillTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+        {
+            // Already gone, or the platform refused. The outcome is already decided either way.
+        }
+    }
+
+    /// <summary>
+    /// Pulls the marker-delimited JSON object out of <paramref name="output"/>.
+    /// </summary>
+    /// <remarks>
+    /// Searched for rather than assumed to be the whole of stdout, because startup files print onto the
+    /// same stream. The first marker and the last are used, so a value that happens to contain the marker
+    /// cannot truncate the payload.
+    /// </remarks>
+    internal static IReadOnlyDictionary<string, string>? ExtractEnvironment(string output, string marker)
+    {
+        if (string.IsNullOrEmpty(output) || string.IsNullOrEmpty(marker))
+        {
+            return null;
+        }
+
+        var start = output.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return null;
+        }
+
+        var payloadStart = start + marker.Length;
+        var end = output.LastIndexOf(marker, StringComparison.Ordinal);
+        if (end <= payloadStart)
+        {
+            return null;
+        }
+
+        try
+        {
+            var payload = output[payloadStart..end];
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(payload);
+            return parsed is null or { Count: 0 } ? null : parsed;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Contributes the bin directories of toolchains installed on disk, including versions that are not
+/// currently active.
+/// </summary>
+/// <remarks>
+/// This is what makes several installed versions visible. A version manager puts only the version it has
+/// activated on PATH, so capturing the user's shell environment reports exactly one node however many are
+/// installed — and the wizard needs the rest to tell a user their agent exists under a version they are
+/// not currently using, which is otherwise indistinguishable from not having it.
+///
+/// It is also the only widening available on Windows, where there is no profile-built PATH to recover.
+///
+/// Scanned once and reused: the answer is a filesystem shape that does not change while the wizard runs,
+/// and the wizard probes many components.
+/// </remarks>
+public sealed class ToolchainScanSearchPathSource : IAcpSearchPathSource
+{
+    private readonly IReadOnlyList<AcpToolchainLayout> _layouts;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private IReadOnlyList<string>? _cached;
+
+    public ToolchainScanSearchPathSource(IReadOnlyList<AcpToolchainLayout>? layouts = null)
+    {
+        _layouts = layouts ?? AcpToolchainLayout.Known;
+    }
+
+    public async Task<IReadOnlyList<string>> GetSearchDirectoriesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (_cached is { } cached)
+        {
+            return cached;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cached is { } existing)
+            {
+                return existing;
+            }
+
+            _cached = Scan(cancellationToken);
+            return _cached;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Expands every layout to the directories that exist, in layout order.
+    /// </summary>
+    /// <remarks>
+    /// Version directories within one layout are sorted descending by name, so a newer version is offered
+    /// before an older one. That is a presentation choice rather than a claim about correctness: the
+    /// wizard shows candidates and the user picks, but the newest install is the likelier intent and
+    /// putting it first spares them reading a list to find it.
+    /// </remarks>
+    private IReadOnlyList<string> Scan(CancellationToken cancellationToken)
+    {
+        var directories = new List<string>();
+        var seen = new HashSet<string>(
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        foreach (var layout in _layouts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var directory in ExpandLayout(layout))
+            {
+                if (seen.Add(directory))
+                {
+                    directories.Add(directory);
+                }
+            }
+        }
+
+        return directories;
+    }
+
+    private static IEnumerable<string> ExpandLayout(AcpToolchainLayout layout)
+    {
+        if (ResolveRoot(layout.Root) is not { } root)
+        {
+            return Array.Empty<string>();
+        }
+
+        return layout.IsVersioned
+            ? ExpandVersioned(root, layout.Segments)
+            : ExpandFixed(root, layout.Segments);
+    }
+
+    /// <summary>
+    /// Resolves a layout root to a directory, or null when this platform has none.
+    /// </summary>
+    /// <remarks>
+    /// The Windows-only root yields null elsewhere rather than an empty string, which
+    /// <c>GetFolderPath</c> returns off-Windows and which would silently resolve layouts against the
+    /// process working directory.
+    /// </remarks>
+    private static string? ResolveRoot(AcpToolchainLayoutRoot root)
+    {
+        switch (root)
+        {
+            case AcpToolchainLayoutRoot.UserHome:
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                return string.IsNullOrEmpty(home) ? null : home;
+
+            case AcpToolchainLayoutRoot.WindowsRoamingAppData:
+                if (!OperatingSystem.IsWindows())
+                {
+                    return null;
+                }
+
+                var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                return string.IsNullOrEmpty(appData) ? null : appData;
+
+            case AcpToolchainLayoutRoot.Absolute:
+                return string.Empty;
+
+            default:
+                return null;
+        }
+    }
+
+    private static IEnumerable<string> ExpandFixed(string root, IReadOnlyList<string> segments)
+    {
+        if (Combine(root, segments, 0, segments.Count) is { } directory && Directory.Exists(directory))
+        {
+            yield return directory;
+        }
+    }
+
+    /// <summary>
+    /// Expands the one wildcard segment against the version directories present.
+    /// </summary>
+    /// <remarks>
+    /// Enumerated with <c>EnumerateDirectories</c> on the parent rather than a recursive glob: the depth is
+    /// known from the layout, so there is no reason to walk a user's home directory.
+    /// </remarks>
+    private static IEnumerable<string> ExpandVersioned(string root, IReadOnlyList<string> segments)
+    {
+        var wildcardIndex = IndexOfWildcard(segments);
+        if (Combine(root, segments, 0, wildcardIndex) is not { } parent || !Directory.Exists(parent))
+        {
+            yield break;
+        }
+
+        string[] versionDirectories;
+        try
+        {
+            versionDirectories = Directory.GetDirectories(parent);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A directory the user cannot read contributes nothing, like one that is not there.
+            yield break;
+        }
+
+        // Newest first by name. Not semantic version ordering: these are directory names a manager chose,
+        // and the wizard shows candidates for the user to pick rather than deciding for them.
+        Array.Sort(versionDirectories, static (left, right) => string.CompareOrdinal(right, left));
+
+        foreach (var versionDirectory in versionDirectories)
+        {
+            if (Combine(versionDirectory, segments, wildcardIndex + 1, segments.Count) is { } directory
+                && Directory.Exists(directory))
+            {
+                yield return directory;
+            }
+        }
+    }
+
+    private static int IndexOfWildcard(IReadOnlyList<string> segments)
+    {
+        for (var index = 0; index < segments.Count; index++)
+        {
+            if (string.Equals(segments[index], AcpToolchainLayout.VersionWildcard, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Joins <paramref name="segments"/> in <c>[start, end)</c> onto <paramref name="root"/>, or null when
+    /// the result is not a path this platform can express.
+    /// </summary>
+    private static string? Combine(string root, IReadOnlyList<string> segments, int start, int end)
+    {
+        try
+        {
+            var path = root;
+            for (var index = start; index < end; index++)
+            {
+                path = Path.Combine(path, segments[index]);
+            }
+
+            return Path.GetFullPath(path);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace SalmonEgg.Infrastructure.Transport;
+
+/// <summary>
+/// One launcher invocation normalized for <c>CreateProcess</c>: the executable to start, the arguments to
+/// pass it, and the command those were derived from.
+/// </summary>
+/// <remarks>
+/// Two rules are shared by everything in this app that starts an external CLI — the ACP wizard's probes
+/// and installs, and the stdio transport that carries a real conversation — so they live here rather than
+/// in either caller:
+///
+/// 1. A <c>.cmd</c> or <c>.bat</c> launcher is not an executable image. <c>CreateProcess</c> requires the
+///    command interpreter to be named explicitly ("To run a batch file, you must start the command
+///    interpreter; set lpApplicationName to cmd.exe and set lpCommandLine to /c plus the name of the
+///    batch file"), and .NET reaches <c>CreateProcess</c> directly whenever
+///    <c>UseShellExecute</c> is false — which redirecting stdio requires. Starting a batch file
+///    without the wrapper fails with Win32 error 193, ERROR_BAD_EXE_FORMAT. This matters because npm
+///    installs every Node CLI on Windows as a <c>.cmd</c> shim (npm shells out to cmd-shim, "since
+///    symlinks are not suitable for this purpose there").
+///
+/// 2. The launcher's own directory goes on the child's PATH. A launcher named by absolute path can still
+///    fail to run: every npm-installed CLI starts with <c>#!/usr/bin/env node</c>, so it resolves and
+///    then exits 127 with "/usr/bin/env: 'node': No such file or directory" when its sibling interpreter
+///    is not on PATH. That is the ordinary case for a GUI-launched app, which inherits the session PATH
+///    rather than the one a shell profile builds, so a version-manager toolchain (nvm, fnm, volta, asdf)
+///    is invisible to it.
+/// </remarks>
+internal sealed record LauncherInvocation(
+    string FileName,
+    IReadOnlyList<string> Arguments,
+    string ResolvedCommand)
+{
+    private static readonly StringComparison DirectoryComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Normalizes <paramref name="command"/> and <paramref name="arguments"/> into something
+    /// <c>CreateProcess</c> accepts, resolving the command against PATH and wrapping a batch launcher in
+    /// the command interpreter.
+    /// </summary>
+    public static LauncherInvocation Create(string? command, IReadOnlyList<string>? arguments)
+    {
+        var trimmedCommand = (command ?? string.Empty).Trim();
+        var trimmedArguments = arguments is null
+            ? Array.Empty<string>()
+            : arguments.Select(argument => (argument ?? string.Empty).Trim()).ToArray();
+
+        var resolvedCommand = StdioCommandResolver.Resolve(trimmedCommand);
+
+        if (IsBatchLauncher(resolvedCommand))
+        {
+            return new LauncherInvocation(
+                FileName: "cmd.exe",
+                Arguments: new[] { "/c", resolvedCommand }.Concat(trimmedArguments).ToArray(),
+                ResolvedCommand: resolvedCommand);
+        }
+
+        return new LauncherInvocation(resolvedCommand, trimmedArguments, resolvedCommand);
+    }
+
+    /// <summary>
+    /// Applies the executable, the arguments, and the launcher's PATH entry to
+    /// <paramref name="startInfo"/>.
+    /// </summary>
+    /// <remarks>
+    /// PATH is written last so the launcher's directory is prepended to whatever the caller configured,
+    /// rather than to the inherited value the caller may have deliberately replaced. Prepending is not a
+    /// preference that competes with the caller's environment: without it the launcher cannot reach the
+    /// interpreter it was written to run under, so there is nothing for the caller's PATH to matter to.
+    /// </remarks>
+    public void ApplyTo(ProcessStartInfo startInfo)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.FileName = FileName;
+        startInfo.ArgumentList.Clear();
+        foreach (var argument in Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (ResolveLauncherDirectory() is { } launcherDirectory)
+        {
+            // Read through the same dictionary that is written, so a caller-configured PATH is the one
+            // extended. On Windows this dictionary compares keys case-insensitively, so the inherited
+            // "Path" is found and updated in place rather than shadowed by a second "PATH" entry.
+            startInfo.Environment["PATH"] = PrependDirectory(
+                launcherDirectory,
+                startInfo.Environment.TryGetValue("PATH", out var existing) ? existing : null);
+        }
+    }
+
+    /// <summary>
+    /// The directory whose siblings the launcher needs, or null when the command carries no directory —
+    /// a bare name that PATH resolution already answered, so PATH needs no help.
+    /// </summary>
+    private string? ResolveLauncherDirectory()
+    {
+        if (string.IsNullOrWhiteSpace(ResolvedCommand))
+        {
+            return null;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(ResolvedCommand));
+            return string.IsNullOrEmpty(directory) ? null : directory;
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // Not a path this platform can express. PATH resolution is the caller's only route anyway.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns <paramref name="path"/> with <paramref name="directory"/> in front, or unchanged when it
+    /// already leads or contains it.
+    /// </summary>
+    /// <remarks>
+    /// Already-present entries are left alone because the wizard runs a probe per component: appending
+    /// unconditionally would grow PATH on every launch, and an oversized environment block is its own
+    /// failure on Windows.
+    /// </remarks>
+    private static string PrependDirectory(string directory, string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return directory;
+        }
+
+        var separator = Path.PathSeparator;
+        foreach (var entry in path.Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (string.Equals(entry.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), directory, DirectoryComparison))
+            {
+                return path;
+            }
+        }
+
+        return directory + separator + path;
+    }
+
+    private static bool IsBatchLauncher(string command)
+        => command.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)
+            || command.EndsWith(".bat", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
@@ -29,8 +29,7 @@ namespace SalmonEgg.Infrastructure.Transport
         private static readonly TimeSpan StartupObservationTimeout = TimeSpan.FromMilliseconds(500);
         private static readonly IReadOnlyDictionary<string, string> EmptyEnvironment =
             new Dictionary<string, string>(StringComparer.Ordinal);
-        private readonly string _command;
-        private readonly string[] _args;
+        private readonly LauncherInvocation _invocation;
         private readonly Encoding _encoding;
         private readonly string _workingDirectory;
         private readonly IReadOnlyDictionary<string, string> _environment;
@@ -72,27 +71,10 @@ namespace SalmonEgg.Infrastructure.Transport
             Encoding? encoding = null,
             IReadOnlyDictionary<string, string>? environment = null)
         {
-            // 去除命令和参数中的首尾空格（避免意外输入导致找不到文件）
-            string trimmedCommand = (command ?? string.Empty).Trim();
-            string[] trimmedArgs = args?.Select(a => a.Trim()).ToArray() ?? Array.Empty<string>();
-
-            // 解析命令并处理 .cmd/.bat 脚本
-            string resolvedCommand = StdioCommandResolver.Resolve(trimmedCommand);
-
-            // 如果是 .cmd 或 .bat 文件，需要通过 cmd.exe 执行
-            if (resolvedCommand.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase) ||
-                resolvedCommand.EndsWith(".bat", StringComparison.OrdinalIgnoreCase))
-            {
-                _command = "cmd.exe";
-                _args = new[] { "/c", resolvedCommand }.Concat(trimmedArgs).ToArray();
-                _workingDirectory = ResolveWorkingDirectory(resolvedCommand);
-            }
-            else
-            {
-                _command = resolvedCommand;
-                _args = trimmedArgs;
-                _workingDirectory = ResolveWorkingDirectory(resolvedCommand);
-            }
+            // 命令解析、.cmd/.bat 包装与启动器目录上 PATH 都由 LauncherInvocation 统一负责，
+            // 使 ACP 向导的探测/安装与本传输走同一套规则。
+            _invocation = LauncherInvocation.Create(command, args);
+            _workingDirectory = ResolveWorkingDirectory(_invocation.ResolvedCommand);
 
             _encoding = NormalizeTransportEncoding(encoding ?? Encoding.UTF8);
             _environment = NormalizeEnvironment(environment);
@@ -163,7 +145,7 @@ namespace SalmonEgg.Infrastructure.Transport
                 starting.EnableRaisingEvents = true;
                 starting.Exited += OnProcessExited;
 
-                _logger.Information("[StdioTransport.Connect] Starting process. Command={Command} ArgsCount={ArgsCount}", _command, processInfo.ArgumentList.Count);
+                _logger.Information("[StdioTransport.Connect] Starting process. Command={Command} ArgsCount={ArgsCount}", _invocation.FileName, processInfo.ArgumentList.Count);
 
                 // 在后台启动进程，避免阻塞 UI 线程
                 await Task.Run(() =>
@@ -241,7 +223,6 @@ namespace SalmonEgg.Infrastructure.Transport
         {
             var processInfo = new ProcessStartInfo
             {
-                FileName = _command,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -253,16 +234,15 @@ namespace SalmonEgg.Infrastructure.Transport
                 WorkingDirectory = _workingDirectory
             };
 
-            foreach (var argument in _args)
-            {
-                processInfo.ArgumentList.Add(argument);
-            }
-
             // Applied after construction so configured values win over the inherited environment.
             foreach (var entry in _environment)
             {
                 processInfo.Environment[entry.Key] = entry.Value;
             }
+
+            // Last, so the launcher's own directory extends whatever PATH the configured environment
+            // settled on rather than the inherited one it may have replaced.
+            _invocation.ApplyTo(processInfo);
 
             return processInfo;
         }

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpComponentInstaller.cs
@@ -21,6 +21,7 @@ public sealed class UnsupportedAcpComponentInstaller : IAcpComponentInstaller
     public Task<AcpComponentInstallResult> InstallAsync(
         AcpComponentDescriptor component,
         Action<string>? onOutput = null,
+        AcpCommandOverrides? overrides = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(component);

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
@@ -35,13 +35,10 @@ public sealed class UnsupportedAcpExecutableProbe : IAcpExecutableProbe
         CancellationToken cancellationToken = default)
         => Task.FromResult<string?>(null);
 
-    public Task<AcpPackageQueryResult> LocateGlobalNodePackageAsync(
+    public Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+        AcpDistributionKind distribution,
         string packageId,
-        CancellationToken cancellationToken = default)
-        => Task.FromResult(AcpPackageQueryResult.Unknown());
-
-    public Task<AcpPackageQueryResult> LocateGlobalUvToolAsync(
-        string packageId,
+        AcpPackageManagerCandidates packageManager,
         CancellationToken cancellationToken = default)
         => Task.FromResult(AcpPackageQueryResult.Unknown());
 }

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpPackageManagerOverrideTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpPackageManagerOverrideTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Application.Tests.Services.AcpSetup;
+
+/// <summary>
+/// Guards that a user-supplied launcher path also decides which package manager answers the detection
+/// query.
+/// </summary>
+/// <remarks>
+/// A GUI process cannot see a version-manager toolchain, so the wizard lets the user name the launcher
+/// their adapter runs through. Detecting that adapter then asks a package manager whether the package is
+/// installed — and asking the <em>wrong</em> toolchain's manager answers about the wrong machine state:
+/// a package installed under the named toolchain reads as absent, or worse, absent under the named one
+/// reads as installed. Either way the wizard acts on a fact about a toolchain the user did not choose.
+///
+/// The manager is reachable without asking the user for a second path because it is the launcher's
+/// sibling: npm publishes <c>npm</c> and <c>npx</c> from one package into one bin directory, and the uv
+/// installer lays down <c>uv</c> and <c>uvx</c> side by side. Naming one names the other.
+/// </remarks>
+public sealed class AcpPackageManagerOverrideTests
+{
+    private const string NodeToolchainBin = "/opt/toolchain/node/bin";
+
+    private static AcpComponentDescriptor NpxAdapter() => new()
+    {
+        Id = "adapter",
+        DisplayName = "Adapter",
+        Distribution = AcpDistributionKind.Npx,
+        DetectionMode = AcpComponentDetectionMode.GlobalNodePackage,
+        ProbeCommand = "npx",
+        PackageId = "@scope/adapter"
+    };
+
+    private static AcpComponentDescriptor UvxAdapter() => new()
+    {
+        Id = "adapter",
+        DisplayName = "Adapter",
+        Distribution = AcpDistributionKind.Uvx,
+        DetectionMode = AcpComponentDetectionMode.GlobalUvTool,
+        ProbeCommand = "uvx",
+        PackageId = "some-tool"
+    };
+
+    /// <summary>
+    /// The launcher the user named decides the toolchain, so the manager queried must be the sibling of
+    /// that launcher rather than whatever bare <c>npm</c> resolves to on the inherited PATH.
+    /// </summary>
+    [Fact]
+    public async Task DetectAsync_WithOverriddenNpxLauncher_ShouldQueryThatToolchainsNpm()
+    {
+        var probe = new RecordingProbe();
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["npx"] = NodeToolchainBin + "/npx"
+        });
+
+        await new AcpComponentDetector(probe).DetectAsync(
+            NpxAdapter(),
+            overrides,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(NodeToolchainBin + "/npm", probe.QueriedPackageManager);
+    }
+
+    /// <summary>The same contract for the Python toolchain: <c>uvx</c> names <c>uv</c>.</summary>
+    [Fact]
+    public async Task DetectAsync_WithOverriddenUvxLauncher_ShouldQueryThatToolchainsUv()
+    {
+        var probe = new RecordingProbe();
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["uvx"] = "/opt/toolchain/python/bin/uvx"
+        });
+
+        await new AcpComponentDetector(probe).DetectAsync(
+            UvxAdapter(),
+            overrides,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("/opt/toolchain/python/bin/uv", probe.QueriedPackageManager);
+    }
+
+    /// <summary>
+    /// With no override the manager stays a bare name, so PATH resolution answers exactly as before.
+    /// </summary>
+    [Fact]
+    public async Task DetectAsync_WithoutOverride_ShouldQueryTheBareManagerName()
+    {
+        var probe = new RecordingProbe();
+
+        await new AcpComponentDetector(probe).DetectAsync(
+            NpxAdapter(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("npm", probe.QueriedPackageManager);
+    }
+
+    /// <summary>
+    /// An explicit manager override wins over the sibling derivation: the derivation exists to spare the
+    /// user a second answer, not to overrule one they gave.
+    /// </summary>
+    [Fact]
+    public async Task DetectAsync_WithExplicitManagerOverride_ShouldPreferItOverTheSibling()
+    {
+        var probe = new RecordingProbe();
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["npx"] = NodeToolchainBin + "/npx",
+            ["npm"] = "/elsewhere/bin/npm"
+        });
+
+        await new AcpComponentDetector(probe).DetectAsync(
+            NpxAdapter(),
+            overrides,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("/elsewhere/bin/npm", probe.QueriedPackageManager);
+    }
+
+    /// <summary>
+    /// Records which package manager the detector asked, so the assertion is about the toolchain chosen
+    /// rather than about a query result the stub invented.
+    /// </summary>
+    private sealed class RecordingProbe : IAcpExecutableProbe
+    {
+        public string? QueriedPackageManager { get; private set; }
+
+        public bool SupportsProcessProbing => true;
+
+        public Task<string?> ResolveExecutablePathAsync(
+            string command,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(command);
+
+        public Task<IReadOnlyList<string>> ResolveExecutableCandidatesAsync(
+            string command,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(new[] { command });
+
+        public Task<string?> ReadVersionAsync(
+            string command,
+            IReadOnlyList<string> versionArguments,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+            AcpDistributionKind distribution,
+            string packageId,
+            AcpPackageManagerCandidates packageManager,
+            CancellationToken cancellationToken = default)
+        {
+            QueriedPackageManager = packageManager.Preferred;
+            return Task.FromResult(AcpPackageQueryResult.Unknown(packageManager.Preferred));
+        }
+    }
+}

--- a/tests/SalmonEgg.Cli.Tests/CliPrintEnvironmentTests.cs
+++ b/tests/SalmonEgg.Cli.Tests/CliPrintEnvironmentTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Cli.Tests;
+
+/// <summary>
+/// Guards the environment-printing protocol the app uses to recover the user's real shell environment.
+/// </summary>
+/// <remarks>
+/// A GUI-launched process inherits the session environment, not the one a shell profile builds, so a
+/// version-manager toolchain is invisible to it. The app asks the user's login shell to run this mode and
+/// reads back what that shell produced.
+///
+/// The contract these tests pin down is what makes the payload findable in a stream the app does not
+/// control: rc files print banners and colour codes onto the same stdout. Marker-delimited JSON survives
+/// that; bare output does not.
+/// </remarks>
+public sealed class CliPrintEnvironmentTests
+{
+    private const string Marker = "abc123marker";
+
+    /// <summary>
+    /// The payload is wrapped in the caller's marker so it can be located inside unrelated shell output.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_WithPrintEnv_ShouldWrapJsonInTheSuppliedMarker()
+    {
+        await using var stdout = new StringWriter();
+        await using var stderr = new StringWriter();
+
+        var exitCode = await CliApplication.RunAsync(
+            [$"--printenv={Marker}"],
+            stdout,
+            stderr,
+            TestContext.Current.CancellationToken);
+
+        var raw = stdout.ToString();
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.StartsWith(Marker, raw, StringComparison.Ordinal);
+        Assert.EndsWith(Marker, raw, StringComparison.Ordinal);
+        Assert.Empty(stderr.ToString());
+    }
+
+    /// <summary>
+    /// The payload deserializes to the process environment, which is the whole point: the caller reads
+    /// PATH out of it.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_WithPrintEnv_ShouldEmitTheProcessEnvironmentAsJson()
+    {
+        const string name = "SALMONEGG_PRINTENV_PROBE";
+        var expected = Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(name, expected);
+        await using var stdout = new StringWriter();
+        await using var stderr = new StringWriter();
+
+        try
+        {
+            await CliApplication.RunAsync(
+                [$"--printenv={Marker}"],
+                stdout,
+                stderr,
+                TestContext.Current.CancellationToken);
+
+            var raw = stdout.ToString();
+            var payload = raw[Marker.Length..^Marker.Length];
+            var environment = JsonSerializer.Deserialize<Dictionary<string, string>>(payload);
+
+            Assert.NotNull(environment);
+            Assert.Equal(expected, environment[name]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    /// <summary>
+    /// The JSON stays on one line, so output a shell interleaves cannot split it across the markers.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_WithPrintEnv_ShouldEmitSingleLineJson()
+    {
+        await using var stdout = new StringWriter();
+        await using var stderr = new StringWriter();
+
+        await CliApplication.RunAsync(
+            [$"--printenv={Marker}"],
+            stdout,
+            stderr,
+            TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain('\n', stdout.ToString());
+    }
+
+    /// <summary>
+    /// A marker is mandatory. Without one the output would be unwrapped and the caller could not locate
+    /// it, so the argument is not recognized and the CLI falls through to ordinary parsing.
+    /// </summary>
+    [Theory]
+    [InlineData("--printenv")]
+    [InlineData("--printenv=")]
+    public void TryGetMarker_WithoutAMarkerValue_ShouldNotSelectPrintEnvMode(string argument)
+        => Assert.False(SalmonEgg.Cli.Hosting.CliPrintEnvironment.TryGetMarker([argument], out _));
+
+    [Fact]
+    public void TryGetMarker_WithMarkerValue_ShouldReturnIt()
+    {
+        Assert.True(SalmonEgg.Cli.Hosting.CliPrintEnvironment.TryGetMarker([$"--printenv={Marker}"], out var marker));
+        Assert.Equal(Marker, marker);
+    }
+
+    /// <summary>
+    /// Recognized wherever it appears, because the shell command line the app builds is not obliged to
+    /// place it first.
+    /// </summary>
+    [Fact]
+    public void TryGetMarker_WithLeadingArguments_ShouldStillFindIt()
+    {
+        Assert.True(
+            SalmonEgg.Cli.Hosting.CliPrintEnvironment.TryGetMarker(["config", $"--printenv={Marker}"], out var marker));
+        Assert.Equal(Marker, marker);
+    }
+
+    [Fact]
+    public void TryGetMarker_WithNoPrintEnvArgument_ShouldReturnFalse()
+        => Assert.False(SalmonEgg.Cli.Hosting.CliPrintEnvironment.TryGetMarker(["config", "list"], out _));
+}

--- a/tests/SalmonEgg.Domain.Tests/Models/AcpSetup/AcpShellInvocationTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/AcpSetup/AcpShellInvocationTests.cs
@@ -1,0 +1,120 @@
+using System;
+using SalmonEgg.Domain.Models.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Domain.Tests.Models.AcpSetup;
+
+/// <summary>
+/// Guards the per-shell invocation rules used to capture the user's real environment.
+/// </summary>
+/// <remarks>
+/// Getting these wrong fails in two ways, and the quiet one is worse: the shell either refuses the flags,
+/// or accepts them and applies fewer startup files than the user's terminal does — yielding a plausible
+/// environment missing exactly the toolchain the probe was looking for.
+/// </remarks>
+public sealed class AcpShellInvocationTests
+{
+    private const string Command = "print-env";
+
+    /// <summary>
+    /// Login and interactive together. Interactive is not optional: nvm's installer appends to
+    /// <c>~/.bashrc</c>, which Debian's stock rc file guards with an interactivity check — verified on a
+    /// real nvm install, where <c>bash -l -c</c> cannot find npm but <c>bash -l -i -c</c> can.
+    /// </summary>
+    [Theory]
+    [InlineData("/bin/bash")]
+    [InlineData("/bin/sh")]
+    [InlineData("/usr/bin/zsh")]
+    [InlineData("/bin/dash")]
+    [InlineData("/usr/bin/ksh")]
+    public void Create_ForPosixShell_ShouldRunLoginAndInteractive(string shellPath)
+    {
+        var invocation = AcpShellInvocation.Create(shellPath, Command);
+
+        Assert.Equal(AcpShellKind.Posix, invocation.Kind);
+        Assert.Equal(new[] { "-l", "-i", "-c", Command }, invocation.Arguments);
+    }
+
+    /// <summary>
+    /// An unrecognized shell is driven as POSIX rather than refused: giving up the user's environment over
+    /// an unfamiliar name is the worse failure.
+    /// </summary>
+    [Theory]
+    [InlineData("/opt/custom/myshell")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_ForUnknownShell_ShouldFallBackToPosix(string shellPath)
+        => Assert.Equal(AcpShellKind.Posix, AcpShellInvocation.Create(shellPath, Command).Kind);
+
+    /// <summary>
+    /// fish must be told to emit its prompt event, because asdf and direnv hook that event rather than
+    /// config.fish — so a capture that never prompts never sees the PATH they set.
+    /// </summary>
+    [Fact]
+    public void Create_ForFish_ShouldEmitThePromptEvent()
+    {
+        var invocation = AcpShellInvocation.Create("/opt/homebrew/bin/fish", Command);
+
+        Assert.Equal(AcpShellKind.Fish, invocation.Kind);
+        Assert.Equal(new[] { "-l", "-i", "-c", "emit fish_prompt; " + Command }, invocation.Arguments);
+    }
+
+    /// <summary>csh and tcsh reject <c>-l</c> combined with <c>-c</c>.</summary>
+    [Theory]
+    [InlineData("/bin/csh")]
+    [InlineData("/bin/tcsh")]
+    public void Create_ForCsh_ShouldNotPassLogin(string shellPath)
+    {
+        var invocation = AcpShellInvocation.Create(shellPath, Command);
+
+        Assert.Equal(AcpShellKind.Csh, invocation.Kind);
+        Assert.Equal(new[] { "-ic", Command }, invocation.Arguments);
+        Assert.DoesNotContain("-l", invocation.Arguments);
+    }
+
+    /// <summary>nushell refuses a non-interactive login shell, and refuses <c>-i</c> with <c>-c</c>.</summary>
+    [Theory]
+    [InlineData("/usr/bin/nu")]
+    [InlineData("/usr/local/bin/nushell")]
+    public void Create_ForNushell_ShouldNotPassInteractive(string shellPath)
+    {
+        var invocation = AcpShellInvocation.Create(shellPath, Command);
+
+        Assert.Equal(AcpShellKind.Nushell, invocation.Kind);
+        Assert.Equal(new[] { "-l", "-c", Command }, invocation.Arguments);
+        Assert.DoesNotContain("-i", invocation.Arguments);
+    }
+
+    /// <summary>PowerShell takes word flags, and the command must come last.</summary>
+    [Theory]
+    [InlineData("/usr/bin/pwsh")]
+    [InlineData(@"C:\Program Files\PowerShell\7\pwsh.exe")]
+    [InlineData(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
+    public void Create_ForPowerShell_ShouldUseWordFlags(string shellPath)
+    {
+        var invocation = AcpShellInvocation.Create(shellPath, Command);
+
+        Assert.Equal(AcpShellKind.PowerShell, invocation.Kind);
+        Assert.Equal(new[] { "-Login", "-Command", Command }, invocation.Arguments);
+    }
+
+    /// <summary>
+    /// The command is always the final argument, so a shell reads it as the thing to run rather than as a
+    /// flag operand.
+    /// </summary>
+    [Theory]
+    [InlineData("/bin/bash")]
+    [InlineData("/bin/tcsh")]
+    [InlineData("/usr/bin/nu")]
+    [InlineData("/usr/bin/pwsh")]
+    public void Create_ForEveryShell_ShouldPlaceTheCommandLast(string shellPath)
+    {
+        var arguments = AcpShellInvocation.Create(shellPath, Command).Arguments;
+
+        Assert.Contains(Command, arguments[^1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_WithNullCommand_ShouldThrow()
+        => Assert.Throws<ArgumentNullException>(() => AcpShellInvocation.Create("/bin/bash", null!));
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpLauncherPathPropagationTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpLauncherPathPropagationTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the contract that a launcher resolved outside the inherited PATH can still run: its own
+/// directory is placed on the child's PATH.
+/// </summary>
+/// <remarks>
+/// This is the failure a GUI-launched app hits. A desktop process started from Finder, a .desktop file,
+/// or Explorer inherits the session PATH, not the PATH a shell profile builds — so a version-manager
+/// toolchain (nvm, fnm, volta, asdf) is invisible to it. The wizard's answer is to let the user name an
+/// absolute path, but naming the launcher is not enough on its own: every Node CLI begins with
+/// <c>#!/usr/bin/env node</c>, so the launcher resolves and then dies with exit 127 —
+/// "/usr/bin/env: 'node': No such file or directory" — because its sibling <c>node</c> is still off PATH.
+///
+/// Verified against a real nvm install: invoking an absolute-path npm/npx/gemini with the systemd user
+/// session PATH exits 127 for exactly that reason. Prepending the launcher's own directory is what makes
+/// the sibling interpreter reachable, which is why these tests assert on PATH content rather than on the
+/// launcher merely resolving.
+/// </remarks>
+public sealed class AcpLauncherPathPropagationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "acp-launcher-path-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A launcher given by absolute path must find its siblings: the directory it lives in is prepended
+    /// to the child's PATH.
+    /// </summary>
+    [Fact]
+    public void CreateProcessStartInfo_WithLauncherOutsidePath_ShouldPrependItsOwnDirectory()
+    {
+        var launcherDirectory = Path.Combine(_root, "toolchain", "bin");
+        Directory.CreateDirectory(launcherDirectory);
+        var launcher = Path.Combine(launcherDirectory, "fake-launcher");
+        File.WriteAllText(launcher, "#!/bin/sh\n");
+
+        var startInfo = AcpSetupProcessRunner.CreateProcessStartInfo(launcher, Array.Empty<string>());
+
+        var path = startInfo.Environment["PATH"] ?? string.Empty;
+        Assert.StartsWith(launcherDirectory, path, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Prepended, not replaced: the inherited PATH still has to work, because a launcher routinely shells
+    /// out to tools that live elsewhere (git, a system compiler) during an install.
+    /// </summary>
+    [Fact]
+    public void CreateProcessStartInfo_WithLauncherOutsidePath_ShouldKeepInheritedPath()
+    {
+        var launcherDirectory = Path.Combine(_root, "keep-inherited");
+        Directory.CreateDirectory(launcherDirectory);
+        var launcher = Path.Combine(launcherDirectory, "fake-launcher");
+        File.WriteAllText(launcher, "#!/bin/sh\n");
+        var inherited = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+
+        var startInfo = AcpSetupProcessRunner.CreateProcessStartInfo(launcher, Array.Empty<string>());
+
+        var path = startInfo.Environment["PATH"] ?? string.Empty;
+        Assert.Contains(inherited, path, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A directory already on PATH must not be prepended again: repeated entries accumulate every time
+    /// the wizard runs a probe, and an unbounded PATH is its own failure on Windows.
+    /// </summary>
+    [Fact]
+    public void CreateProcessStartInfo_WithLauncherAlreadyOnPath_ShouldNotDuplicateTheEntry()
+    {
+        var launcherDirectory = Path.Combine(_root, "already-on-path");
+        Directory.CreateDirectory(launcherDirectory);
+        var launcher = Path.Combine(launcherDirectory, "fake-launcher");
+        File.WriteAllText(launcher, "#!/bin/sh\n");
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", launcherDirectory + separator + "/usr/bin");
+
+            var startInfo = AcpSetupProcessRunner.CreateProcessStartInfo(launcher, Array.Empty<string>());
+
+            var path = startInfo.Environment["PATH"] ?? string.Empty;
+            Assert.Equal(launcherDirectory + separator + "/usr/bin", path);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    /// <summary>
+    /// The real end of the chain: a launcher whose interpreter is a sibling must actually run. This is
+    /// the exit-127 failure expressed as a behaviour rather than as a PATH assertion.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_WithSiblingInterpreterOffPath_ShouldStillRunTheLauncher()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // The shebang mechanism this exercises is POSIX-only.
+            return;
+        }
+
+        var toolchain = Path.Combine(_root, "sibling", "bin");
+        Directory.CreateDirectory(toolchain);
+
+        // The sibling "interpreter" the launcher reaches through `env`, mirroring how every Node CLI
+        // finds `node`.
+        var interpreter = Path.Combine(toolchain, "fake-interpreter");
+        await File.WriteAllTextAsync(interpreter, "#!/bin/sh\necho INTERPRETER-RAN\n");
+        SetExecutable(interpreter);
+
+        var launcher = Path.Combine(toolchain, "fake-launcher");
+        await File.WriteAllTextAsync(launcher, "#!/usr/bin/env fake-interpreter\n");
+        SetExecutable(launcher);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            // A GUI session PATH: the toolchain directory is absent from it.
+            Environment.SetEnvironmentVariable("PATH", "/usr/bin:/bin");
+
+            var result = await AcpSetupProcessRunner.RunAsync(
+                launcher,
+                Array.Empty<string>(),
+                TimeSpan.FromSeconds(30),
+                onOutputLine: null,
+                TestContext.Current.CancellationToken);
+
+            Assert.True(result.Started);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("INTERPRETER-RAN", result.CombinedOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    private static void SetExecutable(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpLauncherPathPropagationTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpLauncherPathPropagationTests.cs
@@ -123,11 +123,17 @@ public sealed class AcpLauncherPathPropagationTests : IDisposable
         // The sibling "interpreter" the launcher reaches through `env`, mirroring how every Node CLI
         // finds `node`.
         var interpreter = Path.Combine(toolchain, "fake-interpreter");
-        await File.WriteAllTextAsync(interpreter, "#!/bin/sh\necho INTERPRETER-RAN\n");
+        await File.WriteAllTextAsync(
+            interpreter,
+            "#!/bin/sh\necho INTERPRETER-RAN\n",
+            TestContext.Current.CancellationToken);
         SetExecutable(interpreter);
 
         var launcher = Path.Combine(toolchain, "fake-launcher");
-        await File.WriteAllTextAsync(launcher, "#!/usr/bin/env fake-interpreter\n");
+        await File.WriteAllTextAsync(
+            launcher,
+            "#!/usr/bin/env fake-interpreter\n",
+            TestContext.Current.CancellationToken);
         SetExecutable(launcher);
 
         var originalPath = Environment.GetEnvironmentVariable("PATH");

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSearchPathSourcesTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSearchPathSourcesTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards which search-path sources an installation gets, and in what order.
+/// </summary>
+/// <remarks>
+/// The two sources answer different questions: the login shell reports the toolchain the user activated —
+/// the only route to a version manager that is a shell function — while the disk scan reports every
+/// installed version, which the shell cannot. Order is the claim that the activated one wins, matching what
+/// the user's own terminal would run.
+/// </remarks>
+public sealed class AcpSearchPathSourcesTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "search-sources-" + Guid.NewGuid().ToString("N"));
+
+    public AcpSearchPathSourcesTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// With the CLI present, the shell capture leads: it reports the toolchain the user has activated, so
+    /// its directories are the ones their terminal would search first.
+    /// </summary>
+    [Fact]
+    public void Create_WithCliAvailable_ShouldPutTheShellSourceFirst()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Windows is deliberately not captured.");
+
+        var cli = Path.Combine(_root, "salmon-egg");
+        File.WriteAllText(cli, string.Empty);
+
+        var sources = AcpSearchPathSources.Create(() => cli);
+
+        Assert.Equal(2, sources.Count);
+        Assert.IsType<LoginShellSearchPathSource>(sources[0]);
+        Assert.IsType<ToolchainScanSearchPathSource>(sources[1]);
+    }
+
+    /// <summary>
+    /// Without the CLI there is nothing that implements the printing mode, so the scan alone widens the
+    /// search rather than the wizard losing the widening altogether.
+    /// </summary>
+    [Fact]
+    public void Create_WithoutCli_ShouldStillProvideTheDiskScan()
+    {
+        var sources = AcpSearchPathSources.Create(() => null);
+
+        Assert.IsType<ToolchainScanSearchPathSource>(Assert.Single(sources));
+    }
+
+    /// <summary>
+    /// A CLI path that does not exist is treated as absent. Building a command around it would produce a
+    /// shell failure indistinguishable from a user's broken rc file.
+    /// </summary>
+    [Fact]
+    public void Create_WithMissingCliPath_ShouldStillProvideTheDiskScan()
+    {
+        var sources = AcpSearchPathSources.Create(() => Path.Combine(_root, "not-installed"));
+
+        Assert.IsType<ToolchainScanSearchPathSource>(Assert.Single(sources));
+    }
+
+    /// <summary>
+    /// The scan is always present, on every platform: it is the only widening available on Windows, where
+    /// there is no profile-built PATH to recover.
+    /// </summary>
+    [Fact]
+    public void Create_OnAnyPlatform_ShouldAlwaysIncludeTheDiskScan()
+        => Assert.Contains(
+            AcpSearchPathSources.Create(() => null),
+            source => source is ToolchainScanSearchPathSource);
+
+    /// <summary>
+    /// The option name is duplicated across a process boundary — the desktop app does not reference the
+    /// CLI — so this pins the two spellings together. If they drift, the capture silently stops working:
+    /// the shell runs the CLI, the CLI does not recognize the argument, and the probe reports nothing.
+    /// </summary>
+    [Fact]
+    public void PrintEnvironmentOptionName_ShouldMatchTheCliSpelling()
+        => Assert.Equal("--printenv", PrintEnvironmentCommandFactory.OptionName);
+
+    /// <summary>
+    /// The command quotes every path, because a shell parses the whole string and paths routinely contain
+    /// spaces.
+    /// </summary>
+    [Fact]
+    public void TryCreate_WithPathContainingSpaces_ShouldQuoteIt()
+    {
+        var directory = Path.Combine(_root, "Program Files");
+        Directory.CreateDirectory(directory);
+        var executable = Path.Combine(directory, "salmon-egg");
+        File.WriteAllText(executable, string.Empty);
+
+        var command = PrintEnvironmentCommandFactory.TryCreate(executable)!("MARK");
+
+        Assert.Contains("'" + executable + "'", command, StringComparison.Ordinal);
+        Assert.Contains("'--printenv=MARK'", command, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryCreate_WithoutAnExecutable_ShouldReturnNull(string? executable)
+        => Assert.Null(PrintEnvironmentCommandFactory.TryCreate(executable));
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
@@ -59,13 +59,10 @@ internal sealed class StubAcpExecutableProbe : IAcpExecutableProbe
         CancellationToken cancellationToken = default)
         => Task.FromResult<string?>(null);
 
-    public Task<AcpPackageQueryResult> LocateGlobalNodePackageAsync(
+    public Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+        AcpDistributionKind distribution,
         string packageId,
-        CancellationToken cancellationToken = default)
-        => Task.FromResult(AcpPackageQueryResult.Unknown());
-
-    public Task<AcpPackageQueryResult> LocateGlobalUvToolAsync(
-        string packageId,
+        AcpPackageManagerCandidates packageManager,
         CancellationToken cancellationToken = default)
         => Task.FromResult(AcpPackageQueryResult.Unknown());
 }

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using SalmonEgg.Domain.Models.AcpSetup;
@@ -55,8 +56,13 @@ public sealed class DesktopAcpComponentInstallerTests
         Assert.Contains("PATH", result.ErrorDetail);
     }
 
+    /// <summary>
+    /// The component's own launcher is resolved before the manager, because the manager is derived from
+    /// the launcher's directory: a user who names <c>npx</c> has named which toolchain's <c>npm</c> to
+    /// install through, and deriving that needs the launcher's real path.
+    /// </summary>
     [Fact]
-    public async Task InstallAsync_ForNpxDistribution_ShouldResolveNpmLauncher()
+    public async Task InstallAsync_ForNpxDistribution_ShouldResolveTheLauncherThenNpm()
     {
         var probe = new StubAcpExecutableProbe();
         probe.SetResolvedPath("npm", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
@@ -64,14 +70,14 @@ public sealed class DesktopAcpComponentInstallerTests
 
         var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent());
 
-        Assert.Equal(new[] { "npm" }, probe.ResolveRequests);
+        Assert.Equal(new[] { "npx", "npm" }, probe.ResolveRequests);
         // The resolved path does not exist, so the attempt fails at start rather than reporting success.
         Assert.False(result.IsSuccess);
         Assert.NotNull(result.ErrorDetail);
     }
 
     [Fact]
-    public async Task InstallAsync_ForUvxDistribution_ShouldResolveUvLauncher()
+    public async Task InstallAsync_ForUvxDistribution_ShouldResolveTheLauncherThenUv()
     {
         var probe = new StubAcpExecutableProbe();
         probe.SetResolvedPath("uv", null);
@@ -79,8 +85,61 @@ public sealed class DesktopAcpComponentInstallerTests
 
         var result = await installer.InstallAsync(AcpSetupFixtures.UvxComponent());
 
-        Assert.Equal(new[] { "uv" }, probe.ResolveRequests);
+        Assert.Equal(new[] { "uvx", "uv" }, probe.ResolveRequests);
         Assert.False(result.IsSuccess);
+    }
+
+    /// <summary>
+    /// The install must run through the toolchain the user named, not through whatever bare <c>npm</c>
+    /// the inherited PATH resolves.
+    /// </summary>
+    /// <remarks>
+    /// Installing into the wrong toolchain is worse than failing: npm reports success, and the component
+    /// lands where the next probe and the saved profile will never look — so the wizard advances on a
+    /// success that guarantees a launch failure. A GUI process is exactly where the two diverge, since it
+    /// cannot see the PATH a shell profile builds.
+    /// </remarks>
+    [Fact]
+    public async Task InstallAsync_WithOverriddenLauncher_ShouldInstallThroughThatToolchainsNpm()
+    {
+        const string toolchainBin = "/opt/toolchain/node/bin";
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath(toolchainBin + "/npx", toolchainBin + "/npx");
+        probe.SetResolvedPath(toolchainBin + "/npm", toolchainBin + "/npm");
+        var installer = new DesktopAcpComponentInstaller(probe);
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["npx"] = toolchainBin + "/npx"
+        });
+
+        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides);
+
+        Assert.Equal(
+            new[] { toolchainBin + "/npx", toolchainBin + "/npm" },
+            probe.ResolveRequests);
+    }
+
+    /// <summary>
+    /// An explicit manager override wins over the sibling derivation, since the derivation exists to
+    /// spare the user a second answer rather than to overrule one they gave.
+    /// </summary>
+    [Fact]
+    public async Task InstallAsync_WithExplicitManagerOverride_ShouldPreferItOverTheSibling()
+    {
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath("/opt/node/bin/npx", "/opt/node/bin/npx");
+        probe.SetResolvedPath("/elsewhere/bin/npm", "/elsewhere/bin/npm");
+        var installer = new DesktopAcpComponentInstaller(probe);
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["npx"] = "/opt/node/bin/npx",
+            ["npm"] = "/elsewhere/bin/npm"
+        });
+
+        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides);
+
+        Assert.Contains("/elsewhere/bin/npm", probe.ResolveRequests);
+        Assert.DoesNotContain("/opt/node/bin/npm", probe.ResolveRequests);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
@@ -24,7 +24,7 @@ public sealed class DesktopAcpComponentInstallerTests
     {
         var installer = new DesktopAcpComponentInstaller(new StubAcpExecutableProbe());
 
-        await Assert.ThrowsAsync<ArgumentNullException>(() => installer.InstallAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => installer.InstallAsync(null!, onOutput: null, overrides: null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public sealed class DesktopAcpComponentInstallerTests
         var probe = new StubAcpExecutableProbe();
         var installer = new DesktopAcpComponentInstaller(probe);
 
-        var result = await installer.InstallAsync(AcpSetupFixtures.BinaryComponent());
+        var result = await installer.InstallAsync(AcpSetupFixtures.BinaryComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.ExitCode);
@@ -48,7 +48,7 @@ public sealed class DesktopAcpComponentInstallerTests
         probe.SetResolvedPath("npm", null);
         var installer = new DesktopAcpComponentInstaller(probe);
 
-        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent());
+        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.ExitCode);
@@ -68,7 +68,7 @@ public sealed class DesktopAcpComponentInstallerTests
         probe.SetResolvedPath("npm", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
         var installer = new DesktopAcpComponentInstaller(probe);
 
-        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent());
+        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { "npx", "npm" }, probe.ResolveRequests);
         // The resolved path does not exist, so the attempt fails at start rather than reporting success.
@@ -83,7 +83,7 @@ public sealed class DesktopAcpComponentInstallerTests
         probe.SetResolvedPath("uv", null);
         var installer = new DesktopAcpComponentInstaller(probe);
 
-        var result = await installer.InstallAsync(AcpSetupFixtures.UvxComponent());
+        var result = await installer.InstallAsync(AcpSetupFixtures.UvxComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { "uvx", "uv" }, probe.ResolveRequests);
         Assert.False(result.IsSuccess);
@@ -112,7 +112,7 @@ public sealed class DesktopAcpComponentInstallerTests
             ["npx"] = toolchainBin + "/npx"
         });
 
-        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides);
+        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides, TestContext.Current.CancellationToken);
 
         Assert.Equal(
             new[] { toolchainBin + "/npx", toolchainBin + "/npm" },
@@ -136,7 +136,7 @@ public sealed class DesktopAcpComponentInstallerTests
             ["npm"] = "/elsewhere/bin/npm"
         });
 
-        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides);
+        await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides, TestContext.Current.CancellationToken);
 
         Assert.Contains("/elsewhere/bin/npm", probe.ResolveRequests);
         Assert.DoesNotContain("/opt/node/bin/npm", probe.ResolveRequests);
@@ -155,7 +155,7 @@ public sealed class DesktopAcpComponentInstallerTests
         var probe = new StubAcpExecutableProbe();
         var installer = new DesktopAcpComponentInstaller(probe);
 
-        var result = await installer.InstallAsync(component);
+        var result = await installer.InstallAsync(component, onOutput: null, overrides: null, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Empty(probe.ResolveRequests);

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
 using SalmonEgg.Infrastructure.Desktop.AcpSetup;
 using Xunit;
 
@@ -101,10 +102,13 @@ public sealed class DesktopAcpExecutableProbeTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task LocateGlobalNodePackageAsync_WithBlankPackageId_ShouldReturnUnknown(string packageId)
+    public async Task LocateGlobalPackageAsync_WithBlankNodePackageId_ShouldReturnUnknown(string packageId)
     {
-        var installed = await new DesktopAcpExecutableProbe()
-            .LocateGlobalNodePackageAsync(packageId, TestContext.Current.CancellationToken);
+        var installed = await new DesktopAcpExecutableProbe().LocateGlobalPackageAsync(
+            AcpDistributionKind.Npx,
+            packageId,
+            AcpPackageManagerCandidates.Exact("npm"),
+            TestContext.Current.CancellationToken);
 
         Assert.Null(installed.IsInstalled);
     }
@@ -112,10 +116,32 @@ public sealed class DesktopAcpExecutableProbeTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task LocateGlobalUvToolAsync_WithBlankPackageId_ShouldReturnUnknown(string packageId)
+    public async Task LocateGlobalPackageAsync_WithBlankUvToolId_ShouldReturnUnknown(string packageId)
     {
-        var installed = await new DesktopAcpExecutableProbe()
-            .LocateGlobalUvToolAsync(packageId, TestContext.Current.CancellationToken);
+        var installed = await new DesktopAcpExecutableProbe().LocateGlobalPackageAsync(
+            AcpDistributionKind.Uvx,
+            packageId,
+            AcpPackageManagerCandidates.Exact("uv"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(installed.IsInstalled);
+    }
+
+    /// <summary>
+    /// A distribution with no package manager has nothing to ask, so the query is unanswerable rather
+    /// than absent — the same rule that keeps an unreachable manager from reading as "not installed".
+    /// </summary>
+    [Theory]
+    [InlineData(AcpDistributionKind.BuiltIn)]
+    [InlineData(AcpDistributionKind.Binary)]
+    public async Task LocateGlobalPackageAsync_WithNonPackageDistribution_ShouldReturnUnknown(
+        AcpDistributionKind distribution)
+    {
+        var installed = await new DesktopAcpExecutableProbe().LocateGlobalPackageAsync(
+            distribution,
+            "some-package",
+            AcpPackageManagerCandidates.Exact("npm"),
+            TestContext.Current.CancellationToken);
 
         Assert.Null(installed.IsInstalled);
     }

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the source that turns a captured shell environment into search directories.
+/// </summary>
+/// <remarks>
+/// This is the only route to a version manager implemented as a shell function — nvm ships no executable,
+/// so nothing on disk reveals the node it activated. The contracts worth pinning down are that the
+/// capture happens at most once (an interactive login shell is expensive, and the wizard probes many
+/// components), that PATH order survives, and that every failure is silent rather than fatal.
+/// </remarks>
+public sealed class LoginShellSearchPathSourceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "login-shell-source-" + Guid.NewGuid().ToString("N"));
+
+    public LoginShellSearchPathSourceTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The captured PATH becomes the search directories, in the order the shell reported — the first entry
+    /// is what the user's own terminal would run.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithCapturedPath_ShouldPreserveShellOrder()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell();
+        var source = new LoginShellSearchPathSource(
+            marker => marker + """{"PATH":"/first:/second:/third"}""" + marker,
+            () => shell);
+
+        var directories = await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(new[] { "/first", "/second", "/third" }, directories);
+    }
+
+    /// <summary>
+    /// Captured at most once. Spawning an interactive login shell runs the user's startup files and
+    /// routinely takes seconds; repeating that for every component the wizard probes would multiply the
+    /// cost for an answer that does not change while the app runs.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_CalledRepeatedly_ShouldCaptureOnce()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell();
+        var captures = 0;
+        var source = new LoginShellSearchPathSource(
+            marker =>
+            {
+                Interlocked.Increment(ref captures);
+                return marker + """{"PATH":"/once"}""" + marker;
+            },
+            () => shell);
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            Assert.Equal(new[] { "/once" }, await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+        }
+
+        Assert.Equal(1, captures);
+    }
+
+    /// <summary>
+    /// Concurrent callers share one capture. The wizard probes components in parallel elsewhere, and a
+    /// second interactive shell is exactly the cost the cache exists to avoid.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_FromConcurrentCallers_ShouldCaptureOnce()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell();
+        var captures = 0;
+        var source = new LoginShellSearchPathSource(
+            marker =>
+            {
+                Interlocked.Increment(ref captures);
+                return marker + """{"PATH":"/shared"}""" + marker;
+            },
+            () => shell);
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ =>
+                source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken)));
+
+        Assert.All(results, directories => Assert.Equal(new[] { "/shared" }, directories));
+        Assert.Equal(1, captures);
+    }
+
+    /// <summary>
+    /// A shell that cannot be determined contributes nothing rather than failing. The inherited PATH is
+    /// still there, so the wizard degrades to the behaviour it had before this source existed.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithNoShell_ShouldReturnEmpty()
+    {
+        var source = new LoginShellSearchPathSource(
+            marker => marker + "{}" + marker,
+            () => null);
+
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>A capture that fails is silent, for the same reason.</summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WhenCaptureFails_ShouldReturnEmpty()
+    {
+        var source = new LoginShellSearchPathSource(
+            marker => marker + "{}" + marker,
+            () => Path.Combine(_root, "does-not-exist"));
+
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// An environment without PATH contributes nothing. A shell can report an environment that simply has
+    /// no PATH, and inventing directories from that would be worse than adding none.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WhenCapturedEnvironmentHasNoPath_ShouldReturnEmpty()
+    {
+        SkipOnWindows();
+
+        var source = new LoginShellSearchPathSource(
+            marker => marker + """{"HOME":"/home/someone"}""" + marker,
+            () => CreateShell());
+
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Constructor_WithNullCommandFactory_ShouldThrow()
+        => Assert.Throws<ArgumentNullException>(() => new LoginShellSearchPathSource(null!));
+
+    /// <summary>A fake shell that echoes the command it was handed, which carries the payload.</summary>
+    private string CreateShell()
+    {
+        var path = Path.Combine(_root, "shell-" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(path, "#!/bin/sh\nprintf '%s' \"$4\"\n");
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        return path;
+    }
+
+    private static void SkipOnWindows()
+        => Assert.SkipWhen(OperatingSystem.IsWindows(), "The fake shell is a POSIX script.");
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
@@ -157,11 +157,14 @@ public sealed class LoginShellSearchPathSourceTests : IDisposable
     {
         var path = Path.Combine(_root, "shell-" + Guid.NewGuid().ToString("N"));
         File.WriteAllText(path, "#!/bin/sh\nprintf '%s' \"$4\"\n");
-        File.SetUnixFileMode(
-            path,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
         return path;
     }
 

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ShellEnvironmentCaptureTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ShellEnvironmentCaptureTests.cs
@@ -258,11 +258,14 @@ public sealed class ShellEnvironmentCaptureTests : IDisposable
     {
         var path = Path.Combine(_root, "fake-shell-" + Guid.NewGuid().ToString("N"));
         File.WriteAllText(path, script);
-        File.SetUnixFileMode(
-            path,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
         return path;
     }
 

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ShellEnvironmentCaptureTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ShellEnvironmentCaptureTests.cs
@@ -1,0 +1,271 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the capture of a user's shell environment against the ways real startup files misbehave.
+/// </summary>
+/// <remarks>
+/// A user's rc files are arbitrary code this app does not control. In the wild they block on input, print
+/// banners onto the same stdout the payload uses, and exit non-zero while still having produced a usable
+/// environment. Each test here pins one of those down, because the failure mode of getting it wrong is
+/// silent: the wizard reports every component missing and blames the machine.
+/// </remarks>
+public sealed class ShellEnvironmentCaptureTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "shell-capture-" + Guid.NewGuid().ToString("N"));
+
+    public ShellEnvironmentCaptureTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    /// <summary>The straightforward case: a shell that prints the payload yields the environment.</summary>
+    [Fact]
+    public async Task CaptureAsync_WithCooperativeShell_ShouldReturnTheEnvironment()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            # $4 is the command, matching the POSIX invocation `-l -i -c <command>`.
+            printf '%s' "$4"
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + """{"PATH":"/from/shell"}""" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("/from/shell", captured["PATH"]);
+    }
+
+    /// <summary>
+    /// A startup file that reads from stdin must not hang the capture. Verified interactively: the same
+    /// shell blocks indefinitely when stdin stays open, and returns at once when it is closed.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_WhenShellReadsStdin_ShouldNotHang()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            read -r ignored
+            printf '%s' "$4"
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + """{"PATH":"/read-then-print"}""" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("/read-then-print", captured["PATH"]);
+    }
+
+    /// <summary>
+    /// A shell that never exits is abandoned at the timeout rather than blocking the wizard forever.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_WhenShellNeverExits_ShouldGiveUpAtTheTimeout()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            sleep 600
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + "{}" + marker,
+            timeout: TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(captured);
+    }
+
+    /// <summary>
+    /// Banners and colour codes around the payload are ordinary, so the marker has to locate it rather
+    /// than stdout being assumed to be the payload.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_WithNoisyStartupFiles_ShouldStillFindThePayload()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            printf 'Welcome to your shell!\n'
+            printf '\033[32mnvm: now using node v24\033[0m\n'
+            printf '%s' "$4"
+            printf '\nHave a nice day\n'
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + """{"PATH":"/despite/noise"}""" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("/despite/noise", captured["PATH"]);
+    }
+
+    /// <summary>
+    /// A non-zero exit does not discard a payload that parsed. rc-file failures are common and unrelated
+    /// to whether the environment was reported.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_WhenShellExitsNonZero_ShouldStillUseThePayload()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            printf '%s' "$4"
+            exit 3
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + """{"PATH":"/nonzero/exit"}""" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("/nonzero/exit", captured["PATH"]);
+    }
+
+    /// <summary>
+    /// The guard variable reaches the child, so a user can make their startup files skip work that would
+    /// hang or pollute a capture.
+    /// </summary>
+    /// <remarks>
+    /// The fake shell cuts the marker out of the command text it was handed and builds the payload around
+    /// the guard's value, so the assertion is that the variable was set in the <em>child's</em>
+    /// environment rather than merely present in this process. Built by the shell rather than through
+    /// <c>eval</c> of the supplied command, because eval would strip the JSON's quotes.
+    /// </remarks>
+    [Fact]
+    public async Task CaptureAsync_ShouldSetTheGuardVariableForTheChild()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            command="$4"
+            marker="${command%%PLACEHOLDER*}"
+            printf '%s{"PATH":"%s"}%s' "$marker" "$SALMONEGG_RESOLVING_ENVIRONMENT" "$marker"
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + "PLACEHOLDER" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("1", captured["PATH"]);
+    }
+
+    /// <summary>A shell that cannot be started is a failed capture, not a crash.</summary>
+    [Fact]
+    public async Task CaptureAsync_WithMissingShell_ShouldReturnNull()
+    {
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            Path.Combine(_root, "does-not-exist"),
+            marker => marker + "{}" + marker,
+            timeout: TimeSpan.FromSeconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(captured);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CaptureAsync_WithBlankShellPath_ShouldReturnNull(string shellPath)
+    {
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shellPath,
+            marker => marker + "{}" + marker,
+            timeout: TimeSpan.FromSeconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(captured);
+    }
+
+    /// <summary>
+    /// A shell that printed nothing recognizable yields null rather than an empty environment, so the
+    /// caller falls back to the inherited PATH instead of treating "nothing" as an answer.
+    /// </summary>
+    [Fact]
+    public async Task CaptureAsync_WhenPayloadIsAbsent_ShouldReturnNull()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell("""
+            #!/bin/sh
+            printf 'no payload here\n'
+            """);
+
+        var captured = await ShellEnvironmentCapture.CaptureAsync(
+            shell,
+            marker => marker + "{}" + marker,
+            timeout: TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(captured);
+    }
+
+    [Fact]
+    public void ExtractEnvironment_WithMarkerInsideAValue_ShouldNotTruncateThePayload()
+    {
+        const string marker = "MK";
+        var extracted = ShellEnvironmentCapture.ExtractEnvironment(
+            marker + """{"A":"contains MK inside","PATH":"/tail"}""" + marker,
+            marker);
+
+        Assert.NotNull(extracted);
+        Assert.Equal("/tail", extracted["PATH"]);
+    }
+
+    [Theory]
+    [InlineData("", "MK")]
+    [InlineData("MK{}", "MK")]
+    [InlineData("MKnot-jsonMK", "MK")]
+    [InlineData("no marker at all", "MK")]
+    public void ExtractEnvironment_WithUnusableOutput_ShouldReturnNull(string output, string marker)
+        => Assert.Null(ShellEnvironmentCapture.ExtractEnvironment(output, marker));
+
+    private string CreateShell(string script)
+    {
+        var path = Path.Combine(_root, "fake-shell-" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(path, script);
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        return path;
+    }
+
+    private static void SkipOnWindows()
+        => Assert.SkipWhen(OperatingSystem.IsWindows(), "The fake shells are POSIX scripts.");
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ToolchainScanSearchPathSourceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ToolchainScanSearchPathSourceTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// Guards the on-disk scan that reveals toolchain versions the user has not activated.
+/// </summary>
+/// <remarks>
+/// A version manager puts only its current version on PATH, so capturing the shell environment reports one
+/// node however many are installed. This source supplies the rest, which is what lets the wizard say an
+/// agent exists under a version the user is not currently using — otherwise indistinguishable from not
+/// having it at all.
+/// </remarks>
+public sealed class ToolchainScanSearchPathSourceTests : IDisposable
+{
+    private readonly string _home = Path.Combine(
+        Path.GetTempPath(),
+        "toolchain-scan-" + Guid.NewGuid().ToString("N"));
+
+    public ToolchainScanSearchPathSourceTests() => Directory.CreateDirectory(_home);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_home))
+        {
+            Directory.Delete(_home, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The point of the source: every installed version is reported, not only the active one.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithSeveralVersions_ShouldReportAllOfThem()
+    {
+        var expected = new[]
+        {
+            CreateDirectory("versions", "v18.0.0", "bin"),
+            CreateDirectory("versions", "v20.1.0", "bin"),
+            CreateDirectory("versions", "v24.14.1", "bin")
+        };
+
+        var directories = await ScanAsync(VersionedLayout());
+
+        Assert.Equal(expected.Length, directories.Count);
+        Assert.All(expected, path => Assert.Contains(path, directories));
+    }
+
+    /// <summary>
+    /// Newest first, so the user is not made to read a list to find the version they most likely want.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithSeveralVersions_ShouldOfferNewestFirst()
+    {
+        CreateDirectory("versions", "v18.0.0", "bin");
+        CreateDirectory("versions", "v20.1.0", "bin");
+        var newest = CreateDirectory("versions", "v24.14.1", "bin");
+
+        var directories = await ScanAsync(VersionedLayout());
+
+        Assert.Equal(newest, directories[0]);
+    }
+
+    /// <summary>
+    /// A version directory without the expected bin subdirectory is skipped: it is a partial install, and
+    /// naming a directory that holds no executables would offer the user a candidate that cannot run.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WhenVersionHasNoBinDirectory_ShouldSkipIt()
+    {
+        var complete = CreateDirectory("versions", "v20.0.0", "bin");
+        CreateDirectory("versions", "v21.0.0");
+
+        var directories = await ScanAsync(VersionedLayout());
+
+        Assert.Equal(complete, Assert.Single(directories));
+    }
+
+    /// <summary>A layout whose directories do not exist contributes nothing rather than failing.</summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithAbsentLayout_ShouldReturnEmpty()
+        => Assert.Empty(await ScanAsync(VersionedLayout()));
+
+    /// <summary>A fixed layout is reported when present, without wildcard expansion.</summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithFixedLayout_ShouldReportTheDirectory()
+    {
+        var shims = CreateDirectory("shims");
+
+        var directories = await ScanAsync(FixedLayout("shims"));
+
+        Assert.Equal(shims, Assert.Single(directories));
+    }
+
+    /// <summary>
+    /// Layout order is preserved, because it encodes precedence: a version manager outranks a system
+    /// directory, mirroring how a shell's PATH is built.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithSeveralLayouts_ShouldPreserveLayoutOrder()
+    {
+        var first = CreateDirectory("first");
+        var second = CreateDirectory("second");
+
+        var directories = await ScanAsync(FixedLayout("first"), FixedLayout("second"));
+
+        Assert.Equal(new[] { first, second }, directories);
+    }
+
+    /// <summary>
+    /// One directory reached by two layouts is reported once. Overlap is ordinary — ~/.local/bin is both a
+    /// manager target and a general per-user directory — and a duplicate would offer the user a choice
+    /// between a path and itself.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithOverlappingLayouts_ShouldDeduplicate()
+    {
+        var shared = CreateDirectory("shared");
+
+        var directories = await ScanAsync(FixedLayout("shared"), FixedLayout("shared"));
+
+        Assert.Equal(shared, Assert.Single(directories));
+    }
+
+    /// <summary>
+    /// Scanned once. The filesystem shape does not change while the wizard runs, and it probes many
+    /// components.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_CalledRepeatedly_ShouldReturnTheSameInstance()
+    {
+        CreateDirectory("shims");
+        var source = new ToolchainScanSearchPathSource(new[] { FixedLayout("shims") });
+
+        var first = await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+        var second = await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Same(first, second);
+    }
+
+    /// <summary>
+    /// The Windows-only root contributes nothing elsewhere. It must not silently resolve against the
+    /// process working directory, which is what an empty base path would do.
+    /// </summary>
+    [Fact]
+    public async Task GetSearchDirectoriesAsync_WithWindowsOnlyRoot_ShouldContributeNothingOffWindows()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The assertion is about non-Windows platforms.");
+
+        var source = new ToolchainScanSearchPathSource(new[]
+        {
+            LayoutFor(AcpToolchainLayoutRoot.WindowsRoamingAppData, "npm")
+        });
+
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>The shipped layout list is data the wizard depends on, so it must not be empty.</summary>
+    [Fact]
+    public void Known_ShouldDeclareLayouts()
+    {
+        Assert.NotEmpty(AcpToolchainLayout.Known);
+        Assert.Contains(AcpToolchainLayout.Known, layout => layout.IsVersioned);
+        Assert.Contains(AcpToolchainLayout.Known, layout => !layout.IsVersioned);
+    }
+
+    /// <summary>
+    /// A second wildcard is refused at declaration. Expansion resolves exactly one version directory, so
+    /// accepting it would silently yield no directories instead of naming the authoring mistake.
+    /// </summary>
+    [Fact]
+    public void Create_WithTwoWildcards_ShouldThrow()
+        => Assert.Throws<ArgumentException>(() => AcpToolchainLayout.Create(
+            AcpToolchainLayoutRoot.UserHome,
+            "a",
+            AcpToolchainLayout.VersionWildcard,
+            "b",
+            AcpToolchainLayout.VersionWildcard));
+
+    private async Task<IReadOnlyList<string>> ScanAsync(params AcpToolchainLayout[] layouts)
+        => await new ToolchainScanSearchPathSource(layouts)
+            .GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+
+    /// <summary>A versioned layout rooted at this test's temporary home.</summary>
+    private AcpToolchainLayout VersionedLayout()
+        => LayoutFor(AcpToolchainLayoutRoot.Absolute, Path.Combine(_home, "versions"), AcpToolchainLayout.VersionWildcard, "bin");
+
+    private AcpToolchainLayout FixedLayout(params string[] segments)
+        => LayoutFor(AcpToolchainLayoutRoot.Absolute, Path.Combine(new[] { _home }.Concat(segments).ToArray()));
+
+    private static AcpToolchainLayout LayoutFor(AcpToolchainLayoutRoot root, params string[] segments)
+        => AcpToolchainLayout.Create(root, segments);
+
+    private string CreateDirectory(params string[] segments)
+    {
+        var path = Path.Combine(new[] { _home }.Concat(segments).ToArray());
+        Directory.CreateDirectory(path);
+        return Path.GetFullPath(path);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/UnsupportedAcpSetupTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/UnsupportedAcpSetupTests.cs
@@ -26,8 +26,16 @@ public sealed class UnsupportedAcpSetupTests
 
         Assert.Null(await probe.ResolveExecutablePathAsync("npx", TestContext.Current.CancellationToken));
         Assert.Null(await probe.ReadVersionAsync("npx", new[] { "--version" }, TestContext.Current.CancellationToken));
-        Assert.Null((await probe.LocateGlobalNodePackageAsync("@scope/pkg", TestContext.Current.CancellationToken)).IsInstalled);
-        Assert.Null((await probe.LocateGlobalUvToolAsync("tool", TestContext.Current.CancellationToken)).IsInstalled);
+        Assert.Null((await probe.LocateGlobalPackageAsync(
+            AcpDistributionKind.Npx,
+            "@scope/pkg",
+            AcpPackageManagerCandidates.Exact("npm"),
+            TestContext.Current.CancellationToken)).IsInstalled);
+        Assert.Null((await probe.LocateGlobalPackageAsync(
+            AcpDistributionKind.Uvx,
+            "tool",
+            AcpPackageManagerCandidates.Exact("uv"),
+            TestContext.Current.CancellationToken)).IsInstalled);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -96,31 +96,33 @@ internal sealed class StubExecutableProbe : IAcpExecutableProbe
         CancellationToken cancellationToken = default)
         => Task.FromResult(_versions.TryGetValue(command, out var version) ? version : null);
 
-    public Task<AcpPackageQueryResult> LocateGlobalNodePackageAsync(
-        string packageId,
-        CancellationToken cancellationToken = default)
-        => Task.FromResult(
-            _nodePackages.TryGetValue(packageId, out var installed)
-                ? installed switch
-                {
-                    true => AcpPackageQueryResult.Found("/test/node_modules", "/test/bin/npm"),
-                    false => AcpPackageQueryResult.Absent("/test/bin/npm"),
-                    null => AcpPackageQueryResult.Unknown()
-                }
-                : AcpPackageQueryResult.Unknown());
+    /// <summary>The package manager each query was asked through, in call order.</summary>
+    public List<string> QueriedPackageManagers { get; } = new();
 
-    public Task<AcpPackageQueryResult> LocateGlobalUvToolAsync(
+    public Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+        AcpDistributionKind distribution,
         string packageId,
+        AcpPackageManagerCandidates packageManager,
         CancellationToken cancellationToken = default)
-        => Task.FromResult(
-            _uvTools.TryGetValue(packageId, out var installed)
+    {
+        QueriedPackageManagers.Add(packageManager.Preferred);
+
+        var (catalog, location, manager) = distribution switch
+        {
+            AcpDistributionKind.Uvx => (_uvTools, "/test/uv-tools", "/test/bin/uv"),
+            _ => (_nodePackages, "/test/node_modules", "/test/bin/npm")
+        };
+
+        return Task.FromResult(
+            catalog.TryGetValue(packageId, out var installed)
                 ? installed switch
                 {
-                    true => AcpPackageQueryResult.Found("/test/uv-tools", "/test/bin/uv"),
-                    false => AcpPackageQueryResult.Absent("/test/bin/uv"),
+                    true => AcpPackageQueryResult.Found(location, manager),
+                    false => AcpPackageQueryResult.Absent(manager),
                     null => AcpPackageQueryResult.Unknown()
                 }
                 : AcpPackageQueryResult.Unknown());
+    }
 }
 
 /// <summary>
@@ -152,12 +154,20 @@ internal sealed class StubComponentInstaller : IAcpComponentInstaller
 
     public List<string> OutputLines { get; } = new();
 
+    /// <summary>
+    /// The overrides each install was given, so a test can prove the install runs through the toolchain
+    /// the user named rather than whatever PATH resolves.
+    /// </summary>
+    public List<AcpCommandOverrides?> ReceivedOverrides { get; } = new();
+
     public Task<AcpComponentInstallResult> InstallAsync(
         AcpComponentDescriptor component,
         Action<string>? onOutput = null,
+        AcpCommandOverrides? overrides = null,
         CancellationToken cancellationToken = default)
     {
         InstalledComponentIds.Add(component.Id);
+        ReceivedOverrides.Add(overrides);
         foreach (var line in OutputLines)
         {
             onOutput?.Invoke(line);


### PR DESCRIPTION
## 背景

用户报告 ACP 配置向导检测不到已安装的 adapter。排查后确认是两类问题，第一类不存在，第二类是真缺陷且有三层。

**适配器命令没有写错。** 8 个 agent 逐条对照官方 registry（`cdn.agentclientprotocol.com/registry/v1/latest/registry.json`）与各 CLI 的实际 `--help`，命令与参数全部正确。注意代码注释里写的 registry 路径 `registry/v1` 会 404，真实路径多一层 `latest/`。

**真正的根因是 GUI 进程拿不到用户的 shell PATH。** 从桌面图标、Finder、`.desktop` 启动的进程继承的是会话环境，不是 shell profile 构建的那份，所以 nvm / fnm / volta / asdf 这类版本管理器的工具链对它完全不可见。

本机实测，同一台装了 4 个 agent 的机器：

| 运行环境 | 检测结果 |
|---|---|
| 终端（有 shell PATH） | 4 个全部 Installed |
| GUI 会话 PATH | **8 个全部 Missing** |

## 三层缺陷

**① 用户填了绝对路径也没用**（`7faf541c`）

向导本来留了"手填路径"作兜底，但这条路当时是断的：所有 npm 装的 CLI 开头都是 `#!/usr/bin/env node`，填了 `gemini` 的绝对路径后它自己能解析，但它要用的 `node` 仍在 PATH 之外，直接 exit 127。

修法是把启动器所在目录 prepend 到子进程 PATH。顺带把散在 `StdioTransport` 里的 `.cmd`/`.bat` 处理抽成共用的 `LauncherInvocation`，检测侧与聊天主链路走同一套规则 —— Windows 上 npm 把每个 CLI 都装成 `.cmd` shim，而 `UseShellExecute=false`（重定向 stdio 的前提）时 `CreateProcess` 起不了批处理文件。

**② 检测问错了包管理器**（`266a1622`）

`npm` / `uv` 被写死成裸名，由 PATH 解析决定问谁 —— 恰恰不会是用户刚指定的工具链。而两者产生分歧的唯一场合，正是用户为绕开"GUI 看不见工具链"才去填路径的时候，所以补救功能自己把自己废掉了。

安装那条更糟：npm 会报成功，但装进了另一个工具链，下一次检测和保存的配置都不去那儿看 —— 向导一路绿灯，启动必失败。

修法是让调用方决定管理器。关键洞察是**不需要多问用户一次**：`npm` 和 `npx` 来自同一个 npm 包同一个 bin 目录，`uv` 和 `uvx` 也是官方安装器并排放的，指定一个等于指定另一个。用户显式填了 `npm` 则以他的为准；推导路径不存在（孤立 shim）则回退裸名。

**③ 根上：从来没有捞回真实 PATH 的能力**（`b5aa0d2a` … `07ae63b4`）

前两条都是这一条的症状。

## 方案

调研了 VS Code（`shellEnv.ts`）、Zed（`util/src/shell_env.rs`）、JetBrains（`EnvironmentUtil`）的实现，三家做法完全收敛，且都是自己实现 —— NuGet 上没有对口的轮子（六组关键词查证过；Node 生态有 `shell-env`/`fix-path`，.NET 没有）。原因是这活儿必须调用**自己的**可执行文件打印环境，天然做不成通用库。

采用**两条腿**，各自补对方的死角：

1. **登录 shell 捞取** —— 拿到用户当前激活的工具链。这是访问 shell 函数型版本管理器的唯一途径：nvm 磁盘上没有可执行文件（`command -v nvm` 什么都没有，只有 `nvm.sh`），扫目录永远发现不了它激活的 node。
2. **磁盘布局扫描** —— 拿到**全部**已装版本。版本管理器只把 current 放进 PATH，所以捞 shell 只能报一个。这是"检测多版本"的原料，也是 Windows 上唯一可用的手段。

两者汇入已有的多候选枚举。

## 关键实现决策

**`-i` 不是可选的。** 本机 nvm 装在 `.bashrc`（其安装器就是这么写的），而 Debian 的 stock `.bashrc` 开头有非交互提前返回。实测 `bash -l -c` 找不到 npm，`bash -l -i -c` 能找到。三家都为此接受交互式 shell 更慢更吵的代价。

**防护全部照抄成熟方案**，每条都有实测依据：

- `stdin` 关闭 —— 否则读输入的 rc 文件永久挂起（调研时我自己那条测试命令就挂死了 120 秒）
- 超时 + 杀整个进程树 —— 登录 shell 会起子进程
- 随机标记界定 payload —— rc 文件往同一个 stdout 打横幅和颜色码；随机是因为打印的是自己的环境，固定标记可能出现在某个变量值里
- 非零退出不丢弃已解析的 payload —— rc 报错很常见，与环境是否报告无关
- 失败静默降级回继承的 PATH —— 丢掉捞取是回到现状，卡住向导比原问题更糟
- 发布逃逸变量 `SALMONEGG_RESOLVING_ENVIRONMENT`，让用户能在 rc 里跳过 tmux 之类（VS Code 有对应物，Zed 缺这个被提了 issue）

**shell 家族分派**：fish 要 `emit fish_prompt`（asdf/direnv 挂在 prompt 事件上，不在 config.fish）、csh/tcsh 拒绝 `-l` 配 `-c`、nushell 拒绝非交互登录 shell、PowerShell 用词标志。未知 shell 按 POSIX 处理 —— 因为不认识一个名字就放弃用户的环境是更坏的失败。

**Windows 刻意不捞**：它的 PATH 在注册表、会话已经持有，`cmd.exe` 没有登录/交互启动文件，捞它等于花一个进程问自己已知的事。那里只有磁盘扫描一条腿。

## 分层

- **Domain**（纯决策、零 IO）：shell 家族分派、布局清单、包管理器选择
- **Infrastructure.Desktop**：跑进程、扫盘、超时
- 组合（"这台机器能用哪些来源、什么顺序"）收在 `AcpSearchPathSources`，DI 只调它 —— 因为"CLI 装没装"是部署事实

过程中把 `Path`/`File.Exists` 从 Domain 挪走了：那会是仓库首例引入 `System.IO`，破坏分层约束。

顺手消掉探针里两处几乎相同的 PATH 遍历。副产品是修好了 Windows 的 PATHEXT 优先级 —— 之前 `.exe` 在 PATH 靠后时会输给靠前的 `.cmd`，与 shell 行为不一致。

## 验证

**真机端到端**，同一台机器同一份 GUI 残缺环境：

| | 修复前 | 修复后 |
|---|---|---|
| 8 个 agent | 全部 Missing | 真实装的 4 个全 Installed |
| gemini / codex（在 nvm 里） | 找不到 | `~/.nvm/versions/node/v24.14.1/bin/...` |
| claude / codex adapter | Undetermined | Installed + 真实安装路径 |

两条腿都在干活：shell 捞回 21 个目录，扫盘补 5 个，均命中 nvm。

**反向验证**（每条都插探针证明非假绿，不靠绿灯自证）：

- 关掉 stdin 守卫 → 挂起测试失败，耗时从 2.5s 飙到 32s
- 关掉缓存 → 两个"只捞一次"测试失败
- 只报一个版本 → 多版本与 newest-first 测试失败
- 屏蔽 printenv 分支 → 三个行为测试失败
- 屏蔽包管理器推导 → 4 个守卫测试抛出探针异常，且推导路径正是断言值

**回归**：Domain 83 / Application 111 / CLI 95 / Infrastructure 687 / Presentation.Core 3224，全绿。Debug 与 Release 构建均 0 错误。

## 自查并修掉的三处

1. Windows 上 `cmd.exe` 会被当 POSIX 收到 `-l -i -c` → 改为 Windows 不捞
2. 为测试开的 `ForTesting` 后门 → 改为正常公开工厂，并在其中强制"至多一个通配符"不变量
3. 测试借进程环境偷传标记 → 改为 shell 从命令文本自取

## 平台前提

真机验证在 Linux + 真实 nvm 完成。macOS 与 Windows 的行为依据的是官方文档与三家实现，未在本机实测 —— 无对应硬件。fish / nushell / csh 的分派同理，本机没有装这些 shell。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
