### PR TITLE
feat(release): derive the version from git tags via MinVer

### DIFF
--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -63,6 +63,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The version identity is derived from git tags by MinVer; a shallow clone sees no tags
+          # and would stamp 0.0.0 into every manifest and binary.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -88,6 +92,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The version identity is derived from git tags by MinVer; a shallow clone sees no tags
+          # and would stamp 0.0.0 into every manifest and binary.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -115,6 +123,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The version identity is derived from git tags by MinVer; a shallow clone sees no tags
+          # and would stamp 0.0.0 into every manifest and binary.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -185,6 +197,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The version identity is derived from git tags by MinVer; a shallow clone sees no tags
+          # and would stamp 0.0.0 into every manifest and binary.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -244,6 +260,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The version identity is derived from git tags by MinVer; a shallow clone sees no tags
+          # and would stamp 0.0.0 into every manifest and binary.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/release-acp-sdk.yml
+++ b/.github/workflows/release-acp-sdk.yml
@@ -28,8 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # The package version is derived from the acp-sdk-v* tag history by MinVer, so the full
+      # history (tags included) must be present. A shallow clone would pack a 0.0.0-alpha version
+      # and the tag/version gate below would catch it - but only after the whole pack had run.
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -41,6 +46,10 @@ jobs:
       - name: Run ACP SDK gate script
         env:
           DOTNET_BIN: dotnet
+          # Once the SDK has shipped its first version, every later version must package-validate
+          # against the last published one. The baseline is the version of the package actually
+          # published before this release; unset for 1.0.0, which has no predecessor.
+          ACP_PACKAGE_BASELINE_VERSION: ${{ vars.ACP_PACKAGE_BASELINE_VERSION }}
         run: ./scripts/gates/run-acp-sdk-gates.sh "${{ env.CONFIGURATION }}" "${{ env.PACKAGE_OUTPUT }}"
 
       # Verify the rule itself before trusting it on an irreversible publish.

--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -72,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -99,10 +103,11 @@ jobs:
           $installerDir = Join-Path $env:GITHUB_WORKSPACE "artifacts\installer"
           New-Item -ItemType Directory -Force -Path $installerDir | Out-Null
 
-          # Evaluate the shared release identity instead of scraping project XML: the version lives in
-          # the repository-root Directory.Build.props, and only MSBuild evaluation sees imports and
+          # Evaluate the shared release identity instead of scraping project XML. The version comes
+          # from the git tag via MinVer, so running the MinVer target is what produces it; the checkout
+          # above uses fetch-depth: 0 so the tag is reachable. Only MSBuild evaluation sees imports and
           # conditions the way the build itself does.
-          $displayVersion = (dotnet msbuild src/SalmonEgg.Cli/SalmonEgg.Cli.csproj -getProperty:SalmonEggDisplayVersion -nologo).Trim()
+          $displayVersion = (dotnet msbuild src/SalmonEgg.Cli/SalmonEgg.Cli.csproj -restore -t:MinVer -getProperty:SalmonEggDisplayVersion -nologo).Trim()
           if ($displayVersion -notmatch '^\d+\.\d+\.\d+$') {
             throw "SalmonEggDisplayVersion must be a three-part numeric version, got: $displayVersion"
           }
@@ -214,6 +219,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -335,6 +342,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -455,6 +464,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -573,6 +584,7 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           path: repo
+          fetch-depth: 0
 
       - name: Download CLI artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -654,7 +666,7 @@ jobs:
           supported_rids="$(cd repo && dotnet msbuild src/SalmonEgg.Cli/SalmonEgg.Cli.csproj \
             -getProperty:SalmonEggCliSupportedRuntimeIdentifiers -nologo | tr -d '\r' | tail -n 1)"
           display_version="$(cd repo && dotnet msbuild src/SalmonEgg.Cli/SalmonEgg.Cli.csproj \
-            -getProperty:SalmonEggDisplayVersion -nologo | tr -d '\r' | tail -n 1)"
+            -restore -t:MinVer -getProperty:SalmonEggDisplayVersion -nologo | tr -d '\r' | tail -n 1)"
 
           missing=""
           IFS=';' read -ra rids <<< "$supported_rids"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,28 @@
     <!-- Suppress SDK preview banner to keep build output clean -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
