### PR TITLE
refactor(discover): let the item container own session row chrome

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Discover/DiscoverSessionsPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Discover/DiscoverSessionsPage.xaml
@@ -19,19 +19,76 @@
         <converters:TransportTypeLocalizationConverter x:Key="TransportTypeLocalizationConverter"/>
         <converters:TransportTypeGlyphConverter x:Key="TransportTypeGlyphConverter"/>
 
-        <!-- Compact short-height default keeps touch-friendly row height (>=44) while
-             reclaiming vertical budget. Comfortable restores prior 104/10 marketing density. -->
+        <!-- Row metrics. Kept as resources (coding-standards 5.2) because the same values are
+             referenced from both container styles and the templates they lay out. -->
+        <Thickness x:Key="DiscoverSessionRowPadding">12,10</Thickness>
+        <Thickness x:Key="DiscoverProfileRowPadding">12,8</Thickness>
+        <Thickness x:Key="DiscoverListInset">12,0</Thickness>
+        <x:Double x:Key="DiscoverRowIconBadgeSize">32</x:Double>
+        <x:Double x:Key="DiscoverRowIconGlyphSize">16</x:Double>
+        <x:Double x:Key="DiscoverRowColumnSpacing">12</x:Double>
+        <x:Double x:Key="DiscoverRowTextSpacing">2</x:Double>
+        <x:Double x:Key="DiscoverRowMetaSpacing">4</x:Double>
+        <x:Double x:Key="DiscoverRowMetaGlyphSpacing">6</x:Double>
+        <x:Double x:Key="DiscoverRowMetaGlyphSize">12</x:Double>
+
+        <!-- Row chrome belongs to the item container, not to the DataTemplate: ListViewItemPresenter
+             renders PointerOver / Selected / Focus *beneath* the template, so an opaque Border in the
+             template would mask every native state. Fills are therefore left entirely to the default
+             ListViewItem style (that is what supplies the state brushes); these styles only set what
+             layout needs. Padding is template-bound to the presenter's ContentMargin, which is why
+             the templates below carry no padding of their own, and why row spacing needs no Margin.
+             Compact short-height default keeps touch-friendly row height (>=44) while reclaiming
+             vertical budget. Comfortable restores prior 104 marketing density. -->
         <Style x:Key="DiscoverSessionItemStyleCompact" TargetType="ListViewItem">
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="Margin" Value="0,0,0,6"/>
             <Setter Property="MinHeight" Value="80"/>
-            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Padding" Value="{StaticResource DiscoverSessionRowPadding}"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
         </Style>
         <Style x:Key="DiscoverSessionItemStyleComfortable" TargetType="ListViewItem">
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="Margin" Value="0,0,0,10"/>
             <Setter Property="MinHeight" Value="104"/>
-            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Padding" Value="{StaticResource DiscoverSessionRowPadding}"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+        </Style>
+
+        <!-- Profile rows are a single-selection master list: the container owns selection visuals,
+             so the template is layout only. -->
+        <Style x:Key="DiscoverProfileItemStyle" TargetType="ListViewItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Padding" Value="{StaticResource DiscoverProfileRowPadding}"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+        </Style>
+
+        <!-- Placeholder blocks for the loading skeletons. They stand in for text and controls that
+             have not arrived yet, so they use the Fluent subtle fills rather than an opacity-scaled
+             control brush, and their sizes match the real row parts they replace. -->
+        <Style x:Key="DiscoverSkeletonIconStyle" TargetType="Border">
+            <Setter Property="Width" Value="{StaticResource DiscoverRowIconBadgeSize}"/>
+            <Setter Property="Height" Value="{StaticResource DiscoverRowIconBadgeSize}"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="DiscoverSkeletonTitleStyle" TargetType="Border">
+            <Setter Property="Height" Value="14"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+        </Style>
+        <Style x:Key="DiscoverSkeletonDetailStyle" TargetType="Border">
+            <Setter Property="Height" Value="10"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+        </Style>
+        <Style x:Key="DiscoverSkeletonActionStyle" TargetType="Border">
+            <Setter Property="Width" Value="96"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
     </Page.Resources>
 
@@ -157,39 +214,36 @@
             <!-- Profiles List Area -->
             <Grid Grid.Row="1">
                 <!-- Skeleton View for Profiles -->
+                <!-- Profile skeleton rows mirror the loaded profile row (icon column + one text line)
+                     at the same container inset, so the list does not shift when data lands. -->
                 <StackPanel x:Name="LeftSkeletonPanel"
                     Visibility="{x:Bind ViewModel.ProfilesViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                    Padding="12" Spacing="12">
