### PR TITLE
Fix four defects in the ACP wizard's dependency install path

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -534,7 +534,12 @@
                             </Expander>
                         </StackPanel>
 
-                        <!-- Busy feedback shared by every long operation. -->
+                        <!-- Busy feedback shared by every long operation, with the way out beside it.
+
+                             Cancel sits here rather than next to each install button because the operation
+                             it stops is shared: whichever entry point started it, this is where the user is
+                             already looking. It is enabled only while something runs, which is the same
+                             condition that reveals this panel. -->
                         <StackPanel Orientation="Horizontal" Spacing="8"
                                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                             <ProgressRing IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}"
@@ -543,6 +548,10 @@
                             <TextBlock x:Uid="AcpSetup_Working"
                                        VerticalAlignment="Center"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <Button x:Name="AcpSetupCancelOperationButton"
+                                    x:Uid="AcpSetup_CancelOperation"
+                                    Command="{x:Bind ViewModel.CancelOperationCommand}"
+                                    AutomationProperties.AutomationId="AcpSetup.CancelOperation"/>
                         </StackPanel>
 
                         <!-- ── Wizard navigation bar ───────────────────────── -->

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -376,42 +376,6 @@
                                       DisplayMemberPath="Component.DisplayName"
                                       MinWidth="280"
                                       HorizontalAlignment="Left"/>
-                            <!-- Installer progress. The latest line stays visible while it runs; the
-                                 full log is one disclosure away because it only matters on failure. -->
-                            <StackPanel Spacing="8"
-                                        Visibility="{x:Bind ViewModel.HasInstallOutput, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                                <TextBlock x:Name="AcpSetupInstallOutputLatest"
-                                           Text="{x:Bind ViewModel.LatestInstallOutputLine, Mode=OneWay}"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           FontFamily="Consolas"
-                                           TextWrapping="NoWrap"
-                                           TextTrimming="CharacterEllipsis"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           AutomationProperties.AutomationId="AcpSetup.Install.LatestLine"/>
-                                <Expander x:Name="AcpSetupInstallOutputExpander"
-                                          IsExpanded="False"
-                                          HorizontalAlignment="Stretch"
-                                          HorizontalContentAlignment="Stretch">
-                                    <Expander.Header>
-                                        <TextBlock x:Uid="AcpSetup_InstallOutputToggle"/>
-                                    </Expander.Header>
-                                    <ListView x:Name="AcpSetupInstallOutputList"
-                                              ItemsSource="{x:Bind ViewModel.InstallOutput}"
-                                              SelectionMode="None"
-                                              MaxHeight="200"
-                                              AutomationProperties.AutomationId="AcpSetup.Install.Output">
-                                        <ListView.ItemTemplate>
-                                            <DataTemplate x:DataType="x:String">
-                                                <TextBlock Text="{x:Bind}"
-                                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                                           FontFamily="Consolas"
-                                                           IsTextSelectionEnabled="True"
-                                                           TextWrapping="Wrap"/>
-                                            </DataTemplate>
-                                        </ListView.ItemTemplate>
-                                    </ListView>
-                                </Expander>
-                            </StackPanel>
                         </StackPanel>
 
                         <!-- ── Step 3: launch parameters ───────────────────── -->
@@ -522,6 +486,52 @@
                                      IsOpen="{x:Bind ViewModel.HasSavedProfile, Mode=OneWay}"
                                      Severity="Success"
                                      IsClosable="False"/>
+                        </StackPanel>
+
+                        <!-- Installer progress, shared by every install entry point.
+
+                             Sits at this level rather than inside a step panel because installs start
+                             from two places: the agent row's inline button on step 1, and the adapter
+                             button on step 2. Nested inside step 2, a row install on step 1 showed only
+                             the shared spinner — the output was being produced into a subtree that step
+                             was not rendering.
+
+                             The latest line stays visible while it runs; the full log is one disclosure
+                             away because it only matters on failure. HasInstallOutput keeps the whole
+                             panel absent until an install has actually produced something. -->
+                        <StackPanel Spacing="8"
+                                    Visibility="{x:Bind ViewModel.HasInstallOutput, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <TextBlock x:Name="AcpSetupInstallOutputLatest"
+                                       Text="{x:Bind ViewModel.LatestInstallOutputLine, Mode=OneWay}"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       FontFamily="Consolas"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       AutomationProperties.AutomationId="AcpSetup.Install.LatestLine"/>
+                            <Expander x:Name="AcpSetupInstallOutputExpander"
+                                      IsExpanded="False"
+                                      HorizontalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch">
+                                <Expander.Header>
+                                    <TextBlock x:Uid="AcpSetup_InstallOutputToggle"/>
+                                </Expander.Header>
+                                <ListView x:Name="AcpSetupInstallOutputList"
+                                          ItemsSource="{x:Bind ViewModel.InstallOutput}"
+                                          SelectionMode="None"
+                                          MaxHeight="200"
+                                          AutomationProperties.AutomationId="AcpSetup.Install.Output">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="x:String">
+                                            <TextBlock Text="{x:Bind}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       FontFamily="Consolas"
+                                                       IsTextSelectionEnabled="True"
+                                                       TextWrapping="Wrap"/>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Expander>
                         </StackPanel>
 
                         <!-- Busy feedback shared by every long operation. -->

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -906,6 +906,9 @@
   <data name="AcpSetup_Working.Text" xml:space="preserve">
     <value>Working, please wait…</value>
   </data>
+  <data name="AcpSetup_CancelOperation.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
     <value>Installed</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1437,6 +1437,9 @@
   <data name="AcpSetup_Working.Text" xml:space="preserve">
     <value>Working, please wait…</value>
   </data>
+  <data name="AcpSetup_CancelOperation.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
     <value>Installed</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -831,6 +831,9 @@
   <data name="AcpSetup_Working.Text" xml:space="preserve">
     <value>正在处理，请稍候…</value>
   </data>
+  <data name="AcpSetup_CancelOperation.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="AcpSetup_StatusInstalled.AutomationProperties.Name" xml:space="preserve">
     <value>已安装</value>
   </data>

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpComponentDetector.cs
@@ -22,6 +22,16 @@ public sealed class AcpComponentDetector
         _probe = probe ?? throw new ArgumentNullException(nameof(probe));
     }
 
+    /// <summary>
+    /// Makes the next detection look at the machine again rather than answer from a cached search.
+    /// </summary>
+    /// <remarks>
+    /// Routed through here because this type owns the probe. A caller that re-detects on the user's request
+    /// is asserting the machine may have changed — which is exactly what happens after the wizard's own
+    /// "install the toolchain, then detect again" advice is followed.
+    /// </remarks>
+    public void InvalidateSearchPaths() => _probe.InvalidateSearchPaths();
+
     /// <param name="overrides">
     /// User-supplied paths for commands the catalog names by executable name. Applied here so a probe
     /// answers about the executable the launch plan will actually run; see

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -99,6 +99,16 @@ public sealed class AcpSetupWizardOrchestrator
         => _detector.DetectToolchainAsync(component, overrides, cancellationToken);
 
     /// <summary>
+    /// Makes the next detection search the machine again instead of answering from a cached search.
+    /// </summary>
+    /// <remarks>
+    /// For callers re-detecting because the user asked. A search is cached to keep the wizard from spawning
+    /// a login shell per component, which means the answer outlives whatever the user did in between — and
+    /// what the wizard asks them to do is install the missing toolchain and detect again.
+    /// </remarks>
+    public void InvalidateSearchPaths() => _detector.InvalidateSearchPaths();
+
+    /// <summary>
     /// Installs a component and re-probes it, so callers always see verified availability rather than
     /// trusting the installer's exit code.
     /// </summary>
@@ -115,6 +125,13 @@ public sealed class AcpSetupWizardOrchestrator
         var install = await _installer
             .InstallAsync(component, onOutput, overrides, cancellationToken)
             .ConfigureAwait(false);