-    <!-- Shared release identity for the GUI and CLI. Keep package and assembly versions derived
-         from the same display version so release assets cannot drift apart. -->
-    <SalmonEggDisplayVersion Condition="'$(SalmonEggDisplayVersion)' == ''">1.3.0</SalmonEggDisplayVersion>
-    <SalmonEggPackageVersion Condition="'$(SalmonEggPackageVersion)' == ''">$(SalmonEggDisplayVersion).0</SalmonEggPackageVersion>
+    <!-- MinVer 6.0.0 treats an empty MinVerTagPrefix as "ignore every tag", so the v* namespace
+         must be declared here. The ACP SDK project overrides it with acp-sdk-v for its own line. -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
+
+  <!-- Shared release identity for the GUI and the CLI. The single source of truth is the git tag:
+       MinVer derives the version from the latest tag reachable from the commit being built, so a
+       release is created by pushing a tag and never by editing a file. Projects that do not
+       reference MinVer never run the MinVer target, and an AfterTargets hook on a target that does
+       not exist is silently inert, so this derive target is harmless everywhere else.
+       SalmonEggPackageVersion is the four-part MSIX form (Major.Minor.Build.Revision): the Store
+       requires four parts, so the revision digit is fixed at 0. Windows Installer (MSI) only
+       accepts the first three parts, and its consumers read SalmonEggDisplayVersion instead. -->
+  <Target Name="SalmonEggDeriveReleaseIdentity" AfterTargets="MinVer">
+    <PropertyGroup>
+      <SalmonEggDisplayVersion Condition="'$(SalmonEggDisplayVersion)' == ''">$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</SalmonEggDisplayVersion>
+      <SalmonEggPackageVersion Condition="'$(SalmonEggPackageVersion)' == ''">$(SalmonEggDisplayVersion).0</SalmonEggPackageVersion>
+      <!-- Unconditional on purpose: MinVer itself sets AssemblyVersion to Major.0.0.0, so a
+           Condition="'$(AssemblyVersion)' == ''" would never fire. About/diagnostics/telemetry read
+           GetName().Version, which must report the shipped version, not MinVer's binding-safe major. -->
+      <AssemblyVersion>$(SalmonEggPackageVersion)</AssemblyVersion>
+      <ApplicationDisplayVersion Condition="'$(ApplicationDisplayVersion)' == ''">$(SalmonEggDisplayVersion)</ApplicationDisplayVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/SalmonEgg/Directory.Packages.props
+++ b/SalmonEgg/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.251217-build.2433" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />

--- a/SalmonEgg/SalmonEgg/SalmonEgg.csproj
+++ b/SalmonEgg/SalmonEgg/SalmonEgg.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Graph" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="MinVer" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Uno.Extensions.Reactive" />
     <PackageReference Include="Uno.Fonts.Fluent" GeneratePathProperty="true" />
@@ -262,13 +263,8 @@
     <ApplicationTitle>SalmonEgg</ApplicationTitle>
     <!-- App Identifier -->
     <ApplicationId>com.companyname.salmonegg</ApplicationId>
-    <!-- Versions. SalmonEggDisplayVersion / SalmonEggPackageVersion come from the repository root
-         Directory.Build.props so the GUI packages and the CLI release assets cannot drift apart. -->
-    <Version>$(SalmonEggPackageVersion)</Version>
-    <AssemblyVersion>$(SalmonEggPackageVersion)</AssemblyVersion>
-    <FileVersion>$(SalmonEggPackageVersion)</FileVersion>
-    <InformationalVersion>$(SalmonEggPackageVersion)</InformationalVersion>
-    <ApplicationDisplayVersion>$(SalmonEggDisplayVersion)</ApplicationDisplayVersion>
+    <!-- Versions are derived from the git tag by MinVer (see the root Directory.Build.props derive
+         target); the Store-facing four-part MSIX form is SalmonEggDisplayVersion + ".0". -->
     <ApplicationVersion>1</ApplicationVersion>
     <!-- Package Publisher -->
     <ApplicationPublisher>SalmonEgg</ApplicationPublisher>
@@ -343,8 +339,12 @@
     <DisableImplicitUnoPackages>true</DisableImplicitUnoPackages>
   </PropertyGroup>
 
+  <!-- DependsOnTargets pins the order against the root derive target: both are AfterTargets="MinVer",
+       and the relative order of two targets on the same hook is unspecified in MSBuild. Without the
+       dependency the manifest could be generated before SalmonEggPackageVersion exists. -->
   <Target Name="GenerateVersionedApplicationManifests"
-          BeforeTargets="_EnsureAppxManifestExists;ResolveReferences;ResolveProjectReferences;BeforeBuild"
+          AfterTargets="MinVer"
+          DependsOnTargets="SalmonEggDeriveReleaseIdentity"
           Condition="'$(SalmonEggGeneratedApplicationManifest)' != ''">
     <PropertyGroup>
       <_SalmonEggPackageManifestTemplate Condition="'$(SalmonEggGeneratedPackageManifest)' != ''">$(MSBuildProjectDirectory)\Package.appxmanifest</_SalmonEggPackageManifestTemplate>

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -364,15 +364,13 @@ git push origin v1.0.0
 发布前检查清单：
 
 - [ ] 所有测试通过
