### PR TITLE
fix(shell): window close is non-blocking and agent processes are drained

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.sh text eol=lf
-*.cs text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+*.cs text eol=lf

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,13 +109,22 @@ jobs:
           ${{ steps.changed_cs.outputs.files }}
           "@
           $files = $raw -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-          # TEMP DIAGNOSTIC: actually apply formatting so `git diff` reveals exactly what the
-          # formatter wants, then fail ourselves. Remove once the silent failure is identified.
+          # TEMP DIAGNOSTIC: apply formatting for real, export the diff as an artifact so the
+          # exact changes the formatter wants are readable locally (CI console eats CRLF diffs).
           dotnet format SalmonEgg.sln --no-restore --verbosity diagnostic --include $files
-          git --no-pager diff --stat
-          git --no-pager diff --unified=6 | Out-File diff.txt
-          Get-Content diff.txt -TotalCount 400
-          if ((git diff --quiet)) { Write-Host "NO DIFF - formatter made no changes" } else { exit 1 }
+          git --no-pager diff | Out-File formatter-diff.txt -Encoding utf8
+          git --no-pager diff --stat | Out-File formatter-stat.txt -Encoding utf8
+          exit 1
+
+      - name: Upload formatter diff
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: formatter-diff
+          path: |
+            formatter-diff.txt
+            formatter-stat.txt
+          if-no-files-found: ignore
 
       - name: Build with analyzers
         run: dotnet build SalmonEgg.sln --configuration ${{ env.CONFIGURATION }} --no-restore /p:EnforceCodeStyleInBuild=true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -112,8 +112,16 @@ jobs:
           # TEMP DIAGNOSTIC: apply formatting for real, export the diff as an artifact so the
           # exact changes the formatter wants are readable locally (CI console eats CRLF diffs).
           dotnet format SalmonEgg.sln --no-restore --verbosity diagnostic --include $files
-          git --no-pager diff | Out-File formatter-diff.txt -Encoding utf8
-          git --no-pager diff --stat | Out-File formatter-stat.txt -Encoding utf8
+          Write-Host "=== core.autocrlf ==="
+          git config --get core.autocrlf
+          Write-Host "=== diff with autocrlf disabled ==="
+          git -c core.autocrlf=false --no-pager diff --stat
+          git -c core.autocrlf=false --no-pager diff | Out-File formatter-diff.txt -Encoding utf8
+          Write-Host "=== first bytes of the 3 flagged files ==="
+          foreach ($f in @('tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs','tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs','tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs'))
+          {
+            (Get-Content $f -AsByteStream -TotalCount 240) -join ' '
+          }
           exit 1
 
       - name: Upload formatter diff

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,30 +109,7 @@ jobs:
           ${{ steps.changed_cs.outputs.files }}
           "@
           $files = $raw -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-          # TEMP DIAGNOSTIC: apply formatting for real, export the diff as an artifact so the
-          # exact changes the formatter wants are readable locally (CI console eats CRLF diffs).
-          dotnet format SalmonEgg.sln --no-restore --verbosity diagnostic --include $files
-          Write-Host "=== core.autocrlf ==="
-          git config --get core.autocrlf
-          Write-Host "=== diff with autocrlf disabled ==="
-          git -c core.autocrlf=false --no-pager diff --stat
-          git -c core.autocrlf=false --no-pager diff | Out-File formatter-diff.txt -Encoding utf8
-          Write-Host "=== first bytes of the 3 flagged files ==="
-          foreach ($f in @('tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs','tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs','tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs'))
-          {
-            (Get-Content $f -AsByteStream -TotalCount 240) -join ' '
-          }
-          exit 1
-
-      - name: Upload formatter diff
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: formatter-diff
-          path: |
-            formatter-diff.txt
-            formatter-stat.txt
-          if-no-files-found: ignore
+          dotnet format SalmonEgg.sln --verify-no-changes --no-restore --include $files
 
       - name: Build with analyzers
         run: dotnet build SalmonEgg.sln --configuration ${{ env.CONFIGURATION }} --no-restore /p:EnforceCodeStyleInBuild=true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,7 +109,13 @@ jobs:
           ${{ steps.changed_cs.outputs.files }}
           "@
           $files = $raw -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-          dotnet format SalmonEgg.sln --verify-no-changes --no-restore --verbosity diagnostic --include $files
+          # TEMP DIAGNOSTIC: actually apply formatting so `git diff` reveals exactly what the
+          # formatter wants, then fail ourselves. Remove once the silent failure is identified.
+          dotnet format SalmonEgg.sln --no-restore --verbosity diagnostic --include $files
+          git --no-pager diff --stat
+          git --no-pager diff --unified=6 | Out-File diff.txt
+          Get-Content diff.txt -TotalCount 400
+          if ((git diff --quiet)) { Write-Host "NO DIFF - formatter made no changes" } else { exit 1 }
 
       - name: Build with analyzers
         run: dotnet build SalmonEgg.sln --configuration ${{ env.CONFIGURATION }} --no-restore /p:EnforceCodeStyleInBuild=true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,7 +109,7 @@ jobs:
           ${{ steps.changed_cs.outputs.files }}
           "@
           $files = $raw -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-          dotnet format SalmonEgg.sln --verify-no-changes --no-restore --include $files
+          dotnet format SalmonEgg.sln --verify-no-changes --no-restore --verbosity diagnostic --include $files
 
       - name: Build with analyzers
         run: dotnet build SalmonEgg.sln --configuration ${{ env.CONFIGURATION }} --no-restore /p:EnforceCodeStyleInBuild=true

--- a/SalmonEgg/.editorconfig
+++ b/SalmonEgg/.editorconfig
@@ -72,10 +72,12 @@ indent_size = 2
 end_of_line = lf
 
 [*.cs]
-# LF on disk is a repo contract (see .gitattributes *.cs eol=lf). This must stay an explicit
-# setting: `unset` used to disable the check, but newer SDKs treat it as "inherit" and fall
-# back to the [*] crlf rule, which flips the whole format gate.
-end_of_line = lf
+# EOL must stay `unset` here. The dotnet format whitespace fixer (verified on SDK 10.0.400)
+# ignores `end_of_line` entirely and demands the running platform's NewLine: CRLF on the
+# Windows runner that hosts the format gate, LF on Linux. Git's core.autocrlf owns what lands
+# on disk (CRLF checked out on Windows, LF on Linux), so both sides agree by construction.
+# Setting any explicit value would be false for one of the two platforms.
+end_of_line = unset
 
 # See https://github.com/dotnet/roslyn/issues/20356#issuecomment-310143926
 trim_trailing_whitespace = false

--- a/SalmonEgg/.editorconfig
+++ b/SalmonEgg/.editorconfig
@@ -72,8 +72,10 @@ indent_size = 2
 end_of_line = lf
 
 [*.cs]
-# EOL should be normalized by Git. See https://github.com/dotnet/format/issues/1099
-end_of_line = unset
+# LF on disk is a repo contract (see .gitattributes *.cs eol=lf). This must stay an explicit
+# setting: `unset` used to disable the check, but newer SDKs treat it as "inherit" and fall
+# back to the [*] crlf rule, which flips the whole format gate.
+end_of_line = lf
 
 # See https://github.com/dotnet/roslyn/issues/20356#issuecomment-310143926
 trim_trailing_whitespace = false

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -655,6 +655,12 @@ public static class DependencyInjection
             sp.GetRequiredService<MainNavigationViewModel>());
         services.AddSingleton<IConversationOpenRouter, ConversationOpenRouter>();
         services.AddSingleton<ShellSessionActivationOverlayViewModel>();
+        // 关闭遮罩必须单例：它订阅 shutdown 进度源，多例会重复起阈值计时。
+        services.AddSingleton<ShellShutdownOverlayViewModel>(sp =>
+            new ShellShutdownOverlayViewModel(
+                sp.GetRequiredService<IApplicationShutdownProgress>(),
+                sp.GetRequiredService<IUiDispatcher>(),
+                sp.GetService<IStringLocalizer<CoreStrings>>()));
         services.AddSingleton<IDiscoverSessionsConnectionFacade>(sp =>
             new DiscoverSessionsConnectionFacade(
                 sp.GetRequiredService<IAcpChatServiceFactory>(),
@@ -764,11 +770,29 @@ public static class DependencyInjection
         });
         services.AddSingleton<ChatCompletionNotificationCoordinator>();
         services.AddSingleton<NotificationActivationCoordinator>();
+        // 关闭进度：Core 持有事实，读写面分开注册，写入面只给 teardown owner。
+        services.AddSingleton<ApplicationShutdownProgressStore>();
+        services.AddSingleton<IApplicationShutdownProgress>(sp =>
+            sp.GetRequiredService<ApplicationShutdownProgressStore>());
+        services.AddSingleton<IApplicationShutdownProgressSink>(sp =>
+            sp.GetRequiredService<ApplicationShutdownProgressStore>());
         services.AddSingleton<IApplicationShutdownWorkflow>(sp =>
             new ApplicationShutdownWorkflow(
                 sp.GetRequiredService<IChatRuntimePersistence>(),
+                sp.GetRequiredService<IAcpConnectionSessionCleaner>(),
+                sp.GetRequiredService<IDiscoverSessionsConnectionFacade>(),
+                sp.GetRequiredService<ITerminalSessionManager>(),
+                sp.GetRequiredService<IApplicationShutdownProgressSink>(),
                 sp.GetRequiredService<ITelemetryRuntime>(),
-                sp.GetRequiredService<ILogger<ApplicationShutdownWorkflow>>()));
+                sp.GetRequiredService<ILogger<ApplicationShutdownWorkflow>>(),
+                // 本地 PTY 协调器只在 desktop 注册；其余平台传 null，由 workflow 跳过该段。
+                // 用 GetService 而非 GetRequiredService 表达"可选"，避免为此在各平台注册空实现。
+#if !__WASM__ && !__ANDROID__ && !__IOS__
+                sp.GetService<LocalTerminalPanelCoordinator>()
+#else
+                null
+#endif
+                ));
 
         // Global search
         services.AddSingleton<IGlobalSearchPipeline, DefaultGlobalSearchPipeline>();

--- a/SalmonEgg/SalmonEgg/MainPage.Default.cs
+++ b/SalmonEgg/SalmonEgg/MainPage.Default.cs
@@ -10,11 +10,11 @@ public sealed partial class MainPage
     {
     }
 
-    partial void DisposePlatformTray()
+    partial void HideMainWindowToTray()
     {
     }
 
-    partial void DetachAppWindowClosing()
+    partial void DisposePlatformTray()
     {
     }
 

--- a/SalmonEgg/SalmonEgg/MainPage.Shutdown.cs
+++ b/SalmonEgg/SalmonEgg/MainPage.Shutdown.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Windowing;
+
+namespace SalmonEgg;
+
+/// <summary>
+/// 窗口关闭路径：拦住原生关闭 → 跑完 teardown → 再真正关闭。
+/// </summary>
+/// <remarks>
+/// 这段逻辑是<b>跨平台共享</b>的，不是 Windows 专属。反编译 Uno 6.6.166 实际发货的
+/// <c>uno-runtime/&lt;tfm&gt;/skia/Uno.UI.dll</c> 确认：X11 / Win32 / macOS 三个 Skia host 都会
+/// raise <c>AppWindow.Closing</c>，且各自的 <c>*NativeWindowFactoryExtension</c>
+/// <c>SupportsClosingCancellation</c> 均为 <c>true</c>——汇聚点 <c>BaseWindowImplementation</c>
+/// 只在 <c>Cancel &amp;&amp; SupportsClosingCancellation</c> 时才真的中止关闭。
+/// （注意：<c>lib/&lt;tfm&gt;/Uno.UI.dll</c> 是 facade，那里该属性硬编码 false，据它会得出
+/// "平台不支持取消"的相反结论。）
+///
+/// 为什么必须在这里 teardown、而不能只依赖宿主返回后再做：desktop 头原先只在
+/// <c>Platforms/Desktop/Program.cs</c> 里等 <c>host.RunAsync()</c> 返回后才清理，
+/// 那时窗口早已销毁——实测窗口 1.1s 就消失而进程活到 10.3s，用户看到的是"关掉了但还在跑"。
+/// 先取消这一轮关闭、清理完再关，窗口在整个 teardown 期间保持可见，
+/// 关闭提示 overlay 才有地方显示（<c>ShellShutdownOverlayViewModel</c>）。
+/// </remarks>
+public sealed partial class MainPage
+{
+    /// <summary>
+    /// 重入闩锁：teardown 完成后我们自己调用 <c>Close()</c>，那一轮必须放行。
+    /// </summary>
+    private bool _allowClose;
+
+    private void AttachAppWindowClosing()
+    {
+        var window = App.MainWindowInstance;
+        if (window?.AppWindow is not { } appWindow)
+        {
+            return;
+        }
+
+        // 先减后加：shell 可被重载（如切换语言会替换根 Frame），重复订阅会让一次关闭
+        // 触发多轮 teardown。workflow 幂等，但重复订阅仍是状态泄漏。
+        appWindow.Closing -= OnAppWindowClosing;
+        appWindow.Closing += OnAppWindowClosing;
+    }
+
+    private void DetachAppWindowClosing()
+    {
+        if (App.MainWindowInstance?.AppWindow is { } appWindow)
+        {
+            appWindow.Closing -= OnAppWindowClosing;
+        }
+    }
+
+    private void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
+    {
+        if (_allowClose)
+        {
+            return;
+        }
+
+        // 托盘由能力位驱动而非 #if：IsMinimizeToTraySupported 已是跨平台事实源
+        // （PlatformCapabilityService.SupportsTray），不支持托盘的平台恒为 false，
+        // 于是这里天然退化为"直接关闭"。但"把窗口藏起来"这个动作本身是 Windows 托盘
+        // 专属能力（Uno 对 AppWindow.Hide 未实现），必须留在平台 partial 里，
+        // 否则共享代码在 desktop 目标上会撞 Uno0001。
+        if (Preferences.IsMinimizeToTraySupported && Preferences.MinimizeToTray)
+        {
+            args.Cancel = true;
+            HideMainWindowToTray();
+            return;
+        }
+
+        // 这是进程边界。teardown 是异步的，而 Closing 事件无法被 await，
+        // 且窗口一旦消失就再也无法持久化任何东西——所以取消这一轮，清理完再真关。
+        args.Cancel = true;
+        _ = FlushRuntimeThenCloseAsync();
+    }
+
+    private async Task FlushRuntimeThenCloseAsync()
+    {
+        try
+        {
+            await App.ShutdownRuntimeAsync().ConfigureAwait(true);
+        }
+        finally
+        {
+            // finally：teardown 失败也必须让窗口关掉，否则用户会卡在一个关不掉的窗口里。
+            _allowClose = true;
+            App.MainWindowInstance?.Close();
+        }
+    }
+}

--- a/SalmonEgg/SalmonEgg/MainPage.xaml
+++ b/SalmonEgg/SalmonEgg/MainPage.xaml
@@ -797,6 +797,44 @@
                     <TranslateTransform x:Name="LeftNavResizerTransform" X="{x:Bind LayoutVM.LeftNavResizerLeft, Mode=OneWay}" />
                 </controls:ResizeGrip.RenderTransform>
             </controls:ResizeGrip>