+
+        // An install is the one moment this layer knows the machine changed, so the re-probe below must not
+        // reuse the search that was current before it. A package manager places a new executable in its own
+        // bin directory, and a first install through a manager can create that directory outright — which a
+        // cached directory list cannot contain.
+        _detector.InvalidateSearchPaths();
+
         var probe = await _detector
             .DetectAsync(component, overrides, cancellationToken)
             .ConfigureAwait(false);

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpExecutableProbe.cs
@@ -29,6 +29,20 @@ public interface IAcpExecutableProbe
     Task<string?> ResolveExecutablePathAsync(string command, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Discards anything this probe cached about where executables live, so the next resolution looks at
+    /// the machine again.
+    /// </summary>
+    /// <remarks>
+    /// Exposed because the wizard's own advice creates the stale state: it tells a user to install a
+    /// toolchain and then detect again, and a probe that answered from before the install reports the
+    /// toolchain still missing. Only the caller knows that the machine may have changed between two probes,
+    /// so the decision to re-look belongs here rather than to a heuristic inside an implementation.
+    ///
+    /// Idempotent, and a no-op on a probe that caches nothing.
+    /// </remarks>
+    void InvalidateSearchPaths();
+
+    /// <summary>
     /// Resolves every distinct executable <paramref name="command"/> matches, in PATH precedence order.
     /// </summary>
     /// <remarks>

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSearchPathSource.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpSearchPathSource.cs
@@ -35,6 +35,23 @@ public interface IAcpSearchPathSource
     /// Empty rather than throwing when this source has nothing to contribute or could not answer. A
     /// source that fails must not deny the search the directories other sources found, and must never
     /// prevent the inherited PATH from being used.
+    ///
+    /// A source may cache its answer, and both shipped ones do — one spawns a login shell, the other walks
+    /// the filesystem, and the wizard probes many components. Callers must therefore treat a repeat call as
+    /// possibly answering from before, and use <see cref="Invalidate"/> when the machine may have changed.
     /// </remarks>
     Task<IReadOnlyList<string>> GetSearchDirectoriesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Discards any cached answer, so the next call looks at the machine again.
+    /// </summary>
+    /// <remarks>
+    /// Part of the seam rather than an implementation detail, because caching is only defensible with a way
+    /// out of it. The wizard's own flow ends in "install the toolchain, then detect again": without this,
+    /// the answer captured before the install is the one every later probe sees, and a user who did exactly
+    /// what the wizard asked is told the toolchain is still missing until they restart the app.
+    ///
+    /// Idempotent and safe on a source that caches nothing, so callers need not know which do.
+    /// </remarks>
+    void Invalidate();
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpExecutableProbe.cs
@@ -36,6 +36,18 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
 
     public bool SupportsProcessProbing => true;
 
+    /// <summary>
+    /// Forwards invalidation to every source. The inherited PATH is re-read on each resolution already, so
+    /// the sources hold the only cached state there is.
+    /// </summary>
+    public void InvalidateSearchPaths()
+    {
+        foreach (var source in _searchPathSources)
+        {
+            source.Invalidate();
+        }
+    }
+
     public async Task<string?> ResolveExecutablePathAsync(
         string command,
         CancellationToken cancellationToken = default)
@@ -103,6 +115,14 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
         return directories;
     }
 
+    /// <summary>
+    /// Runs the command's version arguments and returns the first line it printed.
+    /// </summary>
+    /// <remarks>
+    /// Resolved through the widened search, the same way detection resolves it. Anything narrower reads a
+    /// version for a command the sources found only when PATH could have found it too — so a component
+    /// living in a version-manager directory showed as installed with no version beside it.
+    /// </remarks>
     public async Task<string?> ReadVersionAsync(
         string command,
         IReadOnlyList<string> versionArguments,
@@ -113,7 +133,8 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
             return null;
         }
 
-        var executable = ResolveExecutablePath(command);
+        var executable = await ResolveExecutablePathAsync(command, cancellationToken)
+            .ConfigureAwait(false);
         if (executable is null)
         {
             return null;
@@ -137,6 +158,12 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
     /// never a manager's answer: a manager that ran and said "no" has answered for the toolchain the
     /// caller chose, and trying the next candidate would replace that answer with one about a different
     /// toolchain.
+    ///
+    /// Each candidate is resolved through the widened search, not the inherited PATH: the sources exist
+    /// because a GUI process cannot see a version manager's directories, and a manager reachable only
+    /// through them is the ordinary case on such a machine. Resolving here against PATH alone reported
+    /// <see cref="AcpPackageQueryResult.Unknown()"/> with no executable named, so every package-detected
+    /// component came back undetermined with nothing on screen naming the cause.
     /// </remarks>
     public async Task<AcpPackageQueryResult> LocateGlobalPackageAsync(
         AcpDistributionKind distribution,
@@ -154,7 +181,9 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
         foreach (var candidate in packageManager.Commands)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (ResolveExecutablePath(candidate) is { } executable)
+            var executable = await ResolveExecutablePathAsync(candidate, cancellationToken)
+                .ConfigureAwait(false);
+            if (executable is not null)
             {
                 return await QueryPackageListAsync(executable, arguments, packageId, cancellationToken)
                     .ConfigureAwait(false);
@@ -337,37 +366,6 @@ public sealed class DesktopAcpExecutableProbe : IAcpExecutableProbe
         }
 
         return candidates;
-    }
-
-    /// <summary>
-    /// Resolves <paramref name="command"/> against the inherited PATH only.
-    /// </summary>
-    /// <remarks>
-    /// Used by the paths that run a process they have already decided on. It stays synchronous and
-    /// PATH-only because those callers were handed a command that a source already resolved, or a bare name
-    /// whose own resolution is the caller's question rather than this method's.
-    /// </remarks>
-    private static string? ResolveExecutablePath(string command)
-    {
-        if (string.IsNullOrWhiteSpace(command))
-        {
-            return null;
-        }
-
-        var trimmed = command.Trim();
-        if (trimmed.IndexOfAny(new[] { '/', '\\' }) >= 0)
-        {
-            return File.Exists(trimmed) ? Path.GetFullPath(trimmed) : null;
-        }
-
-        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        var directories = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
-            .Split(
-                isWindows ? ';' : ':',
-                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        var candidates = FindCandidates(trimmed, directories);
-        return candidates.Count == 0 ? null : candidates[0];
     }
 
     /// <summary>

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/LoginShellSearchPathSource.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/LoginShellSearchPathSource.cs
@@ -18,7 +18,9 @@ namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 ///
 /// Captured once and reused. A capture spawns an interactive login shell, which runs the user's startup
 /// files and routinely takes seconds; repeating that per probe would multiply the cost across every
-/// component the wizard inspects, for an answer that does not change while the app runs.
+/// component the wizard inspects. The capture is dropped on <see cref="Invalidate"/> rather than held for
+/// the process lifetime, because a toolchain installer edits the very startup files this reads — so after
+/// the user installs one, the cached answer is the one thing guaranteed not to mention it.
 /// </remarks>
 public sealed class LoginShellSearchPathSource : IAcpSearchPathSource
 {
@@ -26,7 +28,7 @@ public sealed class LoginShellSearchPathSource : IAcpSearchPathSource
     private readonly Func<string, string> _printEnvironmentCommand;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    private IReadOnlyList<string>? _cached;
+    private volatile IReadOnlyList<string>? _cached;
 
     /// <param name="printEnvironmentCommand">
     /// Builds a shell-ready command that prints the environment wrapped in the supplied marker.
@@ -62,14 +64,28 @@ public sealed class LoginShellSearchPathSource : IAcpSearchPathSource
                 return existing;
             }
 
-            _cached = await CaptureDirectoriesAsync(cancellationToken).ConfigureAwait(false);
-            return _cached;
+            // Returned from the local rather than by re-reading the field, for the same reason the scan
+            // source does: an Invalidate landing between the two would make this return null, which callers
+            // are promised never happens.
+            var captured = await CaptureDirectoriesAsync(cancellationToken).ConfigureAwait(false);
+            _cached = captured;
+            return captured;
         }
         finally
         {
             _gate.Release();
         }
     }