-- [ ] 版本号已更新（只改根 `Directory.Build.props` 的 `SalmonEggDisplayVersion`）
 - [ ] CLI 三个支持 RID 的产物均已构建
 - [ ] CLI 真实产物 smoke 与安装 / PATH 门禁通过
 - [ ] 确认 GitHub 自动生成的 release notes 或维护中的变更记录已覆盖本版本
 - [ ] 更新 README.md（如需要）
 - [ ] 构建发布版本
 - [ ] 在测试环境验证
-- [ ] 创建 Git tag
-- [ ] 推送到远程仓库
+- [ ] 创建 Git tag 并推送到远程仓库（版本号由 MinVer 从 tag 推导，无需改任何文件）
 - [ ] 验证 CI/CD 流程
 - [ ] 检查发布产物
 
@@ -424,8 +422,8 @@ SDK 与应用是两条独立的发布线，各有自己的 tag 命名空间与�
 
 | | tag | 版本来源 | workflow |
 |---|---|---|---|
-| GUI / CLI | `v*` | 根 `Directory.Build.props` 的 `SalmonEggDisplayVersion` | `release-packaging.yml` |
-| ACP SDK | `acp-sdk-v*` | `src/SalmonEgg.Acp/SalmonEgg.Acp.csproj` 的 `<Version>` | `release-acp-sdk.yml` |
+| GUI / CLI | `v*` | git tag（MinVer 从 tag 推导，根 `Directory.Build.props` 派生 `SalmonEggDisplayVersion`） | `release-packaging.yml` |
+| ACP SDK | `acp-sdk-v*` | git tag（MinVer 以 `MinVerTagPrefix=acp-sdk-v` 推导） | `release-acp-sdk.yml` |
 
 两者必须保持分离：共用 `v*` 会让每次 SDK 发布都重建桌面安装包，也会让应用发版误触发 NuGet 推送。
 
@@ -462,16 +460,15 @@ OIDC 交换未产出 key 时 `publish-nuget` 会显式失败而非静默跳过 �
 ### 发布步骤
 
 ```bash
-# 1. 更新 SDK 版本（首发之后必须同时提供上一个已发布版本作为兼容性基线）
-#    src/SalmonEgg.Acp/SalmonEgg.Acp.csproj: <Version>1.0.1</Version>
-
-# 2. 本地跑完整门禁 + 真实包消费验证
-./scripts/gates/run-acp-sdk-gates.sh Release artifacts/acp-sdk-pack
+# 1. 本地跑完整门禁 + 真实包消费验证（SDK 版本由 MinVer 从 tag 历史推导；
+#    非首发版本必须同时提供上一个已发布版本作为兼容性基线）
+ACP_PACKAGE_BASELINE_VERSION=1.0.0 ./scripts/gates/run-acp-sdk-gates.sh Release artifacts/acp-sdk-pack
 ./scripts/gates/run-acp-sdk-tag-version-gate-selftest.sh
 ./scripts/gates/run-acp-sdk-tag-version-gate.sh acp-sdk-v1.0.1 artifacts/acp-sdk-pack
 ./scripts/gates/run-acp-consumer-package-smoke.sh artifacts/acp-sdk-pack Release
 
-# 3. 打 tag 推送，workflow 接管 pack -> consumer smoke -> nuget push
+# 2. 打 tag 推送，workflow 接管 pack -> consumer smoke -> nuget push；
+#    版本号即 tag 上的数字，MinVer 负责把同样的版本打进包里
 git tag acp-sdk-v1.0.1
 git push origin acp-sdk-v1.0.1
 ```
@@ -480,11 +477,13 @@ git push origin acp-sdk-v1.0.1
 
 `EnablePackageValidation` 需要一个已发布版本作为对比基线才有意义。首发版本（`AcpPackageFirstReleasedVersion`，当前 `1.0.0`）在 nuget.org 上没有前身，写死基线会导致 restore 报 `NU1101`，因此该版本不启用基线比对。
 
-`<Version>` 一旦超过首发版本，构建就要求显式传入基线，否则 `AcpBaselineRequired` 直接报错：
+版本一旦超过首发版本，pack 就要求显式传入基线，否则 `AcpBaselineRequired` 直接报错（普通开发构建与测试不受影响，报错只在产出包的 pack 管线触发）：
 
 ```bash
 dotnet pack src/SalmonEgg.Acp/SalmonEgg.Acp.csproj -c Release -p:AcpPackageBaselineVersion=1.0.0
 ```
