### PR TITLE
fix(acp-setup): detect adapters by executable entry point

### DIFF
--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
@@ -30,8 +30,9 @@ public sealed class AcpComponentDescriptor
     public IReadOnlyList<string> ProbeVersionArguments { get; init; } = Array.Empty<string>();
 
     /// <summary>
-    /// Package coordinate for package-manager distributions, without a pinned version so the
-    /// launcher resolves the current release.
+    /// Package coordinate the wizard installs for package-manager distributions. Detection may use the
+    /// installed executable instead: a package coordinate identifies one distribution source, not the
+    /// component's runtime identity.
     /// </summary>
     public string PackageId { get; init; } = string.Empty;
 

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpDistributionKind.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpDistributionKind.cs
@@ -9,7 +9,7 @@ public enum AcpDistributionKind
     /// <summary>Shipped with the agent itself; nothing to install.</summary>
     BuiltIn,
 
-    /// <summary>Node package executed through <c>npx</c>.</summary>
+    /// <summary>Node package installed through npm; its declared executable may be launched directly.</summary>
     Npx,
 
     /// <summary>Python package executed through <c>uvx</c>.</summary>

--- a/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
@@ -8,14 +8,11 @@ namespace SalmonEgg.Infrastructure.AcpSetup;
 /// Curated snapshot of the ACP agent registry (<c>cdn.agentclientprotocol.com/registry/v1</c>),
 /// limited to agents whose ACP entry point is a documented stdio command.
 ///
-/// Packages are intentionally unpinned: the launcher resolves the current release, so the wizard does
-/// not go stale when the registry advances. Pinning would freeze users to whatever version happened to
-/// ship with the app.
+/// Installation packages are intentionally unpinned so the wizard does not go stale when the registry
+/// advances. Pinning would freeze users to whatever version happened to ship with the app.
 /// </summary>
 internal static class AcpAgentCatalogEntries
 {
-    private const string NpxCommand = "npx";
-
     internal static IReadOnlyList<AcpAgentDescriptor> Create()
         => new[]
         {
@@ -30,8 +27,14 @@ internal static class AcpAgentCatalogEntries
         };
 
     /// <summary>
-    /// Agent fronted by a separate npx adapter: the runtime CLI is detected on PATH, the adapter is a
-    /// Node package the wizard can install.
+    /// Agent fronted by a separately packaged adapter: the runtime CLI and the adapter entry point are
+    /// detected independently, while the package coordinate is used only when the wizard installs the
+    /// adapter.
+    ///
+    /// The executable is the stable interoperability boundary. The same command can be supplied by a
+    /// renamed package, a third-party distribution, or a standalone install, and all are usable when the
+    /// later ACP handshake succeeds. Treating one publisher's package coordinate as adapter identity
+    /// rejects those valid installations before the protocol can verify them.
     /// </summary>
     private static AcpAgentDescriptor CreateAdapterFrontedAgent(
         string agentId,
@@ -42,9 +45,9 @@ internal static class AcpAgentCatalogEntries
         Uri runtimeDocumentation,
         string adapterId,
         string adapterDisplayName,
+        string adapterProbeCommand,
         string adapterPackageId,
         Uri adapterDocumentation,
-        IReadOnlyList<string> launchArguments,
         IReadOnlyList<AcpSetupParameterDefinition> parameters)
         => new()
         {
@@ -72,15 +75,14 @@ internal static class AcpAgentCatalogEntries
                         Id = adapterId,
                         DisplayName = adapterDisplayName,
                         Distribution = AcpDistributionKind.Npx,
-                        DetectionMode = AcpComponentDetectionMode.GlobalNodePackage,
-                        ProbeCommand = NpxCommand,
+                        DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                        ProbeCommand = adapterProbeCommand,
                         PackageId = adapterPackageId,
                         InstallDocumentation = adapterDocumentation
                     },
                     LaunchTemplate = new AcpLaunchTemplate
                     {
-                        Command = NpxCommand,
-                        FixedArguments = launchArguments,
+                        Command = adapterProbeCommand,
                         Parameters = parameters
                     }
                 }
@@ -164,9 +166,9 @@ internal static class AcpAgentCatalogEntries
             runtimeDocumentation: new Uri("https://docs.claude.com/en/docs/claude-code/setup"),
             adapterId: "claude-agent-acp",
             adapterDisplayName: "Claude Agent ACP",
+            adapterProbeCommand: "claude-agent-acp",
             adapterPackageId: "@agentclientprotocol/claude-agent-acp",
             adapterDocumentation: new Uri("https://github.com/agentclientprotocol/claude-agent-acp"),
-            launchArguments: new[] { "-y", "@agentclientprotocol/claude-agent-acp" },
             parameters: Array.Empty<AcpSetupParameterDefinition>());
 
     private static AcpAgentDescriptor CreateCodex()