-                    <Border Padding="12" CornerRadius="8" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                        <Grid ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Border Width="36" Height="36" CornerRadius="18" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                            <Border Width="120" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                        </Grid>
-                    </Border>
-                    <Border Padding="12" CornerRadius="8" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                        <Grid ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Border Width="36" Height="36" CornerRadius="18" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                            <Border Width="150" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                        </Grid>
-                    </Border>
-                    <Border Padding="12" CornerRadius="8" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                        <Grid ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Border Width="36" Height="36" CornerRadius="18" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                            <Border Width="80" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                        </Grid>
-                    </Border>
+                    Padding="{StaticResource DiscoverListInset}"
+                    Spacing="{StaticResource DiscoverRowMetaSpacing}">
+                    <Grid Padding="{StaticResource DiscoverProfileRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                        <Border Grid.Column="1" Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="120" VerticalAlignment="Center" />
+                    </Grid>
+                    <Grid Padding="{StaticResource DiscoverProfileRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                        <Border Grid.Column="1" Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="150" VerticalAlignment="Center" />
+                    </Grid>
+                    <Grid Padding="{StaticResource DiscoverProfileRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                        <Border Grid.Column="1" Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="80" VerticalAlignment="Center" />
+                    </Grid>
                 </StackPanel>
 
                 <ListView
@@ -201,43 +255,45 @@
                     SelectionMode="Single"
                     IsFocusEngagementEnabled="True"
                     IsItemClickEnabled="True"
-                    ItemClick="OnProfileItemClick">
+                    ItemClick="OnProfileItemClick"
+                    Padding="{StaticResource DiscoverListInset}"
+                    ItemContainerStyle="{StaticResource DiscoverProfileItemStyle}">
+                <!-- Double-line list item (icon + two lines of text), per the WinUI item-template
+                     guidance. Layout only: the container style supplies inset and corner radius so
+                     the presenter's selection and hover fills stay visible. -->
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="models:ServerConfiguration">
-                        <Grid Padding="12,10"
-                              ColumnSpacing="12"
+                        <Grid ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}"
                               AutomationProperties.Name="{x:Bind Name}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            
-                            <Border Grid.Column="0"
-                                    Width="36" Height="36"
-                                    CornerRadius="8"
-                                    Background="{ThemeResource AccentFillColorDefaultBrush}"
-                                    Opacity="0.18"
-                                    VerticalAlignment="Center">
-                                <Viewbox Width="18" Height="18" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                              Glyph="{x:Bind Transport, Converter={StaticResource TransportTypeGlyphConverter}}"
-                                              Foreground="{ThemeResource AccentBrush}" />
-                                </Viewbox>
-                            </Border>
 
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                <TextBlock Text="{x:Bind Name}" Style="{ThemeResource BodyStrongTextBlockStyle}" />
-                                <TextBlock Text="{x:Bind Transport, Converter={StaticResource TransportTypeLocalizationConverter}}" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            <FontIcon Grid.Column="0"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Transport, Converter={StaticResource TransportTypeGlyphConverter}}"
+                                      FontSize="{StaticResource DiscoverRowIconGlyphSize}"
+                                      Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                      Width="{StaticResource DiscoverRowIconBadgeSize}"
+                                      VerticalAlignment="Center" />
+
+                            <StackPanel Grid.Column="1"
+                                        VerticalAlignment="Center"
+                                        Spacing="{StaticResource DiscoverRowTextSpacing}">
+                                <TextBlock Text="{x:Bind Name}"
+                                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           TextTrimming="CharacterEllipsis"
+                                           MaxLines="1" />
+                                <TextBlock Text="{x:Bind Transport, Converter={StaticResource TransportTypeLocalizationConverter}}"
+                                           Style="{ThemeResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextTrimming="CharacterEllipsis"
+                                           MaxLines="1" />
                             </StackPanel>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
-                <ListView.ItemContainerStyle>
-                    <Style TargetType="ListViewItem">
-                        <Setter Property="Margin" Value="12,2,12,2" />
-                        <Setter Property="CornerRadius" Value="6" />
-                    </Style>
-                </ListView.ItemContainerStyle>
             </ListView>
         </Grid>
     </Grid>
@@ -250,7 +306,6 @@
               AutomationProperties.AutomationId="DiscoverSessions.DetailsPane"
               Grid.Column="2"
               Background="Transparent"
-              CornerRadius="8"
               Visibility="{x:Bind ViewModel.ShowDetailsPane, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
             <!-- Empty State when no profile is selected -->
             <Grid Visibility="{x:Bind ViewModel.HasNoSelectedProfile, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
@@ -311,7 +366,7 @@
                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="8">
                             <TextBlock Text="{x:Bind ViewModel.SelectedProfile.Name, Mode=OneWay}" Style="{ThemeResource TitleTextBlockStyle}" FontWeight="Bold" />
                             <StackPanel Orientation="Horizontal" Spacing="12">