+
+CI 侧由仓库变量 `ACP_PACKAGE_BASELINE_VERSION` 提供基线：发下一个 SDK 版本前，把它设为当前已发布的版本号。`run-acp-sdk-gates.sh` 会在带该属性的 restore 中预先下载基线包，pack 时 ApiCompat 才能找到它做比对。
 
 这条门禁是 fail-closed 的：忘记传基线会构建失败，而不是让包验证退化成"什么都不比"的假绿。
 
@@ -498,11 +497,11 @@ nuget.org 的推送无法撤回，也无法覆盖同版本号。因此：
 
 ### SDK 发布清单
 
-- [ ] `<Version>` 已更新，且非首发版本时已确定 `AcpPackageBaselineVersion`
+- [ ] 版本号由 `acp-sdk-v*` tag 决定，无需改文件；非首发版本时已设置仓库变量 `ACP_PACKAGE_BASELINE_VERSION`
 - [ ] `run-acp-sdk-gates.sh` 全绿（format / analyzer / 契约测试 / pack）
 - [ ] `run-acp-sdk-tag-version-gate-selftest.sh` 通过（门禁规则本身的正反例）
 - [ ] `run-acp-sdk-tag-version-gate.sh` 通过
 - [ ] `run-acp-consumer-package-smoke.sh` 通过（真实 nupkg restore + build + run）
-- [ ] tag 使用 `acp-sdk-v` 前缀，且与 `<Version>` 一致
+- [ ] tag 使用 `acp-sdk-v` 前缀（包版本即 tag 上的数字，由 MinVer 推导）
 - [ ] nuget.org 受信任发布策略、`NUGET_USER` 变量与 `nuget-publish` environment 均已就绪
 - [ ] 发布后在 nuget.org 确认包与符号均已上架

--- a/scripts/gates/run-acp-sdk-gates.sh
+++ b/scripts/gates/run-acp-sdk-gates.sh
@@ -11,6 +11,14 @@ mkdir -p "$PACKAGE_OUTPUT"
 
 echo "[gate] Restore ACP SDK"
 "$DOTNET_BIN" restore tests/SalmonEgg.Acp.Tests/SalmonEgg.Acp.Tests.csproj
+# The package-validation baseline is a real nupkg on disk: restoring the SDK project with the
+# baseline property set is what downloads it into the global packages folder, which is where the
+# ApiCompat task looks for it during pack. Set the same property the project will derive later so
+# restore and validation agree on the baseline version.
+if [ -n "${ACP_PACKAGE_BASELINE_VERSION:-}" ]; then
+  "$DOTNET_BIN" restore src/SalmonEgg.Acp/SalmonEgg.Acp.csproj \
+    -p:PackageValidationBaselineVersion="$ACP_PACKAGE_BASELINE_VERSION"
+fi
 
 echo "[gate] Check ACP SDK formatting"
 "$DOTNET_BIN" format src/SalmonEgg.Acp/SalmonEgg.Acp.csproj \
@@ -43,10 +51,18 @@ echo "[gate] ACP SDK contracts"
   --output Normal
 
 echo "[gate] Pack ACP SDK"
+baseline_args=()
+# Versions past the first release must package-validate against the last published package; the
+# project's AcpBaselineRequired target errors out when the baseline is missing. The variable is
+# optional here so the first release (and rehearsed workflow_dispatch runs without tags) still pack.
+if [ -n "${ACP_PACKAGE_BASELINE_VERSION:-}" ]; then
+  baseline_args+=("-p:AcpPackageBaselineVersion=$ACP_PACKAGE_BASELINE_VERSION")
+fi
 "$DOTNET_BIN" pack src/SalmonEgg.Acp/SalmonEgg.Acp.csproj \
   --configuration "$CONFIGURATION" \
   --no-build \
   --output "$PACKAGE_OUTPUT" \
+  "${baseline_args[@]}" \
   -v minimal
 
 echo "[gate] ACP SDK gates passed"

--- a/scripts/release/build-cli-artifacts.sh
+++ b/scripts/release/build-cli-artifacts.sh
@@ -53,6 +53,12 @@ read_project_property() {
   "$DOTNET_BIN" msbuild "$CLI_PROJECT" "-getProperty:$1" -nologo | tr -d '\r' | tail -n 1
 }
 
