### PR TITLE
fix(acp-setup): withhold the install offer when its toolchain is absent

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -142,16 +142,48 @@
                                                                    IsTextSelectionEnabled="True"
                                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                                     </StackPanel>
+                                                    <!-- Offered only when this machine can honour it:
+                                                         CanInstallHere folds the catalog's install path
+                                                         together with a probe of the toolchain that would
+                                                         run it, so the button is absent rather than
+                                                         failing on click. -->
                                                     <Button x:Name="InstallAgentInlineButton"
                                                             x:Uid="AcpSetup_InstallAgentRow"
                                                             Tag="{x:Bind}"
                                                             Click="OnInstallAgentRowClick"
                                                             AutomationProperties.AutomationId="AcpSetup.Agents.InstallRow"
-                                                            Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                            Visibility="{x:Bind CanInstallHere, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                    <!-- Distribution the wizard never automates (a
+                                                         prebuilt binary): the agent's own install page is
+                                                         the right destination. -->
                                                     <HyperlinkButton NavigateUri="{x:Bind InstallDocumentation}"
                                                                      x:Uid="AcpSetup_InstallDocs"
-                                                                     Visibility="{x:Bind SupportsAutomaticInstall, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"/>
+                                                                     Visibility="{x:Bind HasAutomaticInstallPath, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"/>
+                                                    <!-- Installable in principle, but the toolchain is
+                                                         absent. Points at the toolchain rather than the
+                                                         agent, because the agent's page assumes a
+                                                         toolchain this user does not have yet. -->
+                                                    <HyperlinkButton NavigateUri="{x:Bind ToolchainDocumentation, Mode=OneWay}"
+                                                                     x:Uid="AcpSetup_InstallToolchainDocs"
+                                                                     AutomationProperties.AutomationId="AcpSetup.Agents.ToolchainDocs"
+                                                                     Visibility="{x:Bind IsToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                 </StackPanel>
+
+                                                <!-- Says why there is no install button, naming the
+                                                     toolchain. Withdrawing the button without this would
+                                                     leave the row looking like the agent simply cannot be
+                                                     installed, which is a different and wrong conclusion.
+
+                                                     Text is composed by the row rather than carrying an
+                                                     x:Uid: the sentence interpolates the toolchain name,
+                                                     and an x:Uid would assign .Text from the resw and
+                                                     overwrite this binding. -->
+                                                <TextBlock Text="{x:Bind ToolchainMissingHint, Mode=OneWay}"
+                                                           Visibility="{x:Bind IsToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                           AutomationProperties.AutomationId="AcpSetup.Agents.ToolchainMissingHint"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
 
                                                 <Expander x:Name="AgentProbeDiagnosticsExpander"
                                                           IsExpanded="False"
@@ -219,9 +251,28 @@
                                                 x:Uid="AcpSetup_RedetectAdapter"
                                                 AutomationProperties.AutomationId="AcpSetup.Adapter.Redetect"
                                                 Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
+                                        <!-- The install button above is command-bound, so a missing
+                                             toolchain already disables it. A disabled button explains
+                                             nothing on its own, so the way forward is offered beside it:
+                                             the toolchain's own documentation, named in the text below. -->
+                                        <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
+                                                         x:Uid="AcpSetup_InstallToolchainDocs"
+                                                         NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"
+                                                         AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainDocs"
+                                                         Visibility="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                     </StackPanel>
                                 </InfoBar.Content>
                             </InfoBar>
+
+                            <!-- Named separately from the warning above because it is a different
+                                 problem with a different fix: the adapter is installable, but nothing on
+                                 this machine can install it yet. -->
+                            <InfoBar x:Name="AcpSetupAdapterToolchainMissingBar"
+                                     IsOpen="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay}"
+                                     Message="{x:Bind ViewModel.AdapterToolchainMissingText, Mode=OneWay}"
+                                     AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainMissingBar"
+                                     Severity="Warning"
+                                     IsClosable="False"/>
 
                             <InfoBar x:Name="AcpSetupAdapterReadyBar"
                                      x:Uid="AcpSetup_AdapterReadyBar"

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -861,6 +861,9 @@
   <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
     <value>Install docs</value>
   </data>
+  <data name="AcpSetup_InstallToolchainDocs.Content" xml:space="preserve">
+    <value>Set up toolchain</value>
+  </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
     <value>3. Launch parameters</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1389,6 +1389,9 @@
   <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
     <value>Install docs</value>
   </data>
+  <data name="AcpSetup_InstallToolchainDocs.Content" xml:space="preserve">
+    <value>Set up toolchain</value>
+  </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
     <value>3. Launch parameters</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -786,6 +786,9 @@
   <data name="AcpSetup_InstallDocs.Content" xml:space="preserve">
     <value>安装文档</value>
   </data>
+  <data name="AcpSetup_InstallToolchainDocs.Content" xml:space="preserve">
+    <value>安装工具链</value>
+  </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
     <value>3. 启动参数</value>
   </data>

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
@@ -17,6 +17,12 @@ public sealed class AcpAgentDetectionState
     /// <summary>Probe of the recommended adapter, or null when the adapter has not been probed yet.</summary>
     public AcpComponentProbeResult? Adapter { get; init; }
 
+    /// <summary>
+    /// Whether the toolchain the runtime would install through exists here. Null when the runtime needs
+    /// no toolchain, which is not the same as one being absent.
+    /// </summary>
+    public AcpToolchainProbeResult? RuntimeToolchain { get; init; }
+
     /// <summary>True when the agent can be configured without installing anything.</summary>
     public bool IsReady => Runtime.IsUsable && Adapter?.IsUsable == true;
 }

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
@@ -60,6 +60,62 @@ public sealed class AcpComponentDetector
         };
     }
 
+    /// <summary>
+    /// Resolves whether the toolchain <paramref name="component"/> would install through exists on this
+    /// machine, or null when the component needs no toolchain.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately reproduces <c>DesktopAcpComponentInstaller</c>'s command derivation step for
+    /// step — the same launcher resolution, the same sibling derivation, and the same
+    /// <see cref="AcpPackageManagerCandidates.Preferred"/>-only choice. Its whole purpose is to predict
+    /// what an install would do, so a derivation that differed anywhere would let the wizard promise an
+    /// install that then fails, or withhold one that would have worked. If the installer's derivation
+    /// changes, this must change with it.
+    /// </remarks>
+    public async Task<AcpToolchainProbeResult?> DetectToolchainAsync(
+        AcpComponentDescriptor component,
+        AcpCommandOverrides? overrides = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        if (component.RequiredToolchain is not { } requirement)
+        {
+            return null;
+        }
+
+        if (!_probe.SupportsProcessProbing)
+        {
+            return AcpToolchainProbeResult.Undetermined(requirement, ProbingUnsupportedDetail);
+        }
+
+        var effectiveOverrides = overrides ?? AcpCommandOverrides.Empty;
+
+        // The component's own launcher is resolved first only to sharpen the sibling derivation; not
+        // finding it is ordinary, because the manager may be on PATH while the component is not — which is
+        // exactly the state this probe exists to recognise.
+        var resolvedLauncher = await _probe
+            .ResolveExecutablePathAsync(
+                effectiveOverrides.Resolve(component.ProbeCommand),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var manager = AcpPackageManagerCommand
+            .Resolve(component.Distribution, resolvedLauncher, effectiveOverrides)
+            .Preferred;
+
+        var managerPath = await _probe
+            .ResolveExecutablePathAsync(manager, cancellationToken)
+            .ConfigureAwait(false);
+
+        return string.IsNullOrWhiteSpace(managerPath)
+            ? AcpToolchainProbeResult.Missing(requirement, ToolchainMissingDetail(manager))
+            : AcpToolchainProbeResult.Available(requirement, managerPath);
+    }
+
+    private static string ToolchainMissingDetail(string manager)
+        => $"Package manager '{manager}' was not found on PATH.";
+
     private async Task<AcpComponentProbeResult> DetectExecutableAsync(
         AcpComponentDescriptor component,
         AcpCommandOverrides overrides,

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -36,7 +36,13 @@ public sealed class AcpSetupWizardOrchestrator
         _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
     }
 
-    /// <summary>True when this platform can install components for the user.</summary>
+    /// <summary>
+    /// True when this platform can run installers at all.
+    /// </summary>
+    /// <remarks>
+    /// A platform capability. Whether <em>this machine</em> has the toolchain an install needs is
+    /// <see cref="DetectToolchainAsync"/>'s answer, and a caller offering a one-click install needs both.
+    /// </remarks>
     public bool SupportsAutomaticInstall => _installer.SupportsAutomaticInstall;
 
     public IReadOnlyList<AcpAgentDescriptor> Agents => _catalog.Agents;
@@ -56,7 +62,21 @@ public sealed class AcpSetupWizardOrchestrator
             var runtime = await _detector
                 .DetectAsync(agent.Runtime, overrides, cancellationToken)
                 .ConfigureAwait(false);
-            states.Add(new AcpAgentDetectionState { Agent = agent, Runtime = runtime });
+
+            // Probed alongside the runtime rather than on demand from the row, so a row that has to
+            // decide whether to offer an install already holds the answer. Deferring it would either
+            // show a button before the answer arrives — the defect this replaces — or make every row
+            // launch its own process after the sweep already had the chance.
+            var toolchain = await _detector
+                .DetectToolchainAsync(agent.Runtime, overrides, cancellationToken)
+                .ConfigureAwait(false);
+
+            states.Add(new AcpAgentDetectionState
+            {
+                Agent = agent,
+                Runtime = runtime,
+                RuntimeToolchain = toolchain
+            });
         }
 
         return states;
