### PR TITLE
fix: repair both Skia GUI smoke flake signatures

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NumberBoxThemeProbeDriver.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NumberBoxThemeProbeDriver.cs
@@ -40,6 +40,7 @@ internal static class NumberBoxThemeProbeDriver
     private const int RenderCaptureAttemptCount = 5;
     private const int RenderCaptureRetryDelayMilliseconds = 100;
     private const int ViewportSettleAttemptCount = 20;
+    private const int InitialViewportSettleAttemptCount = 100;
     private const int ViewportSettleDelayMilliseconds = 50;
     private const double MinimumBackgroundSampleInset = 6;
     private const int BackgroundClusterTolerance = 6;
@@ -133,7 +134,11 @@ internal static class NumberBoxThemeProbeDriver
 
         return inputBox is null
             ? null
-            : new NumberBoxThemeProbeTargets(numberBox, inputBox, focusSink);
+            : new NumberBoxThemeProbeTargets(
+                numberBox,
+                inputBox,
+                focusSink,
+                FindAncestor<ScrollViewer>(numberBox));
     }
 
     private static async Task<NumberBoxThemeProbeRunResult> CollectSamplesAsync(
@@ -159,6 +164,20 @@ internal static class NumberBoxThemeProbeDriver
             .ConfigureAwait(true);
         await Task.Delay(SampleSettleDelayMilliseconds).ConfigureAwait(true);
 
+        // The first layout after Settings navigation may still be realizing the template, so the
+        // initial centering gets the wider budget; every later sample restores the same offset in
+        // one layout pass.
+        var viewportSettled = await WaitForSampleBoundsInsideViewportAsync(
+                targets,
+                InitialViewportSettleAttemptCount)
+            .ConfigureAwait(true);
+        App.BootLog(string.Create(
+            CultureInfo.InvariantCulture,
+            $"NumberBoxThemeProbe: viewport settled={viewportSettled}"
+            + $" scrollHost={(targets.ScrollHost is null ? "none" : "present")}"
+            + $" offset={targets.ScrollHost?.VerticalOffset ?? 0:F1}"
+            + $" viewport={targets.ScrollHost?.ViewportHeight ?? 0:F1}"));
+
         var completedSamples = 0;
         for (var sampleAttempt = 1;
             sampleAttempt <= SampleAttemptCount && completedSamples < SampleCount;
@@ -179,18 +198,15 @@ internal static class NumberBoxThemeProbeDriver
             targets.NumberBox.UpdateLayout();
             targets.InputBox.UpdateLayout();
 
-            // Focusing the sink scrolls the page away from the NumberBox, and BringIntoView only
-            // requests a scroll: it does not complete before the next layout pass. Capturing here
-            // without waiting samples a rect that still lies outside the render root, which yields
-            // an empty region indistinguishable from an unreadable frame. Wait for the realized
-            // geometry to land inside the render root before sampling pixels.
-            var boundsSettled = await WaitForSampleBoundsInsideRenderRootAsync(
-                    targets.NumberBox,
-                    targets.InputBox)
+            // Focusing the sink scrolls the page away from the NumberBox. Restore the viewport
+            // through its owner and confirm the realized geometry landed inside it: capturing an
+            // off-viewport rect yields an empty region indistinguishable from an unreadable frame.
+            var boundsSettled = await WaitForSampleBoundsInsideViewportAsync(
+                    targets,
+                    ViewportSettleAttemptCount)
                 .ConfigureAwait(true);
             var snapshot = await CaptureSnapshotAsync(
-                    targets.NumberBox,
-                    targets.InputBox,
+                    targets,
                     unfocusedBeforeSample && inputFocused,
                     boundsSettled)
                 .ConfigureAwait(true);
@@ -237,11 +253,12 @@ internal static class NumberBoxThemeProbeDriver
     }
 
     private static async Task<NumberBoxThemeProbeSnapshot> CaptureSnapshotAsync(
-        NumberBox numberBox,
-        TextBox inputBox,
+        NumberBoxThemeProbeTargets targets,
         bool focusTransitionSucceeded,
         bool boundsSettled)
     {
+        var numberBox = targets.NumberBox;
+        var inputBox = targets.InputBox;
         var contentElement = FindDescendant<ScrollViewer>(
             inputBox,
             static candidate => string.Equals(candidate.Name, ContentElementName, StringComparison.Ordinal));
@@ -249,7 +266,7 @@ internal static class NumberBoxThemeProbeDriver
             inputBox,
             static candidate => string.Equals(candidate.Name, BorderElementName, StringComparison.Ordinal));
 
-        var renderedColors = await TryCaptureRenderedColorsAsync(contentElement, borderElement)
+        var renderedColors = await TryCaptureRenderedColorsAsync(contentElement, borderElement, targets)
             .ConfigureAwait(true);
         var background = renderedColors.Background;
         var foreground = renderedColors.Foreground;
@@ -291,7 +308,8 @@ internal static class NumberBoxThemeProbeDriver
 
     private static async Task<RenderedColors> TryCaptureRenderedColorsAsync(
         ScrollViewer? contentElement,
-        Border? borderElement)
+        Border? borderElement,
+        NumberBoxThemeProbeTargets targets)
     {
         if (contentElement is null || borderElement is null)
         {
@@ -305,7 +323,8 @@ internal static class NumberBoxThemeProbeDriver
         for (var attempt = 1; attempt <= RenderCaptureAttemptCount; attempt++)
         {
             borderElement.UpdateLayout();
-            var capture = await TryCaptureRenderedBackgroundAsync(borderElement).ConfigureAwait(true);
+            var capture = await TryCaptureRenderedBackgroundAsync(borderElement, targets.ScrollHost)
+                .ConfigureAwait(true);
             background = capture.Color;
             diagnostic = capture.Diagnostic;
             foreground = background is null
@@ -331,9 +350,13 @@ internal static class NumberBoxThemeProbeDriver
             {
                 // RenderTargetBitmap can transiently return an incomplete Skia frame immediately
                 // after a native focus-state transition. Retry the same realized control instead
-                // of treating an unavailable frame as evidence of unreadable colors. Re-request the
-                // scroll as well: a delay alone cannot move a control that is still out of view.
-                borderElement.StartBringIntoView();
+                // of treating an unavailable frame as evidence of unreadable colors. Re-apply the
+                // owned viewport as well: a delay alone cannot move a control that is out of view.
+                if (TryCenterSampleViewport(targets) is null)
+                {
+                    borderElement.StartBringIntoView();
+                }
+
                 await Task.Delay(RenderCaptureRetryDelayMilliseconds).ConfigureAwait(true);
             }
         }
@@ -347,7 +370,8 @@ internal static class NumberBoxThemeProbeDriver
     /// a translucent offscreen composition or an ambiguous cluster, so every exit reports its cause.
     /// </summary>
     private static async Task<BackgroundCapture> TryCaptureRenderedBackgroundAsync(
-        Border borderElement)
+        Border borderElement,
+        ScrollViewer? scrollHost)
     {
         if (borderElement.DispatcherQueue is null || !borderElement.DispatcherQueue.HasThreadAccess)
         {
@@ -368,6 +392,17 @@ internal static class NumberBoxThemeProbeDriver
         {
             return BackgroundCapture.Unavailable(
                 $"sample-bounds-unresolved border={FormatSize(new Size(borderElement.ActualWidth, borderElement.ActualHeight))}");
+        }
+
+        // A control scrolled outside its scroll host is clipped away, yet its transformed bounds can
+        // still land inside the render root, where the capture would read whatever paints there.
+        // Rejecting that region keeps an unreadable sample from passing as a measured contrast.
+        var visibleRegion = ResolveVisibleSampleRegion(scrollHost, renderRoot);
+        if (!IsInsideRegion(sampleBounds.Value, visibleRegion))
+        {
+            return BackgroundCapture.Unavailable(
+                $"sample-outside-viewport rect={FormatRect(sampleBounds.Value)}"
+                + $" viewport={FormatRect(visibleRegion)}");
         }
 
         var bitmap = new RenderTargetBitmap();
@@ -409,29 +444,74 @@ internal static class NumberBoxThemeProbeDriver
     }
 
     /// <summary>
-    /// Waits until the inset BorderElement sample region is fully inside the render root, so the
-    /// pixel sample measures the realized control instead of an off-viewport empty rect.
+    /// Scrolls the realized NumberBox to the middle of its scroll host viewport, so the sampled
+    /// region cannot fall outside the region that shows it, and returns the applied offset.
     /// </summary>
-    private static async Task<bool> WaitForSampleBoundsInsideRenderRootAsync(
-        NumberBox numberBox,
-        TextBox inputBox)
+    /// <remarks>
+    /// The settled page layout leaves the NumberBox flush against the viewport bottom, where a few
+    /// pixels of scroll are enough to move the inset sample region off screen. Focusing the sink
+    /// scrolls the page away entirely, and <see cref="UIElement.StartBringIntoView()"/> only
+    /// requests an animated return that a slow headless runner does not finish inside the sample
+    /// budget. The scroll host owns the viewport, so the offset is derived from realized geometry
+    /// and applied with animation disabled, which lands in one layout pass and overrides any
+    /// in-flight bring-into-view. Recomputing it is stable: current offset plus the measured
+    /// position is the control position in content coordinates, which layout keeps constant.
+    /// </remarks>
+    private static double? TryCenterSampleViewport(NumberBoxThemeProbeTargets targets)
     {
-        for (var attempt = 1; attempt <= ViewportSettleAttemptCount; attempt++)
+        if (targets.ScrollHost is not { } scrollHost
+            || scrollHost.ViewportHeight <= 0
+            || targets.NumberBox.ActualHeight <= 0)
         {
-            numberBox.StartBringIntoView();
-            numberBox.UpdateLayout();
-            inputBox.UpdateLayout();
+            return null;
+        }
+
+        var positionInHost = targets.NumberBox
+            .TransformToVisual(scrollHost)
+            .TransformBounds(new Rect(0, 0, targets.NumberBox.ActualWidth, targets.NumberBox.ActualHeight));
+        var centeredTop = Math.Max(0, (scrollHost.ViewportHeight - positionInHost.Height) / 2);
+        var offset = Math.Clamp(
+            scrollHost.VerticalOffset + positionInHost.Y - centeredTop,
+            0,
+            Math.Max(0, scrollHost.ScrollableHeight));
+        return scrollHost.ChangeView(null, offset, null, disableAnimation: true) ? offset : null;
+    }
+
+    /// <summary>
+    /// Waits until the inset BorderElement sample region is fully inside the region that shows the
+    /// control, so the pixel sample measures the realized control and not an off-viewport rect.
+    /// </summary>
+    /// <remarks>
+    /// Measures before correcting: a scroll offset applied through the scroll host is realized by
+    /// the next layout pass, so reading the transformed bounds in the same iteration that requested
+    /// the scroll would observe the stale position and never accept a settled viewport.
+    /// </remarks>
+    private static async Task<bool> WaitForSampleBoundsInsideViewportAsync(
+        NumberBoxThemeProbeTargets targets,
+        int attemptCount)
+    {
+        for (var attempt = 1; attempt <= attemptCount; attempt++)
+        {
+            targets.NumberBox.UpdateLayout();
+            targets.InputBox.UpdateLayout();
 
             var borderElement = FindDescendant<Border>(
-                inputBox,
+                targets.InputBox,
                 static candidate => string.Equals(candidate.Name, BorderElementName, StringComparison.Ordinal));
             var renderRoot = borderElement is null ? null : FindVisualRoot(borderElement);
             if (borderElement is not null
                 && renderRoot is not null
                 && TryResolveSampleBounds(borderElement, renderRoot) is { } bounds
-                && IsInsideRenderRoot(bounds, renderRoot.RenderSize))
+                && IsInsideRegion(bounds, ResolveVisibleSampleRegion(targets.ScrollHost, renderRoot)))
             {
                 return true;
+            }
+
+            if (TryCenterSampleViewport(targets) is null)
+            {
+                // Without a scroll host the viewport cannot be owned, so fall back to the framework
+                // request that at least asks for the control to be shown.
+                targets.NumberBox.StartBringIntoView();
             }
 
             await Task.Delay(ViewportSettleDelayMilliseconds).ConfigureAwait(true);
@@ -440,11 +520,37 @@ internal static class NumberBoxThemeProbeDriver
         return false;
     }
 
-    private static bool IsInsideRenderRoot(Rect sampleBounds, Size renderSize)
-        => sampleBounds.X >= 0
-            && sampleBounds.Y >= 0
-            && sampleBounds.X + sampleBounds.Width <= renderSize.Width
-            && sampleBounds.Y + sampleBounds.Height <= renderSize.Height;
+    /// <summary>
+    /// Resolves the render-root region whose pixels actually show the sampled control: the render
+    /// root itself, narrowed to the scroll host viewport when one clips the control.
+    /// </summary>
+    private static Rect ResolveVisibleSampleRegion(ScrollViewer? scrollHost, UIElement renderRoot)
+    {
+        var rootRegion = new Rect(0, 0, renderRoot.RenderSize.Width, renderRoot.RenderSize.Height);
+        if (scrollHost is null || scrollHost.ViewportWidth <= 0 || scrollHost.ViewportHeight <= 0)
+        {
+            return rootRegion;
+        }
+
+        var viewport = scrollHost
+            .TransformToVisual(renderRoot)
+            .TransformBounds(new Rect(0, 0, scrollHost.ViewportWidth, scrollHost.ViewportHeight));
+        var left = Math.Max(rootRegion.X, viewport.X);
+        var top = Math.Max(rootRegion.Y, viewport.Y);
+        var right = Math.Min(rootRegion.X + rootRegion.Width, viewport.X + viewport.Width);
+        var bottom = Math.Min(rootRegion.Y + rootRegion.Height, viewport.Y + viewport.Height);
+        return right <= left || bottom <= top
+            ? new Rect(left, top, 0, 0)
+            : new Rect(left, top, right - left, bottom - top);
+    }
+
+    private static bool IsInsideRegion(Rect sampleBounds, Rect region)
+        => sampleBounds.Width > 0
+            && sampleBounds.Height > 0
+            && sampleBounds.X >= region.X
+            && sampleBounds.Y >= region.Y
+            && sampleBounds.X + sampleBounds.Width <= region.X + region.Width
+            && sampleBounds.Y + sampleBounds.Height <= region.Y + region.Height;
 
     /// <summary>
     /// Projects the inset BorderElement region into render-root coordinates, or <c>null</c> when the
@@ -736,6 +842,21 @@ internal static class NumberBoxThemeProbeDriver
         return default;
     }
 
+    private static T? FindAncestor<T>(DependencyObject element)
+        where T : DependencyObject
+    {
+        DependencyObject? current = element;
+        while ((current = VisualTreeHelper.GetParent(current)) is not null)
+        {
+            if (current is T match)
+            {
+                return match;
+            }
+        }
+
+        return default;
+    }
+
     private static T? FindDescendant<T>(DependencyObject root, Func<T, bool> predicate)
         where T : DependencyObject
     {
@@ -802,7 +923,8 @@ internal static class NumberBoxThemeProbeDriver
     private sealed record NumberBoxThemeProbeTargets(
         NumberBox NumberBox,
         TextBox InputBox,
-        ToggleSwitch FocusSink);
+        ToggleSwitch FocusSink,
+        ScrollViewer? ScrollHost);
 
     private readonly record struct RenderedColors(
         Windows.UI.Color? Foreground,

--- a/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NumberBoxThemeProbeDriver.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NumberBoxThemeProbeDriver.cs
@@ -184,12 +184,15 @@ internal static class NumberBoxThemeProbeDriver
             // without waiting samples a rect that still lies outside the render root, which yields
             // an empty region indistinguishable from an unreadable frame. Wait for the realized
             // geometry to land inside the render root before sampling pixels.
-            await WaitForSampleBoundsInsideRenderRootAsync(targets.NumberBox, targets.InputBox)
+            var boundsSettled = await WaitForSampleBoundsInsideRenderRootAsync(
+                    targets.NumberBox,
+                    targets.InputBox)
                 .ConfigureAwait(true);
             var snapshot = await CaptureSnapshotAsync(
                     targets.NumberBox,
                     targets.InputBox,
-                    unfocusedBeforeSample && inputFocused)
+                    unfocusedBeforeSample && inputFocused,
+                    boundsSettled)
                 .ConfigureAwait(true);
             if (snapshot.Foreground is null || snapshot.Background is null)
             {
@@ -236,7 +239,8 @@ internal static class NumberBoxThemeProbeDriver
     private static async Task<NumberBoxThemeProbeSnapshot> CaptureSnapshotAsync(
         NumberBox numberBox,
         TextBox inputBox,
-        bool focusTransitionSucceeded)
+        bool focusTransitionSucceeded,
+        bool boundsSettled)
     {
         var contentElement = FindDescendant<ScrollViewer>(
             inputBox,
@@ -280,6 +284,8 @@ internal static class NumberBoxThemeProbeDriver
             background,
             contrast,
             renderedColors.Attempts,
+            boundsSettled,
+            renderedColors.Diagnostic,
             passed);
     }
 
@@ -294,17 +300,32 @@ internal static class NumberBoxThemeProbeDriver
 
         Windows.UI.Color? background = null;
         Windows.UI.Color? foreground = null;
+        var diagnostic = "not-attempted";
+        string? firstFailure = null;
         for (var attempt = 1; attempt <= RenderCaptureAttemptCount; attempt++)
         {
             borderElement.UpdateLayout();
-            background = await TryCaptureRenderedBackgroundAsync(borderElement).ConfigureAwait(true);
+            var capture = await TryCaptureRenderedBackgroundAsync(borderElement).ConfigureAwait(true);
+            background = capture.Color;
+            diagnostic = capture.Diagnostic;
             foreground = background is null
                 ? null
                 : TryResolveEffectiveForeground(contentElement.Foreground, background.Value);
             if (background is not null && foreground is not null)
             {
-                return new RenderedColors(foreground, background, attempt);
+                return new RenderedColors(
+                    foreground,
+                    background,
+                    attempt,
+                    firstFailure is null ? diagnostic : $"{diagnostic} recoveredFrom=[{firstFailure}]");
             }
+
+            if (background is not null)
+            {
+                diagnostic = "foreground-brush-unreadable";
+            }
+
+            firstFailure ??= diagnostic;
 
             if (attempt < RenderCaptureAttemptCount)
             {
@@ -317,21 +338,27 @@ internal static class NumberBoxThemeProbeDriver
             }
         }
 
-        return new RenderedColors(foreground, background, RenderCaptureAttemptCount);
+        return new RenderedColors(foreground, background, RenderCaptureAttemptCount, diagnostic);
     }
 