@@ -179,9 +181,9 @@ internal static class AcpAgentCatalogEntries
             runtimeDocumentation: new Uri("https://developers.openai.com/codex/cli/"),
             adapterId: "codex-acp",
             adapterDisplayName: "Codex ACP",
+            adapterProbeCommand: "codex-acp",
             adapterPackageId: "@agentclientprotocol/codex-acp",
             adapterDocumentation: new Uri("https://github.com/agentclientprotocol/codex-acp"),
-            launchArguments: new[] { "-y", "@agentclientprotocol/codex-acp" },
             parameters: Array.Empty<AcpSetupParameterDefinition>());
 
     private static AcpAgentDescriptor CreateGeminiCli()

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -666,12 +666,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Collects the paths the user supplied, keyed by the command name each one replaces.
+    /// Collects authoritative command paths, keyed by the catalog command each one replaces.
     /// </summary>
     /// <remarks>
-    /// Gathered from every row rather than only the selected one, because one command can back several
-    /// agents: a path given for <c>npx</c> while looking at one agent is the same <c>npx</c> the next
-    /// agent's adapter launches.
+    /// User choices outrank probe results. Otherwise, when an adapter launches the command it probed, the
+    /// resolved executable path is carried into the launch plan automatically. Search-path widening can
+    /// find an install outside the GUI process PATH; saving the bare command after that would discard the
+    /// fact detection just established and produce a profile that cannot start.
     /// </remarks>
     private AcpCommandOverrides CollectCommandOverrides()
     {
@@ -684,9 +685,19 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             }
         }
 
-        if (HasAdapterCustomCommand && HasAdapterProbeCommand)
+        if (!string.IsNullOrWhiteSpace(AdapterProbeCommand)
+            && string.Equals(
+                SelectedAdapter?.LaunchTemplate.Command,
+                AdapterProbeCommand,
+                StringComparison.Ordinal))
         {
-            overrides[AdapterProbeCommand] = AdapterCustomCommand;
+            var resolvedAdapterCommand = HasAdapterCustomCommand
+                ? AdapterCustomCommand
+                : AdapterProbe?.ExecutablePath;
+            if (!string.IsNullOrWhiteSpace(resolvedAdapterCommand))
+            {
+                overrides[AdapterProbeCommand] = resolvedAdapterCommand;
+            }
         }
 
         return AcpCommandOverrides.Create(overrides);

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAgentCatalogTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAgentCatalogTests.cs
@@ -87,6 +87,43 @@ public sealed class AcpAgentCatalogTests
     }
 
     /// <summary>