@@ -67,6 +87,16 @@ public sealed class AcpSetupWizardOrchestrator
         AcpCommandOverrides? overrides = null,
         CancellationToken cancellationToken = default)
         => _detector.DetectAsync(component, overrides, cancellationToken);
+
+    /// <summary>
+    /// Probes the toolchain <paramref name="component"/> installs through, or returns null when it needs
+    /// none. Callers offer a one-click install only when the result allows the attempt.
+    /// </summary>
+    public Task<AcpToolchainProbeResult?> DetectToolchainAsync(
+        AcpComponentDescriptor component,
+        AcpCommandOverrides? overrides = null,
+        CancellationToken cancellationToken = default)
+        => _detector.DetectToolchainAsync(component, overrides, cancellationToken);
 
     /// <summary>
     /// Installs a component and re-probes it, so callers always see verified availability rather than

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentDescriptor.cs
@@ -40,12 +40,24 @@ public sealed class AcpComponentDescriptor
     public Uri? InstallDocumentation { get; init; }
 
     /// <summary>
-    /// True when the wizard can install this component itself. Binary distributions are
-    /// download + checksum + unpack flows the wizard deliberately does not automate.
+    /// True when this component's distribution has an automatic install path at all. Binary
+    /// distributions are download + checksum + unpack flows the wizard deliberately does not automate.
     /// </summary>
-    public bool SupportsAutomaticInstall
+    /// <remarks>
+    /// A statement about the catalog entry, not about this machine: it says an install command exists to
+    /// run, not that the toolchain which runs it is present. Offering the user a button needs both, so
+    /// callers pair this with a probe of <see cref="RequiredToolchain"/> rather than reading it alone.
+    /// </remarks>
+    public bool HasAutomaticInstallPath
         => Distribution is AcpDistributionKind.Npx or AcpDistributionKind.Uvx
             && !string.IsNullOrWhiteSpace(PackageId);
+
+    /// <summary>
+    /// The toolchain that must exist before <see cref="HasAutomaticInstallPath"/> can be acted on, or
+    /// null when this component needs none.
+    /// </summary>
+    public AcpToolchainRequirement? RequiredToolchain
+        => HasAutomaticInstallPath ? AcpToolchainRequirement.For(Distribution) : null;
 
     /// <summary>True when nothing has to exist on the machine for this component to be usable.</summary>
     public bool IsBuiltIn => Distribution == AcpDistributionKind.BuiltIn;

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentInstallResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpComponentInstallResult.cs
@@ -16,8 +16,27 @@ public sealed class AcpComponentInstallResult
     /// <summary>Trailing installer output, retained for the failure surface.</summary>
     public string? Output { get; init; }
 
-    /// <summary>Reason the installer could not run or did not succeed.</summary>
+    /// <summary>Reason the installer could not run or did not succeed. Developer-facing English.</summary>
     public string? ErrorDetail { get; init; }
+
+    /// <summary>
+    /// Localization key for advice matching this failure, or null when the failure has none beyond
+    /// <see cref="ErrorDetail"/>.
+    /// </summary>
+    /// <remarks>
+    /// Present so a platform layer can say <em>what to do</em> without owning display text, the same
+    /// contract <see cref="AcpSetupTestResult.RemediationKey"/> uses. Without it the only thing the wizard
+    /// could show for a missing toolchain was the raw detail — which names the executable that was looked
+    /// for rather than the toolchain the user has to install, and is untranslated.
+    /// </remarks>
+    public string? RemediationKey { get; init; }
+
+    /// <summary>
+    /// The toolchain whose absence caused this failure, when that is the cause. Substituted into the
+    /// message <see cref="RemediationKey"/> resolves, so the advice names the toolchain rather than a
+    /// package-manager executable the user may never have heard of.
+    /// </summary>
+    public string? MissingToolchainName { get; init; }
 
     public static AcpComponentInstallResult Success(string componentId, string? output)
         => new() { ComponentId = componentId, IsSuccess = true, ExitCode = 0, Output = output };
@@ -26,13 +45,17 @@ public sealed class AcpComponentInstallResult
         string componentId,
         int? exitCode,
         string? output,
-        string? errorDetail)
+        string? errorDetail,
+        string? remediationKey = null,
+        string? missingToolchainName = null)
         => new()
         {
             ComponentId = componentId,
             IsSuccess = false,
             ExitCode = exitCode,
             Output = output,
-            ErrorDetail = errorDetail
+            ErrorDetail = errorDetail,
+            RemediationKey = remediationKey,
+            MissingToolchainName = missingToolchainName
         };
 }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainProbeResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainProbeResult.cs