-    private static async Task<Windows.UI.Color?> TryCaptureRenderedBackgroundAsync(
+    /// <summary>
+    /// Captures the rendered BorderElement background, or an unavailable sample that names the
+    /// reason. A bare <c>null</c> cannot distinguish an empty Skia frame from an off-viewport rect,
+    /// a translucent offscreen composition or an ambiguous cluster, so every exit reports its cause.
+    /// </summary>
+    private static async Task<BackgroundCapture> TryCaptureRenderedBackgroundAsync(
         Border borderElement)
     {
         if (borderElement.DispatcherQueue is null || !borderElement.DispatcherQueue.HasThreadAccess)
         {
-            return null;
+            return BackgroundCapture.Unavailable("no-dispatcher-access");
         }
 
         var renderRoot = FindVisualRoot(borderElement);
         if (renderRoot is null || renderRoot.RenderSize.Width <= 0 || renderRoot.RenderSize.Height <= 0)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"render-root-unmeasured root={FormatSize(renderRoot?.RenderSize)}");
         }
 
         // Skia Acrylic samples its ancestor backdrop. Rendering only BorderElement, or rebuilding
@@ -339,21 +366,26 @@ internal static class NumberBoxThemeProbeDriver
         var sampleBounds = TryResolveSampleBounds(borderElement, renderRoot);
         if (sampleBounds is null)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"sample-bounds-unresolved border={FormatSize(new Size(borderElement.ActualWidth, borderElement.ActualHeight))}");
         }
 
         var bitmap = new RenderTargetBitmap();
         await bitmap.RenderAsync(renderRoot);
         if (bitmap.PixelWidth <= 0 || bitmap.PixelHeight <= 0)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"render-empty bitmap={bitmap.PixelWidth}x{bitmap.PixelHeight}"