+# Release identity is derived from the git tag by MinVer, so the property only holds a version once
+# the MinVer target has executed; a plain -getProperty evaluation would return the pre-MinVer default.
+read_release_version() {
+  "$DOTNET_BIN" msbuild "$CLI_PROJECT" -restore -t:MinVer "-getProperty:$1" -nologo | tr -d '\r' | tail -n 1
+}
+
 # macOS ships `shasum`, not GNU `sha256sum`. Both print "<hash>  <name>", so the sidecar format is
 # identical either way and `shasum -c` / `sha256sum -c` can both verify it.
 write_sha256() {
@@ -67,7 +73,7 @@ write_sha256() {
   fi
 }
 
-DISPLAY_VERSION="$(read_project_property SalmonEggDisplayVersion)"
+DISPLAY_VERSION="$(read_release_version SalmonEggDisplayVersion)"
 SUPPORTED_RIDS="$(read_project_property SalmonEggCliSupportedRuntimeIdentifiers)"
 
 case "$DISPLAY_VERSION" in

--- a/scripts/release/build-cli-deb.sh
+++ b/scripts/release/build-cli-deb.sh
@@ -59,8 +59,9 @@ if ! command -v dpkg-deb >/dev/null 2>&1; then
 fi
 
 if [ -z "$VERSION" ]; then
+  # -t:MinVer runs the MinVer target so the property holds the tag-derived version, not a default.
   VERSION="$("$DOTNET_BIN" msbuild "$REPO_ROOT/src/SalmonEgg.Cli/SalmonEgg.Cli.csproj" \
-    -getProperty:SalmonEggDisplayVersion -nologo | tr -d '\r' | tail -n 1)"
+    -restore -t:MinVer -getProperty:SalmonEggDisplayVersion -nologo | tr -d '\r' | tail -n 1)"
 fi
 
 case "$VERSION" in

--- a/scripts/release/build-cli-msi.ps1
+++ b/scripts/release/build-cli-msi.ps1
@@ -28,7 +28,8 @@ $executablePath = (Resolve-Path -LiteralPath $Executable).Path
 
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $cliProject = Join-Path $repoRoot 'src/SalmonEgg.Cli/SalmonEgg.Cli.csproj'
-    $Version = (dotnet msbuild $cliProject -getProperty:SalmonEggDisplayVersion -nologo).Trim()
+    # -t:MinVer runs the MinVer target so the property holds the tag-derived version.
+    $Version = (dotnet msbuild $cliProject -restore -t:MinVer -getProperty:SalmonEggDisplayVersion -nologo).Trim()
 }
 
 if ($Version -notmatch '^\d+\.\d+\.\d+$') {

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -11,17 +11,14 @@
     <IsAotCompatible>true</IsAotCompatible>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- Baseline validation diffs the public surface against the last shipped package, so it can only
-         run once something has shipped. 1.0.0 is the first release and has no predecessor on
-         nuget.org; hardcoding a baseline there fails restore with NU1101. Deriving it from
-         AcpPackageBaselineVersion keeps the first release packable while forcing every later version
-         to diff against a real published package instead of silently validating nothing. The
-         AcpBaselineRequired target below turns a missing baseline into a build error. -->
+    <!-- The package version comes from the acp-sdk-v* tag namespace via MinVer, separate from the
+         v* tags that drive the GUI and CLI releases. Baseline validation (PackageValidationBaselineVersion)
+         is wired in the AcpBaselineRequired target below, which runs after MinVer because "$(Version)"
+         is only meaningful once MinVer has derived it. -->
+    <MinVerTagPrefix>acp-sdk-v</MinVerTagPrefix>
     <AcpPackageFirstReleasedVersion>1.0.0</AcpPackageFirstReleasedVersion>
-    <PackageValidationBaselineVersion Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)'">$(AcpPackageBaselineVersion)</PackageValidationBaselineVersion>
 
     <PackageId>SalmonEgg.Acp</PackageId>
-    <Version>1.0.0</Version>
     <Title>SalmonEgg ACP SDK</Title>
     <Description>Agent Client Protocol (ACP) contracts and client primitives for .NET.</Description>
     <Authors>SalmonEgg</Authors>