+
+            <!-- 关闭遮罩（issue #126）：清理超过阈值才出现，结构照 ChatViewLoadingOverlay。
+                 文案由 ShellShutdownOverlayViewModel 按 CoreStrings 本地化，不占 x:Uid 的 Text 面。 -->
+            <ContentControl x:Name="ShellShutdownOverlay"
+                            x:Uid="ShellShutdownOverlay"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            IsTabStop="False"
+                            AutomationProperties.AutomationId="Shell.ShutdownOverlay"
+                            Visibility="{x:Bind ShutdownOverlayVM.IsOverlayVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                <Grid>
+                    <Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                            Opacity="0.85"
+                            AutomationProperties.AutomationId="Shell.ShutdownOverlayMask" />
+
+                    <Grid>
+                        <Border VerticalAlignment="Bottom"
+                                HorizontalAlignment="Center"
+                                Margin="0,0,0,48"
+                                Padding="16,8"
+                                Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="20">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <ProgressRing IsActive="True" Width="16" Height="16" />
+                                <TextBlock AutomationProperties.AutomationId="Shell.ShutdownOverlayStatus"
+                                           Text="{x:Bind ShutdownOverlayVM.StatusText, Mode=OneWay}"
+                                           FontSize="12"
+                                           FontWeight="Medium"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </ContentControl>
         </Grid>
     </Grid>
 </Page>

--- a/SalmonEgg/SalmonEgg/MainPage.xaml.cs
+++ b/SalmonEgg/SalmonEgg/MainPage.xaml.cs
@@ -64,6 +64,7 @@ public sealed partial class MainPage : Page, INavigationIntentConsumer, IGamepad
     private readonly ChatViewModel _chatViewModel;
     public ChatViewModel ChatVM => _chatViewModel;
     public ShellSessionActivationOverlayViewModel ShellOverlayVM { get; }
+    public ShellShutdownOverlayViewModel ShutdownOverlayVM { get; }
     public ShellLayoutViewModel LayoutVM { get; }
     private readonly WindowMetricsProvider _metricsProvider;
     private readonly AppActivationSignalSource _appActivationSignalSource;
@@ -88,6 +89,7 @@ public sealed partial class MainPage : Page, INavigationIntentConsumer, IGamepad
         NavVM = App.ServiceProvider.GetRequiredService<MainNavigationViewModel>();
         _chatViewModel = App.ServiceProvider.GetRequiredService<ChatViewModel>();
         ShellOverlayVM = App.ServiceProvider.GetRequiredService<ShellSessionActivationOverlayViewModel>();
+        ShutdownOverlayVM = App.ServiceProvider.GetRequiredService<ShellShutdownOverlayViewModel>();
         SearchVM = App.ServiceProvider.GetRequiredService<GlobalSearchViewModel>();
 
         LayoutVM = App.ServiceProvider.GetRequiredService<ShellLayoutViewModel>();
@@ -716,6 +718,7 @@ public sealed partial class MainPage : Page, INavigationIntentConsumer, IGamepad
     {
         AttachGamepadInput();
         AttachDebugKeyLogging();
+        AttachAppWindowClosing();
         _titleBarAdapter.Configure(App.MainWindowInstance);
         _appActivationSignalSource.Attach(App.MainWindowInstance!);
         _metricsProvider.Attach(App.MainWindowInstance!, _titleBarAdapter);
@@ -1425,9 +1428,9 @@ public sealed partial class MainPage : Page, INavigationIntentConsumer, IGamepad
 
     partial void UpdateTrayState();
 
-    partial void DisposePlatformTray();
+    partial void HideMainWindowToTray();
 
-    partial void DetachAppWindowClosing();
+    partial void DisposePlatformTray();
 
     partial void AttachDebugKeyLogging();
 

--- a/SalmonEgg/SalmonEgg/Platforms/Windows/MainPage.Windows.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Windows/MainPage.Windows.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Input;
+using Microsoft.UI.Windowing;
 using SalmonEgg.Platforms.Windows;
 using WinUIKeyEventArgs = Microsoft.UI.Input.KeyEventArgs;
 

--- a/SalmonEgg/SalmonEgg/Platforms/Windows/MainPage.Windows.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Windows/MainPage.Windows.cs
@@ -12,18 +12,13 @@ public sealed partial class MainPage
 #if DEBUG
     private InputKeyboardSource? _debugKeyboardSource;
 #endif
-    private bool _allowClose;
 
     partial void InitializeTray()
     {
+        // 只管托盘。窗口关闭路径已上提到共享的 MainPage.Shutdown.cs——Uno 的三个 Skia host
+        // 同样 raise AppWindow.Closing 并尊重 Cancel，留在这里会让非 Windows 平台永远没有
+        // teardown 时机（issue #126）。
         UpdateTrayState();
-
-        var window = App.MainWindowInstance;
-        if (window?.AppWindow != null)
-        {
-            window.AppWindow.Closing -= OnAppWindowClosing;
-            window.AppWindow.Closing += OnAppWindowClosing;
-        }
     }
 
     partial void UpdateTrayState()
@@ -50,13 +45,9 @@ public sealed partial class MainPage
         _trayIcon = null;
     }
 
-    partial void DetachAppWindowClosing()
+    partial void HideMainWindowToTray()
     {
-        var window = App.MainWindowInstance;
-        if (window?.AppWindow != null)
-        {
-            window.AppWindow.Closing -= OnAppWindowClosing;
-        }
+        App.MainWindowInstance?.AppWindow?.Hide();
     }
 
     private void EnsureTrayIcon()
@@ -106,40 +97,6 @@ public sealed partial class MainPage
         // Tray exit is a second process boundary and must persist state like the window close path.
         // The shutdown workflow is idempotent, so both paths can drive it.
         _ = FlushRuntimeThenCloseAsync();
-    }
-
-    private void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
-    {
-        if (_allowClose)
-        {
-            return;
-        }
-
-        if (Preferences.MinimizeToTray)
-        {
-            args.Cancel = true;
-            sender.Hide();
-            return;
-        }
-
-        // This is the WinUI process boundary. Teardown is asynchronous, so cancel this pass, flush,
-        // then close for real: the closing event cannot be awaited and a window that is already gone
-        // can no longer persist anything.
-        args.Cancel = true;
-        _ = FlushRuntimeThenCloseAsync();
-    }
-
-    private async Task FlushRuntimeThenCloseAsync()
-    {
-        try
-        {
-            await App.ShutdownRuntimeAsync().ConfigureAwait(true);
-        }
-        finally
-        {
-            _allowClose = true;
-            App.MainWindowInstance?.Close();
-        }
     }
 
     partial void AttachDebugKeyLogging()

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -1188,6 +1188,9 @@
   <data name="ChatViewLoadingOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Session loading</value>
   </data>
+  <data name="ShellShutdownOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Shutting down</value>
+  </data>
   <data name="ChatMessageCopyMenu.Text" xml:space="preserve">
     <value>Copy message</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -492,6 +492,9 @@
   <data name="ChatViewLoadingOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Session loading</value>
   </data>
+  <data name="ShellShutdownOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Shutting down</value>
+  </data>
   <data name="ChatMessageCopyMenu.Text" xml:space="preserve">
     <value>Copy message</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -1143,6 +1143,9 @@
   <data name="ChatViewLoadingOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>会话加载中</value>
   </data>
+  <data name="ShellShutdownOverlay.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>正在关闭</value>
+  </data>
   <data name="ChatMessageCopyMenu.Text" xml:space="preserve">
     <value>复制消息</value>
   </data>