-                                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="4" Padding="6,2">
+                                <Border Background="{ThemeResource ControlFillColorSecondaryBrush}" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="{ThemeResource ControlCornerRadius}" Padding="{StaticResource DiscoverProfileRowPadding}">
                                     <TextBlock Text="{x:Bind ViewModel.SelectedProfile.Transport, Mode=OneWay, Converter={StaticResource TransportTypeLocalizationConverter}}" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                 </Border>
                                 <TextBlock x:Uid="DiscoverSessionsImportableListLabel" Style="{ThemeResource BodyTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" />
@@ -348,11 +403,13 @@
                             IsOpen="{x:Bind ViewModel.HasError, Mode=OneWay}"
                             IsClosable="False" />
 
+                        <!-- Inline progress status. Uses the Fluent control fill and shared corner
+                             radius so it reads as one surface with the rows below it. -->
                         <Border Grid.Row="1"
-                                Padding="12,8"
-                                CornerRadius="8"
-                                Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                Padding="{StaticResource DiscoverSessionRowPadding}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                 BorderThickness="1"
                                 Visibility="{x:Bind ViewModel.ShowBusyStatus, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                             <StackPanel Orientation="Horizontal"
@@ -396,58 +453,56 @@
                             </StackPanel>
                         </Grid>
 
+                        <!-- Skeleton rows mirror the loaded row's shape (icon column, two text lines,
+                             trailing action) so the list does not reflow when data lands. Placeholder
+                             fills are subtle theme brushes, matching the row chrome the container now
+                             draws instead of the removed card border. -->
                         <StackPanel x:Name="RightSkeletonPanel"
                                     Grid.Row="2"
                                     Visibility="{x:Bind ViewModel.ShowSessionsSkeleton, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                    Spacing="10"
+                                    Spacing="{StaticResource DiscoverRowMetaSpacing}"
                                     Padding="0,0,0,40">
-                            <Border Padding="14" CornerRadius="8" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                                <Grid ColumnSpacing="12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Border Width="36" Height="36" CornerRadius="6" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                                    <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
-                                        <Border Width="160" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" HorizontalAlignment="Left" />
-                                        <Border Width="300" Height="10" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.06" HorizontalAlignment="Left" />
-                                    </StackPanel>
-                                    <Border Grid.Column="2" Width="96" Height="32" CornerRadius="4" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                                </Grid>
-                            </Border>
+                            <Grid Padding="{StaticResource DiscoverSessionRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}" MinHeight="80">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                                <StackPanel Grid.Column="1" Spacing="{StaticResource DiscoverRowMetaGlyphSpacing}" VerticalAlignment="Center">
+                                    <Border Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="160" />
+                                    <Border Style="{StaticResource DiscoverSkeletonDetailStyle}" Width="300" />
+                                </StackPanel>
+                                <Border Grid.Column="2" Style="{StaticResource DiscoverSkeletonActionStyle}" />
+                            </Grid>
 
-                            <Border Padding="14" CornerRadius="8" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                                <Grid ColumnSpacing="12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Border Width="36" Height="36" CornerRadius="6" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                                    <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
-                                        <Border Width="120" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" HorizontalAlignment="Left" />
-                                        <Border Width="260" Height="10" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.06" HorizontalAlignment="Left" />
-                                    </StackPanel>
-                                    <Border Grid.Column="2" Width="96" Height="32" CornerRadius="4" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                                </Grid>
-                            </Border>
+                            <Grid Padding="{StaticResource DiscoverSessionRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}" MinHeight="80">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                                <StackPanel Grid.Column="1" Spacing="{StaticResource DiscoverRowMetaGlyphSpacing}" VerticalAlignment="Center">
+                                    <Border Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="120" />
+                                    <Border Style="{StaticResource DiscoverSkeletonDetailStyle}" Width="260" />
+                                </StackPanel>
+                                <Border Grid.Column="2" Style="{StaticResource DiscoverSkeletonActionStyle}" />
+                            </Grid>
 
-                            <Border Padding="14" CornerRadius="8" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
-                                <Grid ColumnSpacing="12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Border Width="36" Height="36" CornerRadius="6" Background="{ThemeResource ButtonBackground}" Opacity="0.1" />
-                                    <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
-                                        <Border Width="180" Height="14" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.1" HorizontalAlignment="Left" />
-                                        <Border Width="220" Height="10" CornerRadius="2" Background="{ThemeResource ButtonBackground}" Opacity="0.06" HorizontalAlignment="Left" />
-                                    </StackPanel>
-                                    <Border Grid.Column="2" Width="96" Height="32" CornerRadius="4" Background="{ThemeResource ButtonBackground}" Opacity="0.1" VerticalAlignment="Center" />
-                                </Grid>
-                            </Border>
+                            <Grid Padding="{StaticResource DiscoverSessionRowPadding}" ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}" MinHeight="80">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource DiscoverSkeletonIconStyle}" />
+                                <StackPanel Grid.Column="1" Spacing="{StaticResource DiscoverRowMetaGlyphSpacing}" VerticalAlignment="Center">
+                                    <Border Style="{StaticResource DiscoverSkeletonTitleStyle}" Width="180" />
+                                    <Border Style="{StaticResource DiscoverSkeletonDetailStyle}" Width="220" />
+                                </StackPanel>
+                                <Border Grid.Column="2" Style="{StaticResource DiscoverSkeletonActionStyle}" />
+                            </Grid>
                         </StackPanel>
 
                         <ListView