+
+    /// <summary>
+    /// Drops the captured environment, so the next call starts a fresh login shell.
+    /// </summary>
+    /// <remarks>
+    /// Cleared without taking the gate, for the same reason the scan source does: a capture in flight
+    /// overwrites this with a reading of the shell as it was during that call, and waiting on the gate would
+    /// block invalidation behind the capture it means to replace.
+    /// </remarks>
+    public void Invalidate() => _cached = null;
 
     private async Task<IReadOnlyList<string>> CaptureDirectoriesAsync(CancellationToken cancellationToken)
     {

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
@@ -28,7 +28,7 @@ public sealed class ToolchainScanSearchPathSource : IAcpSearchPathSource
     private readonly IReadOnlyList<AcpToolchainLayout> _layouts;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    private IReadOnlyList<string>? _cached;
+    private volatile IReadOnlyList<string>? _cached;
 
     public ToolchainScanSearchPathSource(IReadOnlyList<AcpToolchainLayout>? layouts = null)
     {
@@ -51,14 +51,27 @@ public sealed class ToolchainScanSearchPathSource : IAcpSearchPathSource
                 return existing;
             }
 
-            _cached = Scan(cancellationToken);
-            return _cached;
+            // Returned from the local rather than by re-reading the field: an Invalidate arriving between the
+            // two would otherwise make this return null, which callers are promised never happens.
+            var scanned = Scan(cancellationToken);
+            _cached = scanned;
+            return scanned;
         }
         finally
         {
             _gate.Release();
         }
     }