@@ -53,13 +50,28 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <!-- Fail closed on a missing baseline. Without this, bumping Version past the first release while
-       forgetting AcpPackageBaselineVersion leaves PackageValidationBaselineVersion empty, and package
-       validation silently degrades to comparing nothing - a green build that checks no compatibility. -->
-  <Target Name="AcpBaselineRequired" BeforeTargets="Build">
+  <!-- Package validation needs two things that only exist once MinVer has run: the derived $(Version)
+       and a baseline package restored with PackageValidationBaselineVersion already set. Both hooks are
+       pack-scoped on purpose - a plain developer build or test run must not demand a published baseline,
+       while producing a package past the first release must not silently validate nothing. -->
+  <Target Name="AcpDerivePackageValidationBaseline" AfterTargets="MinVer">
+    <PropertyGroup>
+      <PackageValidationBaselineVersion Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)'">$(AcpPackageBaselineVersion)</PackageValidationBaselineVersion>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Fail closed on a missing baseline. GenerateNuspec only runs during pack, so forgetting
+       AcpPackageBaselineVersion is a pack-time error, not something that blocks everyday builds.
+       The baseline package itself is downloaded by a restore that runs with the baseline property
+       set (see scripts/gates/run-acp-sdk-gates.sh); validation compares against its nupkg on disk. -->
+  <Target Name="AcpBaselineRequired" BeforeTargets="GenerateNuspec">
     <Error Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)' AND '$(PackageValidationBaselineVersion)' == ''"
            Text="SalmonEgg.Acp $(Version) is past the first release $(AcpPackageFirstReleasedVersion), so package validation needs a published baseline. Pass -p:AcpPackageBaselineVersion=&lt;last published version&gt;." />
   </Target>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" />
+  </ItemGroup>
 
   <!-- Internals remain available to first-party contract tests. External consumers use the public surface. -->
   <ItemGroup>

--- a/src/SalmonEgg.Cli/SalmonEgg.Cli.csproj
+++ b/src/SalmonEgg.Cli/SalmonEgg.Cli.csproj
@@ -8,10 +8,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>salmon-egg</AssemblyName>
     <RootNamespace>SalmonEgg.Cli</RootNamespace>
-    <Version>$(SalmonEggPackageVersion)</Version>
-    <AssemblyVersion>$(SalmonEggPackageVersion)</AssemblyVersion>
-    <FileVersion>$(SalmonEggPackageVersion)</FileVersion>
-    <InformationalVersion>$(SalmonEggPackageVersion)</InformationalVersion>
+    <!-- Version identity comes from the git tag via MinVer (root Directory.Build.props). -->
     <SalmonEggCliSupportedRuntimeIdentifiers>win-x64;linux-x64;osx-arm64</SalmonEggCliSupportedRuntimeIdentifiers>
   </PropertyGroup>
 
@@ -66,6 +63,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="MinVer" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>

--- a/tests/SalmonEgg.Cli.Tests/CliApplicationTests.cs
+++ b/tests/SalmonEgg.Cli.Tests/CliApplicationTests.cs
@@ -71,16 +71,16 @@ public sealed class CliApplicationTests
     [Fact]
     public async Task RunAsync_WithVersion_WritesCliAssemblyVersion()
     {
-        // 期望值取自仓库根的共享版本，而不是写死字面量：CLI 与 GUI 共用同一个版本真相源，
-        // 写死会让每次发布抬版本都变成一次红灯。
-        var expectedVersionPrefix = RepositoryLayout.ReadSharedDisplayVersion() + ".";
+        // 期望值取自被测程序集自身的 InformationalVersion，而不是写死字面量：版本真相源现在是
+        // git tag（MinVer 在构建期打进程序集），写死会让每次发布抬版本都变成一次红灯。
+        var expectedVersion = RepositoryLayout.ReadCliInformationalVersion();
         await using var stdout = new StringWriter();
         await using var stderr = new StringWriter();
 
         var exitCode = await CliApplication.RunAsync(["--version"], stdout, stderr, TestContext.Current.CancellationToken);
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.StartsWith(expectedVersionPrefix, stdout.ToString(), StringComparison.Ordinal);
+        Assert.Equal(expectedVersion, stdout.ToString().TrimEnd());
         Assert.Empty(stderr.ToString());
     }
 

--- a/tests/SalmonEgg.Cli.Tests/RepositoryLayout.cs
+++ b/tests/SalmonEgg.Cli.Tests/RepositoryLayout.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using System.Text.RegularExpressions;
+using System.Reflection;
 
 namespace SalmonEgg.Cli.Tests;
 
@@ -8,9 +8,10 @@ namespace SalmonEgg.Cli.Tests;
 /// Locates repository-level release facts that CLI contract tests assert against.
 /// </summary>
 /// <remarks>
-/// Tests must never restate the release version as a literal. The version is owned by the
-/// repository root <c>Directory.Build.props</c> so the GUI and CLI artifacts cannot drift apart;
-/// a hardcoded copy in a test is a second owner that turns every release bump into a red gate.
+/// Tests must never restate the release version as a literal. The version is owned by the git tag
+/// and stamped into the assemblies by MinVer at build time, so the GUI and CLI artifacts cannot
+/// drift apart; a hardcoded copy in a test is a second owner that turns every release bump into a
+/// red gate.
 /// </remarks>
 internal static class RepositoryLayout
 {
@@ -34,25 +35,19 @@ internal static class RepositoryLayout
     }
 
     /// <summary>
