### PR TITLE
fix(ci): resolve the three develop gate failures (#131 #132 #133)

### DIFF
--- a/.github/workflows/ci-acp-sdk.yml
+++ b/.github/workflows/ci-acp-sdk.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   PACKAGE_OUTPUT: "artifacts/acp-sdk-pack"
 
@@ -52,17 +51,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # The package version is derived from the acp-sdk-v* tag history by MinVer, so the full
+      # history (tags included) must be present. A shallow clone would pack a 0.0.0-alpha version
+      # and the baseline guard in SalmonEgg.Acp.csproj would fail the pack.
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Run ACP SDK gate script
         env:
           DOTNET_BIN: dotnet
+          # Every version after the first shipped one must package-validate against the last
+          # published package. The baseline is stored as a repository variable, matching the
+          # release workflow, so CI and release cannot disagree about what was last published.
+          ACP_PACKAGE_BASELINE_VERSION: ${{ vars.ACP_PACKAGE_BASELINE_VERSION }}
         run: ./scripts/gates/run-acp-sdk-gates.sh "${{ env.CONFIGURATION }}" "${{ env.PACKAGE_OUTPUT }}"
 
       - name: Verify release tag/version gate rules
@@ -86,7 +94,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Download ACP SDK package
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -35,7 +35,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   TEST_RESULTS_DIR: "TestResults"
   SALMONEGG_ONEDRIVE_CLIENT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_CLIENT_ID || vars.SALMONEGG_ONEDRIVE_CLIENT_ID }}
@@ -57,7 +56,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools --skip-manifest-update --disable-parallel --no-http-cache

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,7 +35,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   SALMONEGG_ONEDRIVE_CLIENT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_CLIENT_ID || vars.SALMONEGG_ONEDRIVE_CLIENT_ID }}
   SALMONEGG_ONEDRIVE_TENANT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_TENANT_ID || vars.SALMONEGG_ONEDRIVE_TENANT_ID }}
@@ -56,7 +55,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools --skip-manifest-update --disable-parallel --no-http-cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
 
 jobs:
@@ -58,7 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8

--- a/.github/workflows/gui-smoke-gates.yml
+++ b/.github/workflows/gui-smoke-gates.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: "10.0.3xx"
+          global-json-file: global.json
 
       - name: Install Skia Desktop GUI smoke runtime deps
         run: |
@@ -88,7 +88,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: "10.0.3xx"
+          global-json-file: global.json
 
       - name: Build GUI tests
         shell: pwsh

--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -48,7 +48,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   SALMONEGG_ONEDRIVE_CLIENT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_CLIENT_ID || vars.SALMONEGG_ONEDRIVE_CLIENT_ID }}
   SALMONEGG_ONEDRIVE_TENANT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_TENANT_ID || vars.SALMONEGG_ONEDRIVE_TENANT_ID }}
@@ -71,7 +70,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Publish Linux Desktop
         run: >-
@@ -100,7 +99,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Publish macOS Desktop
         run: >-
@@ -131,7 +130,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Restore WinUI app for isolated MSIX build
         shell: pwsh
@@ -205,15 +204,18 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Verify Android .NET SDK
         run: |
           dotnet_version="$(dotnet --version)"
-          case "${dotnet_version}" in
-            10.0.3??) ;;
-            *) echo "Expected .NET SDK 10.0.3xx, got ${dotnet_version}." >&2; exit 1 ;;
-          esac
+          # The expected version is read from global.json so this check can never drift from
+          # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"
+          if [ "${dotnet_version}" != "${expected_version}" ]; then
+            echo "Expected .NET SDK ${expected_version} (pinned in global.json), got ${dotnet_version}." >&2
+            exit 1
+          fi
           echo ".NET SDK ${dotnet_version}"
 
       - name: Install Android workload
@@ -268,7 +270,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Select compatible Xcode
         shell: bash
@@ -298,10 +300,13 @@ jobs:
       - name: Verify iOS .NET SDK
         run: |
           dotnet_version="$(dotnet --version)"
-          case "${dotnet_version}" in
-            10.0.3??) ;;
-            *) echo "Expected .NET SDK 10.0.3xx, got ${dotnet_version}." >&2; exit 1 ;;
-          esac
+          # The expected version is read from global.json so this check can never drift from
+          # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"
+          if [ "${dotnet_version}" != "${expected_version}" ]; then
+            echo "Expected .NET SDK ${expected_version} (pinned in global.json), got ${dotnet_version}." >&2
+            exit 1
+          fi
           echo ".NET SDK ${dotnet_version}"
 
       - name: Install iOS workload