--- a/scripts/gates/run-skia-desktop-close-path-gate.sh
+++ b/scripts/gates/run-skia-desktop-close-path-gate.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Gate for the window-close path (issue #126). The GUI smoke gates only ever SIGTERM the app,
+# which is why a multi-second block between "close clicked" and "process exited" went unnoticed:
+# SIGTERM is not the close button. This gate sends a real WM_DELETE_WINDOW (exactly what a titlebar
+# X produces), then hard-asserts:
+#   1. close -> exit within CLOSE_BUDGET_SECONDS,
+#   2. exit code 0 (teardown, not a crash),
+#   3. every child process recorded before the close is gone after exit (no leak reparented to init).
+# The appdata is seeded with telemetry pointed at a blackhole address, which is the worst case:
+# a waiting telemetry shutdown used to block the close path for ~10s there.
+set -euo pipefail
+
+CONFIGURATION="${1:-Debug}"
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+SCRIPT_DIR="${SCRIPT_SOURCE%/*}"
+if [ "${SCRIPT_DIR}" = "${SCRIPT_SOURCE}" ]; then
+  SCRIPT_DIR="."
+fi
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+PROJECT="${REPO_ROOT}/SalmonEgg/SalmonEgg/SalmonEgg.csproj"
+APP_PATH="${REPO_ROOT}/SalmonEgg/SalmonEgg/bin/${CONFIGURATION}/net10.0-desktop/SalmonEgg"
+CLOSE_SENDER="${REPO_ROOT}/scripts/gates/skia-desktop-x11-close-sender.py"
+SEED_WRITER_PROJECT="${REPO_ROOT}/tests/SalmonEgg.TestSupport/SalmonEgg.TestSupport.csproj"
+READY_MARKER="MainPage: initial shell content activated"
+READY_TIMEOUT_SECONDS=120
+# Budget rationale: fixed code closes in 0.7-2.6s under the blackhole endpoint; the blocking
+# regression measured 5.5s (one provider) up to ~10s (serial). 4s separates both with margin.
+# The wait loop uses nanosecond timestamps on purpose: SECONDS is whole-second granularity and
+# already let a 5.55s regression slip through a "5s" budget once.
+CLOSE_BUDGET_SECONDS=4
+CHILD_EXIT_GRACE_SECONDS=5
+# TEST-NET-1: routed-to-nowhere, so a synchronous OTLP export stalls instead of failing fast.
+BLACKHOLE_ENDPOINT="http://192.0.2.1:4318"
+
+DOTNET_BIN="${DOTNET_BIN:-$(command -v dotnet || true)}"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || true)}"
+
+if [ "${CONFIGURATION}" != "Debug" ]; then
+  echo "Close-path gate requires Debug configuration because the readiness marker is DEBUG-only boot.log output." >&2
+  exit 2
+fi
+
+if [ -z "${DOTNET_BIN}" ]; then
+  echo "Unable to locate dotnet in PATH." >&2
+  exit 1
+fi
+
+if [ -z "${PYTHON_BIN}" ]; then
+  echo "Unable to locate python3 in PATH." >&2
+  exit 1
+fi
+
+OS_NAME="$(uname -s)"
+if [ "${OS_NAME}" != "Linux" ]; then
+  echo "Close-path gate covers the X11 close path; run it on Linux." >&2
+  exit 2
+fi
+
+XVFB_BIN="${XVFB_BIN:-$(command -v Xvfb || true)}"
+if [ -z "${XVFB_BIN}" ]; then
+  echo "Unable to locate Xvfb in PATH. Install xvfb to run the close-path gate headlessly." >&2
+  exit 1
+fi
+
+APPDATA_ROOT="$(mktemp -d -t salmonegg-close-path-appdata.XXXXXX)"
+STDOUT_LOG="$(mktemp -t salmonegg-close-path.XXXXXX.log)"
+XVFB_LOG="$(mktemp -t salmonegg-close-path-xvfb.XXXXXX.log)"
+CLOSE_SENDER_LOG="$(mktemp -t salmonegg-close-path-sender.XXXXXX.log)"
+CHILDREN_FILE="$(mktemp -t salmonegg-close-path-children.XXXXXX.log)"
+BOOT_LOG="${APPDATA_ROOT}/boot.log"
+APP_PID=""
+XVFB_PID=""
+DISPLAY_NUMBER="${SALMONEGG_CLOSE_PATH_DISPLAY_BASE:-140}"
+
+cleanup() {
+  if [ -n "${APP_PID}" ] && kill -0 "${APP_PID}" 2>/dev/null; then
+    kill "${APP_PID}" 2>/dev/null || true
+    wait "${APP_PID}" 2>/dev/null || true
+  fi
+
+  if [ -n "${XVFB_PID}" ] && kill -0 "${XVFB_PID}" 2>/dev/null; then
+    kill "${XVFB_PID}" 2>/dev/null || true
+    wait "${XVFB_PID}" 2>/dev/null || true
+  fi
+
+  if [ -d "${APPDATA_ROOT}" ]; then
+    rm -rf "${APPDATA_ROOT}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+fail() {
+  local message="$1"
+  cat "${STDOUT_LOG}" >&2
+  if [ -f "${BOOT_LOG}" ]; then
+    cat "${BOOT_LOG}" >&2
+  fi
+  echo "[close-path] ${message}" >&2
+  exit 1
+}
+
+start_xvfb() {
+  for offset in $(seq 0 49); do
+    local display_number=$((DISPLAY_NUMBER + offset))
+    CLOSE_DISPLAY=":${display_number}"
+    "${XVFB_BIN}" "${CLOSE_DISPLAY}" -screen 0 1920x1080x24 -nolisten tcp >"${XVFB_LOG}" 2>&1 &
+    XVFB_PID="$!"
+    sleep 0.5
+
+    if kill -0 "${XVFB_PID}" 2>/dev/null; then
+      return 0
+    fi
+
+    wait "${XVFB_PID}" 2>/dev/null || true
+    XVFB_PID=""
+  done
+
+  cat "${XVFB_LOG}" >&2
+  echo "Unable to start Xvfb for the close-path gate." >&2
+  return 1
+}
+
+# Recursive descendants via /proc/<pid>/task/<tid>/children — no ps dependency games, and
+# grandchildren are included, which matters because npm-style launchers put the real agent
+# one level below the process the app spawned.
+snapshot_descendants() {
+  local pid="$1"
+  local output="$2"
+  : >"${output}"
+  local queue=("${pid}")
+  while [ "${#queue[@]}" -gt 0 ]; do
+    local current="${queue[0]}"
+    queue=("${queue[@]:1}")
+    local children_file
+    for children_file in /proc/"${current}"/task/*/children; do
+      [ -f "${children_file}" ] || continue
+      for child in $(cat "${children_file}"); do
+        echo "${child}" >>"${output}"
+        queue+=("${child}")
+      done
+    done
+  done
+  sort -u -o "${output}" "${output}"
+}
+
+seed_appdata() {
+  local seed_dir
+  seed_dir="$(mktemp -d -t salmonegg-close-path-seed.XXXXXX)"
+  cat >"${seed_dir}/Seed.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="${SEED_WRITER_PROJECT}" />
+  </ItemGroup>
+</Project>
+EOF
+  cat >"${seed_dir}/Program.cs" <<'EOF'
+using SalmonEgg.TestSupport;
+var root = args.Length > 0 ? args[0] : throw new ArgumentException("appdata root required");
+_ = SkiaDesktopGuiSeedWriter.WriteMixedTranscriptSeed(root);
+EOF
+
+  if ! "${DOTNET_BIN}" run --project "${seed_dir}/Seed.csproj" -c "${CONFIGURATION}" -- "${APPDATA_ROOT}" >/dev/null; then
+    rm -rf "${seed_dir}"
+    echo "Close-path gate failed to write the AppData seed." >&2
+    exit 1
+  fi
+
+  rm -rf "${seed_dir}"
+
+  # Force the worst case the issue reported: telemetry enabled and exporting into a blackhole.
+  # A shutdown that waits on export used to stall the close path for ~10s here.
+  # Keys follow the yaml store's UnderscoredNamingConvention (AppSettingsYamlV1.TelemetrySharingEnabled
+  # serializes as telemetry_sharing_enabled) — PascalCase here would be silently ignored.
+  if ! grep -Eq "^telemetry_sharing_enabled:[[:space:]]+true$" "${APPDATA_ROOT}/config/app.yaml"; then
+    printf '\ntelemetry_sharing_enabled: true\n' >>"${APPDATA_ROOT}/config/app.yaml"
+  fi
+  printf 'telemetry_custom_endpoint: %s\n' "${BLACKHOLE_ENDPOINT}" >>"${APPDATA_ROOT}/config/app.yaml"
+
+  if ! grep -Fq "telemetry_custom_endpoint: ${BLACKHOLE_ENDPOINT}" "${APPDATA_ROOT}/config/app.yaml"; then
+    echo "Close-path gate seed is missing the blackhole telemetry endpoint." >&2
+    exit 1
+  fi
+}
+
+echo "[gate] Build Skia Desktop app"
+"${DOTNET_BIN}" build "${PROJECT}" \
+  -c "${CONFIGURATION}" \
+  -f net10.0-desktop \
+  -p:SalmonEggTargetFrameworks=net10.0-desktop \
+  -p:SalmonEggAllTargetFrameworks=net10.0-desktop \
+  -v minimal
+
+if [ ! -x "${APP_PATH}" ]; then
+  echo "Missing executable Skia Desktop artifact: ${APP_PATH}" >&2
+  exit 1
+fi
+
+echo "[gate] Seed appdata with blackhole telemetry endpoint"
+seed_appdata
+
+echo "[gate] Launch Skia Desktop app under Xvfb"
+start_xvfb
+env DISPLAY="${CLOSE_DISPLAY}" SALMONEGG_GUI=1 SALMONEGG_APPDATA_ROOT="${APPDATA_ROOT}" "${APP_PATH}" >"${STDOUT_LOG}" 2>&1 &
+APP_PID="$!"
+echo "[close-path] app pid=${APP_PID} display=${CLOSE_DISPLAY}"
+
+ready_deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+while [ "${SECONDS}" -lt "${ready_deadline}" ]; do
+  kill -0 "${APP_PID}" 2>/dev/null || fail "App exited before reaching '${READY_MARKER}'."
+  if [ -f "${BOOT_LOG}" ] && grep -Fq "${READY_MARKER}" "${BOOT_LOG}"; then
+    break
+  fi
+  sleep 0.2
+done
+if ! grep -Fq "${READY_MARKER}" "${BOOT_LOG}" 2>/dev/null; then
+  fail "App did not log '${READY_MARKER}' within ${READY_TIMEOUT_SECONDS}s."
+fi
+
+snapshot_descendants "${APP_PID}" "${CHILDREN_FILE}"
+descendant_count="$(grep -c . "${CHILDREN_FILE}" || true)"
+echo "[close-path] descendants recorded before close: ${descendant_count}"
+
+echo "[gate] Send WM_DELETE_WINDOW and measure close -> exit"
+if ! "${PYTHON_BIN}" "${CLOSE_SENDER}" \
+    --display "${CLOSE_DISPLAY}" \
+    --pid "${APP_PID}" \
+    --timeout 20 \
+    >"${CLOSE_SENDER_LOG}" 2>&1; then
+  cat "${CLOSE_SENDER_LOG}" >&2
+  fail "Failed to deliver WM_DELETE_WINDOW to the app window."
+fi
+cat "${CLOSE_SENDER_LOG}"
+
+close_start="$(date +%s%N)"
+deadline_ns=$((close_start + CLOSE_BUDGET_SECONDS * 1000000000))
+app_exited=0
+while [ "$(date +%s%N)" -le "${deadline_ns}" ]; do
+  if ! kill -0 "${APP_PID}" 2>/dev/null; then
+    app_exited=1
+    break
+  fi
+  sleep 0.05
+done
+
+if [ "${app_exited}" -ne 1 ]; then
+  fail "App still alive ${CLOSE_BUDGET_SECONDS}s after WM_DELETE_WINDOW (issue #126 regression)."
+fi
+
+exit_code=0
+# 不写 `if ! wait`：取反会把非零状态翻成零，退出码断言就永远假绿。
+wait "${APP_PID}" || exit_code=$?
+close_elapsed="$(awk -v s="${close_start}" -v e="$(date +%s%N)" 'BEGIN { printf "%.2f", (e - s) / 1000000000 }')"
+echo "[close-path] app exited after ${close_elapsed}s, exit code ${exit_code}"
+
+if [ "${exit_code}" -ne 0 ]; then
+  fail "App exited with code ${exit_code}; teardown must be a clean exit, not a crash."
+fi
+
+echo "[gate] Assert no descendant survived the exit"
+leaked=0
+child_grace_deadline=$((SECONDS + CHILD_EXIT_GRACE_SECONDS))
+while :; do
+  leaked=0
+  while IFS= read -r child; do
+    [ -n "${child}" ] || continue
+    if kill -0 "${child}" 2>/dev/null; then
+      leaked=$((leaked + 1))
+      echo "[close-path] descendant still alive after app exit: pid=${child} cmd=$(tr '\0' ' ' < /proc/"${child}"/cmdline 2>/dev/null || echo '?')"
+    fi
+  done <"${CHILDREN_FILE}"
+  if [ "${leaked}" -eq 0 ]; then
+    break
+  fi
+  if [ "${SECONDS}" -ge "${child_grace_deadline}" ]; then
+    break
+  fi
+  sleep 0.2
+done
+
+if [ "${leaked}" -ne 0 ]; then
+  fail "${leaked} descendant process(es) survived the app exit (leak regression)."
+fi
+
+if grep -Eiq 'Segmentation fault|Unhandled exception|App.UnhandledException|AppDomain.UnhandledException' "${STDOUT_LOG}" "${BOOT_LOG}"; then
+  fail "Runtime failure signature found in the app logs."
+fi
+
+echo "[gate] Skia Desktop close-path gate passed (${close_elapsed}s close -> exit, code 0, no surviving descendants)"

--- a/scripts/gates/skia-desktop-x11-close-sender.py
+++ b/scripts/gates/skia-desktop-x11-close-sender.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Send a real WM_DELETE_WINDOW ClientMessage to the SalmonEgg X11 window.
+
+Why not `xdotool windowclose`: it sends XDestroyWindow, which makes Uno's X11
+presenter segfault (rc=139, BadWindow) — a crash that masquerades as a fast
+exit. The titlebar close button sends WM_PROTOCOLS/WM_DELETE_WINDOW via
+XSendEvent; that is the message this script delivers, and the only one that
+exercises the real close path (issue #126 gate).
+"""
+import argparse
+import ctypes
+import sys
+import time
+
+IS_VIEWABLE = 2
+XA_CARDINAL = 6
+ANY_PROPERTY_TYPE = 0
+CURRENT_TIME = 0
+NO_EVENT_MASK = 0
+MIN_WINDOW_WIDTH = 200
+MIN_WINDOW_HEIGHT = 200
+
+
+class XWindowAttributes(ctypes.Structure):
+    _fields_ = [
+        ("x", ctypes.c_int),
+        ("y", ctypes.c_int),
+        ("width", ctypes.c_int),
+        ("height", ctypes.c_int),
+        ("border_width", ctypes.c_int),
+        ("depth", ctypes.c_int),
+        ("visual", ctypes.c_void_p),
+        ("root", ctypes.c_ulong),
+        ("class", ctypes.c_int),
+        ("bit_gravity", ctypes.c_int),
+        ("win_gravity", ctypes.c_int),
+        ("backing_store", ctypes.c_int),
+        ("backing_planes", ctypes.c_ulong),
+        ("backing_pixel", ctypes.c_ulong),
+        ("save_under", ctypes.c_int),
+        ("colormap", ctypes.c_ulong),
+        ("map_installed", ctypes.c_int),
+        ("map_state", ctypes.c_int),
+        ("all_event_masks", ctypes.c_long),
+        ("your_event_mask", ctypes.c_long),
+        ("do_not_propagate_mask", ctypes.c_long),
+        ("override_redirect", ctypes.c_int),
+        ("screen", ctypes.c_void_p),
+    ]
+
+
+class XClientMessageEvent(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("serial", ctypes.c_ulong),
+        ("send_event", ctypes.c_bool),
+        ("display", ctypes.c_void_p),
+        ("window", ctypes.c_ulong),
+        ("message_type", ctypes.c_ulong),
+        ("format", ctypes.c_int),
+        ("data", ctypes.c_long * 5),
+    ]
+
+
+class XEvent(ctypes.Union):
+    _fields_ = [
+        ("type", ctypes.c_long),
+        ("xclient", XClientMessageEvent),
+    ]
+
+
+def fetch_window_pid(x11, display, window, atom):
+    if atom == 0:
+        return None
+
+    actual_type = ctypes.c_ulong()
+    actual_format = ctypes.c_int()
+    item_count = ctypes.c_ulong()
+    bytes_after = ctypes.c_ulong()
+    prop = ctypes.POINTER(ctypes.c_ubyte)()
+
+    status = x11.XGetWindowProperty(
+        display, window, atom, 0, 1, 0, ANY_PROPERTY_TYPE,
+        ctypes.byref(actual_type), ctypes.byref(actual_format),
+        ctypes.byref(item_count), ctypes.byref(bytes_after), ctypes.byref(prop),
+    )
+    if status != 0 or not prop:
+        return None
+
+    try:
+        if actual_type.value != XA_CARDINAL or actual_format.value != 32 or item_count.value < 1:
+            return None
+        return ctypes.cast(prop, ctypes.POINTER(ctypes.c_ulong))[0]
+    finally:
+        x11.XFree(prop)
+
+
+def enumerate_windows(x11, display, root):
+    result = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        root_return = ctypes.c_ulong()
+        parent_return = ctypes.c_ulong()
+        children = ctypes.POINTER(ctypes.c_ulong)()
+        child_count = ctypes.c_uint()
+        if x11.XQueryTree(
+            display, current,
+            ctypes.byref(root_return), ctypes.byref(parent_return),
+            ctypes.byref(children), ctypes.byref(child_count),
+        ) == 0:
+            continue
+        try:
+            for index in range(child_count.value):
+                child = children[index]
+                result.append(child)
+                stack.append(child)
+        finally:
+            if children:
+                x11.XFree(children)
+    return result
+
+
+def fetch_window_name(x11, display, window):
+    name = ctypes.c_char_p()
+    if x11.XFetchName(display, window, ctypes.byref(name)) == 0 or not name.value:
+        return ""
+    try:
+        return name.value.decode("utf-8", "replace")
+    finally:
+        x11.XFree(name)
+
+
+def find_target_window(x11, display, target_pid):
+    # 这个 Uno X11 窗口实测不携带可读的 _NET_WM_PID（老 probe 同样显示 pid=<unknown>），
+    # 所以必须像 smoke probe 一样以窗口名匹配为主、pid 匹配为加分项。
+    pid_atom = x11.XInternAtom(display, b"_NET_WM_PID", 1)
+    root = x11.XDefaultRootWindow(display)
+    best = None
+    for window in enumerate_windows(x11, display, root):
+        attributes = XWindowAttributes()
+        if x11.XGetWindowAttributes(display, window, ctypes.byref(attributes)) == 0:
+            continue
+        if attributes.map_state != IS_VIEWABLE:
+            continue
+        if attributes.width < MIN_WINDOW_WIDTH or attributes.height < MIN_WINDOW_HEIGHT:
+            continue
+        name = fetch_window_name(x11, display, window)
+        window_pid = fetch_window_pid(x11, display, window, pid_atom)
+        is_name_match = "SalmonEgg" in name or "Salmon Egg" in name
+        is_pid_match = window_pid == target_pid
+        if not is_name_match and not is_pid_match:
+            continue
+        score = attributes.width * attributes.height
+        if is_pid_match:
+            score += 10_000_000_000
+        if is_name_match:
+            score += 1_000_000_000
+        if best is None or score > best[0]:
+            best = (score, window)
+    return best[1] if best else None
+
+
+def send_close_request(x11, display, window):
+    wm_protocols = x11.XInternAtom(display, b"WM_PROTOCOLS", 1)
+    wm_delete_window = x11.XInternAtom(display, b"WM_DELETE_WINDOW", 1)
+    if not wm_protocols or not wm_delete_window:
+        return False
+
+    event = XEvent()
+    event.xclient.type = 33  # ClientMessage
+    event.xclient.window = window
+    event.xclient.message_type = wm_protocols
+    event.xclient.format = 32
+    event.xclient.data[0] = wm_delete_window
+    event.xclient.data[1] = CURRENT_TIME
+
+    status = x11.XSendEvent(display, window, False, NO_EVENT_MASK, ctypes.byref(event))
+    x11.XFlush(display)
+    return status != 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--display", required=True)
+    parser.add_argument("--pid", required=True, type=int)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    x11 = ctypes.CDLL("libX11.so.6")
+    # argtypes 必须逐个声明：不声明时 ctypes 把 64 位指针按 32 位 int 传参，直接段错误。
+    x11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+    x11.XOpenDisplay.restype = ctypes.c_void_p
+    x11.XCloseDisplay.argtypes = [ctypes.c_void_p]
+    x11.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+    x11.XDefaultRootWindow.restype = ctypes.c_ulong
+    x11.XQueryTree.argtypes = [
+        ctypes.c_void_p, ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong),
+        ctypes.POINTER(ctypes.c_ulong), ctypes.POINTER(ctypes.POINTER(ctypes.c_ulong)),
+        ctypes.POINTER(ctypes.c_uint),
+    ]
+    x11.XQueryTree.restype = ctypes.c_int
+    x11.XGetWindowAttributes.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.POINTER(XWindowAttributes)]
+    x11.XGetWindowAttributes.restype = ctypes.c_int
+    x11.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+    x11.XInternAtom.restype = ctypes.c_ulong
+    x11.XGetWindowProperty.argtypes = [
+        ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_long, ctypes.c_long,
+        ctypes.c_int, ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong),
+        ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_ulong),
+        ctypes.POINTER(ctypes.c_ulong), ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
+    ]
+    x11.XGetWindowProperty.restype = ctypes.c_int
+    x11.XFree.argtypes = [ctypes.c_void_p]
+    x11.XFetchName.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char_p)]
+    x11.XFetchName.restype = ctypes.c_int
+    x11.XSendEvent.argtypes = [
+        ctypes.c_void_p, ctypes.c_ulong, ctypes.c_bool, ctypes.c_long,
+        ctypes.POINTER(XEvent),
+    ]
+    x11.XSendEvent.restype = ctypes.c_int
+    x11.XFlush.argtypes = [ctypes.c_void_p]
+
+    display = x11.XOpenDisplay(args.display.encode())
+    if not display:
+        print(f"Unable to open X display {args.display}", file=sys.stderr)
+        return 1
+
+    try:
+        deadline = time.monotonic() + args.timeout
+        window = None
+        while time.monotonic() < deadline and window is None:
+            window = find_target_window(x11, display, args.pid)
+            if window is None:
+                time.sleep(0.2)
+
+        if window is None:
+            print(f"No viewable window owned by pid {args.pid}", file=sys.stderr)
+            return 1
+
+        if not send_close_request(x11, display, window):
+            print("XSendEvent failed", file=sys.stderr)
+            return 1
+
+        print(f"Sent WM_DELETE_WINDOW to window {window:#x} (pid {args.pid})")
+        return 0
+    finally:
+        x11.XCloseDisplay(ctypes.c_void_p(display))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -2146,8 +2146,11 @@ namespace SalmonEgg.Acp.Client
             // The transport is owned exclusively by this client (process / socket / HttpClient / Rx
             // subject), and Dispose is its authoritative release path; a graceful protocol-level
             // disconnect is the job of an explicit DisconnectAsync, awaited by the caller beforehand.
-            // The terminal session manager is a singleton shared across connections and owned by the DI
-            // container, so this client must not dispose it.
+            // The terminal session manager is shared across connections, so this client must not
+            // dispose it: releasing it here would kill terminals still owned by other live clients.
+            // Its lifetime belongs to whoever supplied it, and that host must dispose it on its own
+            // teardown path — registering it in a container is not by itself such a path, since a
+            // container that is never disposed never runs it (this was a real process-leak defect).
             try
             {
                 _transport.Dispose();

--- a/src/SalmonEgg.Domain/Services/ITelemetryRuntime.cs
+++ b/src/SalmonEgg.Domain/Services/ITelemetryRuntime.cs
@@ -30,11 +30,18 @@ public interface ITelemetryRuntime
     Task ApplyAsync(AppSettings settings, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// 进程退出前尽量导出残留数据。
+    /// 进程退出前收尾遥测管线。
     /// </summary>
     /// <remarks>
-    /// 返回 <see cref="Task"/> 不是假异步：底层 SDK 的 Shutdown 是同步阻塞（按 timeout 等待
-    /// 导出完成），实现必须把它移出调用线程，否则关闭窗口时会冻结 UI 线程数秒。
+    /// 语义是「通知导出线程收尾后立即返回」，<b>不等待导出完成</b>。关闭路径的预算属于
+    /// 用户：底层 SDK 的 Shutdown 是同步阻塞且<em>按 provider 串行</em>计时，tracer 与
+    /// meter 各等一遍，端点不可达时实测把关闭拖到 10s 以上（issue #126）。因此实现既要
+    /// 把同步调用移出调用线程，也要传入非阻塞超时，二者缺一都会让关闭重新卡住。
+    ///
+    /// 代价是明确接受的：进程随即退出，缓冲区中尚未导出的 span 会丢失。若将来需要保住
+    /// 崩溃诊断数据，正确做法是落盘后下次启动补寄，而不是把等待加回关闭路径。
+    ///
+    /// 失败不抛：遥测是旁路能力，收尾失败不得阻塞进程退出。
     /// </remarks>
     Task ShutdownAsync(CancellationToken cancellationToken = default);
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/Services/TerminalSessionManager.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Services/TerminalSessionManager.cs
@@ -238,7 +238,9 @@ namespace SalmonEgg.Infrastructure.Services
 
                 try
                 {
-                    _process.Kill();
+                    // entireProcessTree 与 StdioTransport 同理:agent 请求的命令常经 shell /
+                    // 启动器执行,真正干活的进程是孙进程。只杀直接子进程会把它留给 init。
+                    _process.Kill(entireProcessTree: true);
                 }
                 catch (InvalidOperationException)
                 {
@@ -258,8 +260,10 @@ namespace SalmonEgg.Infrastructure.Services
                 {
                     if (!_process.HasExited)
                     {
-                        _process.Kill();
-                        _process.WaitForExit();
+                        // 不 WaitForExit:本方法在进程退出路径上被调用,而 WaitForExit() 无超时,
+                        // 一个不肯死的子进程就能把关闭无限期挂住(issue #126)。与
+                        // StdioTransport.Dispose 同契约——同步发出终止信号,不等待收尸。
+                        _process.Kill(entireProcessTree: true);
                     }
                 }
                 catch

--- a/src/SalmonEgg.Infrastructure/Observability/DynamicTelemetryLoggerProvider.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/DynamicTelemetryLoggerProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
@@ -82,6 +83,43 @@ public sealed class DynamicTelemetryLoggerProvider : ILoggerProvider
         }
 
         return replacement;
+    }
+
+    /// <summary>
+    /// 进程退出路径专用：立刻停止把日志写入 OTel 管线，但不等待残留批次导出。
+    /// </summary>
+    /// <remarks>
+    /// 为什么不能复用 <see cref="Reconfigure"/>：退役 factory 的 <c>Dispose</c> 最终落到
+    /// OTel 的 <c>LoggerProviderSdk.Dispose</c>，而后者<b>硬编码</b> <c>Processor.Shutdown(5000)</c>；
+    /// <c>ILoggerFactory</c> 这一层没有任何入口能把超时传进去，所以无法像 tracer / meter
+    /// 那样传 <see cref="ITelemetryManager.NonBlockingShutdownTimeoutMilliseconds"/>。
+    /// 若在关闭路径上同步 Dispose，它就成了第三段不受调用方超时约束的 5s 等待（issue #126）。
+    ///
+    /// 因此这里把两件事拆开：<em>摘除</em>同步完成（返回后写日志不再进入该 factory，
+    /// 与代次自增一起对齐 <see cref="TryCommitReplacement"/> 的可见性契约），
+    /// <em>释放</em>交给线程池。线程池线程是后台线程，进程退出时可能被截断——这与
+    /// <see cref="ITelemetryRuntime.ShutdownAsync"/> 声明的取舍一致：宁可丢掉最后一批日志，
+    /// 也不让用户为不可达端点多等几秒。
+    /// </remarks>
+    public void RetireWithoutWaitingForExport()
+    {
+        ILoggerFactory? previous;
+        lock (_sync)
+        {
+            previous = _innerFactory;
+            _innerFactory = null;
+
+            // 与 TryCommitReplacement 同序：先换掉再自增，外壳 logger 才会丢弃旧缓存。
+            _generation++;
+        }
+
+        if (previous is null)
+        {
+            return;
+        }
+
+        // 不 await、不记录 task：DisposeSafely 自吞异常，故不存在 unobserved exception。
+        _ = Task.Run(() => DisposeSafely(previous));
     }
 
     internal bool TryCommitReplacement(ILoggerFactory? replacement)

--- a/src/SalmonEgg.Infrastructure/Observability/ITelemetryManager.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/ITelemetryManager.cs
@@ -13,6 +13,21 @@ namespace SalmonEgg.Infrastructure.Observability;
 public interface ITelemetryManager
 {
     /// <summary>
+    /// 进程退出路径使用的 <see cref="Shutdown"/> 超时：不等待导出完成。
+    /// </summary>
+    /// <remarks>
+    /// 0 不是"跳过关闭"，而是 OpenTelemetry SDK 显式支持的非阻塞分支：
+    /// <c>BatchExportProcessor.OnShutdown</c> 与 <c>BatchExportThreadWorker.Shutdown</c>
+    /// 都对 0 单独取分支——置位 drain target、唤醒导出线程，但不 Join。语义是
+    /// "通知导出线程去收尾，但调用方不等它"。
+    ///
+    /// 关闭路径必须用它：<see cref="Shutdown"/> 逐个 provider 串行等待，tracer 与 meter
+    /// 各等一遍默认 5000ms，端点不可达时实测把关闭拖到 10s 以上（issue #126）。
+    /// 进程退出手感优先于最后一批 span 的送达率。
+    /// </remarks>
+    public const int NonBlockingShutdownTimeoutMilliseconds = 0;
+
+    /// <summary>
     /// 按给定配置装配遥测管线，使端点 / 凭证 / 开关变更立即生效，无需重启。
     /// 启动时的首次装配也走这里。
     /// </summary>
@@ -32,7 +47,12 @@ public interface ITelemetryManager
     /// <summary>
     /// 关闭 OpenTelemetry（应用退出时调用），在 timeout 内尽量导出残留数据。
     /// </summary>
-    /// <param name="timeoutMilliseconds">等待上限；-1 表示无限等待。</param>
+    /// <param name="timeoutMilliseconds">
+    /// 等待上限；-1 表示无限等待；
+    /// <see cref="NonBlockingShutdownTimeoutMilliseconds"/> 表示不等待。
+    /// 注意该上限是<em>每个 provider</em>的：实现串行关闭 tracer 与 meter，
+    /// 故调用方感知到的最长阻塞是本值的两倍。
+    /// </param>
     /// <returns>是否在超时前完成关闭。</returns>
     bool Shutdown(int timeoutMilliseconds = 5000);
 

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetryManager.cs
@@ -210,9 +210,11 @@ public sealed class TelemetryManager : ITelemetryManager, IDisposable
             _tracerProvider = null;
             _meterProvider = null;
             _initialized = false;
-            _dynamicLoggerProvider?.Reconfigure(
-                new TelemetrySettings { Enabled = false, ServiceName = _settings.ServiceName },
-                BuildResource(_settings));
+
+            // 不走 Reconfigure：那条路会同步 Dispose 退役的 OTel logger factory，而
+            // LoggerProviderSdk.Dispose 硬编码 Processor.Shutdown(5000)，会成为第三段
+            // 不受 timeoutMilliseconds 约束的等待（issue #126）。摘除同步完成，释放交后台。
+            _dynamicLoggerProvider?.RetireWithoutWaitingForExport();
             return tracerOk && meterOk;
         }
     }

--- a/src/SalmonEgg.Infrastructure/Observability/TelemetryRuntime.cs
+++ b/src/SalmonEgg.Infrastructure/Observability/TelemetryRuntime.cs
@@ -150,8 +150,14 @@ public sealed class TelemetryRuntime : ITelemetryRuntime
     {
         try
         {
-            // 同上：Shutdown 同步阻塞等待导出，不能占用关闭流程所在线程。
-            await Task.Run(() => _telemetryManager.Shutdown(), cancellationToken).ConfigureAwait(false);
+            // 同上：Shutdown 是同步 API，不能占用关闭流程所在线程。
+            // 传非阻塞超时而非默认值：默认按 provider 串行各等 5000ms，端点不可达时会把
+            // 关闭拖到 10s 以上（issue #126）。这里只通知导出线程收尾，不等它。
+            await Task.Run(
+                    () => _telemetryManager.Shutdown(
+                        ITelemetryManager.NonBlockingShutdownTimeoutMilliseconds),
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -267,6 +267,16 @@
   <data name="ChatLoading_PreparingSession" xml:space="preserve">
     <value>Switching chat...</value>
   </data>
+
+  <data name="ShutdownOverlay_PersistingState" xml:space="preserve">
+    <value>Saving conversations...</value>
+  </data>
+  <data name="ShutdownOverlay_ClosingChildProcesses" xml:space="preserve">
+    <value>Closing agent processes...</value>
+  </data>
+  <data name="ShutdownOverlay_Generic" xml:space="preserve">
+    <value>Shutting down...</value>
+  </data>
   <data name="ChatMiniWindow_OpenFailed" xml:space="preserve">
     <value>Failed to open mini window. Please ensure you are running as an MSIX package.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -267,6 +267,16 @@
   <data name="ChatLoading_PreparingSession" xml:space="preserve">
     <value>Switching chat...</value>
   </data>
+
+  <data name="ShutdownOverlay_PersistingState" xml:space="preserve">
+    <value>Saving conversations...</value>
+  </data>
+  <data name="ShutdownOverlay_ClosingChildProcesses" xml:space="preserve">
+    <value>Closing agent processes...</value>
+  </data>
+  <data name="ShutdownOverlay_Generic" xml:space="preserve">
+    <value>Shutting down...</value>
+  </data>
   <data name="ChatMiniWindow_OpenFailed" xml:space="preserve">
     <value>Failed to open mini window. Please ensure you are running as an MSIX package.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -265,6 +265,16 @@
   <data name="ChatLoading_PreparingSession" xml:space="preserve">
     <value>正在切换会话...</value>
   </data>
+
+  <data name="ShutdownOverlay_PersistingState" xml:space="preserve">
+    <value>正在保存会话记录...</value>
+  </data>
+  <data name="ShutdownOverlay_ClosingChildProcesses" xml:space="preserve">
+    <value>正在关闭 agent 进程...</value>
+  </data>
+  <data name="ShutdownOverlay_Generic" xml:space="preserve">
+    <value>正在关闭...</value>
+  </data>
   <data name="ChatMiniWindow_OpenFailed" xml:space="preserve">
     <value>无法打开迷你窗口。请确认应用以 MSIX 包方式运行。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -265,6 +265,16 @@
   <data name="ChatLoading_PreparingSession" xml:space="preserve">
     <value>正在切换会话...</value>
   </data>
+
+  <data name="ShutdownOverlay_PersistingState" xml:space="preserve">
+    <value>正在保存会话记录...</value>
+  </data>
+  <data name="ShutdownOverlay_ClosingChildProcesses" xml:space="preserve">
+    <value>正在关闭 agent 进程...</value>
+  </data>
+  <data name="ShutdownOverlay_Generic" xml:space="preserve">
+    <value>正在关闭...</value>
+  </data>
   <data name="ChatMiniWindow_OpenFailed" xml:space="preserve">
     <value>无法打开迷你窗口。请确认应用以 MSIX 包方式运行。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownProgressStore.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownProgressStore.cs
@@ -1,0 +1,35 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SalmonEgg.Presentation.Core.Services;
+
+/// <summary>
+/// <see cref="IApplicationShutdownProgress"/> 的实现，同时向 teardown owner 暴露写入面。
+/// </summary>
+/// <remarks>
+/// 读写分离成两个接口，是为了让"谁能写"在类型上就是显式的：View 与投影 ViewModel 只拿到
+/// <see cref="IApplicationShutdownProgress"/>，写入面 <see cref="IApplicationShutdownProgressSink"/>
+/// 只注入给 <see cref="ApplicationShutdownWorkflow"/>。这样第二套写入者无法被顺手加进来。
+///
+/// 与 <see cref="ShellNavigationRuntimeStateStore"/> 同型：Core 持有事实，用
+/// <c>ObservableObject</c> 通知投影层。
+/// </remarks>
+public sealed partial class ApplicationShutdownProgressStore
+    : ObservableObject, IApplicationShutdownProgress, IApplicationShutdownProgressSink
+{
+    [ObservableProperty]
+    private bool _isShuttingDown;
+
+    [ObservableProperty]
+    private ApplicationShutdownPhase _phase = ApplicationShutdownPhase.NotStarted;
+
+    public void ReportPhase(ApplicationShutdownPhase phase)
+    {
+        // 单调置位：一旦进入关闭就不再回落到"未开始"，投影层因此无需处理抖动。
+        if (phase != ApplicationShutdownPhase.NotStarted)
+        {
+            IsShuttingDown = true;
+        }
+
+        Phase = phase;
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownWorkflow.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownWorkflow.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SalmonEgg.Application.Services.Acp;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Services.Chat;
 
@@ -10,19 +12,39 @@ namespace SalmonEgg.Presentation.Core.Services;
 public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
 {
     private readonly IChatRuntimePersistence _chatRuntimePersistence;
+    private readonly IAcpConnectionSessionCleaner _connectionSessionCleaner;
+    private readonly IDiscoverSessionsConnectionFacade _discoverConnectionFacade;
+    private readonly ITerminalSessionManager _terminalSessionManager;
+    private readonly IAsyncDisposable? _localTerminalSessions;
+    private readonly IApplicationShutdownProgressSink _progressSink;
     private readonly ITelemetryRuntime _telemetryRuntime;
     private readonly ILogger<ApplicationShutdownWorkflow> _logger;
     private readonly object _shutdownSync = new();
     private Task? _shutdownTask;
 
+    /// <param name="localTerminalSessions">
+    /// 本地交互式终端（PTY）的释放入口，仅 desktop 注册，其余平台为 null。
+    /// 声明为 <see cref="IAsyncDisposable"/> 而非具体类型：本层只需要"能异步释放"这一契约，
+    /// 依赖具体协调器类型会把仅存在于部分平台的实现拖进所有平台的构造签名。
+    /// </param>
     public ApplicationShutdownWorkflow(
         IChatRuntimePersistence chatRuntimePersistence,
+        IAcpConnectionSessionCleaner connectionSessionCleaner,
+        IDiscoverSessionsConnectionFacade discoverConnectionFacade,
+        ITerminalSessionManager terminalSessionManager,
+        IApplicationShutdownProgressSink progressSink,
         ITelemetryRuntime telemetryRuntime,
-        ILogger<ApplicationShutdownWorkflow> logger)
+        ILogger<ApplicationShutdownWorkflow> logger,
+        IAsyncDisposable? localTerminalSessions = null)
     {
         _chatRuntimePersistence = chatRuntimePersistence ?? throw new ArgumentNullException(nameof(chatRuntimePersistence));
+        _connectionSessionCleaner = connectionSessionCleaner ?? throw new ArgumentNullException(nameof(connectionSessionCleaner));
+        _discoverConnectionFacade = discoverConnectionFacade ?? throw new ArgumentNullException(nameof(discoverConnectionFacade));
+        _terminalSessionManager = terminalSessionManager ?? throw new ArgumentNullException(nameof(terminalSessionManager));
+        _progressSink = progressSink ?? throw new ArgumentNullException(nameof(progressSink));
         _telemetryRuntime = telemetryRuntime ?? throw new ArgumentNullException(nameof(telemetryRuntime));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _localTerminalSessions = localTerminalSessions;
     }
 
     public Task ShutdownAsync(CancellationToken cancellationToken = default)
@@ -38,24 +60,137 @@ public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
 
     private async Task ShutdownCoreAsync(CancellationToken cancellationToken)
     {
+        // 进度只由本 owner 置位。finally 保证异常路径也会落到 Completed，
+        // 否则 overlay 会永久停在"正在关闭"。
+        var stopwatch = Stopwatch.StartNew();
         try
         {
-            await _chatRuntimePersistence.FlushPendingStateAsync(cancellationToken).ConfigureAwait(false);
+            // 顺序有意义：用户状态的持久性优先于释放 OS 资源——先杀子进程再写盘，
+            // 会让"写盘失败"多出一个本可避免的成因。
+            _progressSink.ReportPhase(ApplicationShutdownPhase.PersistingState);
+            await RunStageAsync(
+                () => _chatRuntimePersistence.FlushPendingStateAsync(cancellationToken),
+                "Application shutdown flush failed",
+                cancellationToken).ConfigureAwait(false);
+
+            // 子进程释放不接 cancellationToken：这些进程一旦脱离注册表就再无持有者，
+            // 中途放弃等于把它们过继给 init 继续运行（issue #126 的原始症状）。
+            _progressSink.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
+            await RunStageAsync(
+                DrainChildProcessesAsync,
+                "Application shutdown child-process drain failed",
+                cancellationToken: default).ConfigureAwait(false);
+
+            // Telemetry is last and unconditional: user state durability comes first, and a failure
+            // above is exactly the kind of event whose spans must still reach the backend. Shutdown no
+            // longer waits for export (see ITelemetryRuntime.ShutdownAsync), so this cannot stall exit.
+            // Hosts must not reach into the telemetry manager themselves — teardown has one owner.
+            //
+            // Wrapped like every other stage rather than awaited bare: today's ITelemetryRuntime
+            // implementation swallows its own failures, but this workflow runs inside a platform close
+            // handler and must not depend on a downstream class continuing to do that. Leaving it bare
+            // makes "teardown never throws at the host" a property of another type's catch block.
+            await RunStageAsync(
+                () => _telemetryRuntime.ShutdownAsync(cancellationToken),
+                "Application shutdown telemetry teardown failed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Application shutdown completed. elapsedMs={ElapsedMilliseconds}",
+                stopwatch.ElapsedMilliseconds);
+            _progressSink.ReportPhase(ApplicationShutdownPhase.Completed);
+        }
+    }
+
+    /// <summary>
+    /// 终止本进程启动的所有子进程：缓存的 ACP agent、Discover 浏览连接、ACP 终端、本地 PTY。
+    /// </summary>
+    /// <remarks>
+    /// 这些 owner 都实现了正确的释放（<c>Kill(entireProcessTree: true)</c>），但在此之前
+    /// 关闭路径无人调用它们——DI 容器从不 Dispose，所以 singleton 的 <c>Dispose()</c>
+    /// 在退出时是死代码。此处逐个显式释放，而不是改为 dispose 整个容器：WinUI 头在
+    /// teardown 全程窗口仍可见且在绑定，dispose ViewModel singleton 会拆掉活着的 UI。
+    ///
+    /// 各段彼此独立 try/catch：任一 owner 失败不得让其余子进程继续泄漏。
+    /// </remarks>
+    private async Task DrainChildProcessesAsync()
+    {
+        var drainResult = await TryRunAsync(
+            _connectionSessionCleaner.DrainAllAsync,
+            "Failed to drain cached ACP connection sessions during shutdown").ConfigureAwait(false);
+        if (drainResult is { } result && (result.RemovedCount > 0 || result.DisposeFailureCount > 0))
+        {
+            _logger.LogInformation(
+                "Drained cached ACP sessions during shutdown. removedCount={RemovedCount} disposeFailureCount={DisposeFailureCount}",
+                result.RemovedCount,
+                result.DisposeFailureCount);
+        }
+
+        // Discover 的浏览连接自持 IChatService 且从不进注册表，registry 式 drain 抓不到它。
+        await TryRunAsync(
+            _discoverConnectionFacade.DisposeAsync().AsTask,
+            "Failed to dispose the Discover ACP browse connection during shutdown").ConfigureAwait(false);
+
+        await TryRunAsync(
+            () =>
+            {
+                _terminalSessionManager.Dispose();
+                return Task.CompletedTask;
+            },
+            "Failed to dispose ACP terminal sessions during shutdown").ConfigureAwait(false);
+
+        if (_localTerminalSessions is not null)
+        {
+            await TryRunAsync(
+                _localTerminalSessions.DisposeAsync().AsTask,
+                "Failed to dispose local terminal sessions during shutdown").ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunStageAsync(Func<Task> stage, string failureMessage, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await stage().ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _logger.LogWarning("Application shutdown flush was canceled; pending state may not be persisted");
+            _logger.LogWarning("Application shutdown stage was canceled; pending work may not have completed");
         }
         catch (Exception ex)
         {
-            // Teardown must not throw into a platform close handler: a failed flush should not also
+            // Teardown must not throw into a platform close handler: a failed stage should not also
             // block the window from closing.
-            _logger.LogError(ex, "Application shutdown flush failed");
+            _logger.LogError(ex, "{FailureMessage}", failureMessage);
         }
+    }
 
-        // Telemetry is flushed last and unconditionally: user state durability comes first, and a
-        // failure above is exactly the kind of event whose spans must still reach the backend.
-        // Hosts must not reach into the telemetry manager themselves — teardown has one owner.
-        await _telemetryRuntime.ShutdownAsync(cancellationToken).ConfigureAwait(false);
+    private async Task<T?> TryRunAsync<T>(Func<Task<T>> operation, string failureMessage)
+        where T : struct
+    {
+        try
+        {
+            return await operation().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{FailureMessage}", failureMessage);
+            return null;
+        }
+    }
+
+    private async Task TryRunAsync(Func<Task> operation, string failureMessage)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{FailureMessage}", failureMessage);
+        }
     }
 }

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpConnectionSessionCleaner.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpConnectionSessionCleaner.cs
@@ -19,6 +19,21 @@ public interface IAcpConnectionSessionCleaner
         Func<AcpConnectionSession, bool>? isPinned = null,
         Func<AcpConnectionSession, bool>? isHardPinned = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 进程退出路径专用：摘除并释放<b>全部</b>缓存会话，含当前活跃的那一个。
+    /// </summary>
+    /// <remarks>
+    /// 为什么不是给 <see cref="CleanupStaleAsync"/> 加参数：那条路的两项保护
+    /// （放过 <c>activeService</c>、放过 soft/hard pinned）在关闭语义下全部是错的——
+    /// 关闭时活跃连接同样必须终止，否则 agent 子进程会被 reparent 到 init 后继续运行
+    /// （issue #126 实测）。把互斥语义塞进同一方法会让"关闭"与"换配置"共用一组判定，
+    /// 日后任一侧的改动都会静默影响另一侧。
+    ///
+    /// 不接受 <c>CancellationToken</c>：摘除之后这些会话再无任何持有者，唯有本方法负责
+    /// 归还底层进程 / 套接字；中途放弃就等于制造无主的泄漏连接。
+    /// </remarks>
+    Task<AcpConnectionSessionCleanupResult> DrainAllAsync();
 }
 
 public sealed class AcpConnectionSessionCleaner : IAcpConnectionSessionCleaner
@@ -163,6 +178,35 @@ public sealed class AcpConnectionSessionCleaner : IAcpConnectionSessionCleaner
         }
 
         return new AcpConnectionSessionCleanupResult(removed.Count + removedWarmCount, disposeFailureCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<AcpConnectionSessionCleanupResult> DrainAllAsync()
+    {
+        // 一次 RemoveWhere 全部摘净：逐个 RemoveByProfile 会在两次调用之间留出窗口，
+        // 让并发的 connect apply 又塞回一个会话，从而漏掉它。
+        var removed = _sessionRegistry.RemoveWhere(static _ => true);
+        if (removed.Count == 0)
+        {
+            return new AcpConnectionSessionCleanupResult(0, 0);
+        }
+
+        // releaseAfterDisconnectFailure: true —— 关闭路径上 DisconnectAsync 失败（例如对端
+        // 已经没了）绝不能就此放手：Dispose 才是真正 Kill(entireProcessTree) 的那一步。
+        var disposeFailureCount = await DisposeDetachedSessionsAsync(
+            removed,
+            static (logger, session, ex) => logger.LogDebug(
+                ex,
+                "Failed to disconnect cached ACP session during shutdown drain. profileId={ProfileId}",
+                session.ProfileId),
+            releaseAfterDisconnectFailure: true).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "ACP connection pool drained for shutdown. removedCount={RemovedCount} disposeFailureCount={DisposeFailureCount}",
+            removed.Count,
+            disposeFailureCount);
+
+        return new AcpConnectionSessionCleanupResult(removed.Count, disposeFailureCount);
     }
 
     /// <summary>

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/DiscoverSessionsConnectionFacade.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/DiscoverSessionsConnectionFacade.cs
@@ -9,7 +9,14 @@ using SalmonEgg.Domain.Services;
 
 namespace SalmonEgg.Presentation.Core.Services.Chat;
 
-public interface IDiscoverSessionsConnectionFacade : INotifyPropertyChanged
+/// <remarks>
+/// 继承 <see cref="IAsyncDisposable"/> 而非只依赖 <see cref="IDisposable"/>：本 facade 持有的
+/// 是<b>不在会话注册表里</b>的 ACP 连接（它从不 <c>RecordSession</c>），因此基于注册表的
+/// 关闭 drain 抓不到它，只能由 teardown owner 直接释放。而释放要 <c>DisconnectAsync</c> 后
+/// 再 <c>Dispose</c>——同步的 <see cref="IDisposable.Dispose"/> 只能 fire-and-forget 这一段，
+/// 在进程退出路径上等于和进程赛跑，agent 子进程可能来不及被终止（issue #126）。
+/// </remarks>
+public interface IDiscoverSessionsConnectionFacade : INotifyPropertyChanged, IAsyncDisposable
 {
     bool IsConnecting { get; }
 
@@ -169,20 +176,9 @@ public sealed class DiscoverSessionsConnectionFacade : IDiscoverSessionsConnecti
 
     public void Dispose()
     {
-        if (_disposed)
+        if (!TryClaimDisposal(out var cts, out var currentService))
         {
             return;
-        }
-
-        _disposed = true;
-        CancellationTokenSource? cts;
-        IChatService? currentService;
-        lock (_connectSync)
-        {
-            cts = _connectCts;
-            _connectCts = null;
-            currentService = _currentChatService;
-            _currentChatService = null;
         }
 
         cts?.Cancel();
@@ -192,12 +188,52 @@ public sealed class DiscoverSessionsConnectionFacade : IDiscoverSessionsConnecti
             try
             {
                 // Dispose is synchronous by IDisposable contract; fire-and-forget is acceptable here.
+                // 关闭路径必须走 DisposeAsync 而不是这里——见 IDiscoverSessionsConnectionFacade 注释。
                 _ = DisposeServiceAsync(currentService).AsTask();
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Failed to dispose Discover ACP browse service");
             }
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (!TryClaimDisposal(out var cts, out var currentService))
+        {
+            return;
+        }
+
+        cts?.Cancel();
+        cts?.Dispose();
+
+        // 与 Dispose 的唯一区别：等待服务真正断开并释放。DisposeServiceAsync 自吞异常，
+        // 所以关闭路径不会因为这一步抛出。
+        await DisposeServiceAsync(currentService).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 原子地认领这一次释放：胜者拿走 CTS 与当前服务，其余调用直接返回。
+    /// </summary>
+    private bool TryClaimDisposal(out CancellationTokenSource? cts, out IChatService? currentService)
+    {
+        lock (_connectSync)
+        {
+            if (_disposed)
+            {
+                cts = null;
+                currentService = null;
+                return false;
+            }
+
+            _disposed = true;
+            cts = _connectCts;
+            _connectCts = null;
+            currentService = _currentChatService;
+            _currentChatService = null;
+            return true;
         }
     }
 

--- a/src/SalmonEgg.Presentation.Core/Services/IApplicationShutdownProgress.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/IApplicationShutdownProgress.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+
+namespace SalmonEgg.Presentation.Core.Services;
+
+/// <summary>
+/// 关闭进度的 authoritative 状态：进程退出前的清理是否正在进行。
+/// </summary>
+/// <remarks>
+/// 与 <see cref="IShellNavigationRuntimeState"/> 同型——Core 持有事实，View 只投影。
+/// 唯一写入者是 <see cref="IApplicationShutdownWorkflow"/> 的实现（teardown 的单一 owner）；
+/// 任何 View、ViewModel 或平台宿主都不得回写，否则"正在关闭"会出现第二套状态源。
+///
+/// 这里只表达<b>事实</b>（在关吗、清到哪一步了），不表达<b>呈现策略</b>（要不要弹遮罩、
+/// 多久之后弹）。阈值判断属于呈现层，放在投影 ViewModel 里，因此本接口无需时间抽象，
+/// 也就没有依赖挂钟的测试。
+/// </remarks>
+public interface IApplicationShutdownProgress : INotifyPropertyChanged
+{
+    /// <summary>
+    /// 关闭清理是否正在进行。
+    /// </summary>
+    /// <remarks>
+    /// 一经置位便不再回落：进程正在退出，"关闭又取消了"不是本应用存在的状态。
+    /// 让它单调可以使投影层无需处理抖动。
+    /// </remarks>
+    bool IsShuttingDown { get; }
+
+    /// <summary>
+    /// 当前正在进行的清理阶段，供提示文案区分"保存记录"与"关闭 agent 进程"。
+    /// </summary>
+    ApplicationShutdownPhase Phase { get; }
+}
+
+/// <summary>
+/// 关闭清理的阶段。顺序与 <see cref="IApplicationShutdownWorkflow"/> 的执行顺序一致。
+/// </summary>
+public enum ApplicationShutdownPhase
+{
+    /// <summary>尚未开始关闭。</summary>
+    NotStarted = 0,
+
+    /// <summary>正在把未落盘的会话状态写入磁盘。</summary>
+    PersistingState = 1,
+
+    /// <summary>正在终止 agent 子进程与终端会话。</summary>
+    ClosingChildProcesses = 2,
+
+    /// <summary>清理已完成，进程即将退出。</summary>
+    Completed = 3
+}

--- a/src/SalmonEgg.Presentation.Core/Services/IApplicationShutdownProgressSink.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/IApplicationShutdownProgressSink.cs
@@ -1,0 +1,18 @@
+namespace SalmonEgg.Presentation.Core.Services;
+
+/// <summary>
+/// 关闭进度的写入面，只应注入给 teardown 的单一 owner。
+/// </summary>
+/// <remarks>
+/// 之所以与只读的 <see cref="IApplicationShutdownProgress"/> 分开：关闭进度必须只有一个写入者
+/// （<see cref="IApplicationShutdownWorkflow"/> 的实现）。若读写同在一个接口上，任何拿到它做
+/// 投影的 View 或 ViewModel 都能顺手回写，"正在关闭"就有了第二套状态源——这正是本仓库
+/// 「单一状态链路」约束要禁止的形态。
+/// </remarks>
+public interface IApplicationShutdownProgressSink
+{
+    /// <summary>
+    /// 记录清理已进入某一阶段。
+    /// </summary>
+    void ReportPhase(ApplicationShutdownPhase phase);
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Navigation/ShellShutdownOverlayViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Navigation/ShellShutdownOverlayViewModel.cs
@@ -1,0 +1,162 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
+
+namespace SalmonEgg.Presentation.ViewModels.Navigation;
+
+/// <summary>
+/// 把 <see cref="IApplicationShutdownProgress"/> 的事实投影成"正在关闭"遮罩的可见性与文案。
+/// </summary>
+/// <remarks>
+/// 与 <see cref="ShellSessionActivationOverlayViewModel"/> 同型：订阅事实源 → 映射 →
+/// <see cref="ObservableObject.OnPropertyChanged(string?)"/>，跨线程更新经 <see cref="IUiDispatcher"/>
+/// 封送回 UI 线程（teardown 在线程池上跑，事件不带 UI 线程上下文）。
+///
+/// 为什么有阈值：正常关闭几百毫秒就结束，立刻弹遮罩是"闪一下"的廉价感；
+/// 只有清理真的超过 <see cref="RevealThresholdMilliseconds"/> 才浮出提示（issue #126 的交互决策）。
+/// 阈值属于呈现策略，所以放在这里而不是 <see cref="IApplicationShutdownProgress"/>。
+/// </remarks>
+public sealed class ShellShutdownOverlayViewModel : ObservableObject, IDisposable
+{
+    /// <summary>
+    /// 清理进行多久之后才显示遮罩（毫秒）。低于该时长的关闭对用户完全无感。
+    /// </summary>
+    public const int RevealThresholdMilliseconds = 400;
+
+    private readonly IApplicationShutdownProgress _progress;
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly IStringLocalizer<CoreStrings>? _localizer;
+    private readonly object _revealGate = new();
+    private CancellationTokenSource? _revealCts;
+    private bool _isRevealed;
+
+    public ShellShutdownOverlayViewModel(
+        IApplicationShutdownProgress progress,
+        IUiDispatcher uiDispatcher,
+        IStringLocalizer<CoreStrings>? localizer = null)
+    {
+        _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+        _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
+        _localizer = localizer;
+
+        _progress.PropertyChanged += OnProgressPropertyChanged;
+    }
+
+    /// <summary>遮罩当前是否可见。只有清理超过阈值后才会变 true。</summary>
+    public bool IsOverlayVisible => _isRevealed;
+
+    /// <summary>按阶段区分的提示文案；阶段没细分信息时退化为通用文案。</summary>
+    public string StatusText => _progress.Phase switch
+    {
+        ApplicationShutdownPhase.PersistingState => Localize(
+            "ShutdownOverlay_PersistingState",
+            "Saving conversations..."),
+        ApplicationShutdownPhase.ClosingChildProcesses => Localize(
+            "ShutdownOverlay_ClosingChildProcesses",
+            "Closing agent processes..."),
+        _ => Localize(
+            "ShutdownOverlay_Generic",
+            "Shutting down...")
+    };
+
+    public void Dispose()
+    {
+        _progress.PropertyChanged -= OnProgressPropertyChanged;
+        CancelRevealTimer();
+    }
+
+    private void OnProgressPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is not (nameof(IApplicationShutdownProgress.IsShuttingDown)
+            or nameof(IApplicationShutdownProgress.Phase)))
+        {
+            return;
+        }
+
+        RunOnUi(() =>
+        {
+            // Phase 变化只影响文案；可见性由"第一次进入关闭"这一跳变驱动。
+            OnPropertyChanged(nameof(StatusText));
+            if (_progress.Phase == ApplicationShutdownPhase.Completed)
+            {
+                // 清理已收尾：取消还挂在阈值里的显示计时，否则遮罩会在退出前一刻闪出。
+                CancelRevealTimer();
+                return;
+            }
+
+            if (_progress.IsShuttingDown)
+            {
+                StartRevealTimer();
+            }
+        });
+    }
+
+    private void StartRevealTimer()
+    {
+        lock (_revealGate)
+        {
+            if (_revealCts is not null)
+            {
+                return;
+            }
+
+            _revealCts = new CancellationTokenSource();
+            var token = _revealCts.Token;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(RevealThresholdMilliseconds, token).ConfigureAwait(false);
+                    RunOnUi(() =>
+                    {
+                        _isRevealed = true;
+                        OnPropertyChanged(nameof(IsOverlayVisible));
+                        OnPropertyChanged(nameof(StatusText));
+                    });
+                }
+                catch (OperationCanceledException)
+                {
+                    // 清理在阈值内完成：遮罩永不出场，这正是设计目标。
+                }
+            }, CancellationToken.None);
+        }
+    }
+
+    private void CancelRevealTimer()
+    {
+        lock (_revealGate)
+        {
+            _revealCts?.Cancel();
+            _revealCts = null;
+        }
+    }
+
+    private string Localize(string key, string fallback)
+    {
+        if (_localizer is null)
+        {
+            return fallback;
+        }
+
+        var localized = _localizer[key];
+        return localized.ResourceNotFound || string.IsNullOrWhiteSpace(localized.Value)
+            ? fallback
+            : localized.Value;
+    }
+
+    private void RunOnUi(Action action)
+    {
+        if (_uiDispatcher.HasThreadAccess)
+        {
+            action();
+            return;
+        }
+
+        _uiDispatcher.Enqueue(action);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/DynamicTelemetryLoggerProviderTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/DynamicTelemetryLoggerProviderTests.cs
@@ -100,6 +100,37 @@ public sealed class DynamicTelemetryLoggerProviderTests
     }
 
     [Fact]
+    public void RetireWithoutWaitingForExport_StopsLoggingSynchronously()
+    {
+        // 关闭路径的契约：本方法返回后，写日志必须已经不再进入 OTel 管线（摘除是同步的），
+        // 而释放退役 factory 允许滞后。若摘除也被挪到后台，关闭瞬间的日志会写进正在被
+        // dispose 的 factory。
+        var factory = new CapturingExporterFactory();
+        using var provider = new DynamicTelemetryLoggerProvider(factory);
+        using var loggerFactory = CreateLoggerFactory(provider);
+        var logger = loggerFactory.CreateLogger("Test");
+
+        provider.Reconfigure(CreateSettings(enabled: true, "https://first.example.com:4318"), ResourceBuilder.CreateDefault());
+        Assert.True(logger.IsEnabled(LogLevel.Information));
+
+        provider.RetireWithoutWaitingForExport();
+
+        Assert.False(logger.IsEnabled(LogLevel.Information));
+        Assert.Null(Record.Exception(() => logger.LogInformation("after retire")));
+    }
+
+    [Fact]
+    public void RetireWithoutWaitingForExport_WhenNothingConfigured_IsNoOp()
+    {
+        // 遥测从未启用时关闭路径同样会走到这里，不得抛。
+        var factory = new CapturingExporterFactory();
+        using var provider = new DynamicTelemetryLoggerProvider(factory);
+
+        Assert.Null(Record.Exception(provider.RetireWithoutWaitingForExport));
+        Assert.Null(Record.Exception(provider.RetireWithoutWaitingForExport));
+    }
+
+    [Fact]
     public void AfterDispose_LoggingIsInert()
     {
         var factory = new CapturingExporterFactory();

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs
@@ -194,6 +194,22 @@ public sealed class TelemetryRuntimeTests
     }
 
     [Fact]
+    public async Task ShutdownAsync_DoesNotWaitForExport()
+    {
+        // issue #126：默认超时是「每个 provider」5000ms 且串行，端点不可达时实测把关闭
+        // 拖到 10s 以上。关闭路径必须传非阻塞超时，否则用户为不可达端点买单。
+        // 断言复用契约常量而非魔法数 0。
+        var manager = new RecordingTelemetryManager();
+        var runtime = CreateRuntime(manager);
+
+        await runtime.ShutdownAsync();
+
+        Assert.Equal(
+            new[] { ITelemetryManager.NonBlockingShutdownTimeoutMilliseconds },
+            manager.ShutdownTimeouts);
+    }
+
+    [Fact]
     public async Task ShutdownAsync_WhenManagerThrows_DoesNotPropagate()
     {
         // 关闭路径不得抛：flush 失败不应阻塞进程退出。
@@ -222,6 +238,8 @@ public sealed class TelemetryRuntimeTests
         public List<TelemetrySettings> Applied { get; } = new();
 
         public int ShutdownCount { get; private set; }
+
+        public List<int> ShutdownTimeouts { get; } = new();
 
         public int MaxConcurrentReconfigures { get; private set; }
 
@@ -287,6 +305,7 @@ public sealed class TelemetryRuntimeTests
             lock (_sync)
             {
                 ShutdownCount++;
+                ShutdownTimeouts.Add(timeoutMilliseconds);
             }
 
             return true;

--- a/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Observability/TelemetryRuntimeTests.cs
@@ -24,7 +24,7 @@ public sealed class TelemetryRuntimeTests
             TelemetrySharingEnabled = true,
             TelemetryCustomEndpoint = "https://collector.example.com:4318",
             TelemetryAuthHeader = "api-key=abc123"
-        });
+        }, TestContext.Current.CancellationToken);
 
         var applied = Assert.Single(manager.Applied);
         Assert.True(applied.Enabled);
@@ -38,7 +38,7 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager();
         var runtime = CreateRuntime(manager);
 
-        await runtime.ApplyAsync(new AppSettings { TelemetrySharingEnabled = false });
+        await runtime.ApplyAsync(new AppSettings { TelemetrySharingEnabled = false }, TestContext.Current.CancellationToken);
 
         var applied = Assert.Single(manager.Applied);
         Assert.False(applied.Enabled);
@@ -51,8 +51,8 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager();
         var runtime = CreateRuntime(manager);
 
-        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" });
-        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" });
+        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" }, TestContext.Current.CancellationToken);
+        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" }, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, manager.Applied.Count);
         Assert.Equal("https://second.example.com:4318", manager.Applied[^1].OtlpEndpoint);
@@ -69,12 +69,12 @@ public sealed class TelemetryRuntimeTests
         {
             TelemetryCustomEndpoint = "https://collector.example.com:4318",
             TelemetryAuthHeader = "api-key=old"
-        });
+        }, TestContext.Current.CancellationToken);
         await runtime.ApplyAsync(new AppSettings
         {
             TelemetryCustomEndpoint = "https://collector.example.com:4318",
             TelemetryAuthHeader = "api-key=new"
-        });
+        }, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, manager.Applied.Count);
         Assert.Equal("api-key=new", manager.Applied[^1].OtlpHeaders);
@@ -91,12 +91,12 @@ public sealed class TelemetryRuntimeTests
         {
             Theme = "Light",
             TelemetryCustomEndpoint = "https://collector.example.com:4318"
-        });
+        }, TestContext.Current.CancellationToken);
         await runtime.ApplyAsync(new AppSettings
         {
             Theme = "Dark",
             TelemetryCustomEndpoint = "https://collector.example.com:4318"
-        });
+        }, TestContext.Current.CancellationToken);
 
         Assert.Single(manager.Applied);
     }
@@ -108,9 +108,9 @@ public sealed class TelemetryRuntimeTests
         var runtime = CreateRuntime(manager);
         var settings = new AppSettings { TelemetryCustomEndpoint = "https://collector.example.com:4318" };
 
-        await runtime.ApplyAsync(settings);
-        await runtime.ApplyAsync(settings);
-        await runtime.ApplyAsync(settings);
+        await runtime.ApplyAsync(settings, TestContext.Current.CancellationToken);
+        await runtime.ApplyAsync(settings, TestContext.Current.CancellationToken);
+        await runtime.ApplyAsync(settings, TestContext.Current.CancellationToken);
 
         Assert.Single(manager.Applied);
     }
@@ -122,8 +122,8 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager();
         var runtime = CreateRuntime(manager);
 
-        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" });
-        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" });
+        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" }, TestContext.Current.CancellationToken);
+        await runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" }, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, manager.Applied.Count);
         Assert.Equal(
@@ -139,7 +139,7 @@ public sealed class TelemetryRuntimeTests
         var runtime = CreateRuntime(manager);
 
         var exception = await Record.ExceptionAsync(
-            () => runtime.ApplyAsync(new AppSettings()));
+            () => runtime.ApplyAsync(new AppSettings(), TestContext.Current.CancellationToken));
 
         Assert.Null(exception);
     }
@@ -152,9 +152,9 @@ public sealed class TelemetryRuntimeTests
         var runtime = CreateRuntime(manager);
         var settings = new AppSettings { TelemetryCustomEndpoint = "https://collector.example.com:4318" };
 
-        await runtime.ApplyAsync(settings);
+        await runtime.ApplyAsync(settings, TestContext.Current.CancellationToken);
         manager.ThrowOnReconfigure = false;
-        await runtime.ApplyAsync(settings);
+        await runtime.ApplyAsync(settings, TestContext.Current.CancellationToken);
 
         Assert.Single(manager.Applied);
         Assert.Equal("https://collector.example.com:4318", manager.Applied[0].OtlpEndpoint);
@@ -167,13 +167,13 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager { BlockInsideReconfigure = true };
         var runtime = CreateRuntime(manager);
 
-        var first = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" });
+        var first = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://first.example.com:4318" }, TestContext.Current.CancellationToken);
         Assert.True(
-            await manager.ReconfigureEntered.WaitAsync(TimeSpan.FromSeconds(5)),
+            await manager.ReconfigureEntered.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
             "The first apply never reached the manager.");
 
-        var second = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" });
-        var third = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://third.example.com:4318" });
+        var second = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://second.example.com:4318" }, TestContext.Current.CancellationToken);
+        var third = runtime.ApplyAsync(new AppSettings { TelemetryCustomEndpoint = "https://third.example.com:4318" }, TestContext.Current.CancellationToken);
 
         manager.ReleaseReconfigure();
         await Task.WhenAll(first, second, third);
@@ -188,7 +188,7 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager();
         var runtime = CreateRuntime(manager);
 
-        await runtime.ShutdownAsync();
+        await runtime.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, manager.ShutdownCount);
     }
@@ -202,7 +202,7 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager();
         var runtime = CreateRuntime(manager);
 
-        await runtime.ShutdownAsync();
+        await runtime.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(
             new[] { ITelemetryManager.NonBlockingShutdownTimeoutMilliseconds },
@@ -216,7 +216,7 @@ public sealed class TelemetryRuntimeTests
         var manager = new RecordingTelemetryManager { ThrowOnShutdown = true };
         var runtime = CreateRuntime(manager);
 
-        var exception = await Record.ExceptionAsync(() => runtime.ShutdownAsync());
+        var exception = await Record.ExceptionAsync(() => runtime.ShutdownAsync(TestContext.Current.CancellationToken));
 
         Assert.Null(exception);
     }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Discover/DiscoverSessionsViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Discover/DiscoverSessionsViewModelTests.cs
@@ -1579,6 +1579,13 @@ public sealed class DiscoverSessionsViewModelTests
             IsConnected = true;
         }
 
+        public ValueTask DisposeAsync()
+        {
+            IsConnected = false;
+            CurrentChatService = null;
+            return ValueTask.CompletedTask;
+        }
+
         private void SetProperty<T>(ref T field, T value, string propertyName)
         {
             if (EqualityComparer<T>.Default.Equals(field, value))

--- a/tests/SalmonEgg.Presentation.Core.Tests/Discover/DiscoverSessionsViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Discover/DiscoverSessionsViewModelTests.cs
@@ -1712,7 +1712,7 @@ public sealed class DiscoverSessionsViewModelTests
 
     }
 
-        private sealed class StubProjectAffinityResolver : IProjectAffinityResolver
+    private sealed class StubProjectAffinityResolver : IProjectAffinityResolver
     {
         private readonly ProjectAffinityResolution _resolution;
 
@@ -1724,7 +1724,7 @@ public sealed class DiscoverSessionsViewModelTests
         public ProjectAffinityResolution Resolve(ProjectAffinityRequest request) => _resolution;
     }
 
-private sealed class FakeChatService : IChatService
+    private sealed class FakeChatService : IChatService
     {
         public void Dispose()
         {

--- a/tests/SalmonEgg.Presentation.Core.Tests/Navigation/NavigationCoordinatorTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Navigation/NavigationCoordinatorTests.cs
@@ -2286,6 +2286,7 @@ public sealed class NavigationCoordinatorTests
         public string? ConnectionErrorMessage => null;
         public IChatService? CurrentChatService { get; set; } = new FakeDiscoverChatService();
         public Task ConnectToProfileAsync(ServerConfiguration profile) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeDiscoverChatService : IChatService

--- a/tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.ViewModels.Navigation;
+using Xunit;
+
+namespace SalmonEgg.Presentation.Core.Tests.Navigation;
+
+/// <summary>
+/// ShellShutdownOverlayViewModel 的投影行为：阈值前不出场、超阈值出场、
+/// 完成即取消挂起的显示计时、文案随阶段映射。
+/// </summary>
+public sealed class ShellShutdownOverlayViewModelTests
+{
+    private static readonly TimeSpan Threshold = TimeSpan.FromMilliseconds(
+        ShellShutdownOverlayViewModel.RevealThresholdMilliseconds);
+
+    [Fact]
+    public async Task BelowThreshold_ShowsNothing()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        store.ReportPhase(ApplicationShutdownPhase.PersistingState);
+
+        await Task.Delay(Threshold / 2);
+        Assert.False(sut.IsOverlayVisible);
+    }
+
+    [Fact]
+    public async Task AboveThreshold_RevealsOverlay()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        store.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
+
+        // 阈值计时器自身还有调度抖动，多留一截余量，别让测试去撞调度器的下限。
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        Assert.True(sut.IsOverlayVisible);
+    }
+
+    [Fact]
+    public async Task CompletedBeforeThreshold_CancelPendingReveal()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        store.ReportPhase(ApplicationShutdownPhase.PersistingState);
+        store.ReportPhase(ApplicationShutdownPhase.Completed);
+
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        Assert.False(sut.IsOverlayVisible);
+    }
+
+    [Fact]
+    public async Task RevealTimer_StartsOnceAcrossPhaseChanges()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        // 连续两个阶段都会尝试起计时；实现里第二次必须被去重，
+        // 否则每个阶段各挂一个计时器，触发次数随阶段数增长。
+        store.ReportPhase(ApplicationShutdownPhase.PersistingState);
+        store.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
+
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        Assert.True(sut.IsOverlayVisible);
+    }
+
+    [Fact]
+    public void StatusText_MapsPhase()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        Assert.False(string.IsNullOrWhiteSpace(sut.StatusText));
+
+        store.ReportPhase(ApplicationShutdownPhase.PersistingState);
+        Assert.Equal("Saving conversations...", sut.StatusText);
+
+        store.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
+        Assert.Equal("Closing agent processes...", sut.StatusText);
+
+        store.ReportPhase(ApplicationShutdownPhase.Completed);
+        Assert.Equal("Shutting down...", sut.StatusText);
+    }
+
+    [Fact]
+    public void CompletedPhase_IsNeverRevealed()
+    {
+        var store = new ApplicationShutdownProgressStore();
+        using var sut = new ShellShutdownOverlayViewModel(store, new ImmediateUiDispatcher());
+
+        // 直接跳到 Completed（极快的关闭）也不该出现遮罩。
+        store.ReportPhase(ApplicationShutdownPhase.Completed);
+
+        Assert.False(sut.IsOverlayVisible);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Navigation/ShellShutdownOverlayViewModelTests.cs
@@ -24,7 +24,7 @@ public sealed class ShellShutdownOverlayViewModelTests
 
         store.ReportPhase(ApplicationShutdownPhase.PersistingState);
 
-        await Task.Delay(Threshold / 2);
+        await Task.Delay(Threshold / 2, TestContext.Current.CancellationToken);
         Assert.False(sut.IsOverlayVisible);
     }
 
@@ -37,7 +37,7 @@ public sealed class ShellShutdownOverlayViewModelTests
         store.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
 
         // 阈值计时器自身还有调度抖动，多留一截余量，别让测试去撞调度器的下限。
-        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
         Assert.True(sut.IsOverlayVisible);
     }
 
@@ -50,7 +50,7 @@ public sealed class ShellShutdownOverlayViewModelTests
         store.ReportPhase(ApplicationShutdownPhase.PersistingState);
         store.ReportPhase(ApplicationShutdownPhase.Completed);
 
-        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
         Assert.False(sut.IsOverlayVisible);
     }
 
@@ -65,7 +65,7 @@ public sealed class ShellShutdownOverlayViewModelTests
         store.ReportPhase(ApplicationShutdownPhase.PersistingState);
         store.ReportPhase(ApplicationShutdownPhase.ClosingChildProcesses);
 
-        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500));
+        await Task.Delay(Threshold + TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
         Assert.True(sut.IsOverlayVisible);
     }
 

--- a/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Acp;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Services;
 using SalmonEgg.Presentation.Core.Services.Chat;
@@ -9,83 +11,316 @@ namespace SalmonEgg.Presentation.Core.Tests.Services;
 public sealed class ApplicationShutdownWorkflowTests
 {
     [Fact]
-    public async Task ShutdownAsync_FlushesChatStateThenTelemetry()
+    public async Task ShutdownAsync_FlushesStateThenDrainsChildProcessesThenTelemetry()
     {
-        // 顺序有意义：用户状态的持久性优先，遥测最后 flush，这样上面任何失败产生的 span
-        // 仍能进入这次导出。
-        var order = new List<string>();
-        var persistence = new Mock<IChatRuntimePersistence>();
-        persistence
-            .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Callback(() => order.Add("chat"));
-        var telemetry = new Mock<ITelemetryRuntime>();
-        telemetry
-            .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Callback(() => order.Add("telemetry"));
+        // 顺序有意义：用户状态的持久性优先于释放 OS 资源（先杀子进程再写盘会给"写盘失败"
+        // 多出一个本可避免的成因），遥测最后 flush，这样上面任何失败产生的 span 仍能被处理。
+        var harness = new Harness();
 
-        var workflow = new ApplicationShutdownWorkflow(
-            persistence.Object,
-            telemetry.Object,
-            NullLogger<ApplicationShutdownWorkflow>.Instance);
+        await harness.Workflow.ShutdownAsync();
 
-        await workflow.ShutdownAsync();
-
-        Assert.Equal(new[] { "chat", "telemetry" }, order);
+        Assert.Equal(
+            new[] { "chat", "acp-drain", "discover", "acp-terminal", "local-terminal", "telemetry" },
+            harness.Order);
     }
 
     [Fact]
-    public async Task ShutdownAsync_WhenChatFlushFails_StillShutsDownTelemetry()
+    public async Task ShutdownAsync_DrainsEveryChildProcessOwnerExactlyOnce()
     {
-        // 状态 flush 失败恰恰是最需要把诊断数据送出去的场景；若因它抛出而跳过遥测
-        // shutdown，缓冲区里的错误 span 会随进程一起消失。
-        var persistence = new Mock<IChatRuntimePersistence>();
-        persistence
+        // issue #126：这四个 owner 各自持有 agent 子进程 / PTY，且都不在彼此的释放链路上——
+        // 缓存会话走注册表，Discover 的浏览连接从不 RecordSession，两类终端各有自己的 manager。
+        // 漏掉任何一个，那一类子进程就会被 reparent 到 init 后继续运行。
+        var harness = new Harness();
+
+        await harness.Workflow.ShutdownAsync();
+
+        harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
+        Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
+        Assert.Equal(1, harness.AcpTerminals.DisposeCount);
+        Assert.Equal(1, harness.LocalTerminals.DisposeAsyncCount);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_WhenOneChildProcessOwnerFails_StillReleasesTheRest()
+    {
+        // 一个 owner 释放失败不得让其余子进程继续泄漏：这正是"关不掉的 agent"最常见的成因。
+        var harness = new Harness();
+        harness.ConnectionCleaner
+            .Setup(cleaner => cleaner.DrainAllAsync())
+            .ThrowsAsync(new InvalidOperationException("drain failed"));
+
+        await harness.Workflow.ShutdownAsync();
+
+        Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
+        Assert.Equal(1, harness.AcpTerminals.DisposeCount);
+        Assert.Equal(1, harness.LocalTerminals.DisposeAsyncCount);
+        harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_WhenChatFlushFails_StillDrainsAndShutsDownTelemetry()
+    {
+        // 状态 flush 失败恰恰是最需要把诊断数据送出去、也最需要收干子进程的场景；
+        // 若因它抛出而跳过后续阶段，子进程会泄漏且缓冲区里的错误 span 会随进程消失。
+        var harness = new Harness();
+        harness.Persistence
             .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("flush failed"));
-        var telemetry = new Mock<ITelemetryRuntime>();
-        telemetry
-            .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
 
-        var workflow = new ApplicationShutdownWorkflow(
-            persistence.Object,
-            telemetry.Object,
-            NullLogger<ApplicationShutdownWorkflow>.Instance);
+        await harness.Workflow.ShutdownAsync();
 
-        await workflow.ShutdownAsync();
-
-        telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
+        harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
+        harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task ShutdownAsync_WhenCalledFromSeveralClosePaths_RunsOnce()
     {
         // 窗口关闭、托盘退出、平台生命周期都可能同时触发关闭，必须共享同一次运行，
-        // 否则会并发 flush 同一批状态。
+        // 否则会并发 flush 同一批状态、并对同一批子进程重复释放。
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var persistence = new Mock<IChatRuntimePersistence>();
-        persistence
+        var harness = new Harness();
+        harness.Persistence
             .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
             .Returns(release.Task);
-        var telemetry = new Mock<ITelemetryRuntime>();
-        telemetry
-            .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
 
-        var workflow = new ApplicationShutdownWorkflow(
-            persistence.Object,
-            telemetry.Object,
-            NullLogger<ApplicationShutdownWorkflow>.Instance);
-
-        var first = workflow.ShutdownAsync();
-        var second = workflow.ShutdownAsync();
+        var first = harness.Workflow.ShutdownAsync();
+        var second = harness.Workflow.ShutdownAsync();
         release.SetResult();
         await Task.WhenAll(first, second);
-        await workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync();
 
-        persistence.Verify(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()), Times.Once);
-        telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
+        harness.Persistence.Verify(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()), Times.Once);
+        harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
+        Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
+        harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_WithoutLocalTerminals_StillCompletes()
+    {
+        // 本地 PTY 只在 desktop 注册，WASM / 移动端为 null：可选依赖缺失不得让关闭崩掉。
+        var harness = new Harness(includeLocalTerminals: false);
+
+        await harness.Workflow.ShutdownAsync();
+
+        harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
+        harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(ApplicationShutdownPhase.Completed, harness.Progress.Phase);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_ReportsPhasesInOrderAndEndsCompleted()
+    {
+        // overlay 的唯一事实源。阶段必须按执行顺序推进，且最终必须落到 Completed，
+        // 否则提示会永久停在"正在关闭"。
+        var harness = new Harness();
+
+        await harness.Workflow.ShutdownAsync();
+
+        Assert.Equal(
+            new[]
+            {
+                ApplicationShutdownPhase.PersistingState,
+                ApplicationShutdownPhase.ClosingChildProcesses,
+                ApplicationShutdownPhase.Completed
+            },
+            harness.Progress.ReportedPhases);
+        Assert.True(harness.Progress.IsShuttingDown);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_WhenTelemetryThrows_StillReportsCompleted()
+    {
+        // 最后一段抛出时也必须落到 Completed：否则 overlay 永久挂在"正在关闭"，
+        // 而进程其实已经准备退出了。
+        var harness = new Harness();
+        harness.Telemetry
+            .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("telemetry shutdown failed"));
+
+        var exception = await Record.ExceptionAsync(() => harness.Workflow.ShutdownAsync());
+
+        Assert.Null(exception);
+        Assert.Equal(ApplicationShutdownPhase.Completed, harness.Progress.Phase);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_WhenCanceled_StillDrainsChildProcesses()
+    {
+        // 取消只能缩短"等写盘"，不能缩短"收子进程"：会话一旦脱离注册表就再无持有者，
+        // 中途放弃等于把 agent 过继给 init 继续运行。
+        var harness = new Harness();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        harness.Persistence
+            .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        await harness.Workflow.ShutdownAsync(cts.Token);
+
+        harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
+        Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
+        Assert.Equal(1, harness.AcpTerminals.DisposeCount);
+        Assert.Equal(ApplicationShutdownPhase.Completed, harness.Progress.Phase);
+    }
+
+    private sealed class Harness
+    {
+        public Harness(bool includeLocalTerminals = true)
+        {
+            Persistence = new Mock<IChatRuntimePersistence>();
+            Persistence
+                .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Callback(() => Order.Add("chat"));
+
+            ConnectionCleaner = new Mock<IAcpConnectionSessionCleaner>();
+            ConnectionCleaner
+                .Setup(cleaner => cleaner.DrainAllAsync())
+                .ReturnsAsync(new AcpConnectionSessionCleanupResult(2, 0))
+                .Callback(() => Order.Add("acp-drain"));
+
+            DiscoverFacade = new RecordingDiscoverFacade(Order);
+            AcpTerminals = new RecordingTerminalSessionManager(Order);
+            LocalTerminals = includeLocalTerminals ? new RecordingAsyncDisposable(Order) : null;
+
+            Telemetry = new Mock<ITelemetryRuntime>();
+            Telemetry
+                .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Callback(() => Order.Add("telemetry"));
+
+            Workflow = new ApplicationShutdownWorkflow(
+                Persistence.Object,
+                ConnectionCleaner.Object,
+                DiscoverFacade,
+                AcpTerminals,
+                Progress,
+                Telemetry.Object,
+                NullLogger<ApplicationShutdownWorkflow>.Instance,
+                LocalTerminals);
+        }
+
+        public List<string> Order { get; } = new();
+
+        public Mock<IChatRuntimePersistence> Persistence { get; }
+
+        public Mock<IAcpConnectionSessionCleaner> ConnectionCleaner { get; }
+
+        public RecordingDiscoverFacade DiscoverFacade { get; }
+
+        public RecordingTerminalSessionManager AcpTerminals { get; }
+
+        public RecordingAsyncDisposable? LocalTerminals { get; }
+
+        public Mock<ITelemetryRuntime> Telemetry { get; }
+
+        public RecordingProgressSink Progress { get; } = new();
+
+        public ApplicationShutdownWorkflow Workflow { get; }
+    }
+
+    /// <remarks>
+    /// 记录 <c>ReportPhase</c> 的完整序列而非只看末值：overlay 的正确性依赖阶段推进顺序，
+    /// 只断言末值会让"跳过中间阶段"通过。
+    /// </remarks>
+    private sealed class RecordingProgressSink : IApplicationShutdownProgress, IApplicationShutdownProgressSink
+    {
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+
+        public List<ApplicationShutdownPhase> ReportedPhases { get; } = new();
+
+        public bool IsShuttingDown { get; private set; }
+
+        public ApplicationShutdownPhase Phase { get; private set; } = ApplicationShutdownPhase.NotStarted;
+
+        public void ReportPhase(ApplicationShutdownPhase phase)
+        {
+            ReportedPhases.Add(phase);
+            if (phase != ApplicationShutdownPhase.NotStarted)
+            {
+                IsShuttingDown = true;
+            }
+
+            Phase = phase;
+        }
+    }
+
+    private sealed class RecordingDiscoverFacade : IDiscoverSessionsConnectionFacade
+    {
+        private readonly List<string> _order;
+
+        public RecordingDiscoverFacade(List<string> order) => _order = order;
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+
+        public int DisposeAsyncCount { get; private set; }
+
+        public bool IsConnecting => false;
+
+        public bool IsInitializing => false;
+
+        public bool IsConnected => false;
+
+        public string? ConnectionErrorMessage => null;
+
+        public SalmonEgg.Application.Services.Chat.IChatService? CurrentChatService => null;
+
+        public Task ConnectToProfileAsync(SalmonEgg.Domain.Models.ServerConfiguration profile)
+            => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCount++;
+            _order.Add("discover");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingTerminalSessionManager : ITerminalSessionManager
+    {
+        private readonly List<string> _order;
+
+        public RecordingTerminalSessionManager(List<string> order) => _order = order;
+
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            _order.Add("acp-terminal");
+        }
+
+        public Task<TerminalCreateResponse> CreateAsync(TerminalCreateRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TerminalOutputResponse> GetOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TerminalWaitForExitResponse> WaitForExitAsync(TerminalWaitForExitRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TerminalKillResponse> KillAsync(TerminalKillRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TerminalReleaseResponse> ReleaseAsync(TerminalReleaseRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingAsyncDisposable : IAsyncDisposable
+    {
+        private readonly List<string> _order;
+
+        public RecordingAsyncDisposable(List<string> order) => _order = order;
+
+        public int DisposeAsyncCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCount++;
+            _order.Add("local-terminal");
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
@@ -17,7 +17,7 @@ public sealed class ApplicationShutdownWorkflowTests
         // 多出一个本可避免的成因），遥测最后 flush，这样上面任何失败产生的 span 仍能被处理。
         var harness = new Harness();
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(
             new[] { "chat", "acp-drain", "discover", "acp-terminal", "local-terminal", "telemetry" },
@@ -32,7 +32,7 @@ public sealed class ApplicationShutdownWorkflowTests
         // 漏掉任何一个，那一类子进程就会被 reparent 到 init 后继续运行。
         var harness = new Harness();
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
         Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
@@ -49,7 +49,7 @@ public sealed class ApplicationShutdownWorkflowTests
             .Setup(cleaner => cleaner.DrainAllAsync())
             .ThrowsAsync(new InvalidOperationException("drain failed"));
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, harness.DiscoverFacade.DisposeAsyncCount);
         Assert.Equal(1, harness.AcpTerminals.DisposeCount);
@@ -67,7 +67,7 @@ public sealed class ApplicationShutdownWorkflowTests
             .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("flush failed"));
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
         harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -84,11 +84,11 @@ public sealed class ApplicationShutdownWorkflowTests
             .Setup(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()))
             .Returns(release.Task);
 
-        var first = harness.Workflow.ShutdownAsync();
-        var second = harness.Workflow.ShutdownAsync();
+        var first = harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
+        var second = harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
         release.SetResult();
         await Task.WhenAll(first, second);
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         harness.Persistence.Verify(p => p.FlushPendingStateAsync(It.IsAny<CancellationToken>()), Times.Once);
         harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
@@ -102,7 +102,7 @@ public sealed class ApplicationShutdownWorkflowTests
         // 本地 PTY 只在 desktop 注册，WASM / 移动端为 null：可选依赖缺失不得让关闭崩掉。
         var harness = new Harness(includeLocalTerminals: false);
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         harness.ConnectionCleaner.Verify(cleaner => cleaner.DrainAllAsync(), Times.Once);
         harness.Telemetry.Verify(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -116,7 +116,7 @@ public sealed class ApplicationShutdownWorkflowTests
         // 否则提示会永久停在"正在关闭"。
         var harness = new Harness();
 
-        await harness.Workflow.ShutdownAsync();
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(
             new[]
@@ -139,7 +139,7 @@ public sealed class ApplicationShutdownWorkflowTests
             .Setup(runtime => runtime.ShutdownAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("telemetry shutdown failed"));
 
-        var exception = await Record.ExceptionAsync(() => harness.Workflow.ShutdownAsync());
+        var exception = await Record.ExceptionAsync(() => harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken));
 
         Assert.Null(exception);
         Assert.Equal(ApplicationShutdownPhase.Completed, harness.Progress.Phase);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceMainNavigationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Ui/XamlComplianceMainNavigationTests.cs
@@ -595,9 +595,28 @@ public sealed class XamlComplianceMainNavigationTests
         Assert.Contains("partial void InitializeTray();", sharedPage, StringComparison.Ordinal);
         Assert.Contains("partial void DisposePlatformTray();", sharedPage, StringComparison.Ordinal);
         Assert.DoesNotContain("TrayIconManager", sharedPage, StringComparison.Ordinal);
-        Assert.DoesNotContain("AppWindowClosingEventArgs", sharedPage, StringComparison.Ordinal);
         Assert.Contains("TrayIconManager", windowsPage, StringComparison.Ordinal);
-        Assert.Contains("AppWindowClosingEventArgs", windowsPage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MainPage_KeepsClosePathSharedAndTrayOutOfIt()
+    {
+        // issue #126：关闭路径（AppWindow.Closing 拦截 → teardown → 真关闭）是跨平台共享代码，
+        // 放在 Platforms/Windows 会让 Skia 三端永远没有 teardown 时机。托盘是 Windows 专属，
+        // 且 AppWindow.Hide() 未在 Uno 实现，hide 动作必须留在平台 partial。
+        var shutdownPage = LoadText(@"SalmonEgg\SalmonEgg\MainPage.Shutdown.cs");
+        var sharedPage = LoadText(@"SalmonEgg\SalmonEgg\MainPage.xaml.cs");
+        var windowsPage = LoadText(@"SalmonEgg\SalmonEgg\Platforms\Windows\MainPage.Windows.cs");
+        var defaultPage = LoadText(@"SalmonEgg\SalmonEgg\MainPage.Default.cs");
+
+        Assert.Contains("AppWindowClosingEventArgs", shutdownPage, StringComparison.Ordinal);
+        Assert.Contains("FlushRuntimeThenCloseAsync", shutdownPage, StringComparison.Ordinal);
+        Assert.Contains("AttachAppWindowClosing", shutdownPage, StringComparison.Ordinal);
+        Assert.Contains("HideMainWindowToTray();", shutdownPage, StringComparison.Ordinal);
+        Assert.Contains("partial void HideMainWindowToTray();", sharedPage, StringComparison.Ordinal);
+        Assert.DoesNotContain("AppWindowClosingEventArgs", windowsPage, StringComparison.Ordinal);
+        Assert.DoesNotContain("TrayIconManager", shutdownPage, StringComparison.Ordinal);
+        Assert.Contains("partial void HideMainWindowToTray()", defaultPage, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #126

## 根因（实测归因，推翻了 issue 里的猜测）

Xvfb + 真 `WM_DELETE_WINDOW`（非 SIGTERM）测量：点叉号后卡顿的真凶是**遥测关闭**——`TelemetryManager.Shutdown()` 对 tracer/meter 串行各等 5000ms，默认端点不可达时 close→exit 长达 ~10s。agent 子进程带真 ACP agent 时实测 0.276s，与 0.25s 地板无差别，**不是卡顿源**。

调查同时暴露三个伴生缺陷，一并修：

1. **子进程全泄漏**：DI 容器从不 Dispose，所有 singleton 的清理是死代码；agent 被 reparent 到 init 继续跑。
2. **Linux/macOS 僵尸期 ~9s**：窗口 1.1s 消失、进程活到 10.3s（teardown 全在 `RunAsync()` 返回之后）。
3. **cancel-flush-close 只有 Windows 有**：desktop TFM 移除了 `Platforms/Windows/**`，拦截关闭逻辑根本不存在。

## 修复内容

- **遥测非阻塞**：走 OTel 官方 `timeoutMilliseconds: 0` 分支（通知导出线程收尾、不 Join，非 hack）；dynamic-provider reconfigure 一并堵掉第三段默认 30s/10s 等待；契约注释同步改写，防止后人改回去。
- **全量 drain**：`ApplicationShutdownWorkflow`（唯一 teardown owner）在 chat flush 后按限并发（复用既有 `DefaultMaxConcurrentDisposals` 节流）释放 warm ACP 池、discover facade、terminal 会话与 desktop 本地终端协调器；npm `.CMD` 启动器的孙进程随 `entireProcessTree` 一起清。
- **关闭路径上提为跨平台共享**（`MainPage.Shutdown.cs`）：三个 Skia host 都在窗口消失前完成 teardown；托盘留平台 partial（`AppWindow.Hide()` 是 WinUI 专属，Uno0001）。
- **关闭提示 overlay**：shutdown 进度由 Core 持有（读/写接口分离），shell 投影为超 400ms 阈值才淡入的遮罩——快时不闪屏，慢时用户知道在关什么。

## 验证

- 单元：6 个新投影 VM 测试、shutdown workflow 顺序/幂等/故障隔离、遥测非阻塞断言复用契约常量（非魔法数）、x:Uid fail-closed 门禁；Presentation.Core 全量 3240/3240 绿。
- **新 GUI 门禁** `scripts/gates/run-skia-desktop-close-path-gate.sh`（老门禁只会 SIGTERM，这正是缺陷长期没暴露的原因）：Xvfb + 黑洞遥测端点（最坏场景）+ 真 `WM_DELETE_WINDOW`（xdotool 会把 Uno 段错误，不可用），硬断言 close→exit 预算、退出码 0、无残留子进程。
  - 修复后：**1.12s 退出、码 0、零残留**（预算 4s）。
  - **反向验证**：临时恢复 5000ms 阻塞 → 门禁红（`App still alive 4s after WM_DELETE_WINDOW`）；恢复修复 → 再绿。门禁自身也修过一个假绿（SECONDS 秒级精度放过 5.55s 回归，已换纳秒计时）。

## 平台前提（AGENTS §8.2）

- ✅ 本机验证：Skia X11 desktop 端到端（构建 0 警告 0 错误、GUI 门禁、全量 Core 测试）。
- ⚠️ **WinUI 头 / iOS / Android 未在本机验证**（UNOB0014，Linux 无法构建 WinUI）；平台 partial 对齐为静态核对，依赖 CI 兜底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)