-    /// Reads the shared display version (for example <c>1.1.0</c>) from the root build properties.
+    /// Reads the informational version MinVer stamped onto the CLI assembly (for example <c>1.1.0</c>).
     /// </summary>
-    public static string ReadSharedDisplayVersion()
+    public static string ReadCliInformationalVersion()
     {
-        var propertiesPath = Path.Combine(FindRoot(), "Directory.Build.props");
-        var properties = File.ReadAllText(propertiesPath);
-        var match = Regex.Match(
-            properties,
-            @"<SalmonEggDisplayVersion[^>]*>(?<version>[^<]+)</SalmonEggDisplayVersion>",
-            RegexOptions.None,
-            TimeSpan.FromSeconds(5));
+        var attribute = typeof(CliApplication).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
 
-        if (!match.Success)
+        if (attribute is null || string.IsNullOrWhiteSpace(attribute.InformationalVersion))
         {
             throw new InvalidOperationException(
-                $"SalmonEggDisplayVersion is not declared in '{propertiesPath}'. The shared release "
-                + "identity must stay in the repository root build properties.");
+                "SalmonEgg.Cli carries no AssemblyInformationalVersion. The release identity is derived "
+                + "from the git tag by MinVer and must stay stamped onto the shipped assembly.");
         }
 
-        return match.Groups["version"].Value.Trim();
+        return attribute.InformationalVersion;
     }
 }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Build/WindowsVersioningContractTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Build/WindowsVersioningContractTests.cs
@@ -18,10 +18,16 @@ public sealed class WindowsVersioningContractTests
         var applicationManifestTemplate = File.ReadAllText(
             Path.Combine(repositoryRoot, "SalmonEgg", "SalmonEgg", "app.manifest"));
 
-        // The display version lives at the repository root so the GUI and the CLI ship the same
-        // release identity. The condition keeps release automation able to override it per build.
+        // The release identity is derived from the git tag by MinVer in the repository-root
+        // Directory.Build.props, so the GUI and the CLI ship the same identity without anyone editing
+        // a file. The four-part Store version is the three-part display version plus ".0" (the MSIX
+        // revision digit); Windows Installer consumers read the three-part form instead.
         Assert.Contains(
-            "<SalmonEggDisplayVersion Condition=\"'$(SalmonEggDisplayVersion)' == ''\">",
+            "<Target Name=\"SalmonEggDeriveReleaseIdentity\" AfterTargets=\"MinVer\">",
+            rootBuildProperties,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "<SalmonEggDisplayVersion Condition=\"'$(SalmonEggDisplayVersion)' == ''\">$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</SalmonEggDisplayVersion>",
             rootBuildProperties,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -29,17 +35,38 @@ public sealed class WindowsVersioningContractTests
             rootBuildProperties,
             StringComparison.Ordinal);
 
-        // Second-owner ban: the GUI project may only consume the shared properties. Redeclaring one
-        // here is how the packaged MSIX and the CLI artifacts silently drift onto two versions.
+        // MinVer itself stamps AssemblyVersion as Major.0.0.0, which would make the About page,
+        // diagnostics and telemetry service.version report "1.0.0" while the Store shows 1.3.1.
+        // The derive target must override it unconditionally (a Condition on "already empty" never
+        // fires because MinVer has already assigned the property).
+        Assert.Contains(
+            "<AssemblyVersion>$(SalmonEggPackageVersion)</AssemblyVersion>",
+            rootBuildProperties,
+            StringComparison.Ordinal);
+
+        // Second-owner ban: the GUI project may only consume the shared derive target. Redeclaring a
+        // version here is how the packaged MSIX and the CLI artifacts silently drift onto two versions.
         Assert.DoesNotContain("<SalmonEggDisplayVersion>", projectFile, StringComparison.Ordinal);
         Assert.DoesNotContain("<SalmonEggPackageVersion>", projectFile, StringComparison.Ordinal);
+        Assert.DoesNotContain("<Version>", projectFile, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"MinVer\" />", projectFile, StringComparison.Ordinal);
 