--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -211,9 +211,11 @@ jobs:
           dotnet_version="$(dotnet --version)"
           # The expected version is read from global.json so this check can never drift from
           # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          # global.json's rollForward: latestPatch legitimately resolves to a newer patch within
+          # the same feature band, so the gate is: same band, never an older patch than the pin.
           expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"
-          if [ "${dotnet_version}" != "${expected_version}" ]; then
-            echo "Expected .NET SDK ${expected_version} (pinned in global.json), got ${dotnet_version}." >&2
+          if [ "${dotnet_version%??}" != "${expected_version%??}" ] || [ "$((10#${dotnet_version##*.}))" -lt "$((10#${expected_version##*.}))" ]; then
+            echo "Expected .NET SDK ${expected_version} or a same-band patch roll-forward, got ${dotnet_version}." >&2
             exit 1
           fi
           echo ".NET SDK ${dotnet_version}"
@@ -302,9 +304,11 @@ jobs:
           dotnet_version="$(dotnet --version)"
           # The expected version is read from global.json so this check can never drift from
           # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          # global.json's rollForward: latestPatch legitimately resolves to a newer patch within
+          # the same feature band, so the gate is: same band, never an older patch than the pin.
           expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"
-          if [ "${dotnet_version}" != "${expected_version}" ]; then
-            echo "Expected .NET SDK ${expected_version} (pinned in global.json), got ${dotnet_version}." >&2
+          if [ "${dotnet_version%??}" != "${expected_version%??}" ] || [ "$((10#${dotnet_version##*.}))" -lt "$((10#${expected_version##*.}))" ]; then
+            echo "Expected .NET SDK ${expected_version} or a same-band patch roll-forward, got ${dotnet_version}." >&2
             exit 1
           fi
           echo ".NET SDK ${dotnet_version}"

--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           dotnet_version="$(dotnet --version)"
           # The expected version is read from global.json so this check can never drift from
-          # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          # the file that actually pins the SDK (the previous wildcard install did exactly that).
           # global.json's rollForward: latestPatch legitimately resolves to a newer patch within
           # the same feature band, so the gate is: same band, never an older patch than the pin.
           expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"
@@ -303,7 +303,7 @@ jobs:
         run: |
           dotnet_version="$(dotnet --version)"
           # The expected version is read from global.json so this check can never drift from
-          # the file that actually pins the SDK (the old "10.0.3xx" wildcard did exactly that).
+          # the file that actually pins the SDK (the previous wildcard install did exactly that).
           # global.json's rollForward: latestPatch legitimately resolves to a newer patch within
           # the same feature band, so the gate is: same band, never an older patch than the pin.
           expected_version="$(python3 -c 'import json; print(json.load(open("global.json"))["sdk"]["version"])')"

--- a/.github/workflows/release-acp-sdk.yml
+++ b/.github/workflows/release-acp-sdk.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   PACKAGE_OUTPUT: "artifacts/acp-sdk-pack"
 
@@ -39,7 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       # The same gates that guard every PR guard the release: format, analyzers, contract tests, pack.
       # A release must not have a weaker bar than a pull request.
@@ -80,7 +79,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Download ACP SDK package
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -117,7 +116,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Download ACP SDK package
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -24,7 +24,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Release"
   SALMONEGG_ONEDRIVE_CLIENT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_CLIENT_ID || vars.SALMONEGG_ONEDRIVE_CLIENT_ID }}
   SALMONEGG_ONEDRIVE_TENANT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_TENANT_ID || vars.SALMONEGG_ONEDRIVE_TENANT_ID }}
@@ -45,7 +44,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools --skip-manifest-update --disable-parallel --no-http-cache
@@ -80,7 +79,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Publish Desktop (Windows)
         run: |
@@ -225,7 +224,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Restore WinUI app for isolated MSIX build
         shell: pwsh
@@ -348,7 +347,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Publish macOS app bundle
         shell: pwsh
@@ -470,7 +469,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Build CLI artifact
         id: build-cli
@@ -543,7 +542,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Download Windows MSIX artifact
         if: needs.package-windows-msix.result == 'success'