@@ -462,132 +517,129 @@
                             Padding="0,0,0,40"
                             ItemContainerStyle="{StaticResource DiscoverSessionItemStyleCompact}">
 
+                            <!-- Layout-only row template: the container supplies the inset and corner
+                                 radius, and the default ListViewItem style supplies the state fills.
+                                 ListViewItemPresenter draws PointerOver / Focus beneath the template,
+                                 so painting card chrome here would mask them. -->
                             <ListView.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:DiscoverSessionItemViewModel">
-                                    <Border
-                                        AutomationProperties.Name="{x:Bind AutomationName}"
-                                        Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="8"
-                                        Padding="14">
+                                    <Grid AutomationProperties.Name="{x:Bind AutomationName}"
+                                          ColumnSpacing="{StaticResource DiscoverRowColumnSpacing}"
+                                          RowSpacing="{StaticResource DiscoverRowTextSpacing}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
 
-                                        <Grid ColumnSpacing="12" RowSpacing="6">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto" />
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="Auto" />
-                                            </Grid.RowDefinitions>
+                                        <FontIcon Grid.Column="0"
+                                                  Grid.RowSpan="3"
+                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                  Glyph="&#xE8F2;"
+                                                  FontSize="{StaticResource DiscoverRowIconGlyphSize}"
+                                                  Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                                  Width="{StaticResource DiscoverRowIconBadgeSize}"
+                                                  VerticalAlignment="Top" />
 
-                                            <Border Grid.Column="0"
-                                                    Grid.RowSpan="3"
-                                                    Width="36" Height="36"
-                                                    CornerRadius="8"
-                                                    Background="{ThemeResource AccentFillColorDefaultBrush}"
-                                                    Opacity="0.18"
-                                                    VerticalAlignment="Top">
-                                                <Viewbox Width="18" Height="18" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                              Glyph="&#xE8F2;"
-                                                              Foreground="{ThemeResource AccentBrush}" />
-                                                </Viewbox>
-                                            </Border>
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            Grid.Row="0"
+                                            Text="{x:Bind Title}"
+                                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                            TextWrapping="NoWrap"
+                                            TextTrimming="CharacterEllipsis" />
 
-                                            <TextBlock
-                                                Grid.Column="1"
-                                                Grid.Row="0"
-                                                Text="{x:Bind Title}"
-                                                Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                                TextWrapping="NoWrap"
-                                                TextTrimming="CharacterEllipsis" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            Grid.Row="1"
+                                            Text="{x:Bind Description}"
+                                            Style="{ThemeResource BodyTextBlockStyle}"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            TextWrapping="Wrap"
+                                            MaxLines="2"
+                                            TextTrimming="CharacterEllipsis" />
 
-                                            <TextBlock
-                                                Grid.Column="1"
-                                                Grid.Row="1"
-                                                Text="{x:Bind Description}"
-                                                Style="{ThemeResource BodyTextBlockStyle}"
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                TextWrapping="Wrap"
-                                                MaxLines="2"
-                                                TextTrimming="CharacterEllipsis" />
+                                        <Grid Grid.Column="1"
+                                              Grid.Row="2"
+                                              RowDefinitions="Auto,Auto,Auto"
+                                              RowSpacing="{StaticResource DiscoverRowMetaSpacing}">
+                                            <StackPanel Orientation="Horizontal"
+                                                        Spacing="{StaticResource DiscoverRowMetaGlyphSpacing}"
+                                                        Visibility="{x:Bind HasFormattedDate, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE787;" FontSize="{StaticResource DiscoverRowMetaGlyphSize}" Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
+                                                <TextBlock
+                                                    Text="{x:Bind FormattedDate}"
+                                                    Style="{ThemeResource CaptionTextBlockStyle}"
+                                                    Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                            </StackPanel>
 