-        Assert.Contains("<Version>$(SalmonEggPackageVersion)</Version>", projectFile, StringComparison.Ordinal);
+        // The manifest templates are stamped with $(SalmonEggPackageVersion) at execution time, and
+        // MinVer only fills that value inside its own target. Chaining the generation after MinVer is
+        // what keeps the tag-derived version from being replaced by a pre-MinVer default, so the
+        // ordering is part of the contract, not an implementation detail.
         Assert.Contains(
-            "<ApplicationDisplayVersion>$(SalmonEggDisplayVersion)</ApplicationDisplayVersion>",
+            "<Target Name=\"GenerateVersionedApplicationManifests\"",
             projectFile,
             StringComparison.Ordinal);
-        Assert.Contains("GenerateVersionedApplicationManifests", projectFile, StringComparison.Ordinal);
+        Assert.Contains("AfterTargets=\"MinVer\"", projectFile, StringComparison.Ordinal);
+        // Both the derive target and this one hang off AfterTargets="MinVer"; MSBuild does not define
+        // the order between two targets on the same hook, so the dependency is what guarantees the
+        // manifest is generated after the tag-derived version exists.
+        Assert.Contains(
+            "DependsOnTargets=\"SalmonEggDeriveReleaseIdentity\"",
+            projectFile,
+            StringComparison.Ordinal);
         Assert.Contains(
             "<WindowsAppxManifestPath>$(SalmonEggGeneratedPackageManifest)</WindowsAppxManifestPath>",
             projectFile,
@@ -79,6 +106,10 @@ public sealed class WindowsVersioningContractTests
             Path.Combine(repositoryRoot, ".github", "workflows", "release-packaging.yml"));
 
         Assert.Contains("$displayVersion", releaseWorkflow, StringComparison.Ordinal);
+        // The release identity is tag-derived, so the workflow must run MinVer to read it and must
+        // check out the full history for the tag to be reachable at all.
+        Assert.Contains("-t:MinVer", releaseWorkflow, StringComparison.Ordinal);
+        Assert.Contains("fetch-depth: 0", releaseWorkflow, StringComparison.Ordinal);
         Assert.DoesNotContain("Version=\"1.0.0\"", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("Import-PfxCertificate", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("$certificate.HasPrivateKey", releaseWorkflow, StringComparison.Ordinal);


### PR DESCRIPTION
## Why

Releases previously required hand-editing the version quartet in the GUI and CLI csproj files. This PR makes the **git tag the single source of truth**: a release is created by pushing `v*` (or `acp-sdk-v*` for the SDK), never by editing a file.

## How

- **MinVer 6.0.0** in the root `Directory.Build.props`, with `MinVerTagPrefix=v` (6.0.0 matches *no* tags when the prefix is empty — verified locally).
- A derive target produces `SalmonEggDisplayVersion` (three-part, MSI) and `SalmonEggPackageVersion` (four-part, MSIX/Store = display + ".0"), keeping the Store's four-part requirement compatible.
- `AssemblyVersion` is overridden **unconditionally**: MinVer stamps `Major.0.0.0`, but About/diagnostics/telemetry read `GetName().Version` and must report the shipped version. ApiCompat baseline validation accepts the bump (verified against the 1.0.0 baseline).
- The GUI manifest target uses `DependsOnTargets` on the derive target — both hook `AfterTargets="MinVer"` and MSBuild leaves same-hook order undefined.
- Every release script/workflow reads the version via `dotnet msbuild -restore -t:MinVer -getProperty:...`; every checkout it runs on (including the PR-time MSIX gate) uses `fetch-depth: 0` — a shallow clone sees no tags and would stamp `0.0.0`, which the MSIX gate rejects.
- ACP SDK keeps its `acp-sdk-v` namespace; package-validation baseline is enforced at pack time only, so everyday builds are not blocked.

## Verification

- ACP gates: format, analyzers, 336 tests, pack + ApiCompat vs 1.0.0 baseline ✅
- CLI tests 95/95; Presentation build-contract tests 36/36 (new assertions pin the two MinVer traps) ✅
- End-to-end on Linux: real Skia desktop publish → generated `app.manifest` carries `version="1.3.1.0"` from the tag ✅; CLI release script produced `salmon-egg-cli-1.3.1-linux-x64.tar.gz` ✅
- ACP tag-version gate self-test ✅

## Notes for reviewers

- The Store-facing four-part MSIX version stays `X.Y.Z.0`; MSI consumers keep the three-part form (the MSI contract gate already rejects four-part ProductVersion).
- After merging, before the next SDK release, set the repo variable `ACP_PACKAGE_BASELINE_VERSION=1.0.0` (the last version published to nuget.org). Missing it fails closed at pack time with an explanatory error.
- WinUI's `net10.0-windows` MSIX manifest substitution is exercised by the `windows-msix` PR gate rather than locally (WinUI cannot build on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)