+                + $" root={FormatSize(renderRoot.RenderSize)}");
         }
 
         var pixelBuffer = await bitmap.GetPixelsAsync();
         var expectedLength = checked(bitmap.PixelWidth * bitmap.PixelHeight * 4);
         if (pixelBuffer.Length != (uint)expectedLength)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"pixel-buffer-mismatch length={pixelBuffer.Length} expected={expectedLength}"
+                + $" bitmap={bitmap.PixelWidth}x{bitmap.PixelHeight}");
         }
 
         var pixels = new byte[expectedLength];
@@ -455,7 +487,7 @@ internal static class NumberBoxThemeProbeDriver
         return root;
     }
 
-    private static Windows.UI.Color? TrySampleOpaqueBackground(
+    private static BackgroundCapture TrySampleOpaqueBackground(
         byte[] pixels,
         int pixelWidth,
         int pixelHeight,
@@ -467,10 +499,13 @@ internal static class NumberBoxThemeProbeDriver
         var bottom = Math.Min(pixelHeight, (int)Math.Floor(sampleBounds.Y + sampleBounds.Height));
         if (right <= left || bottom <= top)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"sample-region-empty rect={FormatRect(sampleBounds)} bitmap={pixelWidth}x{pixelHeight}");
         }
 
-        var samples = new List<Windows.UI.Color>(checked((right - left) * (bottom - top)));
+        var regionPixelCount = checked((right - left) * (bottom - top));
+        var samples = new List<Windows.UI.Color>(regionPixelCount);
+        var translucentPixelCount = 0;
         for (var y = top; y < bottom; y++)
         {
             for (var x = left; x < right; x++)
@@ -478,7 +513,8 @@ internal static class NumberBoxThemeProbeDriver
                 var offset = ((y * pixelWidth) + x) * 4;
                 if (pixels[offset + 3] != byte.MaxValue)
                 {
-                    return null;
+                    translucentPixelCount++;
+                    continue;
                 }
 
                 samples.Add(Windows.UI.Color.FromArgb(
@@ -487,6 +523,16 @@ internal static class NumberBoxThemeProbeDriver
                     pixels[offset + 1],
                     pixels[offset]));
             }