@@ -1,0 +1,80 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Whether the toolchain a distribution installs through is present on this machine.
+/// </summary>
+/// <remarks>
+/// Three states rather than a boolean, for the same reason component detection has three: a probe that
+/// could not run has not established absence. Telling a user their toolchain is missing when the wizard
+/// merely failed to look would send them to install something they already have.
+/// </remarks>
+public enum AcpToolchainAvailability
+{
+    /// <summary>The toolchain's package manager resolved to an executable.</summary>
+    Available,
+
+    /// <summary>The package manager was searched for and not found.</summary>
+    Missing,
+
+    /// <summary>The search could not be performed on this platform.</summary>
+    Undetermined
+}
+
+/// <summary>
+/// What a probe learned about the toolchain a package-manager distribution needs.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="AcpComponentProbeResult"/> because it answers a different question about a
+/// different subject: a component probe says whether the agent is here, this says whether the machine can
+/// install one at all. Collapsing them would make a missing toolchain read as a missing agent, which is
+/// the confusion this type exists to prevent.
+/// </remarks>
+public sealed class AcpToolchainProbeResult
+{
+    private AcpToolchainProbeResult(
+        AcpToolchainRequirement requirement,
+        AcpToolchainAvailability availability,
+        string? managerPath,
+        string? detail)
+    {
+        Requirement = requirement;
+        Availability = availability;
+        ManagerPath = managerPath;
+        Detail = detail;
+    }
+
+    /// <summary>The toolchain this result is about.</summary>
+    public AcpToolchainRequirement Requirement { get; }
+
+    public AcpToolchainAvailability Availability { get; }
+
+    /// <summary>Absolute path of the package manager, when one was resolved.</summary>
+    public string? ManagerPath { get; }
+
+    /// <summary>
+    /// Diagnostic detail naming what was looked for. Developer-facing; never the primary message.
+    /// </summary>
+    public string? Detail { get; }
+
+    /// <summary>
+    /// True when an install may be attempted.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AcpToolchainAvailability.Undetermined"/> counts as usable: the wizard offers the attempt
+    /// and lets the installer report what really happened, rather than withholding a button over a
+    /// question it could not answer. Only a positive "not here" withholds it.
+    /// </remarks>
+    public bool AllowsInstallAttempt => Availability is not AcpToolchainAvailability.Missing;
+
+    /// <summary>True when the toolchain was searched for and positively not found.</summary>
+    public bool IsMissing => Availability is AcpToolchainAvailability.Missing;
+
+    public static AcpToolchainProbeResult Available(AcpToolchainRequirement requirement, string? managerPath)
+        => new(requirement, AcpToolchainAvailability.Available, managerPath, detail: null);
+
+    public static AcpToolchainProbeResult Missing(AcpToolchainRequirement requirement, string? detail = null)
+        => new(requirement, AcpToolchainAvailability.Missing, managerPath: null, detail);
+
+    public static AcpToolchainProbeResult Undetermined(AcpToolchainRequirement requirement, string? detail = null)
+        => new(requirement, AcpToolchainAvailability.Undetermined, managerPath: null, detail);
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainRequirement.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainRequirement.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// The toolchain a package-manager distribution needs before anything can be installed through it.
+/// </summary>
+/// <remarks>
+/// Modelled because it is the one prerequisite the catalog never declares and the machine may not have.
+/// A component's distribution says how it arrives, not whether the thing that carries it exists here — so
+/// "installable" was previously answered from authoring data alone and could only be contradicted by a
+/// failed install. Naming the requirement lets the wizard ask first.
+///
+/// Derived from the distribution rather than declared per component: every Node package needs the same
+/// Node toolchain, and asking each catalog entry to repeat that would let entries disagree about a fact
+/// that is not theirs to hold.
+///
+/// The launcher name is deliberately not repeated here. Which <em>executable</em> answers for a toolchain
+/// depends on the user's overrides and on which launcher was resolved, which is
+/// <see cref="AcpPackageManagerCommand"/>'s decision; this type only says which toolchain is needed and
+/// where its documentation lives.
+/// </remarks>
+public sealed class AcpToolchainRequirement
+{
+    private AcpToolchainRequirement(string displayName, Uri documentation)
+    {
+        DisplayName = displayName;
+        Documentation = documentation;
+    }
+
+    /// <summary>Human-facing toolchain name. A vendor product name, so it is not localized.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Where the user is sent to install the toolchain themselves.</summary>
+    public Uri Documentation { get; }
+
+    /// <summary>
+    /// The toolchain <paramref name="distribution"/> needs, or null when it needs none.
+    /// </summary>
+    /// <remarks>
+    /// Null for the distributions that carry no package manager at all — a built-in adapter installs
+    /// nothing, and a prebuilt binary is fetched by the user out of band. Callers must read null as "no
+    /// prerequisite to check" rather than as "prerequisite missing".
+    /// </remarks>
+    public static AcpToolchainRequirement? For(AcpDistributionKind distribution)
+        => distribution switch
+        {
+            AcpDistributionKind.Npx => Node,
+            AcpDistributionKind.Uvx => Uv,
+            _ => null
+        };
+
+    /// <summary>
+    /// The Node toolchain, which supplies both <c>node</c> and <c>npm</c>.
+    /// </summary>
+    /// <remarks>
+    /// Documented at the download page rather than at a version-specific installer, and named without a
+    /// minimum version: each package declares its own <c>engines</c> range, so a version asserted here
+    /// would be a claim this type cannot keep true for every catalog entry.
+    /// </remarks>
+    public static AcpToolchainRequirement Node { get; } = new(
+        "Node.js",
+        new Uri("https://nodejs.org/en/download"));
+
+    /// <summary>The uv toolchain, which supplies both <c>uv</c> and <c>uvx</c>.</summary>
+    public static AcpToolchainRequirement Uv { get; } = new(
+        "uv",
+        new Uri("https://docs.astral.sh/uv/getting-started/installation/"));
+}

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpComponentInstaller.cs
@@ -7,7 +7,7 @@ namespace SalmonEgg.Domain.Services.AcpSetup;
 
 /// <summary>
 /// Installs an ACP component through its declared package manager. Only distributions that report
-/// <see cref="AcpComponentDescriptor.SupportsAutomaticInstall"/> may be passed in.
+/// <see cref="AcpComponentDescriptor.HasAutomaticInstallPath"/> may be passed in.
 /// </summary>
 public interface IAcpComponentInstaller
 {
@@ -15,6 +15,11 @@ public interface IAcpComponentInstaller
     /// True when this platform can run installers at all. When false the wizard shows manual
     /// instructions instead of a one-click button.
     /// </summary>
+    /// <remarks>
+    /// A platform capability, not a machine fact: a desktop reports true even with no toolchain
+    /// installed, because it can run a package manager once one exists. Whether this particular machine
+    /// has one is a probe's answer, not this property's.
+    /// </remarks>
     bool SupportsAutomaticInstall { get; }
 
     /// <summary>

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpComponentInstaller.cs
@@ -21,6 +21,12 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
 {
     private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(10);
 
+    /// <summary>
+    /// Advice key for an install that could not start because the toolchain is absent. A key rather than a
+    /// sentence: this layer knows the cause, and the presentation layer owns the words.
+    /// </summary>
+    internal const string ToolchainMissingRemediationKey = "AcpSetup_Install_ToolchainMissing";
+
     private readonly IAcpExecutableProbe _probe;
 
     public DesktopAcpComponentInstaller(IAcpExecutableProbe probe)
@@ -38,7 +44,7 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
     {
         ArgumentNullException.ThrowIfNull(component);
 
-        if (!component.SupportsAutomaticInstall)
+        if (!component.HasAutomaticInstallPath)
         {
             return AcpComponentInstallResult.Failure(
                 component.Id,
@@ -64,11 +70,17 @@ public sealed class DesktopAcpComponentInstaller : IAcpComponentInstaller
 
         if (string.IsNullOrWhiteSpace(launcherPath))
         {
+            // The absent executable is a package manager, so the user's problem is a missing toolchain
+            // rather than a missing command. Naming the toolchain — and carrying a key the presentation
+            // layer localizes — is the difference between advice they can act on and an untranslated
+            // sentence about a program they may never have installed deliberately.
             return AcpComponentInstallResult.Failure(
                 component.Id,
                 exitCode: null,
                 output: null,
-                errorDetail: $"'{launcher}' was not found on PATH.");
+                errorDetail: $"'{launcher}' was not found on PATH.",
+                remediationKey: ToolchainMissingRemediationKey,
+                missingToolchainName: component.RequiredToolchain?.DisplayName);
         }
 
         var result = await AcpSetupProcessRunner

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -503,6 +503,15 @@ Create the corresponding Markdown file in:
   <data name="AcpSetup_Install_Failed" xml:space="preserve">
     <value>Installation failed.</value>
   </data>
+  <data name="AcpSetup_Adapter_ToolchainMissing" xml:space="preserve">
+    <value>{0} is required before this adapter can be installed. Install it, then detect again.</value>
+  </data>
+  <data name="AcpSetup_Agent_ToolchainMissingHint" xml:space="preserve">
+    <value>{0} is required to install this automatically.</value>
+  </data>
+  <data name="AcpSetup_Install_ToolchainMissing" xml:space="preserve">
+    <value>{0} is required before this component can be installed automatically. Install it, then run detection again.</value>
+  </data>
   <data name="AcpSetup_Stage_Validation" xml:space="preserve">
     <value>Parameter validation</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -503,6 +503,15 @@ Create the corresponding Markdown file in:
   <data name="AcpSetup_Install_Failed" xml:space="preserve">
     <value>Installation failed.</value>
   </data>
+  <data name="AcpSetup_Adapter_ToolchainMissing" xml:space="preserve">
+    <value>{0} is required before this adapter can be installed. Install it, then detect again.</value>
+  </data>
+  <data name="AcpSetup_Agent_ToolchainMissingHint" xml:space="preserve">
+    <value>{0} is required to install this automatically.</value>
+  </data>
+  <data name="AcpSetup_Install_ToolchainMissing" xml:space="preserve">
+    <value>{0} is required before this component can be installed automatically. Install it, then run detection again.</value>
+  </data>
   <data name="AcpSetup_Stage_Validation" xml:space="preserve">
     <value>Parameter validation</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -505,6 +505,15 @@
   <data name="AcpSetup_Install_Failed" xml:space="preserve">
     <value>安装失败。</value>
   </data>
+  <data name="AcpSetup_Adapter_ToolchainMissing" xml:space="preserve">
+    <value>需要先安装 {0} 才能安装此适配器。安装完成后请重新检测。</value>
+  </data>
+  <data name="AcpSetup_Agent_ToolchainMissingHint" xml:space="preserve">
+    <value>需要 {0} 才能自动安装。</value>
+  </data>
+  <data name="AcpSetup_Install_ToolchainMissing" xml:space="preserve">
+    <value>需要先安装 {0} 才能自动安装此组件。安装完成后请重新检测。</value>
+  </data>
   <data name="AcpSetup_Stage_Validation" xml:space="preserve">
     <value>参数校验</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -505,6 +505,15 @@
   <data name="AcpSetup_Install_Failed" xml:space="preserve">
     <value>安装失败。</value>
   </data>
+  <data name="AcpSetup_Adapter_ToolchainMissing" xml:space="preserve">
+    <value>需要先安装 {0} 才能安装此适配器。安装完成后请重新检测。</value>
+  </data>
+  <data name="AcpSetup_Agent_ToolchainMissingHint" xml:space="preserve">
+    <value>需要 {0} 才能自动安装。</value>
+  </data>
+  <data name="AcpSetup_Install_ToolchainMissing" xml:space="preserve">
+    <value>需要先安装 {0} 才能自动安装此组件。安装完成后请重新检测。</value>
+  </data>
   <data name="AcpSetup_Stage_Validation" xml:space="preserve">
     <value>参数校验</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
@@ -98,8 +98,77 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
 
     public bool HasVersion => !string.IsNullOrWhiteSpace(Runtime.Version);
 
-    /// <summary>True when this agent can be installed by the wizard rather than by hand.</summary>
-    public bool SupportsAutomaticInstall => Agent.Runtime.SupportsAutomaticInstall;
+    /// <summary>
+    /// Latest toolchain probe for this agent's runtime, or null when it needs no toolchain or has not
+    /// been probed yet.
+    /// </summary>
+    /// <remarks>
+    /// Null carries two meanings that both resolve to "do not withhold the button": a component with no
+    /// prerequisite, and one whose prerequisite has not been established. Only a probe that positively
+    /// reports the toolchain missing turns the offer into documentation, matching how a
+    /// <see cref="AcpComponentAvailability.Undetermined"/> component probe does not block the wizard.
+    /// </remarks>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanInstallHere))]
+    [NotifyPropertyChangedFor(nameof(IsToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(MissingToolchainName))]
+    [NotifyPropertyChangedFor(nameof(ToolchainMissingHint))]
+    [NotifyPropertyChangedFor(nameof(ToolchainDocumentation))]
+    private AcpToolchainProbeResult? _runtimeToolchain;
+
+    /// <summary>
+    /// True when this agent's distribution has an install command the wizard could run.
+    /// </summary>
+    /// <remarks>
+    /// Authoring data only. The view gates on <see cref="CanInstallHere"/>; this stays exposed because
+    /// it is what distinguishes "we never automate this distribution" (goose) from "we would, but this
+    /// machine lacks the toolchain" — two states that must not share one message.
+    /// </remarks>
+    public bool HasAutomaticInstallPath => Agent.Runtime.HasAutomaticInstallPath;
+
+    /// <summary>True when the wizard should offer to install this agent on this machine.</summary>
+    public bool CanInstallHere
+        => HasAutomaticInstallPath && RuntimeToolchain?.IsMissing != true;
+
+    /// <summary>
+    /// True when an install path exists but the toolchain that would run it does not.
+    /// </summary>
+    /// <remarks>
+    /// The state the wizard previously had no name for: it showed an enabled install button and let the
+    /// package manager's absence surface as a failed install.
+    /// </remarks>
+    public bool IsToolchainMissing
+        => HasAutomaticInstallPath && RuntimeToolchain?.IsMissing == true;
+
+    /// <summary>Name of the absent toolchain, empty when none is absent. A vendor name, not localized.</summary>
+    public string MissingToolchainName
+        => IsToolchainMissing ? RuntimeToolchain!.Requirement.DisplayName : string.Empty;
+
+    /// <summary>
+    /// Localized sentence explaining why this row offers no install button, empty when it offers one.
+    /// </summary>
+    /// <remarks>
+    /// Composed here because it interpolates <see cref="MissingToolchainName"/>, and the UI layer's
+    /// <c>x:Uid</c> pipeline cannot reach this assembly's CoreStrings resources — the same reason
+    /// <see cref="Description"/> resolves here rather than in the view.
+    /// </remarks>
+    public string ToolchainMissingHint
+        => IsToolchainMissing
+            ? CoreStringResolver.ResolveFormat(
+                _localizer,
+                ToolchainMissingHintKey,
+                "{0} is required to install this automatically.",
+                MissingToolchainName)
+            : string.Empty;
+
+    private const string ToolchainMissingHintKey = "AcpSetup_Agent_ToolchainMissingHint";
+
+    /// <summary>
+    /// Where to send the user when the toolchain is missing: the toolchain's own documentation, since
+    /// the agent's install page assumes a toolchain they do not have yet.
+    /// </summary>
+    public Uri? ToolchainDocumentation
+        => IsToolchainMissing ? RuntimeToolchain!.Requirement.Documentation : null;
 
     /// <summary>Documentation to offer when automatic installation is unavailable or fails.</summary>
     public Uri? InstallDocumentation => Agent.Runtime.InstallDocumentation;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -112,6 +112,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
     [NotifyPropertyChangedFor(nameof(AdapterProbeCommand))]
     [NotifyPropertyChangedFor(nameof(HasAdapterProbeCommand))]
+    // Read by IsAdapterToolchainMissing for the component's install path.
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
     private AcpAdapterDescriptor? _selectedAdapter;
 
     /// <summary>
@@ -122,6 +127,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     partial void OnSelectedAdapterChanged(AcpAdapterDescriptor? value)
     {
         AdapterProbe = null;
+        AdapterToolchain = null;
         TestResult = null;
         Parameters.Clear();
         LaunchCommandPreview = string.Empty;
@@ -147,7 +153,29 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsAdapterBuiltIn))]
     [NotifyPropertyChangedFor(nameof(IsAdapterInstalled))]
     [NotifyPropertyChangedFor(nameof(HasAdapterProbeCommand))]
+    // IsAdapterToolchainMissing is gated on IsAdapterMissing, so it changes with the component probe as
+    // well as with the toolchain probe. Both notify lists must raise it or the surface it gates goes stale.
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
     private AcpComponentProbeResult? _adapterProbe;
+
+    /// <summary>
+    /// Latest toolchain probe for the selected adapter, or null when it needs none or has not been
+    /// probed.
+    /// </summary>
+    /// <remarks>
+    /// Null does not withhold the install offer, for the same reason an undetermined component probe does
+    /// not block the walk: an unanswered question is not evidence of absence.
+    /// </remarks>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
+    [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
+    private AcpToolchainProbeResult? _adapterToolchain;
 
     /// <summary>
     /// A path the user supplied for the adapter's launcher, empty when they supplied none.
@@ -231,6 +259,43 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     public bool IsAdapterUndetermined
         => AdapterProbe?.Availability == AcpComponentAvailability.Undetermined;
+
+    /// <summary>
+    /// True when the selected adapter is missing and the toolchain that would install it is absent too —
+    /// the state where a one-click install cannot succeed and the user needs the toolchain first.
+    /// </summary>
+    /// <remarks>
+    /// Gated on the adapter actually being missing so this never contradicts an installed adapter: an
+    /// adapter already present on a machine whose package manager has since gone is usable, and telling
+    /// the user to install a toolchain for it would be advice about nothing.
+    /// </remarks>
+    public bool IsAdapterToolchainMissing
+        => IsAdapterMissing
+            && SelectedAdapter?.Component.HasAutomaticInstallPath == true
+            && AdapterToolchain?.IsMissing == true;
+
+    /// <summary>Name of the adapter's absent toolchain, empty when none is absent.</summary>
+    public string MissingAdapterToolchainName
+        => IsAdapterToolchainMissing ? AdapterToolchain!.Requirement.DisplayName : string.Empty;
+
+    /// <summary>Documentation for the adapter's absent toolchain, null when none is absent.</summary>
+    public Uri? AdapterToolchainDocumentation
+        => IsAdapterToolchainMissing ? AdapterToolchain!.Requirement.Documentation : null;
+
+    /// <summary>
+    /// Localized sentence naming the toolchain the adapter install needs, empty when it is present.
+    /// </summary>
+    /// <remarks>
+    /// Composed here rather than through the view's <c>x:Uid</c> because it interpolates the toolchain
+    /// name, and a <c>Message</c> assigned from a resw would overwrite the binding.
+    /// </remarks>
+    public string AdapterToolchainMissingText
+        => IsAdapterToolchainMissing
+            ? FormatLocalize(
+                AdapterToolchainMissingKey,
+                "{0} is required before this adapter can be installed. Install it, then detect again.",
+                MissingAdapterToolchainName)
+            : string.Empty;
 
     /// <summary>
     /// Diagnostic detail from the adapter probe, empty when it reported none.
@@ -363,9 +428,18 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         await RunOperationAsync(
             async token =>
             {
+                var overrides = CollectCommandOverrides();
                 var probe = await _orchestrator
-                    .DetectComponentAsync(adapter.Component, CollectCommandOverrides(), token)
+                    .DetectComponentAsync(adapter.Component, overrides, token)
                     .ConfigureAwait(false);
+
+                // Probed in the same operation as the component: the install button this gates appears on
+                // the same render as the "missing" verdict that reveals it, so it is never briefly offered
+                // on a machine that cannot honour it.
+                var toolchain = await _orchestrator
+                    .DetectToolchainAsync(adapter.Component, overrides, token)
+                    .ConfigureAwait(false);
+
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
@@ -375,6 +449,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                         if (ReferenceEquals(SelectedAdapter, adapter))
                         {
                             AdapterProbe = probe;
+                            AdapterToolchain = toolchain;
                         }
                     })
                     .ConfigureAwait(false);
@@ -396,10 +471,15 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// see whether its own component is installable; whether this platform installs anything at all is
     /// the orchestrator's answer, and a platform that declines every request would otherwise be handed
     /// one and report its refusal as a failure the user is invited to retry.
+    ///
+    /// <see cref="AcpSetupAgentRowViewModel.CanInstallHere"/> covers the machine's own toolchain, so a
+    /// row whose package manager is absent is not handed a request that could only fail. This is restated
+    /// here rather than trusted to the button's visibility because the button raises an event rather than
+    /// binding a command, and an event has no CanExecute to consult.
     /// </remarks>
     private void InstallAgentRow(AcpSetupAgentRowViewModel row)
     {
-        if (IsBusy || !SupportsAutomaticInstall || !row.SupportsAutomaticInstall)
+        if (IsBusy || !SupportsAutomaticInstall || !row.CanInstallHere)
         {
             return;
         }
@@ -407,13 +487,23 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         _ = RunOperationAsync(
             async token =>
             {
+                var overrides = CollectCommandOverrides();
                 var (install, probe) = await _orchestrator
-                    .InstallComponentAsync(row.Agent.Runtime, AppendInstallOutput, CollectCommandOverrides(), token)
+                    .InstallComponentAsync(row.Agent.Runtime, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
+
+                // Re-probed after the attempt because a failed install is evidence about the toolchain
+                // too: the manager may have disappeared since the sweep, and leaving the stale verdict
+                // would keep offering a button that just failed.
+                var toolchain = await _orchestrator
+                    .DetectToolchainAsync(row.Agent.Runtime, overrides, token)
+                    .ConfigureAwait(false);
+
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
                         row.Runtime = probe;
+                        row.RuntimeToolchain = toolchain;
                         ReportInstallFailure(install);
                     })
                     .ConfigureAwait(false);
@@ -433,15 +523,21 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         await RunOperationAsync(
             async token =>
             {
+                var overrides = CollectCommandOverrides();
                 var (install, probe) = await _orchestrator
-                    .InstallComponentAsync(adapter.Component, AppendInstallOutput, CollectCommandOverrides(), token)
+                    .InstallComponentAsync(adapter.Component, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
+                var toolchain = await _orchestrator
+                    .DetectToolchainAsync(adapter.Component, overrides, token)
+                    .ConfigureAwait(false);
+
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
                         if (ReferenceEquals(SelectedAdapter, adapter))
                         {
                             AdapterProbe = probe;
+                            AdapterToolchain = toolchain;
                             ReportInstallFailure(install);
                         }
                     })
@@ -450,11 +546,20 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Installing the adapter needs three things to hold: the platform runs installers, the component has
+    /// an install command, and this machine has the toolchain to run it.
+    /// </summary>
+    /// <remarks>
+    /// A toolchain probe that came back undetermined does not withhold the offer — the installer's own
+    /// report is a better answer than refusing over a question the probe could not settle.
+    /// </remarks>
     private bool CanInstallAdapter()
         => !IsBusy
             && SelectedAdapter is not null
             && SupportsAutomaticInstall
-            && SelectedAdapter.Component.SupportsAutomaticInstall;
+            && SelectedAdapter.Component.HasAutomaticInstallPath
+            && AdapterToolchain?.IsMissing != true;
 
     // ── Test and save ───────────────────────────────────────────────────────
 
@@ -772,19 +877,25 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         });
     }
 
+    /// <remarks>
+    /// The toolchain verdict is written before the component probe. Both feed the row's install offer, and
+    /// the component probe is what raises the flags the view reads — so writing it last means the view
+    /// never renders a "missing" row against a toolchain answer from the previous sweep.
+    /// </remarks>
     private void ApplyRuntimeProbes(IReadOnlyList<AcpAgentDetectionState> states)
     {
-        var byAgentId = new Dictionary<string, AcpComponentProbeResult>(StringComparer.Ordinal);
+        var byAgentId = new Dictionary<string, AcpAgentDetectionState>(StringComparer.Ordinal);
         foreach (var state in states)
         {
-            byAgentId[state.Agent.Id] = state.Runtime;
+            byAgentId[state.Agent.Id] = state;
         }
 
         foreach (var row in Agents)
         {
-            if (byAgentId.TryGetValue(row.AgentId, out var probe))
+            if (byAgentId.TryGetValue(row.AgentId, out var state))
             {
-                row.Runtime = probe;
+                row.RuntimeToolchain = state.RuntimeToolchain;
+                row.Runtime = state.Runtime;
             }
         }
     }
@@ -855,10 +966,27 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         OnPropertyChanged(nameof(HasInstallOutput));
     }
 
+    /// <summary>
+    /// Surfaces a failed install, preferring localized advice over the platform layer's raw detail.
+    /// </summary>
+    /// <remarks>
+    /// A remediation key wins over <see cref="AcpComponentInstallResult.ErrorDetail"/> because the detail
+    /// is untranslated diagnostics naming an executable, while the key resolves to the thing the user has
+    /// to do. The detail is not lost — the installer output surface still carries it.
+    /// </remarks>
     private void ReportInstallFailure(AcpComponentInstallResult install)
     {
         if (install.IsSuccess)
         {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(install.RemediationKey))
+        {
+            ErrorMessage = FormatLocalize(
+                install.RemediationKey!,
+                "{0} is required to install this component. Install it, then run detection again.",
+                install.MissingToolchainName ?? string.Empty);
             return;
         }
 
@@ -910,6 +1038,8 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         => CoreStringResolver.ResolveFormat(_localizer, key, fallbackFormat, arguments);
 
     private const string InstallFailedKey = "AcpSetup_Install_Failed";
+
+    private const string AdapterToolchainMissingKey = "AcpSetup_Adapter_ToolchainMissing";
 
     /// <summary>Localization keys for the stage a failed test reached.</summary>
     private static class StageKeys

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpToolchainDetectionTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpToolchainDetectionTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+using Xunit;
+
+namespace SalmonEgg.Application.Tests.Services.AcpSetup;
+
+/// <summary>
+/// Guards that the wizard establishes whether the toolchain an install runs through exists, before it
+/// offers that install.
+/// </summary>
+/// <remarks>
+/// The wizard shipped answering "can this be installed" from the catalog alone: a Node package with a
+/// package id reported itself installable on a machine with no Node at all, so the absence surfaced only
+/// as a failed install after the user clicked. This probe is what turns that into a fact known up front.
+///
+/// Its whole value rests on predicting the installer faithfully. The install derives its package manager
+/// from the launcher's own directory and uses only the preferred candidate, so this must derive the same
+/// command from the same inputs — a probe that looked somewhere else would either promise an install that
+/// fails or withhold one that would have worked.
+/// </remarks>
+public sealed class AcpToolchainDetectionTests
+{
+    private const string NodeToolchainBin = "/opt/toolchain/node/bin";
+
+    private static AcpComponentDescriptor NpxRuntime() => new()
+    {
+        Id = "runtime",
+        DisplayName = "Agent CLI",
+        Distribution = AcpDistributionKind.Npx,
+        DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+        ProbeCommand = "agent",
+        PackageId = "@scope/agent"
+    };
+
+    private static AcpComponentDescriptor UvxRuntime() => new()
+    {
+        Id = "runtime",
+        DisplayName = "Agent CLI",
+        Distribution = AcpDistributionKind.Uvx,
+        DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+        ProbeCommand = "agent",
+        PackageId = "some-tool"
+    };
+
+    private static AcpComponentDescriptor BinaryRuntime() => new()
+    {
+        Id = "runtime",
+        DisplayName = "Agent CLI",
+        Distribution = AcpDistributionKind.Binary,
+        DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+        ProbeCommand = "agent",
+        InstallDocumentation = new Uri("https://example.invalid/install")
+    };
+
+    private static AcpComponentDescriptor BuiltInAdapter() => new()
+    {
+        Id = "adapter",
+        DisplayName = "Built-in ACP",
+        Distribution = AcpDistributionKind.BuiltIn,
+        DetectionMode = AcpComponentDetectionMode.None
+    };
+
+    /// <summary>
+    /// The defect's root: a Node package on a machine with no npm. The probe must report the toolchain
+    /// missing and name it, so the wizard can withdraw the offer and say why.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_WithNoPackageManagerOnPath_ReportsMissingAndNamesTheToolchain()
+    {
+        var probe = new StubProbe();
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(result!.IsMissing);
+        Assert.False(result.AllowsInstallAttempt);
+        Assert.Equal("Node.js", result.Requirement.DisplayName);
+        // The advice has to lead somewhere, or naming the toolchain is a dead end.
+        Assert.NotNull(result.Requirement.Documentation);
+    }
+
+    /// <summary>
+    /// Reverse verification: with npm present the same component must read as available, so the check
+    /// narrows the offer for a real absence rather than suppressing it everywhere.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_WithPackageManagerOnPath_ReportsAvailable()
+    {
+        var probe = new StubProbe();
+        probe.SetExecutable("npm", "/usr/bin/npm");
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(AcpToolchainAvailability.Available, result!.Availability);
+        Assert.True(result.AllowsInstallAttempt);
+        Assert.Equal("/usr/bin/npm", result.ManagerPath);
+    }
+
+    /// <summary>
+    /// The prediction contract. The installer resolves the component's launcher, derives the manager as
+    /// that launcher's sibling, and uses only the preferred candidate. So a machine whose npm sits beside
+    /// the resolved launcher is installable, and this must be the command the probe looks for — asking a
+    /// bare <c>npm</c> instead would answer about a different toolchain.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_DerivesTheManagerAsTheResolvedLaunchersSibling()
+    {
+        var probe = new StubProbe();
+        probe.SetExecutable("agent", NodeToolchainBin + "/agent");
+        probe.SetExecutable(NodeToolchainBin + "/npm", NodeToolchainBin + "/npm");
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(AcpToolchainAvailability.Available, result!.Availability);
+        Assert.Equal(NodeToolchainBin + "/npm", result.ManagerPath);
+        Assert.Contains(NodeToolchainBin + "/npm", probe.ResolvedCommands);
+    }
+
+    /// <summary>
+    /// A user-named launcher decides the toolchain here exactly as it does for detection and installation,
+    /// so the answer is about the toolchain they chose.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_HonoursALauncherOverride()
+    {
+        var probe = new StubProbe();
+        probe.SetExecutable(NodeToolchainBin + "/agent", NodeToolchainBin + "/agent");
+        probe.SetExecutable(NodeToolchainBin + "/npm", NodeToolchainBin + "/npm");
+        var overrides = AcpCommandOverrides.Create(new Dictionary<string, string>
+        {
+            ["agent"] = NodeToolchainBin + "/agent"
+        });
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(NodeToolchainBin + "/npm", result!.ManagerPath);
+    }
+
+    /// <summary>
+    /// A launcher that does not resolve is ordinary rather than fatal: the manager may be on PATH while the
+    /// component is not, which is precisely the state an install is meant to fix.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_WithUnresolvedLauncher_StillFindsAManagerOnPath()
+    {
+        var probe = new StubProbe();
+        probe.SetExecutable("npm", "/usr/bin/npm");
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(AcpToolchainAvailability.Available, result!.Availability);
+    }
+
+    /// <summary>The Python toolchain is modelled the same way, so the concept is not Node-specific.</summary>
+    [Fact]
+    public async Task DetectToolchainAsync_ForUvxDistribution_NamesTheUvToolchain()
+    {
+        var probe = new StubProbe();
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            UvxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(result!.IsMissing);
+        Assert.Equal("uv", result.Requirement.DisplayName);
+    }
+
+    /// <summary>
+    /// Distributions the wizard never installs have no prerequisite to report. Null rather than "missing":
+    /// a binary distribution is not blocked by the absence of a package manager it would never use, and
+    /// reporting one would tell most of the catalog's users to install a toolchain for nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("binary")]
+    [InlineData("builtin")]
+    public async Task DetectToolchainAsync_ForDistributionsWithNoInstallPath_ReportsNoRequirement(string kind)
+    {
+        var component = kind == "binary" ? BinaryRuntime() : BuiltInAdapter();
+
+        var result = await new AcpComponentDetector(new StubProbe()).DetectToolchainAsync(
+            component,
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// A platform that cannot start processes has not established absence, so the verdict is undetermined
+    /// and the install attempt stays allowed — matching how an undetermined component probe does not block
+    /// the wizard. Reporting "missing" here would send a WASM user to install Node for no reason.
+    /// </summary>
+    [Fact]
+    public async Task DetectToolchainAsync_WhenProbingIsUnsupported_IsUndeterminedAndStillAllowsTheAttempt()
+    {
+        var probe = new StubProbe { SupportsProcessProbing = false };
+
+        var result = await new AcpComponentDetector(probe).DetectToolchainAsync(
+            NpxRuntime(),
+            overrides: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(AcpToolchainAvailability.Undetermined, result!.Availability);
+        Assert.False(result.IsMissing);
+        Assert.True(result.AllowsInstallAttempt);
+    }
+
+    /// <summary>
+    /// Probe answering from declared paths and recording what was asked for, so an assertion can be about
+    /// the command the detector chose rather than only about the verdict it returned.
+    /// </summary>
+    private sealed class StubProbe : IAcpExecutableProbe
+    {
+        private readonly Dictionary<string, string?> _paths = new(StringComparer.Ordinal);
+
+        public bool SupportsProcessProbing { get; set; } = true;
+
+        public List<string> ResolvedCommands { get; } = new();
+
+        public void SetExecutable(string command, string? path) => _paths[command] = path;
+
+        public Task<string?> ResolveExecutablePathAsync(
+            string command,
+            CancellationToken cancellationToken = default)
+        {
+            ResolvedCommands.Add(command);
+            return Task.FromResult(_paths.TryGetValue(command, out var path) ? path : null);
+        }
+
+        public Task<IReadOnlyList<string>> ResolveExecutableCandidatesAsync(
+            string command,
+            CancellationToken cancellationToken = default)
+        {
+            var resolved = _paths.TryGetValue(command, out var path) ? path : null;
+            return Task.FromResult<IReadOnlyList<string>>(
+                resolved is null ? Array.Empty<string>() : new[] { resolved });
+        }
+
+        public Task<string?> ReadVersionAsync(
+            string command,
+            IReadOnlyList<string> versionArguments,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
+            AcpDistributionKind distribution,
+            string packageId,
+            AcpPackageManagerCandidates packageManager,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(AcpPackageQueryResult.Unknown(packageManager.Preferred));
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAgentCatalogTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAgentCatalogTests.cs
@@ -146,7 +146,7 @@ public sealed class AcpAgentCatalogTests
 
         void Check(string label, AcpComponentDescriptor component)
         {
-            if (component.SupportsAutomaticInstall)
+            if (component.HasAutomaticInstallPath)
             {
                 if (string.IsNullOrWhiteSpace(component.PackageId))
                 {

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpComponentInstallerTests.cs
@@ -57,6 +57,47 @@ public sealed class DesktopAcpComponentInstallerTests
     }
 
     /// <summary>
+    /// An absent package manager is a missing toolchain, and the result must say so in a form the
+    /// presentation layer can localize.
+    /// </summary>
+    /// <remarks>
+    /// What shipped was the raw detail above and nothing else, so the user read an untranslated sentence
+    /// naming <c>npm</c> — an executable they may never have installed deliberately — rather than being
+    /// told they need Node.js. The detail stays for diagnostics; the key and the toolchain name are what
+    /// the wizard shows.
+    /// </remarks>
+    [Fact]
+    public async Task InstallAsync_WhenLauncherMissingFromPath_ShouldCarryLocalizableToolchainAdvice()
+    {
+        var probe = new StubAcpExecutableProbe();
+        probe.SetResolvedPath("npm", null);
+        var installer = new DesktopAcpComponentInstaller(probe);
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.NpxComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            DesktopAcpComponentInstaller.ToolchainMissingRemediationKey,
+            result.RemediationKey);
+        Assert.Equal("Node.js", result.MissingToolchainName);
+    }
+
+    /// <summary>
+    /// Reverse verification: a failure from the package manager itself carries no toolchain advice, so the
+    /// key marks the one cause it names rather than every install failure.
+    /// </summary>
+    [Fact]
+    public async Task InstallAsync_ForBinaryDistribution_ShouldCarryNoToolchainAdvice()
+    {
+        var installer = new DesktopAcpComponentInstaller(new StubAcpExecutableProbe());
+
+        var result = await installer.InstallAsync(AcpSetupFixtures.BinaryComponent(), onOutput: null, overrides: null, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.RemediationKey);
+        Assert.Null(result.MissingToolchainName);
+    }
+
+    /// <summary>
     /// The component's own launcher is resolved before the manager, because the manager is derived from
     /// the launcher's directory: a user who names <c>npx</c> has named which toolchain's <c>npm</c> to
     /// install through, and deriving that needs the launcher's real path.

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -54,6 +54,29 @@ internal sealed class StubExecutableProbe : IAcpExecutableProbe
     private readonly Dictionary<string, bool?> _uvTools = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IReadOnlyList<string>> _candidates = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Package managers resolve by default, so the stub models an ordinary developer machine.
+    /// </summary>
+    /// <remarks>
+    /// The wizard withholds an install offer when the toolchain that would run it is absent, so an
+    /// unset manager is not a neutral default — it makes every install test a toolchain-absence test.
+    /// A test about that case removes them with <see cref="WithoutPackageManagers"/>, which states the
+    /// intent where the reader can see it.
+    /// </remarks>
+    public StubExecutableProbe()
+    {
+        _paths["npm"] = "/test/bin/npm";
+        _paths["uv"] = "/test/bin/uv";
+    }
+
+    /// <summary>Models a machine with no Node or uv toolchain at all.</summary>
+    public StubExecutableProbe WithoutPackageManagers()
+    {
+        _paths["npm"] = null;
+        _paths["uv"] = null;
+        return this;
+    }
+
     public bool SupportsProcessProbing { get; set; } = true;
 
     public void SetExecutable(string command, string? path, string? version = null)

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -1008,10 +1008,21 @@ public sealed class AcpSetupWizardViewModelTests
         return (wizard, installer);
     }
 
+    /// <summary>
+    /// A machine with the runtime installed and its package manager beside it.
+    /// </summary>
+    /// <remarks>
+    /// The sibling entry is load-bearing, not padding. An install derives its package manager from the
+    /// resolved launcher's own directory and uses only that candidate, so a machine whose npm is somewhere
+    /// else genuinely cannot install this component — and the wizard now withholds the offer instead of
+    /// discovering it on click. Registering the sibling is what makes this the ordinary machine the
+    /// install tests mean to describe.
+    /// </remarks>
     private static StubExecutableProbe ProbeForInstalledRuntime()
     {
         var probe = new StubExecutableProbe();
         probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+        probe.SetExecutable("/usr/bin/npm", "/usr/bin/npm");
         return probe;
     }
 
@@ -1035,4 +1046,247 @@ public sealed class AcpSetupWizardViewModelTests
             tester ?? new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success()),
             configuration ?? new RecordingConfigurationService(),
             localizer);
+
+    // ── Missing toolchain ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The shipped defect: a row whose agent is missing offered an enabled install button on a machine
+    /// with no package manager at all, and the absence only surfaced as a failed install after the click.
+    /// </summary>
+    /// <remarks>
+    /// Asserts the offer is withdrawn <em>and</em> that the row says why — withdrawing it alone would
+    /// leave the row looking like the agent cannot be installed, which is a different, wrong conclusion.
+    /// </remarks>
+    [Fact]
+    public async Task DetectAgents_WithNoPackageManager_WithdrawsTheInstallOfferAndExplainsWhy()
+    {
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, path: null);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizard(probe, installer);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        var row = Assert.Single(wizard.Agents);
+        Assert.True(row.IsMissing);
+        Assert.False(row.CanInstallHere);
+        Assert.True(row.IsToolchainMissing);
+        Assert.Equal("Node.js", row.MissingToolchainName);
+        Assert.NotNull(row.ToolchainDocumentation);
+        // The row still reports an install path exists, so the view can tell "we never automate this"
+        // from "we would, but not on this machine".
+        Assert.True(row.HasAutomaticInstallPath);
+    }
+
+    /// <summary>
+    /// Reverse verification for the test above: the very same walk on a machine that <em>does</em> have a
+    /// package manager must keep offering the install. Without this, a bug that withheld the button
+    /// unconditionally would pass the assertions above.
+    /// </summary>
+    [Fact]
+    public async Task DetectAgents_WithPackageManagerPresent_StillOffersTheInstall()
+    {
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, path: null);
+        var wizard = CreateWizard(probe, new StubComponentInstaller());
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        var row = Assert.Single(wizard.Agents);
+        Assert.True(row.IsMissing);
+        Assert.True(row.CanInstallHere);
+        Assert.False(row.IsToolchainMissing);
+        Assert.Empty(row.MissingToolchainName);
+        Assert.Null(row.ToolchainDocumentation);
+        Assert.Empty(row.ToolchainMissingHint);
+    }
+
+    /// <summary>
+    /// The install request itself must be refused, not merely hidden. The row's button raises an event
+    /// rather than binding a command, so there is no CanExecute to stop it — a caller reaching the
+    /// handler directly (or a stale view) would otherwise run an install that cannot succeed.
+    /// </summary>
+    [Fact]
+    public async Task InstallAgentRow_WithNoPackageManager_IsRefusedWithoutCallingTheInstaller()
+    {
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, path: null);
+        var installer = new StubComponentInstaller();
+        installer.OutputLines.Add("added 1 package");
+        var wizard = CreateWizard(probe, installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Single(wizard.Agents).RequestInstall();
+
+        Assert.Empty(installer.InstalledComponentIds);
+        Assert.False(wizard.HasInstallOutput);
+        Assert.False(wizard.IsBusy);
+    }
+
+    /// <summary>
+    /// A missing toolchain must reach the user as localized advice naming the toolchain, not as the
+    /// platform layer's raw diagnostic naming a package-manager executable.
+    /// </summary>
+    /// <remarks>
+    /// The installer is the real desktop one's contract rather than a bare stub: the key and the toolchain
+    /// name travel on <see cref="AcpComponentInstallResult"/>, and this asserts the wizard prefers them
+    /// over <c>ErrorDetail</c>. The raw detail is what shipped, and it was untranslated.
+    /// </remarks>
+    [Fact]
+    public async Task InstallAgentRow_ToolchainFailure_SurfacesLocalizedAdviceRatherThanRawDetail()
+    {
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", "AcpSetup_Install_ToolchainMissing", "先装 {0} 再来。");
+        var installer = new StubComponentInstaller(component =>
+            AcpComponentInstallResult.Failure(
+                component.Id,
+                exitCode: null,
+                output: null,
+                errorDetail: "'npm' was not found on PATH.",
+                remediationKey: "AcpSetup_Install_ToolchainMissing",
+                missingToolchainName: "Node.js"));
+        var wizard = CreateWizard(ProbeForInstalledRuntime(), installer, localizer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Single(wizard.Agents).RequestInstall();
+
+        Assert.Equal("先装 Node.js 再来。", wizard.ErrorMessage);
+        // The executable-naming diagnostic must not be what the user reads.
+        Assert.DoesNotContain("npm", wizard.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Reverse verification: a failure carrying no remediation key still surfaces its raw detail, so the
+    /// change above narrowed the message for one cause rather than swallowing every other one.
+    /// </summary>
+    [Fact]
+    public async Task InstallAgentRow_FailureWithoutRemediationKey_StillSurfacesRawDetail()
+    {
+        var installer = new StubComponentInstaller(component =>
+            AcpComponentInstallResult.Failure(component.Id, 1, output: null, "network down"));
+        var wizard = CreateWizard(ProbeForInstalledRuntime(), installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Single(wizard.Agents).RequestInstall();
+
+        Assert.Equal("network down", wizard.ErrorMessage);
+    }
+
+    /// <summary>
+    /// An undetermined toolchain probe must not withhold the offer, matching how an undetermined component
+    /// probe does not block the walk: an unanswerable probe is not evidence of absence, and the installer's
+    /// own report is a better answer than refusing up front.
+    /// </summary>
+    [Fact]
+    public async Task DetectAgents_WhenProbingIsUnsupported_StillOffersTheInstall()
+    {
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, path: null);
+        probe.SupportsProcessProbing = false;
+        var wizard = CreateWizard(probe, new StubComponentInstaller());
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        var row = Assert.Single(wizard.Agents);
+        Assert.True(row.IsUndetermined);
+        Assert.False(row.IsToolchainMissing);
+        Assert.True(row.CanInstallHere);
+    }
+
+    /// <summary>
+    /// Installing a toolchain out of band and re-detecting must restore the offer. Without a re-probe the
+    /// row would keep the stale verdict and the user could never get the button back.
+    /// </summary>
+    [Fact]
+    public async Task DetectAgents_AfterToolchainAppears_RestoresTheInstallOffer()
+    {
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, path: null);
+        var wizard = CreateWizard(probe, new StubComponentInstaller());
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var row = Assert.Single(wizard.Agents);
+        Assert.True(row.IsToolchainMissing);
+
+        probe.SetExecutable("npm", "/usr/local/bin/npm");
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.False(row.IsToolchainMissing);
+        Assert.True(row.CanInstallHere);
+    }
+
+    /// <summary>
+    /// The adapter step's install command is gated the same way. Its button is command-bound, so this
+    /// asserts CanExecute goes false and that the step names the toolchain the user has to install.
+    /// </summary>
+    [Fact]
+    public async Task AdapterStep_WithNoPackageManager_DisablesInstallAndNamesTheToolchain()
+    {
+        var agent = AcpSetupWizardFixtures.Agent(
+            adapters: new[] { AcpSetupWizardFixtures.PackagedAdapter() });
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", "AcpSetup_Adapter_ToolchainMissing", "缺少 {0}。");
+        var wizard = CreateWizardFor(agent, probe, new StubComponentInstaller(), localizer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsAdapterMissing);
+        Assert.True(wizard.IsAdapterToolchainMissing);
+        Assert.Equal("Node.js", wizard.MissingAdapterToolchainName);
+        Assert.Equal("缺少 Node.js。", wizard.AdapterToolchainMissingText);
+        Assert.NotNull(wizard.AdapterToolchainDocumentation);
+        Assert.False(wizard.InstallAdapterCommand.CanExecute(null));
+
+        // Direct invocation bypasses CanExecute, so the handler must hold the line too.
+        await wizard.InstallAdapterCommand.ExecuteAsync(null);
+        Assert.Empty(wizard.InstallOutput);
+    }
+
+    /// <summary>
+    /// Reverse verification for the adapter gate: with a package manager present the same walk keeps the
+    /// install enabled and raises none of the toolchain surface.
+    /// </summary>
+    [Fact]
+    public async Task AdapterStep_WithPackageManagerPresent_KeepsInstallEnabled()
+    {
+        var agent = AcpSetupWizardFixtures.Agent(
+            adapters: new[] { AcpSetupWizardFixtures.PackagedAdapter() });
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable("npx", "/usr/bin/npx");
+        probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, installed: false);
+        var wizard = CreateWizardFor(agent, probe, new StubComponentInstaller(), localizer: null);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsAdapterMissing);
+        Assert.False(wizard.IsAdapterToolchainMissing);
+        Assert.Empty(wizard.AdapterToolchainMissingText);
+        Assert.True(wizard.InstallAdapterCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// A built-in adapter has no toolchain to need, so the toolchain surface must stay silent. This is the
+    /// case a naive "no manager on PATH means missing toolchain" rule would get wrong, telling most of the
+    /// catalog's users to install Node for an adapter that installs nothing.
+    /// </summary>
+    [Fact]
+    public async Task AdapterStep_BuiltInAdapter_NeverReportsAMissingToolchain()
+    {
+        var probe = new StubExecutableProbe().WithoutPackageManagers();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+        var wizard = CreateWizard(probe, new StubComponentInstaller());
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        Assert.True(wizard.IsAdapterBuiltIn);
+        Assert.False(wizard.IsAdapterToolchainMissing);
+        Assert.Empty(wizard.AdapterToolchainMissingText);
+    }
 }


### PR DESCRIPTION
## What was wrong

The wizard offered a one-click install for every npm-distributed agent on **every** machine, including machines with no Node at all.

`AcpComponentDescriptor.SupportsAutomaticInstall` answered "can this be installed" from the catalog alone — distribution is `Npx`/`Uvx`, and a package id exists. Both are authoring facts that say nothing about the machine. So the button rendered enabled, and the absence of a package manager surfaced only *after* the click, as a failed install reading:

```
'npm' was not found on PATH.
```

Untranslated, and it names an executable the user may never have installed deliberately. What they actually need is Node.js.

The gap was structural: the domain had no way to express "this needs a toolchain first".

## What changed

**Domain** — `AcpToolchainRequirement` (Npx→Node.js, Uvx→uv, each with its own documentation) derived from the distribution rather than declared per component, so catalog entries cannot disagree about a fact that is not theirs. `AcpToolchainProbeResult` carries the tri-state answer. `SupportsAutomaticInstall` → `HasAutomaticInstallPath`, which is what it always meant.

**Application** — `AcpComponentDetector.DetectToolchainAsync`, probed alongside the runtime sweep so a row that must decide whether to offer an install already holds the answer.

**Presentation** — the row gates on `CanInstallHere`, which folds the catalog's install path together with the probe.

**Infrastructure.Desktop** — the failure now travels as a remediation key plus the toolchain's name (the contract `AcpSetupTestResult` already uses), so the platform layer says what went wrong without owning display text. The raw detail stays for diagnostics in the output panel.

### The load-bearing invariant

`DetectToolchainAsync` reproduces `DesktopAcpComponentInstaller`'s command derivation step for step — same launcher resolution, same sibling derivation, same `Preferred`-only choice. That is the whole contract: a derivation that differed anywhere would promise an install that then fails, or withhold one that would have worked. Both sides carry a comment pointing at the other.

### The row's third state is new

It previously had two — installable, or a distribution the wizard never automates (goose) — and a missing toolchain masqueraded as the first. It now renders the **toolchain's** documentation, not the agent's, whose install page assumes a toolchain the user lacks, plus a line naming what is missing. Withdrawing the button without that line would leave the row looking like the agent cannot be installed, a different and wrong conclusion.

### What is deliberately not blocked

- An **undetermined** probe still offers the install, matching how an undetermined component probe does not block the walk: an unanswerable probe is not evidence of absence, and the installer's own report beats refusing over a question nothing settled.
- A **built-in** adapter reports no requirement at all, so the common case never tells a user to install Node for an adapter that installs nothing.
- **Detection was already correct and is untouched.** It probes the agent executable, never npm, so an agent installed through Homebrew, winget or a vendor installer has always been found. This narrows one wrong offer rather than closing a route.

## Verification

All five source projects build with **0 warnings** (analyzer warnings fail the Code Quality gate here). The desktop project compiles — the only real check for `x:Bind`. The restricted target graph the core gate uses (`SalmonEggTargetFrameworks=net10.0-desktop`) builds clean, as does `dotnet build --configuration Release /p:EnforceCodeStyleInBuild=true` over the whole solution, and `dotnet format --verify-no-changes` over all 16 changed `.cs` files.

| Suite | Result |
|---|---|
| Presentation.Core | 3242 passed |
| Infrastructure | 690 passed, 6 skipped |
| Application | 120 passed |
| Domain | 83 passed |

21 tests added.

### Reverse verification

Green tests prove nothing until they are shown to catch the defect, so each claim was probed by reverting the fix and confirming the failure:

| Probe | Result |
|---|---|
| Row guard back to catalog-only | 2 tests red |
| Adapter gate without the toolchain condition | 1 red |
| Error message back to `ErrorDetail` only | 1 red |
| Toolchain derivation changed to a bare name | 2 red |
| Installer stops emitting the remediation key | 1 red |
| New `x:Uid` property name corrupted `Content`→`Text` | localized-uid gate names both call sites and the crash |

### A note on three pre-existing tests

They failed on the first run. That was not a regression — it was the new guard working. Their stubs modelled a machine with no package manager while asserting install behaviour, so under the new rule that machine genuinely cannot install. The stub now defaults to having a toolchain (an ordinary developer machine) and tests about absence say so explicitly through `WithoutPackageManagers()`. One of them additionally exposed the sibling derivation: the stub placed the agent in `/usr/bin/` with no `/usr/bin/npm`, which by the installer's real rule is not installable.

## Scope

This is the fail-fast half. It does **not** add non-npm install channels or an app-provisioned Node runtime — both were researched and are viable, but they are separate changes.

One fact worth recording for whoever picks those up: `claude` and `codex` do **not** speak ACP themselves (verified by downloading the real binaries, enumerating subcommands, and grepping for protocol markers — zero hits). Their ACP support lives in `claude-agent-acp` and `codex-acp`, which are plain `#!/usr/bin/env node` scripts whose standalone binary releases stopped in April 2026. So for those two agents a Node runtime is a hard prerequisite today, and the honest fix is to say so — which is what this PR does. The five agents with built-in `--acp` are not constrained this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)