--- a/.github/workflows/wasm-smoke-gates.yml
+++ b/.github/workflows/wasm-smoke-gates.yml
@@ -36,7 +36,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: "10.0.3xx"
   CONFIGURATION: "Debug"
   SALMONEGG_ONEDRIVE_CLIENT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_CLIENT_ID || vars.SALMONEGG_ONEDRIVE_CLIENT_ID }}
   SALMONEGG_ONEDRIVE_TENANT_ID: ${{ secrets.SALMONEGG_ONEDRIVE_TENANT_ID || vars.SALMONEGG_ONEDRIVE_TENANT_ID }}
@@ -55,7 +54,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/SalmonEgg/SalmonEgg/SalmonEgg.csproj
+++ b/SalmonEgg/SalmonEgg/SalmonEgg.csproj
@@ -339,13 +339,20 @@
     <DisableImplicitUnoPackages>true</DisableImplicitUnoPackages>
   </PropertyGroup>
 
-  <!-- DependsOnTargets pins the order against the root derive target: both are AfterTargets="MinVer",
-       and the relative order of two targets on the same hook is unspecified in MSBuild. Without the
-       dependency the manifest could be generated before SalmonEggPackageVersion exists. -->
+  <!-- The generated manifest is consumed early: WindowsAppSDK's CreateWinRTRegistration merges it
+       with mt.exe BeforeTargets="AssignTargetPaths", and the version substitution needs MinVer's
+       output, which only exists once the MinVer target has run. So this target must not hang off
+       AfterTargets="MinVer" (that fires at BeforeCompile, after the mt.exe merge) — instead it runs
+       at the pre-resolve consumer point and pulls MinVer in explicitly. Depending on MinVer triggers
+       the AfterTargets="MinVer" derive target first, which pins the ordering against
+       SalmonEggDeriveReleaseIdentity; MinVer itself is cached via $(MinVerVersion), so the later
+       BeforeCompile hook is a no-op. The condition mirrors MinVer's own skip conditions: a design-time
+       or skipped MinVer would make the DependsOnTargets reference resolve to a missing target
+       (MSB4057), and versioned manifests are meaningless without a version anyway. -->
   <Target Name="GenerateVersionedApplicationManifests"
-          AfterTargets="MinVer"
-          DependsOnTargets="SalmonEggDeriveReleaseIdentity"
-          Condition="'$(SalmonEggGeneratedApplicationManifest)' != ''">
+          BeforeTargets="_EnsureAppxManifestExists;ResolveReferences;ResolveProjectReferences;BeforeBuild"
+          DependsOnTargets="MinVer"
+          Condition="'$(SalmonEggGeneratedApplicationManifest)' != '' AND '$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
     <PropertyGroup>
       <_SalmonEggPackageManifestTemplate Condition="'$(SalmonEggGeneratedPackageManifest)' != ''">$(MSBuildProjectDirectory)\Package.appxmanifest</_SalmonEggPackageManifestTemplate>
       <_SalmonEggApplicationManifestTemplate>$(MSBuildProjectDirectory)\app.manifest</_SalmonEggApplicationManifestTemplate>

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -76,7 +76,10 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="6.0.0" />
+    <!-- MinVer is a build-time versioning tool, not a runtime dependency: PrivateAssets keeps it
+         out of the packed nuspec, where it would force every consumer to resolve a package their
+         source mapping may not carry. -->
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Internals remain available to first-party contract tests. External consumers use the public surface. -->

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -63,10 +63,16 @@
   <!-- Fail closed on a missing baseline. GenerateNuspec only runs during pack, so forgetting
        AcpPackageBaselineVersion is a pack-time error, not something that blocks everyday builds.
        The baseline package itself is downloaded by a restore that runs with the baseline property
-       set (see scripts/gates/run-acp-sdk-gates.sh); validation compares against its nupkg on disk. -->
+       set (see scripts/gates/run-acp-sdk-gates.sh); validation compares against its nupkg on disk.
+
+       The first error is a distinct diagnosis: 0.0.0 is MinVer's no-tag fallback, so reaching it
+       means the acp-sdk-v* history was never fetched (shallow checkout), not that the baseline is
+       missing. Packing a 0.0.0 package must fail regardless of what baseline was supplied. -->
   <Target Name="AcpBaselineRequired" BeforeTargets="GenerateNuspec">