+        }
+
+        // Preserved semantics: a partially transparent offscreen composition is not evidence of the
+        // realized background, so the sample stays unavailable. The counts identify how much of the
+        // region failed to composite, which a bare null could not.
+        if (translucentPixelCount > 0)
+        {
+            return BackgroundCapture.Unavailable(
+                $"sample-translucent translucent={translucentPixelCount}/{regionPixelCount}"
+                + $" rect={FormatRect(sampleBounds)}");
         }
 
         var reds = new List<byte>(samples.Count);
@@ -526,19 +572,33 @@ internal static class NumberBoxThemeProbeDriver
 
         if (inlierReds.Count * 3 < reds.Count * 2)
         {
-            return null;
+            return BackgroundCapture.Unavailable(
+                $"sample-cluster-ambiguous inliers={inlierReds.Count}/{reds.Count}"
+                + $" median=#{red:X2}{green:X2}{blue:X2}");
         }
 
         inlierReds.Sort();
         inlierGreens.Sort();
         inlierBlues.Sort();
         var inlierMedianIndex = inlierReds.Count / 2;
-        return Windows.UI.Color.FromArgb(
-            byte.MaxValue,
-            inlierReds[inlierMedianIndex],
-            inlierGreens[inlierMedianIndex],
-            inlierBlues[inlierMedianIndex]);
+        return BackgroundCapture.Available(
+            Windows.UI.Color.FromArgb(
+                byte.MaxValue,
+                inlierReds[inlierMedianIndex],
+                inlierGreens[inlierMedianIndex],
+                inlierBlues[inlierMedianIndex]),
+            $"ok inliers={inlierReds.Count}/{reds.Count} rect={FormatRect(sampleBounds)}");
     }