+
+    /// <summary>
+    /// Drops the scan, so the next call walks the filesystem again.
+    /// </summary>
+    /// <remarks>
+    /// Cleared without taking the gate: a scan already in flight will overwrite this with its own result,
+    /// which is a scan of the machine as it was during that call rather than a stale one, and taking the
+    /// gate would make invalidation wait on the very scan it wants replaced.
+    /// </remarks>
+    public void Invalidate() => _cached = null;
 
     /// <summary>
     /// Expands every layout to the directories that exist, in layout order.

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpExecutableProbe.cs
@@ -19,6 +19,11 @@ public sealed class UnsupportedAcpExecutableProbe : IAcpExecutableProbe
 {
     public bool SupportsProcessProbing => false;
 
+    /// <summary>Nothing was ever searched for, so there is nothing to discard.</summary>
+    public void InvalidateSearchPaths()
+    {
+    }
+
     public Task<string?> ResolveExecutablePathAsync(
         string command,
         CancellationToken cancellationToken = default)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -68,14 +68,21 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     public ObservableCollection<AcpSetupParameterRowViewModel> Parameters { get; } = new();
 
     /// <summary>
-    /// Live installer output, capped so a chatty installer cannot grow without bound.
+    /// Live output of the install currently running or last run, capped so a chatty installer cannot grow
+    /// without bound.
     /// </summary>
     /// <remarks>
+    /// One collection for every install entry point, because the surface showing it is shared: a runtime
+    /// install starts from an agent row on the selection step and an adapter install from the component
+    /// step, and both are watched in the same place. Each install therefore clears this before it begins,
+    /// so the log on screen always belongs to the component named beside it.
+    ///
     /// <see cref="LatestInstallOutputLine"/> and <see cref="HasInstallOutput"/> are computed from this
     /// collection, and a collection's own change notifications say nothing about properties derived from
     /// it. Every mutation therefore goes through <see cref="AppendInstallOutput"/> or
-    /// <see cref="ResetInstallOutput"/>, which raise those two — mutating this collection directly
-    /// leaves the surface bound to a stale value.
+    /// <see cref="ResetInstallOutput"/>, which raise those two and marshal to the UI thread — mutating this
+    /// collection directly leaves the surface bound to a stale value, and does so from whichever thread the
+    /// caller happened to be on.
     /// </remarks>
     public ObservableCollection<string> InstallOutput { get; } = new();
 
@@ -376,12 +383,22 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     // ── Detection ───────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Probes every catalog agent, searching the machine afresh.
+    /// </summary>
+    /// <remarks>
+    /// The search is invalidated first because this command is the button the wizard points a user at after
+    /// telling them to install a missing toolchain. Reusing the cached search would answer about the machine
+    /// as it was before they did so, and report the toolchain still absent no matter how many times they
+    /// pressed it.
+    /// </remarks>
     [RelayCommand(CanExecute = nameof(CanRunOperation))]
     private async Task DetectAgentsAsync(CancellationToken cancellationToken)
     {
         await RunOperationAsync(
             async token =>
             {
+                _orchestrator.InvalidateSearchPaths();
                 MarkAgentsChecking();
                 var states = await _orchestrator
                     .DetectAgentsAsync(CollectCommandOverrides(), token)
@@ -428,6 +445,10 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         await RunOperationAsync(
             async token =>
             {
+                // Same reason as DetectAgentsAsync: this command backs the "detect again" button the
+                // toolchain-missing surface offers, so it must look at the machine rather than at the
+                // search that was current when the wizard first said the toolchain was absent.
+                _orchestrator.InvalidateSearchPaths();
                 var overrides = CollectCommandOverrides();
                 var probe = await _orchestrator
                     .DetectComponentAsync(adapter.Component, overrides, token)
@@ -484,6 +505,12 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             return;
         }
 
+        // Each install starts from its own log. The output surface is shared by every install entry point,
+        // so without this a row install would open showing the lines a previous component produced,
+        // attributed to this one. Cleared before the operation starts so the panel is empty for the whole of
+        // it, rather than showing the previous log until the first line of this one arrives.
+        ResetInstallOutput();
+
         _ = RunOperationAsync(
             async token =>
             {
@@ -519,6 +546,9 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         {
             return;
         }
+
+        // Same reason as the row install: one shared surface, so each install starts from its own log.
+        ResetInstallOutput();
 
         await RunOperationAsync(
             async token =>
@@ -953,11 +983,23 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         });
     }
 
-    /// <summary>Clears installer output so a new component's install does not inherit the last one's.</summary>
+    /// <summary>
+    /// Clears installer output so a new component's install does not inherit the last one's.
+    /// </summary>
+    /// <remarks>
+    /// Marshalled like <see cref="AppendInstallOutput"/> rather than mutating the collection directly. This
+    /// collection is bound to a list, so a change raised off the UI thread is a crash on WinUI rather than a
+    /// glitch — and the callers are no longer all on that thread now that both install entry points clear
+    /// before starting. Routing it here means the guarantee holds wherever it is called from, instead of
+    /// resting on each call site sitting in the right place.
+    /// </remarks>
     private void ResetInstallOutput()
     {
-        InstallOutput.Clear();
-        NotifyInstallOutputChanged();
+        _uiDispatcher.Enqueue(() =>
+        {
+            InstallOutput.Clear();
+            NotifyInstallOutputChanged();
+        });
     }
 
     private void NotifyInstallOutputChanged()

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -107,6 +107,9 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
     [NotifyCanExecuteChangedFor(nameof(TestCommand))]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    // Cancel is the one command enabled *by* being busy, so it tracks the same flag in the opposite
+    // direction rather than needing a signal of its own.
+    [NotifyCanExecuteChangedFor(nameof(CancelOperationCommand))]
     private bool _isBusy;
 
     [ObservableProperty]
@@ -1038,6 +1041,39 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     private bool CanRunOperation() => !IsBusy;
 
     /// <summary>
+    /// Asks the running operation to stop.
+    /// </summary>
+    /// <remarks>
+    /// Needed most by installs, which are the wizard's one genuinely long operation: a package manager
+    /// fetching over a slow network can sit for minutes, and the guard against that hanging forever is a
+    /// ten-minute timeout. Without a way out, a user who started the wrong install, or whose network
+    /// stalled, could only wait it out or kill the app.
+    ///
+    /// Cancelling is not the same as undoing. The package manager is killed with its process tree, which
+    /// leaves whatever it had already written on disk — so the re-probe after the operation is what says
+    /// where the component actually stands, exactly as it does for an install that ran to completion.
+    ///
+    /// Placed on the shared operation scope rather than per command because one entry point has no command
+    /// to cancel: an agent row raises an event, so a per-command token would leave the row's install — the
+    /// most likely one to need stopping — the only one that could not be.
+    ///
+    /// A no-op once the operation has released its cancellation source, which is briefly true while the busy
+    /// flag is still on its way to the UI thread. Doing nothing is the right answer there: the work being
+    /// cancelled has already finished.
+    /// </remarks>
+    [RelayCommand(CanExecute = nameof(IsBusy))]
+    private void CancelOperation() => _operationCancellation?.Cancel();
+
+    /// <summary>
+    /// Cancellation source for the operation in flight, or null when none is running.
+    /// </summary>
+    /// <remarks>
+    /// Single because <see cref="RunOperationAsync"/> admits one operation at a time; the busy flag it
+    /// checks is what makes that true.
+    /// </remarks>
+    private CancellationTokenSource? _operationCancellation;
+
+    /// <summary>
     /// Runs one wizard operation with the shared busy flag and failure surface, so no command has to
     /// re-implement that bookkeeping and none can leave the wizard stuck busy.
     /// </summary>
@@ -1050,11 +1086,15 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             return;
         }
 
+        // Linked so both routes into cancellation work: the caller's own token — a command's token, or
+        // CancellationToken.None from an event-raised install — and the user pressing cancel.
+        var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _operationCancellation = cancellation;
         IsBusy = true;
         ErrorMessage = string.Empty;
         try
         {
-            await operation(cancellationToken).ConfigureAwait(false);
+            await operation(cancellation.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -1069,7 +1109,15 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         }
         finally
         {
+            // Released before it is disposed, and disposed only after the busy flag has been cleared.
+            // The flag is marshalled to the UI thread, so it lands after this method has moved on: that
+            // leaves a window where the button is still enabled with nothing left to cancel. Clearing the
+            // field first makes a click in that window a no-op — the alternative order leaves the field
+            // pointing at a disposed source, where Cancel throws ObjectDisposedException inside a command
+            // handler.
+            _operationCancellation = null;
             await _uiDispatcher.EnqueueAsync(() => IsBusy = false).ConfigureAwait(false);
+            cancellation.Dispose();
         }
     }
 

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpPackageManagerOverrideTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpPackageManagerOverrideTests.cs
@@ -134,6 +134,10 @@ public sealed class AcpPackageManagerOverrideTests
 
         public bool SupportsProcessProbing => true;
 
+        public void InvalidateSearchPaths() => InvalidateCount++;
+
+        public int InvalidateCount { get; private set; }
+
         public Task<string?> ResolveExecutablePathAsync(
             string command,
             CancellationToken cancellationToken = default)

--- a/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpToolchainDetectionTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/AcpSetup/AcpToolchainDetectionTests.cs
@@ -242,6 +242,11 @@ public sealed class AcpToolchainDetectionTests
 
         public bool SupportsProcessProbing { get; set; } = true;
 
+        /// <summary>How many times a caller asked for the search to be redone.</summary>
+        public int InvalidateCount { get; private set; }
+
+        public void InvalidateSearchPaths() => InvalidateCount++;
+
         public List<string> ResolvedCommands { get; } = new();
 
         public void SetExecutable(string command, string? path) => _paths[command] = path;

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSetupTestDoubles.cs
@@ -19,6 +19,11 @@ internal sealed class StubAcpExecutableProbe : IAcpExecutableProbe
 
     public bool SupportsProcessProbing { get; init; } = true;
 
+    /// <summary>How many times a caller asked for the search to be redone.</summary>
+    public int InvalidateCount { get; private set; }
+
+    public void InvalidateSearchPaths() => InvalidateCount++;
+
     public List<string> ResolveRequests { get; } = new();
 
     public void SetResolvedPath(string command, string? path) => _resolvedPaths[command] = path;

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
@@ -278,7 +278,7 @@ public sealed class DesktopAcpExecutableProbeTests
     [Fact]
     public async Task ReadVersionAsync_ForCommandOnlyASourceCanSee_ShouldReadTheVersion()
     {
-        using var toolchain = ExecutableFixture.Create("#!/bin/sh\necho 9.9.9\n");
+        using var toolchain = ExecutableFixture.Printing("9.9.9");
 
         var version = await new DesktopAcpExecutableProbe(new[] { toolchain.Source })
             .ReadVersionAsync(toolchain.Command, new[] { "--version" }, TestContext.Current.CancellationToken);
@@ -293,7 +293,7 @@ public sealed class DesktopAcpExecutableProbeTests
     [Fact]
     public async Task ReadVersionAsync_ForTheSameCommandWithoutTheSource_ShouldReturnNull()
     {
-        using var toolchain = ExecutableFixture.Create("#!/bin/sh\necho 9.9.9\n");
+        using var toolchain = ExecutableFixture.Printing("9.9.9");
 
         var version = await new DesktopAcpExecutableProbe()
             .ReadVersionAsync(toolchain.Command, new[] { "--version" }, TestContext.Current.CancellationToken);
@@ -313,8 +313,7 @@ public sealed class DesktopAcpExecutableProbeTests
     [Fact]
     public async Task LocateGlobalPackageAsync_ForManagerOnlyASourceCanSee_ShouldQueryIt()
     {
-        using var manager = ExecutableFixture.Create(
-            "#!/bin/sh\necho /fake/lib/node_modules/probe-pkg\n");
+        using var manager = ExecutableFixture.Printing("/fake/lib/node_modules/probe-pkg");
 
         var result = await new DesktopAcpExecutableProbe(new[] { manager.Source }).LocateGlobalPackageAsync(
             AcpDistributionKind.Npx,
@@ -332,8 +331,7 @@ public sealed class DesktopAcpExecutableProbeTests
     [Fact]
     public async Task LocateGlobalPackageAsync_ForTheSameManagerWithoutTheSource_ShouldReturnUnknown()
     {
-        using var manager = ExecutableFixture.Create(
-            "#!/bin/sh\necho /fake/lib/node_modules/probe-pkg\n");
+        using var manager = ExecutableFixture.Printing("/fake/lib/node_modules/probe-pkg");
 
         var result = await new DesktopAcpExecutableProbe().LocateGlobalPackageAsync(
             AcpDistributionKind.Npx,

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
@@ -266,6 +266,85 @@ public sealed class DesktopAcpExecutableProbeTests
         Assert.Equal(expectedMatch, location is not null);
     }
 
+    /// <summary>
+    /// A version read must search the same directories a resolution does.
+    /// </summary>
+    /// <remarks>
+    /// The widened search is this feature's whole reason for existing: a GUI process cannot see the PATH a
+    /// shell profile builds, so a version-manager toolchain is reachable only through the sources. A version
+    /// read that consulted the inherited PATH alone therefore failed on exactly the machines the sources were
+    /// added for, and the row showed a component as installed with no version beside it.
+    /// </remarks>
+    [Fact]
+    public async Task ReadVersionAsync_ForCommandOnlyASourceCanSee_ShouldReadTheVersion()
+    {
+        using var toolchain = ExecutableFixture.Create("#!/bin/sh\necho 9.9.9\n");
+
+        var version = await new DesktopAcpExecutableProbe(new[] { toolchain.Source })
+            .ReadVersionAsync(toolchain.Command, new[] { "--version" }, TestContext.Current.CancellationToken);
+
+        Assert.Equal("9.9.9", version);
+    }
+
+    /// <summary>
+    /// Reverse verification: without the source, the same command is unreachable — so the test above
+    /// passes because of the widened search rather than because the command happened to be on PATH.
+    /// </summary>
+    [Fact]
+    public async Task ReadVersionAsync_ForTheSameCommandWithoutTheSource_ShouldReturnNull()
+    {
+        using var toolchain = ExecutableFixture.Create("#!/bin/sh\necho 9.9.9\n");
+
+        var version = await new DesktopAcpExecutableProbe()
+            .ReadVersionAsync(toolchain.Command, new[] { "--version" }, TestContext.Current.CancellationToken);
+
+        Assert.Null(version);
+    }
+
+    /// <summary>
+    /// A package query must reach a manager only a source can see, for the same reason.
+    /// </summary>
+    /// <remarks>
+    /// This failure was worse than the version one: the query reported <c>Unknown</c> with no executable
+    /// named, which the wizard renders as "could not determine". A user whose npm lives in an nvm directory
+    /// therefore got an undetermined verdict for every package-detected component, with nothing on screen
+    /// pointing at the cause.
+    /// </remarks>
+    [Fact]
+    public async Task LocateGlobalPackageAsync_ForManagerOnlyASourceCanSee_ShouldQueryIt()
+    {
+        using var manager = ExecutableFixture.Create(
+            "#!/bin/sh\necho /fake/lib/node_modules/probe-pkg\n");
+
+        var result = await new DesktopAcpExecutableProbe(new[] { manager.Source }).LocateGlobalPackageAsync(
+            AcpDistributionKind.Npx,
+            "probe-pkg",
+            AcpPackageManagerCandidates.Exact(manager.Command),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsInstalled);
+        Assert.Equal(manager.Path, result.QueryExecutablePath);
+    }
+
+    /// <summary>
+    /// Reverse verification for the query: the same manager is unreachable without the source.
+    /// </summary>
+    [Fact]
+    public async Task LocateGlobalPackageAsync_ForTheSameManagerWithoutTheSource_ShouldReturnUnknown()
+    {
+        using var manager = ExecutableFixture.Create(
+            "#!/bin/sh\necho /fake/lib/node_modules/probe-pkg\n");
+
+        var result = await new DesktopAcpExecutableProbe().LocateGlobalPackageAsync(
+            AcpDistributionKind.Npx,
+            "probe-pkg",
+            AcpPackageManagerCandidates.Exact(manager.Command),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result.IsInstalled);
+        Assert.Null(result.QueryExecutablePath);
+    }
+
     [Fact]
     public void FindPackageLocation_ReturnsTheMatchedPath_SoTheToolchainCanBeNamed()
     {

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/DesktopAcpExecutableProbeTests.cs
@@ -322,7 +322,13 @@ public sealed class DesktopAcpExecutableProbeTests
             TestContext.Current.CancellationToken);
 
         Assert.True(result.IsInstalled);
-        Assert.Equal(manager.Path, result.QueryExecutablePath);
+        // Compared the way this platform compares file names. On Windows the probe appends an extension from
+        // PATHEXT, which is conventionally upper case, so the path it reports differs in case from the one on
+        // disk while naming the same file.
+        Assert.Equal(
+            manager.Path,
+            result.QueryExecutablePath,
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
     }
 
     /// <summary>

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ExecutableFixture.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ExecutableFixture.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>
+/// A real executable in a directory that only an <see cref="IAcpSearchPathSource"/> reports, so a test can
+/// tell "the probe consulted the sources" apart from "the command happened to be on PATH".
+/// </summary>
+/// <remarks>
+/// A real file rather than a stubbed probe: the behaviour under test is how this probe resolves and starts a
+/// command, which a stub would replace rather than exercise. The command name carries a GUID so nothing the
+/// host machine has installed can answer for it — which is what makes the paired negative tests meaningful.
+/// </remarks>
+internal sealed class ExecutableFixture : IDisposable
+{
+    private readonly string _root;
+
+    private ExecutableFixture(string root, string command, string path)
+    {
+        _root = root;
+        Command = command;
+        Path = path;
+        Source = new FixedSearchPathSource(System.IO.Path.GetDirectoryName(path)!);
+    }
+
+    /// <summary>The bare name to ask the probe for. Unique per fixture.</summary>
+    public string Command { get; }
+
+    /// <summary>Absolute path of the executable, for asserting which one answered.</summary>
+    public string Path { get; }
+
+    /// <summary>A source reporting the executable's directory, and nothing else.</summary>
+    public IAcpSearchPathSource Source { get; }
+
+    /// <summary>
+    /// Writes an executable script whose body is <paramref name="body"/>.
+    /// </summary>
+    public static ExecutableFixture Create(string body)
+    {
+        var root = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "acp-fixture-" + Guid.NewGuid().ToString("N"));
+        var bin = System.IO.Path.Combine(root, "bin");
+        Directory.CreateDirectory(bin);
+
+        var command = "acp-fixture-cmd-" + Guid.NewGuid().ToString("N");
+        var path = System.IO.Path.Combine(bin, command);
+        File.WriteAllText(path, body);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return new ExecutableFixture(root, command, path);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+
+    private sealed class FixedSearchPathSource : IAcpSearchPathSource
+    {
+        private readonly string[] _directories;
+
+        public FixedSearchPathSource(string directory) => _directories = new[] { directory };
+
+        public Task<IReadOnlyList<string>> GetSearchDirectoriesAsync(
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(_directories);
+
+        /// <summary>Nothing is cached, so there is nothing to discard.</summary>
+        public void Invalidate()
+        {
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ExecutableFixture.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ExecutableFixture.cs
@@ -8,13 +8,19 @@ using SalmonEgg.Domain.Services.AcpSetup;
 namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
 
 /// <summary>
-/// A real executable in a directory that only an <see cref="IAcpSearchPathSource"/> reports, so a test can
-/// tell "the probe consulted the sources" apart from "the command happened to be on PATH".
+/// A real, runnable executable in a directory that only an <see cref="IAcpSearchPathSource"/> reports, so a
+/// test can tell "the probe consulted the sources" apart from "the command happened to be on PATH".
 /// </summary>
 /// <remarks>
-/// A real file rather than a stubbed probe: the behaviour under test is how this probe resolves and starts a
-/// command, which a stub would replace rather than exercise. The command name carries a GUID so nothing the
-/// host machine has installed can answer for it — which is what makes the paired negative tests meaningful.
+/// A real file rather than a stubbed probe: the behaviour under test is how this probe resolves and then
+/// starts a command, which a stub would replace rather than exercise. The command name carries a GUID so
+/// nothing the host machine has installed can answer for it — which is what makes the paired negative tests
+/// meaningful.
+///
+/// Written per platform rather than skipped off POSIX, because both platforms have a scriptable launcher and
+/// the resolution being tested is platform-specific in exactly this way: Windows finds a bare name through
+/// PATHEXT and cannot start an extensionless file, so a <c>#!/bin/sh</c> script there resolves to nothing.
+/// A batch shim is also what npm actually installs on Windows, so this is the shape the wizard meets.
 /// </remarks>
 internal sealed class ExecutableFixture : IDisposable
 {
@@ -28,7 +34,7 @@ internal sealed class ExecutableFixture : IDisposable
         Source = new FixedSearchPathSource(System.IO.Path.GetDirectoryName(path)!);
     }
 
-    /// <summary>The bare name to ask the probe for. Unique per fixture.</summary>
+    /// <summary>The bare name to ask the probe for. Unique per fixture, and carries no extension.</summary>
     public string Command { get; }
 
     /// <summary>Absolute path of the executable, for asserting which one answered.</summary>
@@ -38,9 +44,13 @@ internal sealed class ExecutableFixture : IDisposable
     public IAcpSearchPathSource Source { get; }
 
     /// <summary>
-    /// Writes an executable script whose body is <paramref name="body"/>.
+    /// Writes an executable that prints <paramref name="output"/> and exits successfully.
     /// </summary>
-    public static ExecutableFixture Create(string body)
+    /// <remarks>
+    /// The caller supplies what the command should print rather than a whole script, because the script
+    /// around it has to differ per platform and every caller wants the same thing from it.
+    /// </remarks>
+    public static ExecutableFixture Printing(string output)
     {
         var root = System.IO.Path.Combine(
             System.IO.Path.GetTempPath(),
@@ -49,9 +59,19 @@ internal sealed class ExecutableFixture : IDisposable
         Directory.CreateDirectory(bin);
 
         var command = "acp-fixture-cmd-" + Guid.NewGuid().ToString("N");
-        var path = System.IO.Path.Combine(bin, command);
-        File.WriteAllText(path, body);
-        if (!OperatingSystem.IsWindows())
+        var isWindows = OperatingSystem.IsWindows();
+        // Resolved by PATHEXT on Windows, where an extensionless file cannot be started at all.
+        var path = System.IO.Path.Combine(bin, isWindows ? command + ".cmd" : command);
+
+        File.WriteAllText(
+            path,
+            isWindows
+                // @echo off so the interpreter does not echo the command itself onto the same stdout the
+                // caller reads the payload from.
+                ? "@echo off\r\necho " + output + "\r\n"
+                : "#!/bin/sh\necho '" + output + "'\n");
+
+        if (!isWindows)
         {
             File.SetUnixFileMode(
                 path,

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/LoginShellSearchPathSourceTests.cs
@@ -148,6 +148,65 @@ public sealed class LoginShellSearchPathSourceTests : IDisposable
         Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
     }
 
+    /// <summary>
+    /// Invalidating drops the capture, so the next call runs the shell again and sees what it now reports.
+    /// </summary>
+    /// <remarks>
+    /// A toolchain installer edits the very startup files this reads — nvm appends its sourcing lines to the
+    /// user's profile. So after the user installs one, the cached capture is the one answer guaranteed not to
+    /// mention it, and holding it for the process lifetime made the wizard's "install it, then detect again"
+    /// advice impossible to follow.
+    /// </remarks>
+    [Fact]
+    public async Task Invalidate_ShouldRecaptureWhatTheShellNowReports()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell();
+        var captures = 0;
+        var source = new LoginShellSearchPathSource(
+            marker =>
+            {
+                var path = Interlocked.Increment(ref captures) == 1 ? "/before" : "/before:/after-install";
+                return marker + $$"""{"PATH":"{{path}}"}""" + marker;
+            },
+            () => shell);
+
+        Assert.Equal(new[] { "/before" }, await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+
+        source.Invalidate();
+
+        Assert.Equal(
+            new[] { "/before", "/after-install" },
+            await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(2, captures);
+    }
+
+    /// <summary>
+    /// Reverse verification: without invalidating, the same source keeps answering from the first capture —
+    /// so the test above passes because the cache was dropped, not because it never cached.
+    /// </summary>
+    [Fact]
+    public async Task WithoutInvalidate_ShouldKeepAnsweringFromTheFirstCapture()
+    {
+        SkipOnWindows();
+
+        var shell = CreateShell();
+        var captures = 0;
+        var source = new LoginShellSearchPathSource(
+            marker =>
+            {
+                var path = Interlocked.Increment(ref captures) == 1 ? "/before" : "/before:/after-install";
+                return marker + $$"""{"PATH":"{{path}}"}""" + marker;
+            },
+            () => shell);
+
+        Assert.Equal(new[] { "/before" }, await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(new[] { "/before" }, await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(1, captures);
+    }
+
     [Fact]
     public void Constructor_WithNullCommandFactory_ShouldThrow()
         => Assert.Throws<ArgumentNullException>(() => new LoginShellSearchPathSource(null!));

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ToolchainScanSearchPathSourceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/ToolchainScanSearchPathSourceTests.cs
@@ -184,6 +184,64 @@ public sealed class ToolchainScanSearchPathSourceTests : IDisposable
             "b",
             AcpToolchainLayout.VersionWildcard));
 
+    /// <summary>
+    /// The wizard's own advice, end to end: it reports the toolchain missing, the user installs it, the user
+    /// presses detect again. That last step has to see the install.
+    /// </summary>
+    /// <remarks>
+    /// The scan is cached because the wizard probes many components and the filesystem does not change
+    /// mid-sweep. It does change between sweeps, and the one action the wizard asks the user to take is
+    /// exactly what changes it — so a cache with no way out reported the toolchain missing forever and the
+    /// only fix was restarting the app.
+    /// </remarks>
+    [Fact]
+    public async Task Invalidate_AfterAToolchainIsInstalled_ShouldReportIt()
+    {
+        var source = new ToolchainScanSearchPathSource(new[] { VersionedLayout() });
+        var before = await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(before);
+
+        var installed = CreateDirectory("versions", "v24.14.1", "bin");
+        source.Invalidate();
+
+        var after = await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(installed, Assert.Single(after));
+    }
+
+    /// <summary>
+    /// Reverse verification: without the invalidation the same install stays invisible, so the test above
+    /// passes because the cache was dropped rather than because the scan never cached at all.
+    /// </summary>
+    [Fact]
+    public async Task WithoutInvalidate_AToolchainInstalledLater_StaysInvisible()
+    {
+        var source = new ToolchainScanSearchPathSource(new[] { VersionedLayout() });
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+
+        CreateDirectory("versions", "v24.14.1", "bin");
+
+        Assert.Empty(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Invalidating before anything was cached, and twice in a row, must both be harmless: callers
+    /// invalidate on every user-requested detection without knowing whether a scan has happened.
+    /// </summary>
+    [Fact]
+    public async Task Invalidate_BeforeAnyScanAndTwice_ShouldStillScan()
+    {
+        var installed = CreateDirectory("versions", "v22.0.0", "bin");
+        var source = new ToolchainScanSearchPathSource(new[] { VersionedLayout() });
+
+        source.Invalidate();
+        source.Invalidate();
+
+        Assert.Equal(
+            installed,
+            Assert.Single(await source.GetSearchDirectoriesAsync(TestContext.Current.CancellationToken)));
+    }
+
     private async Task<IReadOnlyList<string>> ScanAsync(params AcpToolchainLayout[] layouts)
         => await new ToolchainScanSearchPathSource(layouts)
             .GetSearchDirectoriesAsync(TestContext.Current.CancellationToken);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -79,6 +79,11 @@ internal sealed class StubExecutableProbe : IAcpExecutableProbe
 
     public bool SupportsProcessProbing { get; set; } = true;
 
+    /// <summary>How many times a caller asked for the search to be redone.</summary>
+    public int InvalidateCount { get; private set; }
+
+    public void InvalidateSearchPaths() => InvalidateCount++;
+
     public void SetExecutable(string command, string? path, string? version = null)
     {
         _paths[command] = path;

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -10,6 +10,7 @@ using SalmonEgg.Domain.Models.AcpSetup;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Domain.Services.AcpSetup;
 using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
 using SalmonEgg.Presentation.Core.Tests.Threading;
 using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
 
@@ -188,6 +189,19 @@ internal sealed class StubComponentInstaller : IAcpComponentInstaller
     /// </summary>
     public List<AcpCommandOverrides?> ReceivedOverrides { get; } = new();
 
+    /// <summary>
+    /// Invoked with the token the install was handed, before any result is produced.
+    /// </summary>
+    /// <remarks>
+    /// Lets a test model an install that is still running: the real installer waits on a package manager,
+    /// which this stub cannot do without becoming a timing test. A hook that observes the token instead
+    /// lets the test assert what the token does, which is the whole contract cancellation rests on.
+    /// </remarks>
+    public Action<CancellationToken>? OnInstallWithToken { get; set; }
+
+    /// <summary>The token each install was handed, so a test can assert cancellation reached it.</summary>
+    public List<CancellationToken> ReceivedTokens { get; } = new();
+
     public Task<AcpComponentInstallResult> InstallAsync(
         AcpComponentDescriptor component,
         Action<string>? onOutput = null,
@@ -196,12 +210,18 @@ internal sealed class StubComponentInstaller : IAcpComponentInstaller
     {
         InstalledComponentIds.Add(component.Id);
         ReceivedOverrides.Add(overrides);
+        ReceivedTokens.Add(cancellationToken);
         foreach (var line in OutputLines)
         {
             onOutput?.Invoke(line);
         }
 
+        OnInstallWithToken?.Invoke(cancellationToken);
         OnInstall?.Invoke(component);
+
+        // Honoured the way the real installer does: a cancelled install reports cancellation rather than a
+        // result, so the wizard's own cancellation handling is what the test exercises.
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(_resultFactory(component));
     }
 }
@@ -388,7 +408,8 @@ internal static class AcpSetupWizardFixtures
         IAcpComponentInstaller installer,
         IAcpSetupConnectivityTester connectivityTester,
         IConfigurationService configurationService,
-        IStringLocalizer<CoreStrings>? localizer = null)
+        IStringLocalizer<CoreStrings>? localizer = null,
+        IUiDispatcher? uiDispatcher = null)
         => new(
             new AcpSetupWizardOrchestrator(
                 catalog,
@@ -396,7 +417,10 @@ internal static class AcpSetupWizardFixtures
                 installer,
                 connectivityTester,
                 configurationService),
-            new ImmediateUiDispatcher(),
+            // Immediate by default so most tests read as straight-line code. A test about what the wizard
+            // does while a UI update is still in flight supplies a queueing dispatcher instead, which is
+            // what the real WinUI one does: every marshalled write lands later, on another thread.
+            uiDispatcher ?? new ImmediateUiDispatcher(),
             NullLogger<AcpSetupWizardViewModel>.Instance,
             localizer);
 

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -1048,6 +1048,153 @@ public sealed class AcpSetupWizardViewModelTests
         Assert.Equal("second install line", wizard.LatestInstallOutputLine);
     }
 
+    // ── Cancelling a running operation ──────────────────────────────────────
+
+    /// <summary>
+    /// Cancelling reaches an install started from an agent row.
+    /// </summary>
+    /// <remarks>
+    /// The row is the case a per-command token cannot serve: its button raises an event rather than binding
+    /// a command, so the install was previously started with <c>CancellationToken.None</c> and the only
+    /// thing that could end it was the installer's own ten-minute timeout. Cancellation therefore lives on
+    /// the shared operation scope, which every entry point already goes through.
+    /// </remarks>
+    [Fact]
+    public async Task CancelOperation_ShouldCancelAnInstallStartedFromAnAgentRow()
+    {
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizard(probe, installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        // Cancelled from inside the install, which is where a user would press it: while it runs.
+        installer.OnInstallWithToken += _ => wizard.CancelOperationCommand.Execute(null);
+
+        wizard.Agents[0].RequestInstall();
+
+        var token = Assert.Single(installer.ReceivedTokens);
+        Assert.True(token.IsCancellationRequested);
+        // Cancellation is a user action, so it leaves no error on screen and does not wedge the wizard.
+        Assert.False(wizard.IsBusy);
+        Assert.False(wizard.HasErrorMessage);
+    }
+
+    /// <summary>
+    /// Reverse verification: without pressing cancel the same install runs with an uncancelled token, so
+    /// the assertion above is about cancellation rather than about a token that arrives cancelled anyway.
+    /// </summary>
+    [Fact]
+    public async Task WithoutCancelling_AnInstallShouldRunWithALiveToken()
+    {
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizard(probe, installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        wizard.Agents[0].RequestInstall();
+
+        Assert.False(Assert.Single(installer.ReceivedTokens).IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// Cancel is offered exactly while something is running: enabled during an operation, and not before
+    /// or after, so it is never a button that does nothing.
+    /// </summary>
+    [Fact]
+    public async Task CancelOperation_ShouldOnlyBeExecutableWhileBusy()
+    {
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizard(probe, installer);
+        Assert.False(wizard.CancelOperationCommand.CanExecute(null));
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var executableDuringInstall = false;
+        installer.OnInstallWithToken += _ => executableDuringInstall = wizard.CancelOperationCommand.CanExecute(null);
+
+        wizard.Agents[0].RequestInstall();
+
+        Assert.True(executableDuringInstall);
+        Assert.False(wizard.CancelOperationCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// Cancelling with nothing running is a no-op rather than a crash: the button's enablement and the
+    /// command's own behaviour are separate guarantees, and only the latter holds on every platform where a
+    /// stale binding could still invoke it.
+    /// </summary>
+    [Fact]
+    public void CancelOperation_WithNothingRunning_ShouldDoNothing()
+    {
+        var wizard = CreateWizard();
+
+        wizard.CancelOperationCommand.Execute(null);
+
+        Assert.False(wizard.IsBusy);
+        Assert.False(wizard.HasErrorMessage);
+    }
+
+    /// <summary>
+    /// A cancel arriving while an operation is still unwinding is harmless.
+    /// </summary>
+    /// <remarks>
+    /// The real dispatcher marshals every UI write to another thread, so <c>IsBusy = false</c> lands after
+    /// the operation's cleanup has already released its cancellation source. The button a user sees is
+    /// therefore still enabled for a moment after there is anything left to cancel, and a click in that
+    /// window must not reach a disposed source. Clearing the field before disposing it is what makes the
+    /// click a no-op instead of an <see cref="ObjectDisposedException"/> inside a command handler.
+    ///
+    /// Modelled with a queueing dispatcher because an immediate one closes the window by construction: it
+    /// applies the busy flag inline, so the button is already disabled.
+    /// </remarks>
+    [Fact]
+    public async Task CancelOperation_ArrivingAsAnOperationWindsDown_ShouldBeHarmless()
+    {
+        var dispatcher = new QueueingUiDispatcher();
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var wizard = AcpSetupWizardFixtures.CreateWizard(
+            new StubAgentCatalog(AcpSetupWizardFixtures.Agent()),
+            probe,
+            new StubComponentInstaller(),
+            new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success()),
+            new RecordingConfigurationService(),
+            localizer: null,
+            dispatcher);
+
+        var detecting = wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        // Pump the queue, pressing cancel from inside every callback. One of those callbacks is the
+        // cleanup's own IsBusy = false, which runs between the wizard releasing its cancellation source and
+        // disposing it — the precise window a user's click can land in, and the only one where the two
+        // orderings of that release differ. Driving it from inside the callback makes hitting it certain
+        // rather than a matter of thread timing.
+        while (!detecting.IsCompleted)
+        {
+            while (dispatcher.PendingCount > 0)
+            {
+                if (wizard.CancelOperationCommand.CanExecute(null))
+                {
+                    wizard.CancelOperationCommand.Execute(null);
+                }
+
+                dispatcher.RunNext();
+                if (wizard.CancelOperationCommand.CanExecute(null))
+                {
+                    wizard.CancelOperationCommand.Execute(null);
+                }
+            }
+
+            await Task.Delay(25);
+        }
+
+        dispatcher.RunAll();
+        Assert.False(wizard.IsBusy);
+        Assert.False(wizard.HasErrorMessage);
+    }
+
     // ── Re-detection sees the machine as it is now ──────────────────────────
 
     /// <summary>

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -1187,7 +1187,7 @@ public sealed class AcpSetupWizardViewModelTests
                 }
             }
 
-            await Task.Delay(25);
+            await Task.Delay(25, TestContext.Current.CancellationToken);
         }
 
         dispatcher.RunAll();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -1015,6 +1015,116 @@ public sealed class AcpSetupWizardViewModelTests
     /// The sibling entry is load-bearing, not padding. An install derives its package manager from the
     /// resolved launcher's own directory and uses only that candidate, so a machine whose npm is somewhere
     /// else genuinely cannot install this component — and the wizard now withholds the offer instead of
+    /// <summary>
+    /// A second install starts from an empty log rather than appending to the previous one's.
+    /// </summary>
+    /// <remarks>
+    /// The output surface is shared by both install entry points, so a log that carried over would show one
+    /// component's installer lines under another component's name. Clearing on step entry alone did not
+    /// cover this: two installs can happen without ever leaving the selection step.
+    /// </remarks>
+    [Fact]
+    public async Task ASecondInstall_ShouldNotInheritTheFirstInstallsOutput()
+    {
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var installer = new StubComponentInstaller();
+        installer.OutputLines.Add("first install line");
+        var wizard = CreateWizard(probe, installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var row = wizard.Agents[0];
+
+        row.RequestInstall();
+        Assert.False(wizard.IsBusy);
+        Assert.Equal(new[] { "first install line" }, wizard.InstallOutput);
+
+        installer.OutputLines.Clear();
+        installer.OutputLines.Add("second install line");
+
+        row.RequestInstall();
+        Assert.False(wizard.IsBusy);
+
+        Assert.Equal(new[] { "second install line" }, wizard.InstallOutput);
+        Assert.Equal("second install line", wizard.LatestInstallOutputLine);
+    }
+
+    // ── Re-detection sees the machine as it is now ──────────────────────────
+
+    /// <summary>
+    /// Detecting on the user's request must search the machine again, not answer from a cached search.
+    /// </summary>
+    /// <remarks>
+    /// This is the wizard's own loop: it reports a toolchain missing, points the user at its documentation,
+    /// and offers "detect again". The search behind that is cached — it spawns a login shell and walks the
+    /// filesystem, which is too expensive to repeat per component — so without this the button re-ran a
+    /// detection against the machine as it was <em>before</em> the user installed anything, and reported the
+    /// toolchain missing however many times they pressed it. The only way out was restarting the app.
+    /// </remarks>
+    [Fact]
+    public async Task DetectAgents_ShouldInvalidateTheSearchFirst()
+    {
+        var probe = ProbeForInstalledRuntime();
+        var wizard = CreateWizard(probe);
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, probe.InvalidateCount);
+    }
+
+    /// <summary>
+    /// Re-detecting the adapter does the same, since it backs the "detect again" button beside the
+    /// adapter's own toolchain-missing surface.
+    /// </summary>
+    [Fact]
+    public async Task DetectAdapter_ShouldInvalidateTheSearchFirst()
+    {
+        var probe = ProbeForInstalledRuntime();
+        var wizard = CreateWizard(probe);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[0];
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        var afterWalk = probe.InvalidateCount;
+
+        await wizard.DetectAdapterCommand.ExecuteAsync(null);
+
+        Assert.True(
+            probe.InvalidateCount > afterWalk,
+            $"expected re-detection to invalidate the search; count stayed at {afterWalk}.");
+    }
+
+    /// <summary>
+    /// An install changes the machine, so the re-probe that follows it must not reuse the search from
+    /// before.
+    /// </summary>
+    /// <remarks>
+    /// A package manager writes the new executable into its own bin directory, and a first global install
+    /// can create that directory outright — which a directory list captured beforehand cannot contain. The
+    /// re-probe would then contradict an install that had just succeeded.
+    /// </remarks>
+    [Fact]
+    public async Task InstallAgentRow_ShouldInvalidateTheSearchBeforeReprobing()
+    {
+        var probe = ProbeForInstalledRuntime();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, null);
+        var installer = new StubComponentInstaller();
+        var wizard = CreateWizard(probe, installer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var row = wizard.Agents[0];
+        var afterDetect = probe.InvalidateCount;
+        installer.OnInstall += _ =>
+            probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/usr/bin/test-agent", "1.0.0");
+
+        row.RequestInstall();
+        // Inline completion: the stub installer and the test dispatcher are both synchronous, so a settled
+        // busy flag is proof the whole chain finished rather than a race.
+        Assert.False(wizard.IsBusy);
+
+        Assert.True(
+            probe.InvalidateCount > afterDetect,
+            $"expected the install's re-probe to invalidate the search; count stayed at {afterDetect}.");
+        Assert.True(row.IsInstalled);
+    }
+
     /// discovering it on click. Registering the sibling is what makes this the ordinary machine the
     /// install tests mean to describe.
     /// </remarks>


### PR DESCRIPTION
Audit of the ACP setup wizard's dependency install capability, and fixes for what it turned out to be hiding. Every defect below was reproduced against real toolchains on a machine with nvm + npm + uv before being fixed, and each fix is covered by a test that fails without it.

## What was wrong

**Version and package queries bypassed the widened search.** `DesktopAcpExecutableProbe` had a private PATH-only resolver that `ReadVersionAsync` and `LocateGlobalPackageAsync` both used, so `IAcpSearchPathSource` did not apply to either. That is the one thing the sources exist for — a GUI process inherits the session PATH rather than the one a shell profile builds. Measured: a component found in a scanned toolchain directory reported `Installed` with `version=<null>`, and the same manager resolved to an absolute path through one call while the package query answered `Unknown` with no executable named.

**A re-detect could not see a toolchain installed since the last one.** Both search path sources cached for the process lifetime with no way to invalidate, so the wizard could not honour its own advice: it reports a toolchain missing, sends the user to install it, offers "detect again" — and that button re-ran detection against the machine as it was beforehand. Measured across the full sequence: `first=<null>`, `secondAfterInstall=<null>`. Only an app restart helped.

**Installer output was invisible from one of the two install entry points.** The output panel was nested inside the component step, but a runtime install starts from an agent row on the selection step. Verified by resolving the XAML ancestor chains: the lines were appended into a subtree that step does not render, so a row install showed the shared spinner and nothing else.

**A running install could not be cancelled.** Ten-minute timeout, `CancellationToken.None` on both event-driven entry points, no cancel affordance.

## Two more found while reviewing the fixes

Clearing the install log ran off the UI thread once both entry points cleared before starting. The collection is bound to a list, so that is a crash on WinUI rather than a glitch — clearing now goes through the dispatcher like appending already did.

Each search source returned its answer by re-reading the cache field it had just written, so an invalidation between the two made the method return `null` — which callers are promised never happens, and which the consumer's catch silently swallows as "this source contributed nothing". Measured at ~8 nulls in 200,000 calls.

## Notes on the tests

Every fix has a paired negative test, and each one was reverse-verified by breaking the implementation and confirming the test goes red. Two tests were written, found to be false greens, and deleted rather than kept: one asserted a thread invariant that the operation body's synchronous prefix made unobservable, and one tried to hit a window that cannot be reached deterministically from outside the type. The null-return fix therefore ships with its reasoning in a comment rather than a probabilistic guard — a hammer test needed 200k iterations to land in the window, which is not a test worth keeping under AGENTS.md §5.

## Verification

- Skia desktop build: 0 warnings, 0 errors (XAML compiles)
- WASM `Compile` target: 0 warnings — the `__WASM__` DI branch builds. Full WASM packaging fails locally for want of the `wasm-tools` workload, after all C# projects compile.
- Domain 83, Application 120, Infrastructure 702, Presentation.Core 3264 — all passing

One caveat: `StartViewModelTests.StartModeSelector_WhenSelectedAgentSwitches_WaitsForForegroundProfileAndStillBecomesReady` fails intermittently under the full concurrent run (a 10s polling timeout). Verified pre-existing and unrelated — stashing every change on this branch and running that class in isolation gives 60/60, and so does running it in isolation with the changes applied.

The catalog itself came out clean: all nine package coordinates exist on npm, and every published `bin` name matches its `ProbeCommand` exactly, so the comment asserting that equivalence holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)