+    <Error Condition="$([System.String]::Copy('$(Version)').StartsWith('0.0.0'))"
+           Text="SalmonEgg.Acp version is $(Version), which means MinVer found no acp-sdk-v* tag: the checkout is shallow. Fetch the full history (fetch-depth: 0) so the package version can be derived, instead of packing a placeholder version." />
     <Error Condition="'$(Version)' != '$(AcpPackageFirstReleasedVersion)' AND '$(PackageValidationBaselineVersion)' == ''"
-           Text="SalmonEgg.Acp $(Version) is past the first release $(AcpPackageFirstReleasedVersion), so package validation needs a published baseline. Pass -p:AcpPackageBaselineVersion=&lt;last published version&gt;." />
+           Text="SalmonEgg.Acp $(Version) is past the first release $(AcpPackageFirstReleasedVersion), so package validation needs a published baseline. Pass -p:AcpPackageBaselineVersion=&lt;last published version&gt; (or set the ACP_PACKAGE_BASELINE_VERSION repository variable)." />
   </Target>
 
   <ItemGroup>

--- a/tests/SalmonEgg.Application.Tests/UiConventionsTests.cs
+++ b/tests/SalmonEgg.Application.Tests/UiConventionsTests.cs
@@ -505,10 +505,15 @@ public class UiConventionsTests
             "MIT",
             root.Descendants("PackageLicenseExpression").Select(node => node.Value.Trim()).SingleOrDefault(),
             StringComparer.Ordinal);
+        // The version identity is derived from the acp-sdk-v* tag history by MinVer. A hardcoded
+        // <Version> would silently override it and desync the published package from the tag that
+        // released it, so the convention is: the tag namespace is pinned, the version is not.
         Assert.Equal(
-            "1.0.0",
-            root.Descendants("Version").Select(node => node.Value.Trim()).SingleOrDefault(),
+            "acp-sdk-v",
+            root.Descendants("MinVerTagPrefix").Select(node => node.Value.Trim()).SingleOrDefault(),
             StringComparer.Ordinal);