-                                            <Grid Grid.Column="1"
-                                                  Grid.Row="2"
-                                                  RowDefinitions="Auto,Auto,Auto"
-                                                  RowSpacing="4">
-                                                <StackPanel Orientation="Horizontal"
-                                                            Spacing="6"
-                                                            Visibility="{x:Bind HasFormattedDate, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}">
-                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE787;" FontSize="12" Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
+                                            <StackPanel Grid.Row="1"
+                                                        Orientation="Horizontal"
+                                                        Spacing="{StaticResource DiscoverRowMetaGlyphSpacing}"
+                                                        Visibility="{x:Bind HasSessionCwd, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8B7;" FontSize="{StaticResource DiscoverRowMetaGlyphSize}" Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
+                                                <TextBlock
+                                                    Text="{x:Bind SessionCwdDisplayText, Mode=OneTime}"
+                                                    Style="{ThemeResource CaptionTextBlockStyle}"
+                                                    Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                                    TextTrimming="CharacterEllipsis" />
+                                            </StackPanel>
+
+                                            <Grid Grid.Row="2"
+                                                  ColumnDefinitions="Auto,Auto,*"
+                                                  ColumnSpacing="{StaticResource DiscoverRowMetaGlyphSpacing}">
+                                                <!-- Affinity badge. The one deliberate piece of chrome in this
+                                                     template: it is a distinct inline surface inside the row, not
+                                                     the row itself, so it does not compete with container states. -->
+                                                <Border
+                                                    Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                                                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="{ThemeResource ControlCornerRadius}"
+                                                    Padding="{StaticResource DiscoverProfileRowPadding}">
                                                     <TextBlock
-                                                        Text="{x:Bind FormattedDate}"
+                                                        Text="{x:Bind ProjectAffinityBadgeText, Mode=OneTime}"
                                                         Style="{ThemeResource CaptionTextBlockStyle}"
-                                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
-                                                </StackPanel>
-
-                                                <StackPanel Grid.Row="1"
-                                                            Orientation="Horizontal"
-                                                            Spacing="6"
-                                                            Visibility="{x:Bind HasSessionCwd, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}">
-                                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8B7;" FontSize="12" Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
-                                                    <TextBlock
-                                                        Text="{x:Bind SessionCwdDisplayText, Mode=OneTime}"
-                                                        Style="{ThemeResource CaptionTextBlockStyle}"
-                                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                        MaxWidth="280"
                                                         TextTrimming="CharacterEllipsis" />