+
+    private static string FormatRect(Rect rect)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{rect.X:F1},{rect.Y:F1}+{rect.Width:F1}x{rect.Height:F1}");
+
+    private static string FormatSize(Size? size)
+        => size is { } value
+            ? string.Create(CultureInfo.InvariantCulture, $"{value.Width:F1}x{value.Height:F1}")
+            : "<none>";
 
     private static Windows.UI.Color? TryResolveEffectiveForeground(
         Brush? foreground,
@@ -711,6 +771,8 @@ internal static class NumberBoxThemeProbeDriver
         Windows.UI.Color? Background,
         double Contrast,
         int CaptureAttempts,
+        bool BoundsSettled,
+        string CaptureDiagnostic,
         bool Passed)
     {
         public string Format(int sample)
@@ -720,14 +782,16 @@ internal static class NumberBoxThemeProbeDriver
                 + $" contentTheme={ContentTheme} borderTheme={BorderTheme}"
                 + $" foreground={FormatColor(Foreground)} background={FormatColor(Background)}"
                 + $" contrast={Contrast.ToString("F2", CultureInfo.InvariantCulture)}"
-                + $" captureAttempts={CaptureAttempts} passed={Passed}";
+                + $" captureAttempts={CaptureAttempts} boundsSettled={BoundsSettled}"
+                + $" passed={Passed} captureReason=[{CaptureDiagnostic}]";
 
         public string FormatUnavailable(int attempt)
             => $"NumberBoxThemeProbe: capture-unavailable attempt={attempt} visible={Visible}"
                 + $" focusTransition={FocusTransitionSucceeded} focused={Focused}"
                 + $" focusState={FocusState} numberBoxTheme={NumberBoxTheme} inputTheme={InputTheme}"
                 + $" contentTheme={ContentTheme} borderTheme={BorderTheme}"
-                + $" captureAttempts={CaptureAttempts}";
+                + $" captureAttempts={CaptureAttempts} boundsSettled={BoundsSettled}"
+                + $" captureReason=[{CaptureDiagnostic}]";
 
         private static string FormatColor(Windows.UI.Color? color)
             => color is { } value
@@ -743,9 +807,21 @@ internal static class NumberBoxThemeProbeDriver
     private readonly record struct RenderedColors(
         Windows.UI.Color? Foreground,
         Windows.UI.Color? Background,
-        int Attempts)
+        int Attempts,
+        string Diagnostic)
     {
-        public static RenderedColors Unavailable { get; } = new(null, null, 0);
+        public static RenderedColors Unavailable { get; } = new(null, null, 0, "template-parts-missing");
+    }
+
+    /// <summary>
+    /// A rendered background sample, or an unavailable one that names why it could not be read.
+    /// </summary>
+    private readonly record struct BackgroundCapture(Windows.UI.Color? Color, string Diagnostic)
+    {
+        public static BackgroundCapture Available(Windows.UI.Color color, string diagnostic)
+            => new(color, diagnostic);
+
+        public static BackgroundCapture Unavailable(string diagnostic) => new(null, diagnostic);
     }
 
     private readonly record struct ColorLayer(

--- a/scripts/gates/run-skia-desktop-gui-smoke-gates.sh
+++ b/scripts/gates/run-skia-desktop-gui-smoke-gates.sh
@@ -13,6 +13,8 @@ APP_PATH="${REPO_ROOT}/SalmonEgg/SalmonEgg/bin/${CONFIGURATION}/net10.0-desktop/
 X11_PROBE="${REPO_ROOT}/scripts/gates/skia-desktop-x11-window-probe.py"
 SEED_WRITER_PROJECT="${REPO_ROOT}/tests/SalmonEgg.TestSupport/SalmonEgg.TestSupport.csproj"
 READY_MARKER="MainPage: initial shell content activated"
+WINDOW_CREATED_MARKER="OnLaunched: window created"
+WINDOW_CREATED_TIMEOUT_SECONDS=120
 TRANSCRIPT_SEED_CONVERSATION_ID="skia-mixed-session-01"
 TRANSCRIPT_SEED_MARKER="SKIA_MD_MARKER_7f3a"
 NUMBERBOX_PROBE_COMPLETE_MARKER="NumberBoxThemeProbe: complete"
@@ -99,6 +101,29 @@ start_xvfb() {
 
   cat "${XVFB_LOG}" >&2
   echo "Unable to start Xvfb for Skia Desktop GUI smoke." >&2
+  return 1
+}
+
+# Waits for a boot.log marker, failing fast if the app exits first. Startup duration and window
+# paint latency are separate facts: a shared deadline lets slow startup consume the paint budget and
+# report as "window never painted", which is the wrong diagnosis and the wrong thing to fix.
+wait_for_boot_marker() {
+  local marker="$1"
+  local timeout_seconds="$2"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    if ! kill -0 "${APP_PID}" 2>/dev/null; then
+      return 2
+    fi
+
+    if [ -f "${BOOT_LOG}" ] && grep -Fq "${marker}" "${BOOT_LOG}"; then
+      return 0
+    fi
+
+    sleep 0.2
+  done
+
   return 1
 }
 
@@ -201,6 +226,24 @@ fi
 APP_PID="$!"
 
 if [ "${OS_NAME}" = "Linux" ]; then
+  # A hosted runner has been measured taking 15s from process start to window creation, which left
+  # 5s of a shared 20s budget for map and paint and failed with distinctPixels=1 on an app that went
+  # on to render correctly. Spend the startup wait here so the probe budget measures only the paint.
+  wait_for_boot_marker "${WINDOW_CREATED_MARKER}" "${WINDOW_CREATED_TIMEOUT_SECONDS}"
+  window_created_status="$?"
+  if [ "${window_created_status}" -ne 0 ]; then
+    cat "${STDOUT_LOG}" >&2
+    if [ -f "${BOOT_LOG}" ]; then
+      cat "${BOOT_LOG}" >&2
+    fi
+    if [ "${window_created_status}" -eq 2 ]; then
+      echo "Skia Desktop GUI smoke exited before creating its window." >&2
+    else
+      echo "Skia Desktop GUI smoke did not log '${WINDOW_CREATED_MARKER}' within ${WINDOW_CREATED_TIMEOUT_SECONDS}s." >&2
+    fi
+    exit 1
+  fi
+
   if ! "${PYTHON_BIN}" "${X11_PROBE}" \
       --display "${SMOKE_DISPLAY}" \
       --pid "${APP_PID}" \

--- a/tests/SalmonEgg.Presentation.Core.Tests/Build/GuiSmokeGateContractTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Build/GuiSmokeGateContractTests.cs
@@ -49,6 +49,9 @@ public sealed class GuiSmokeGateContractTests
         Assert.Contains("libXtst.so.6", x11Probe, StringComparison.Ordinal);
         Assert.Contains("XTestFakeKeyEvent", x11Probe, StringComparison.Ordinal);
         Assert.Contains("Install the XTest runtime", x11Probe, StringComparison.Ordinal);
+        Assert.Contains("WINDOW_CREATED_MARKER=\"OnLaunched: window created\"", script, StringComparison.Ordinal);
+        Assert.Contains("wait_for_boot_marker \"${WINDOW_CREATED_MARKER}\" \"${WINDOW_CREATED_TIMEOUT_SECONDS}\"", script, StringComparison.Ordinal);
+        Assert.Contains("Skia Desktop GUI smoke exited before creating its window.", script, StringComparison.Ordinal);
         Assert.Contains("Skia Desktop GUI smoke did not expose a mapped, nonblank X11 window.", script, StringComparison.Ordinal);
         Assert.Contains("Skia Desktop GUI smoke did not expose a focusable X11 window that accepts synthetic keyboard input.", script, StringComparison.Ordinal);
         Assert.Contains("Skia Desktop GUI smoke requires Debug configuration", script, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

`Skia Desktop GUI Smoke` has been red roughly half the time on `develop` for weeks. Two distinct failure signatures, two different root causes, neither of them a product defect — both are the gate's own timing assumptions being wrong.

**Diagnosis method mattered here.** This flake does not reproduce locally: 6/6 concurrent local runs pass, and it still passes with the retry budget cut to a single attempt. What made it solvable was making the gate say *why* it failed first. Five distinct causes (empty frame, off-viewport rect, translucent composition, region clipped to nothing, ambiguous colour cluster) all collapsed into a bare `null`, so the log only ever said `capture-unavailable`. With reason codes added, temporary branches reproduced it on CI 2 out of 3 times with the cause quoted verbatim.

## Signature 1 — `capture-unavailable`, fewer than 3 samples

Not an incomplete Skia frame, which is what the previous retry-based stabilization assumed. CI reported, verbatim:

```
sample-region-empty rect=849.0,739.0+128.0x21.0 bitmap=1024x640 boundsSettled=False
```

The sample rect sits 99px below a 640px-tall render root, so the region clips to nothing.

Why intermittent: sample 1 succeeds at y=601 in a 640px root, leaving **18px of slack**. Each sample focuses the sink to prove the focus transition is real, which scrolls the page away, and the return trip was `StartBringIntoView()` — a request for an *animated* scroll. On a fast machine it lands inside the settle budget; on a slow runner it does not, and 18px is all it takes to miss. Once missed, every retry re-requests the same animation and re-observes the same stale position — hence the run of nine identical failures.

Fix: ask the `ScrollViewer` host that owns the viewport directly. `ChangeView(disableAnimation: true)` to an offset derived from realized geometry lands in one layout pass and overrides any in-flight bring-into-view. Centering rather than merely revealing turns 18px of slack into ~270px on either side.

**Also closes a false-green hole.** `IsInsideRenderRoot` accepted any rect inside the window, but a control scrolled under the header is clipped away while its transformed bounds still land inside the render root — the capture would read whatever paints there and report it as the control's contrast. The check is now against the region that actually shows the control, and the capture site rejects an off-viewport rect rather than sampling it.

## Signature 2 — `X11 window probe failed ... distinctPixels=1`

A misdiagnosis. The probe's 20s budget was counted from process launch, while startup to window creation measured **15.0s** (run 32881073024) and 14.2s (32967087798) on hosted runners — leaving 5s for map and paint. Both runs went on to log `contrast=16.10 passed=True`, so the app rendered real pixels, just later than a clock already spent elsewhere.

Fix: startup duration and paint latency are separate facts, so they get separate budgets. The gate waits for `OnLaunched: window created` (120s) first, then hands the probe its full 20s to measure only map and paint. An early app exit now takes its own fail-fast branch with its own message — previously it also surfaced as "window never painted".

## Testing

- **CI: 12/12 green** across dispatched runs, the last 4 carrying all three commits. Baseline for comparison: 11 of the preceding 15 runs failed.
- **Reproduced before fixing**: runs 33002398560 and 33002401187 (diagnostics-only commit) failed with the reason code quoted above.
- Presentation.Core: 3224 tests pass.
- Real gate passes end to end locally; `dotnet format --verify-no-changes` clean; analyzer build clean (0 warnings).
- **Reverse-verified** per AGENTS.md #100: all three branches of the new wait exercised directly (marker present → 0, app alive without marker → 1, app exited → 2, including when boot.log was never created). Removing the wait fails the contract test (`Assert.Contains`, sub-string not found); restoring it passes.

## Notes

Deliberately *not* done: raising `RenderCaptureAttemptCount` or the retry delay. That does not fix the cause — re-reading a stale position more times changes nothing — and it pushes the probe past the gate's 60s readiness deadline, trading one failure signature for another.

Local runs cannot substitute for CI verification here: this machine is arm64 and the runners are x86_64, and the flake depends on animation latency the local machine does not exhibit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)