+        Assert.Empty(root.Descendants("Version"));
+        Assert.Empty(root.Descendants("VersionPrefix"));
         Assert.Equal(
             "true",
             root.Descendants("GenerateDocumentationFile").Select(node => node.Value.Trim()).SingleOrDefault(),

--- a/tests/SalmonEgg.Application.Tests/UiConventionsTests.cs
+++ b/tests/SalmonEgg.Application.Tests/UiConventionsTests.cs
@@ -372,7 +372,7 @@ public class UiConventionsTests
 
         // The WINDOWS branch only compiles on Windows CI; at least keep it syntactically valid
         // from the cross-platform suite (ReadCSharpSyntaxTree parses with WINDOWS defined).
-        Assert.Empty(root.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.DoesNotContain(root.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
 
         var displayNameConst = root
             .DescendantNodes()

--- a/tests/SalmonEgg.Infrastructure.Tests/Architecture/DesktopBuildContractTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Architecture/DesktopBuildContractTests.cs
@@ -65,7 +65,15 @@ public sealed class DesktopBuildContractTests
                 .Any(static write => (string?)write.Attribute("File") == "$(SalmonEggGeneratedApplicationManifest)"))
             .Single();
 
-        Assert.Equal("'$(SalmonEggGeneratedApplicationManifest)' != ''", (string?)manifestGenerationTarget.Attribute("Condition"));
+        // The condition mirrors MinVer's own skip conditions: a design-time or skipped MinVer would
+        // make the DependsOnTargets reference resolve to a missing target (MSB4057).
+        Assert.Equal(
+            "'$(SalmonEggGeneratedApplicationManifest)' != '' AND '$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'",
+            (string?)manifestGenerationTarget.Attribute("Condition"));
+        // The version substitution needs MinVer's output, and the WindowsAppSDK mt.exe merge consumes
+        // the manifest before BeforeCompile, so the target must pull MinVer in itself rather than
+        // hang off AfterTargets="MinVer" (that hook fires too late on a clean obj).
+        Assert.Equal("MinVer", (string?)manifestGenerationTarget.Attribute("DependsOnTargets"));
     }
 
     private static string LoadText(string relativePath)

--- a/tests/SalmonEgg.Presentation.Core.Tests/Build/WindowsVersioningContractTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Build/WindowsVersioningContractTests.cs
@@ -52,19 +52,24 @@ public sealed class WindowsVersioningContractTests
         Assert.Contains("<PackageReference Include=\"MinVer\" />", projectFile, StringComparison.Ordinal);
 
         // The manifest templates are stamped with $(SalmonEggPackageVersion) at execution time, and
-        // MinVer only fills that value inside its own target. Chaining the generation after MinVer is
-        // what keeps the tag-derived version from being replaced by a pre-MinVer default, so the
-        // ordering is part of the contract, not an implementation detail.
+        // MinVer only fills that value inside its own target. The ordering is part of the contract,
+        // not an implementation detail, so the exact target wiring is pinned below.
         Assert.Contains(
             "<Target Name=\"GenerateVersionedApplicationManifests\"",
             projectFile,
             StringComparison.Ordinal);
-        Assert.Contains("AfterTargets=\"MinVer\"", projectFile, StringComparison.Ordinal);
-        // Both the derive target and this one hang off AfterTargets="MinVer"; MSBuild does not define
-        // the order between two targets on the same hook, so the dependency is what guarantees the
-        // manifest is generated after the tag-derived version exists.
+        // The generated manifest is consumed before BeforeCompile: WindowsAppSDK's mt.exe merge runs
+        // at AssignTargetPaths. Hanging the generation off AfterTargets="MinVer" loses that race on a
+        // clean obj, so the target runs at the pre-resolve consumer point and pulls MinVer in itself.
+        // Depending on MinVer also fires the derive target (which hangs off AfterTargets="MinVer")
+        // before the manifest is written, which is what pins the ordering against
+        // SalmonEggDeriveReleaseIdentity without two targets on the same undefined-order hook.
         Assert.Contains(
-            "DependsOnTargets=\"SalmonEggDeriveReleaseIdentity\"",
+            "BeforeTargets=\"_EnsureAppxManifestExists;ResolveReferences;ResolveProjectReferences;BeforeBuild\"",
+            projectFile,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "DependsOnTargets=\"MinVer\"",
             projectFile,
             StringComparison.Ordinal);
         Assert.Contains(

--- a/tests/SalmonEgg.Presentation.Core.Tests/WasmStartupAssetsTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/WasmStartupAssetsTests.cs
@@ -288,13 +288,11 @@ public sealed class WasmStartupAssetsTests
         Assert.Equal(2, gate.Split("-p:TrimMode=copy", StringSplitOptions.None).Length - 1);
         Assert.DoesNotContain("-p:PublishTrimmed=false", gate, StringComparison.Ordinal);
         Assert.DoesNotContain("-p:MtouchLink=", gate, StringComparison.Ordinal);
-        Assert.Contains("DOTNET_VERSION: \"10.0.3xx\"", gate, StringComparison.Ordinal);
-
         // One per job: linux-desktop, macos-desktop, windows-msix, android, ios. Every job must resolve
-        // the SDK from the shared DOTNET_VERSION rather than pinning its own.
+        // the SDK from global.json -- the file that pins it -- rather than restating a version band.
         Assert.Equal(
             5,
-            gate.Split("dotnet-version: ${{ env.DOTNET_VERSION }}", StringSplitOptions.None).Length - 1);
+            gate.Split("global-json-file: global.json", StringSplitOptions.None).Length - 1);
 
         // The MSIX job is the one place a single TargetFramework is legitimately forced: the WinUI head is
         // built in isolation, exactly as the release workflow does it, because its target cannot be
@@ -304,9 +302,15 @@ public sealed class WasmStartupAssetsTests
             2,
             gate.Split("/p:TargetFramework=net10.0-windows10.0.26100.0", StringSplitOptions.None).Length - 1);
         Assert.Contains("/p:AppxPackageSigningEnabled=false", gate, StringComparison.Ordinal);
-        Assert.DoesNotContain("global-json-file:", gate, StringComparison.Ordinal);
         Assert.Equal(2, gate.Split("dotnet workload list", StringSplitOptions.None).Length - 1);