-                                                </StackPanel>
-
-                                                <Grid Grid.Row="2"
-                                                      ColumnDefinitions="Auto,Auto,*"
-                                                      ColumnSpacing="8">
-                                                    <Border
-                                                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                                        BorderThickness="1"
-                                                        CornerRadius="4"
-                                                        Padding="6,2">
-                                                        <TextBlock
-                                                            Text="{x:Bind ProjectAffinityBadgeText, Mode=OneTime}"
-                                                            Style="{ThemeResource CaptionTextBlockStyle}"
-                                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                            MaxWidth="280"
-                                                            TextTrimming="CharacterEllipsis" />
-                                                    </Border>
-                                                    <FontIcon
-                                                        Grid.Column="1"
-                                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                        Glyph="&#xE7BA;"
-                                                        FontSize="12"
-                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                        VerticalAlignment="Center"
-                                                        Visibility="{x:Bind NeedsUserAttention, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                    <TextBlock
-                                                        Grid.Column="2"
-                                                        Text="{x:Bind AffinityStatusText, Mode=OneTime}"
-                                                        Style="{ThemeResource CaptionTextBlockStyle}"
-                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                        TextWrapping="WrapWholeWords"
-                                                        MaxLines="2" />
-                                                </Grid>
+                                                </Border>
+                                                <FontIcon
+                                                    Grid.Column="1"
+                                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    Glyph="&#xE7BA;"
+                                                    FontSize="{StaticResource DiscoverRowMetaGlyphSize}"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{x:Bind NeedsUserAttention, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                <TextBlock
+                                                    Grid.Column="2"
+                                                    Text="{x:Bind AffinityStatusText, Mode=OneTime}"
+                                                    Style="{ThemeResource CaptionTextBlockStyle}"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    TextWrapping="WrapWholeWords"
+                                                    MaxLines="2" />
                                             </Grid>
-
-                                            <Button
-                                                x:Name="ActionBtn"
-                                                AutomationProperties.AutomationId="DiscoverSessions.ImportButton"
-                                                Grid.Column="2"
-                                                Grid.RowSpan="3"
-                                                x:Uid="DiscoverSessionsImportButton"
-                                                Style="{StaticResource AccentButtonStyle}"
-                                                VerticalAlignment="Center"
-                                                Command="{x:Bind LoadSessionCommand, Mode=OneTime}"
-                                                CommandParameter="{x:Bind}" />
                                         </Grid>
-                                    </Border>
+
+                                        <!-- Nested UI: secondary action sits at the right of the row, per the
+                                             WinUI nested-UI placement guidance. -->
+                                        <Button
+                                            x:Name="ActionBtn"
+                                            AutomationProperties.AutomationId="DiscoverSessions.ImportButton"
+                                            Grid.Column="2"
+                                            Grid.RowSpan="3"
+                                            x:Uid="DiscoverSessionsImportButton"
+                                            Style="{StaticResource AccentButtonStyle}"
+                                            VerticalAlignment="Center"
+                                            Command="{x:Bind LoadSessionCommand, Mode=OneTime}"
+                                            CommandParameter="{x:Bind}" />
+                                    </Grid>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Navigation/SessionsListDialog.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Navigation/SessionsListDialog.xaml
@@ -16,6 +16,11 @@
     <ContentDialog.Resources>
         <Style TargetType="navViews:SessionsListDialog"
                BasedOn="{StaticResource DefaultContentDialogStyle}" />
+        <!-- Row and search metrics named as resources rather than inlined (coding-standards 5.2). -->
+        <Thickness x:Key="SessionsDialogRowPadding">12,8</Thickness>
+        <Thickness x:Key="SessionsDialogSearchMargin">0,0,0,12</Thickness>
+        <x:Double x:Key="SessionsDialogRowSpacing">12</x:Double>
+        <x:Double x:Key="SessionsDialogAttentionDotSize">8</x:Double>
     </ContentDialog.Resources>
 
     <Grid x:Name="SessionsDialogRoot"
@@ -46,34 +51,45 @@
         <TextBox x:Uid="SessionsDialogSearchBox"
                  AutomationProperties.AutomationId="SessionsDialog.SearchBox"
                  Text="{x:Bind FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                 Margin="0,0,0,12"/>
+                 Margin="{StaticResource SessionsDialogSearchMargin}"/>
 
+        <!-- Single-line list item: the row is the primary action (pick a session), so selection and
+             hover visuals stay with the container and the template only lays content out. Padding
+             lives on the container because ListViewItemPresenter template-binds it to ContentMargin. -->
         <ListView Grid.Row="1"
                   AutomationProperties.AutomationId="SessionsDialog.List"
                   ItemsSource="{x:Bind FilteredSessions, Mode=OneWay}"
                   IsItemClickEnabled="True"
                   ItemClick="OnSessionItemClick"
                   SelectionMode="None">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <!-- Stretch so the trailing timestamp reaches the row's right edge; without it
+                         ListViewItem left-aligns its content (WinUI item-container guidance). -->
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="{StaticResource SessionsDialogRowPadding}"/>
+                </Style>
+            </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="nav:SessionNavItemViewModel">
                     <Grid ColumnDefinitions="*,Auto,Auto"
-                          Padding="12,8"
+                          ColumnSpacing="{StaticResource SessionsDialogRowSpacing}"
                           AutomationProperties.AutomationId="{x:Bind navUi:MainNavigationAutomationIds.SessionsDialogItem(SessionId)}">
                         <TextBlock Text="{x:Bind Title, Mode=OneWay}"
                                    TextTrimming="CharacterEllipsis"
-                                   MaxLines="1"/>
+                                   MaxLines="1"
+                                   VerticalAlignment="Center"/>
                         <Ellipse Grid.Column="1"
-                                 Width="8"
-                                 Height="8"
-                                 Fill="{ThemeResource AccentBrush}"
-                                 Margin="8,0,0,0"
+                                 Width="{StaticResource SessionsDialogAttentionDotSize}"
+                                 Height="{StaticResource SessionsDialogAttentionDotSize}"
+                                 Fill="{ThemeResource AccentFillColorDefaultBrush}"
                                  VerticalAlignment="Center"
                                  Visibility="{x:Bind HasUnreadAttention, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                         <TextBlock Grid.Column="2"
                                    Text="{x:Bind RelativeTimeText, Mode=OneWay}"
                                    Style="{ThemeResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Margin="12,0,0,0"/>
+                                   VerticalAlignment="Center"/>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceMainNavigationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceMainNavigationTests.cs
@@ -365,17 +365,62 @@ public sealed class XamlComplianceMainNavigationTests
 
 
     [Fact]
-    public void DiscoverSessionsPage_ProfileTransportChipsUseFluentAccentThemePattern()
+    public void DiscoverSessionsPage_RowAccentsUseThemeBrushesWithoutOpacityScaling()
     {
         var xaml = LoadXaml(@"SalmonEgg\SalmonEgg\Presentation\Views\Discover\DiscoverSessionsPage.xaml");
 
-        // Profiles list and session rows share the Fluent soft-accent chip used on
-        // AcpConnectionSettingsPage (AccentFill + low Opacity + AccentBrush icon).
-        Assert.Contains("Background=\"{ThemeResource AccentFillColorDefaultBrush}\"", xaml, StringComparison.Ordinal);
-        Assert.Contains("Foreground=\"{ThemeResource AccentBrush}\"", xaml, StringComparison.Ordinal);
+        // Row leading icons tint with the Fluent accent *text* brush. The previous soft-accent badge
+        // (AccentFill + Opacity=0.18 + a Viewbox'd FontIcon) is deliberately gone: an opacity-scaled
+        // fill inside the DataTemplate sits above the container's own PointerOver/Selected fills, so
+        // it dulled every native row state. Opacity is not a theming mechanism here at all — any
+        // Opacity= in this file would mean chrome is being faked instead of themed.
+        Assert.Contains("Foreground=\"{ThemeResource AccentTextFillColorPrimaryBrush}\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Opacity=", xaml, StringComparison.Ordinal);
         Assert.DoesNotContain("SystemControlBackgroundAccentBrush", xaml, StringComparison.Ordinal);
         Assert.DoesNotContain("TextOnAccentFillColorPrimaryBrush", xaml, StringComparison.Ordinal);
-        Assert.DoesNotContain("Opacity=\"0.8\"", xaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DiscoverSessionsPage_RowChromeBelongsToTheItemContainerNotTheDataTemplate()
+    {
+        var xaml = LoadXaml(@"SalmonEgg\SalmonEgg\Presentation\Views\Discover\DiscoverSessionsPage.xaml");
+
+        // ListViewItemPresenter renders PointerOver / Selected / Focus *beneath* the DataTemplate
+        // (WinUI "Item containers and templates"), so an opaque card Border at the template root
+        // masks every native row state — and then row spacing has to be faked with container
+        // Margin + Padding="0". Both container styles therefore carry the inset and corner radius,
+        // and no row template paints a card fill.
+        var sessionRowTemplate = ExtractSection(
+            xaml,
+            "<DataTemplate x:DataType=\"viewModels:DiscoverSessionItemViewModel\">",
+            "</DataTemplate>");
+        Assert.DoesNotContain("CardBackgroundFillColorSecondaryBrush", sessionRowTemplate, StringComparison.Ordinal);
+
+        Assert.Contains("Property=\"Padding\" Value=\"{StaticResource DiscoverSessionRowPadding}\"", xaml, StringComparison.Ordinal);
+        Assert.Contains("Property=\"CornerRadius\" Value=\"{ThemeResource ControlCornerRadius}\"", xaml, StringComparison.Ordinal);
+        Assert.Contains("Property=\"HorizontalContentAlignment\" Value=\"Stretch\"", xaml, StringComparison.Ordinal);
+        Assert.Contains("ItemContainerStyle=\"{StaticResource DiscoverProfileItemStyle}\"", xaml, StringComparison.Ordinal);
+
+        // The spacing hacks that the masked states used to require.
+        Assert.DoesNotContain("Property=\"Padding\" Value=\"0\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Property=\"Margin\" Value=\"0,0,0,6\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Property=\"Margin\" Value=\"0,0,0,10\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Property=\"Margin\" Value=\"12,2,12,2\"", xaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionsListDialog_TrailingMetadataReachesTheRowEdge()
+    {
+        var xaml = LoadXaml(@"SalmonEgg\SalmonEgg\Presentation\Views\Navigation\SessionsListDialog.xaml");
+
+        // ListViewItem left-aligns its content by default, so a trailing timestamp column only
+        // reaches the row's right edge once the container stretches (WinUI item-container guidance).
+        Assert.Contains("Property=\"HorizontalContentAlignment\" Value=\"Stretch\"", xaml, StringComparison.Ordinal);
+        Assert.Contains("Property=\"Padding\" Value=\"{StaticResource SessionsDialogRowPadding}\"", xaml, StringComparison.Ordinal);
+        // Row inset comes from the container, and gaps from ColumnSpacing, not per-child margins.
+        Assert.DoesNotContain("Padding=\"12,8\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Margin=\"8,0,0,0\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("Margin=\"12,0,0,0\"", xaml, StringComparison.Ordinal);
     }
 
 


### PR DESCRIPTION
## 问题

"导入外部会话"的几个列表看起来不像 Fluent，因为行是在 `DataTemplate` 里自己画了一张不透明卡片（`CardBackgroundFillColorSecondaryBrush` + 描边 + 圆角 + 自带 padding）。

官方 [Item containers and templates](https://learn.microsoft.com/en-us/windows/apps/design/controls/item-containers-templates) 明确：`ListViewItemPresenter` 的 PointerOver / Selected / Focus 状态视觉渲染在 `DataTemplate` **之下**。那张卡片把它们全糊住了 —— 鼠标划过没反应、键盘焦点看不见。糊住之后行距只能靠容器 `Padding="0"` + `Margin="0,0,0,6"` 手搓补回来，于是成了一叠僵硬的静态卡片。

ACP 配置向导的 agent 列表恰好是正样本：模板透明、状态归原生容器。本 PR 把这两处对齐到那个形状。

## 改动

**会话行 / 配置行**
- 删掉模板根的卡片 `Border`；行内距与圆角搬到 `ListViewItem` 容器样式（`Padding` 会 template-bind 到 `ListViewItemPresenter.ContentMargin`），填充完全留给默认样式 —— 那才是状态刷的来源。
- 行距不再靠 `Margin`，容器有真实 `Padding` 后自然成立。
- 图标的 `AccentFill` + `Opacity="0.18"` 圆底座换成裸 `FontIcon` + `AccentTextFillColorPrimaryBrush`。半透明填充叠在容器状态刷之上会把每个状态调暗，且 `Opacity` 本就不是主题机制。
- 配置行改用官方 double-line list item 形状；逐行 `Margin="12,2,12,2"` 换成列表 `Padding` + 容器样式。
- 保留行内 affinity 徽章：它是行**内部**的独立小面，不与容器状态争位置。

**"全部会话"弹窗**
- 补 `HorizontalContentAlignment="Stretch"`。缺它 `ListViewItem` 默认左对齐内容，右侧时间戳其实到不了行右边缘。
- 零散 `Margin` 换 `ColumnSpacing`；像素值按 coding-standards §5.2 提为命名资源。

**骨架屏**
- 两处骨架屏改成与真实行同形（图标列 + 文本行 + 尾部动作、同 `Padding`、同 `MinHeight`），数据到位时不再跳版；占位块改用 Fluent subtle 填充，不再 `ButtonBackground` + `Opacity`。

**未改动**：手柄导航契约（`SelectionMode=None` / `IsItemClickEnabled=False` / 列表级 `IsFocusEngagementEnabled`）、全部 automation id、全部 `x:Uid`、两档响应式密度状态。

> 顺带说明一处**有意的收手**：官方 nested-UI 指南建议把 `IsFocusEngagementEnabled` 放在**容器**上。但那会把手柄行为从"方向键进按钮"改成"A 键接合"，而这条路径由 `DiscoverProfilesSelection_VirtualGamepadDPadRight_CanReachImportAction` 守着（Windows GUI smoke，我在 Linux 上跑不了）。不在本 PR 范围内，已撤回。

## 验证

| 项 | 结果 |
|---|---|
| Desktop 构建 (`net10.0-desktop`) | 0 警告 0 错误 |
| WASM 构建 (`net10.0-browserwasm`) | 0 警告 0 错误 |
| Release 全解决方案 + `EnforceCodeStyleInBuild=true` | 0 错误，改动文件零警告 |
| `dotnet format --verify-no-changes` | 通过 |
| `run-core-gates.sh Release` | 通过 |
| 相关 XAML 门禁 5 个类 | 102/102 |
| 全量 Core 测试 | 3226 项，详见下方 |

**新增 3 条门禁，并逐分支反向验证**（AGENTS 视觉树门禁纪律）：把卡片填充改回去、把 `Padding=0`+`Margin` 行距 hack 改回去、把 `Opacity` 徽章改回去、把弹窗 `Stretch` 删掉 —— 四个分支各自见红，恢复后稳定通过。

跨平台资源核对：新引用的 9 个 `ThemeResource`（`AccentTextFillColorPrimaryBrush`、`SubtleFillColor*`、`ControlFillColorSecondaryBrush` 等）均已确认存在于 Uno 6.6.166 主题字典；改动只用基础属性，无 WinUI-only API、无 `#if`。

## 未验证项（显式声明）

1. **真实观感未亲眼确认。** Fluent 悬停 / 焦点视觉要在真机 GUI 上才算数。以上是编译 + 门禁级验证，建议 review 时在 Windows 上装包点一遍：鼠标划过会话行、Tab 到导入按钮。
2. **WinUI 3 目标 (`net10.0-windows10.0.26100.0`) 本地未编译。** 该 TFM 只在 windows runner 上进入构建图（`EnableWinUiBuild` 条件），Linux 编不到。XAML 是同一份共享文件且已在两个 Uno 渲染器上编译通过，风险低但由 CI 兜底。
3. **全量 Core 3226 项中 1 条红**：`StartViewModelTests.StartSessionDraft_WhenRemoteProfileCwdFaults_SwitchingToConfiguredRemoteDirectory_RecoversReadyModes`。该测试不读 Discover 任何文件，单独重跑通过，判断为既有负载敏感 flaky（与此前记录一致）。**我没能排除到确定** —— 若 CI 复现，值得单独查。

## 已知遗留（未纳入本 PR）

`DiscoverSessionsPage.xaml` 的 `InverseBooleanConverter` 是死资源 —— 本次改动**之前**就无人引用（可见性走 `BoolToVisibility` + `ConverterParameter='Invert'`）。属既有状况，避免扩大改动面，未清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)