+    /// A separately packaged adapter can move between publishers or be distributed independently while
+    /// keeping the same executable entry point. Detection and launch therefore meet at that executable;
+    /// the package coordinate remains only the wizard's recommended installation source.
+    /// </summary>
+    [Fact]
+    public void PackagedAdapters_DetectAndLaunchTheSameExecutable()
+    {
+        var failures = new System.Collections.Generic.List<string>();
+
+        foreach (var agent in new AcpAgentCatalog().Agents)
+        {
+            foreach (var adapter in agent.Adapters.Where(adapter => !adapter.Component.IsBuiltIn))
+            {
+                if (adapter.Component.DetectionMode != AcpComponentDetectionMode.ExecutableOnPath)
+                {
+                    failures.Add(
+                        $"{agent.Id}: detects adapter '{adapter.Component.Id}' by"
+                        + $" {adapter.Component.DetectionMode} instead of its executable entry point.");
+                    continue;
+                }
+
+                if (!string.Equals(
+                        adapter.Component.ProbeCommand,
+                        adapter.LaunchTemplate.Command,
+                        StringComparison.Ordinal))
+                {
+                    failures.Add(
+                        $"{agent.Id}: probes '{adapter.Component.ProbeCommand}' but launches"
+                        + $" '{adapter.LaunchTemplate.Command}'.");
+                }
+            }
+        }
+
+        Assert.True(failures.Count == 0, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>
     /// A component the wizard offers to install must name the package to install, and one it cannot
     /// install must offer documentation instead. Otherwise a row shows a button that cannot work, or no
     /// route at all.

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -246,6 +246,7 @@ internal sealed class RecordingConfigurationService : IConfigurationService
 internal static class AcpSetupWizardFixtures
 {
     public const string RuntimeCommand = "test-agent";
+    public const string AdapterCommand = "test-agent-acp";
     public const string AdapterPackage = "@scope/test-adapter";
 
     public static AcpComponentDescriptor Runtime(string id = "runtime.test")
@@ -298,6 +299,27 @@ internal static class AcpSetupWizardFixtures
             {
                 Command = "npx",
                 FixedArguments = new[] { AdapterPackage },
+                Parameters = parameters
+            }
+        };
+
+    public static AcpAdapterDescriptor ExecutableAdapter(
+        string id = "adapter.executable",
+        params AcpSetupParameterDefinition[] parameters)
+        => new()
+        {
+            Component = new AcpComponentDescriptor
+            {
+                Id = id,
+                DisplayName = "Executable ACP Adapter",
+                Distribution = AcpDistributionKind.Npx,
+                DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                ProbeCommand = AdapterCommand,
+                PackageId = AdapterPackage
+            },
+            LaunchTemplate = new AcpLaunchTemplate
+            {
+                Command = AdapterCommand,
                 Parameters = parameters
             }
         };

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -310,6 +310,54 @@ public sealed class AcpSetupWizardViewModelTests
     }
 
     /// <summary>
+    /// A package coordinate is one installation source, not adapter identity. Detection accepts the
+    /// adapter executable regardless of which package or vendor supplied it, and the resolved path must
+    /// be the command tested and persisted when the GUI process PATH cannot resolve the bare name.
+    /// </summary>
+    [Fact]
+    public async Task Save_WithExecutableAdapter_UsesTheResolvedCommandWithoutQueryingPackageIdentity()
+    {
+        const string resolvedAdapter = "/home/user/.nvm/versions/node/v24/bin/test-agent-acp";
+        var adapter = AcpSetupWizardFixtures.ExecutableAdapter();
+        var agent = AcpSetupWizardFixtures.Agent(adapters: adapter);
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+        probe.SetExecutable(AcpSetupWizardFixtures.AdapterCommand, resolvedAdapter);
+        var tester = new StubConnectivityTester(StubConnectivityTester.SuccessfulHandshake());
+        var configuration = new RecordingConfigurationService();
+        var wizard = CreateWizardFor(
+            agent,
+            probe,
+            new StubComponentInstaller(),
+            localizer: null,
+            tester,
+            configuration);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+        await wizard.GoNextCommand.ExecuteAsync(null); // -> ComponentSetup
+
+        Assert.True(wizard.IsAdapterUsable);
+        Assert.Empty(probe.QueriedPackageManagers);
+
+        await wizard.GoNextCommand.ExecuteAsync(null); // -> Parameters
+        Assert.StartsWith(resolvedAdapter, wizard.LaunchCommandPreview, StringComparison.Ordinal);
+        await wizard.GoNextCommand.ExecuteAsync(null); // -> Test
+        await wizard.TestCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsTestSuccessful);
+        Assert.Equal(resolvedAdapter, tester.LastPlan!.Command);
+
+        await wizard.GoNextCommand.ExecuteAsync(null); // -> Save
+        wizard.ProfileName = "Executable Adapter";
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        var saved = Assert.Single(configuration.Saved);
+        Assert.Equal(resolvedAdapter, saved.StdioCommand);
+        Assert.Empty(saved.StdioArguments!);
+    }
+
+    /// <summary>
     /// Six of the eight shipped agents carry a built-in adapter, and the step rendered nothing at all for
     /// them: a title over an empty panel, correct but indistinguishable from a page that failed to load.
     /// Built-in is now its own state, separate from "installed", so the step can say why it is satisfied.


### PR DESCRIPTION
## Root cause

The setup catalog treated one npm package coordinate as the installed adapter identity. This rejected valid renamed or third-party distributions even when they supplied the same working `claude-agent-acp` or `codex-acp` executable. Local logs showed both commands completing ACP initialization while the wizard still reported the adapter missing.

The widened GUI search path exposed a second ownership gap: a resolved adapter path could be discarded when the launch plan was built, falling back to a bare command that the GUI process could not necessarily resolve.

## Fix

- Detect separately packaged adapters through their executable ACP entry point.
- Keep the official package coordinate only as the wizard's recommended automatic installation source.
- Launch the same executable that detection verified.
- Carry the resolved absolute adapter path into the connectivity test and persisted profile, while preserving an explicit user override as higher priority.
- Add catalog and wizard regression coverage that does not query package identity.

The existing end-to-end connectivity step remains the authoritative ACP protocol check through `initialize`.

## Verification

- `dotnet format SalmonEgg.sln --verify-no-changes --no-restore --include <changed files>`
- `dotnet build SalmonEgg.sln --configuration Release --no-restore /p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors
- `dotnet test --solution SalmonEgg.sln --configuration Release --no-build --timeout 20m --long-running 300` under CI-equivalent `en-US` — 4540 total, 4516 passed, 24 platform skips
- `./scripts/gates/run-core-gates.ps1 -Configuration Release -SkipSolutionRestore -SkipContractSuites`
- Real stdio ACP initialize smoke with locally installed `claude-agent-acp` — passed
- Real stdio ACP initialize smoke with locally installed `codex-acp` — passed