-        Assert.Equal(2, gate.Split("10.0.3??", StringSplitOptions.None).Length - 1);
+        // The Android/iOS "Verify .NET SDK" steps read the expected version from global.json at run
+        // time and accept only a same-band patch roll-forward, so the check can never drift from the
+        // file that pins the SDK.
+        Assert.Equal(
+            2,
+            gate.Split("expected_version=\"$(python3 -c 'import json; print(json.load(open(\"global.json\"))[\"sdk\"][\"version\"])')\"", StringSplitOptions.None).Length - 1);
+        Assert.DoesNotContain("10.0.3xx", gate, StringComparison.Ordinal);
+        Assert.DoesNotContain("10.0.3??", gate, StringComparison.Ordinal);
         Assert.True(
             gate.IndexOf("Verify Android .NET SDK", StringComparison.Ordinal)
             < gate.IndexOf("Install Android workload", StringComparison.Ordinal));
@@ -358,9 +362,12 @@ public sealed class WasmStartupAssetsTests
         foreach (var workflowPath in workflowPaths)
         {
             var workflow = LoadFile(workflowPath);
-            Assert.Contains("10.0.3xx", workflow, StringComparison.Ordinal);
-            Assert.DoesNotContain("10.0.x", workflow, StringComparison.Ordinal);
-            Assert.DoesNotContain("global-json-file:", workflow, StringComparison.Ordinal);
+            // The single source of truth for the SDK version is global.json: workflows hand that
+            // file to setup-dotnet instead of restating a version band here, where it would drift
+            // from the pin.
+            Assert.Contains("global-json-file: global.json", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("10.0.3xx", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("dotnet-version:", workflow, StringComparison.Ordinal);
         }
 
         foreach (var gate in new[] { wasmSmokeGate, linuxGamepadGate })


### PR DESCRIPTION
Fixes #131, fixes #132, fixes #133.

## What was actually wrong

The issue triage had two root causes wrong; every claim below is verified against run logs.

**#132 (mt.exe c1010070) is not environment drift.** Timeline check:
- `2c96089a` CI Core "red" was the **Test step timing out after 20 minutes** — an unrelated flake; its Platform Build Gates run (33238124638) was green.
- The mt.exe failure starts at `f4b14c27` (the MinVer commit): runs 33243697184 / 33243697206.

Real mechanism: the MinVer migration moved `GenerateVersionedApplicationManifests` to `AfterTargets="MinVer"`, but WindowsAppSDK's `CreateWinRTRegistration` merges the generated manifest with mt.exe `BeforeTargets="AssignTargetPaths"` — a stage that runs *before* `BeforeCompile`, where the MinVer hook fires. On a clean CI obj the manifest did not exist yet. Local builds were masked by a stale generated manifest plus the target's `Outputs="$(ApplicationManifest)"` up-to-date check.

**#131 (ACP pack 0.0.0-alpha.0)**: the CI checkout is shallow, so MinVer sees no `acp-sdk-v*` tag; and `ACP_PACKAGE_BASELINE_VERSION` did not exist as a repository variable at all, so the release workflow's `vars` wiring was silently empty too.

## Fixes

1. **#132** (`b215db77`): hang `GenerateVersionedApplicationManifests` back at the pre-resolve consumer point (`BeforeTargets="…BeforeBuild"`) and pull MinVer in via `DependsOnTargets="MinVer"` — the dependency triggers the AfterTargets derive target first (order pinned) and MinVer's own version cache makes the later BeforeCompile hook a no-op. The condition mirrors MinVer's skip conditions so design-time builds never resolve a missing DependsOnTargets (fail-closed MSB4057 instead of the silent AfterTargets ignore).
2. **#131** (`40d3eb3a`): `fetch-depth: 0` on the CI checkout; the gate script now reads the baseline from `vars.ACP_PACKAGE_BASELINE_VERSION` (repository variable created = `1.0.0`), matching the release workflow. The csproj guard gains a distinct `0.0.0` sentinel error ("checkout is shallow") instead of the misleading past-release message, and a placeholder version fails even if a baseline was supplied.
3. **#133** (`9d910bb0`): all 22 setup-dotnet steps switch from the `"10.0.3xx"` wildcard to `global-json-file: global.json`; the two platform-gate shell assertions read the expected version out of global.json at run time instead of hardcoding the wildcard.

## Verification

- #132: clean-obj Linux desktop full build regenerates `obj/generated/desktop/app.manifest` with the MinVer-derived version, no placeholder left.
- #131: full gate script locally green — 336 tests, pack `1.0.1-alpha.0.45`, package validation against the 1.0.0 baseline.
- #133: all 9 workflow YAMLs parse; assertion logic tested locally against global.json (`10.0.302`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)