### PR TITLE
fix(acp-setup-wizard): move adapter recovery actions out of the InfoBar

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -237,32 +237,37 @@
                                      x:Uid="AcpSetup_AdapterMissingBar"
                                      IsOpen="{x:Bind ViewModel.IsAdapterMissing, Mode=OneWay}"
                                      Severity="Warning"
-                                     IsClosable="False">
-                                <!-- Two actions, so they go in Content: ActionButton holds a single
-                                     ButtonBase and a panel there would not render as buttons. -->
-                                <InfoBar.Content>
-                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
-                                        <Button x:Name="AcpSetupInstallAdapterButton"
-                                                x:Uid="AcpSetup_InstallAdapter"
-                                                Style="{StaticResource AccentButtonStyle}"
-                                                AutomationProperties.AutomationId="AcpSetup.Adapter.Install"
-                                                Command="{x:Bind ViewModel.InstallAdapterCommand}"/>
-                                        <Button x:Name="AcpSetupRedetectAdapterButton"
-                                                x:Uid="AcpSetup_RedetectAdapter"
-                                                AutomationProperties.AutomationId="AcpSetup.Adapter.Redetect"
-                                                Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
-                                        <!-- The install button above is command-bound, so a missing
-                                             toolchain already disables it. A disabled button explains
-                                             nothing on its own, so the way forward is offered beside it:
-                                             the toolchain's own documentation, named in the text below. -->
-                                        <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
-                                                         x:Uid="AcpSetup_InstallToolchainDocs"
-                                                         NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"
-                                                         AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainDocs"
-                                                         Visibility="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    </StackPanel>
-                                </InfoBar.Content>
-                            </InfoBar>
+                                     IsClosable="False"/>
+                            <!-- The three recovery actions sit beside the verdict instead of inside
+                                 it. The InfoBar template places Content on a second row below the
+                                 icon-height first row, so buttons hosted there float in the gap
+                                 under the text and end flush against the bar's bottom border, and
+                                 both spacings shift again once the panel stacks vertically.
+                                 ActionButton holds a single ButtonBase, so it cannot carry the
+                                 three actions either; a plain row in the step's flow is the one
+                                 place whose spacing holds on every platform and width. -->
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="8"
+                                        Visibility="{x:Bind ViewModel.IsAdapterMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                <Button x:Name="AcpSetupInstallAdapterButton"
+                                        x:Uid="AcpSetup_InstallAdapter"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        AutomationProperties.AutomationId="AcpSetup.Adapter.Install"
+                                        Command="{x:Bind ViewModel.InstallAdapterCommand}"/>
+                                <Button x:Name="AcpSetupRedetectAdapterButton"
+                                        x:Uid="AcpSetup_RedetectAdapter"
+                                        AutomationProperties.AutomationId="AcpSetup.Adapter.Redetect"
+                                        Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
+                                <!-- The install button above is command-bound, so a missing
+                                     toolchain already disables it. A disabled button explains
+                                     nothing on its own, so the way forward is offered beside it:
+                                     the toolchain's own documentation, named in the text below. -->
+                                <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
+                                                 x:Uid="AcpSetup_InstallToolchainDocs"
+                                                 NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"
+                                                 AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainDocs"
+                                                 Visibility="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            </StackPanel>
 
                             <!-- Named separately from the warning above because it is a different
                                  problem with a different fix: the adapter is installable, but nothing on


### PR DESCRIPTION
## Problem

Step 2 ("Check components") of the ACP setup wizard rendered its warning InfoBar with three layout defects (screenshot in #137):

- the title and message were crammed onto the same line
- an abnormal dead gap sat between the text and the buttons
- the buttons sat flush against the bar's bottom border

## Root cause

The page stacked its three recovery actions (Install adapter / Detect again / toolchain docs link) inside `InfoBar.Content`. The WinUI/Uno InfoBar template (verified byte-for-byte identical between Uno 6.6.166 and WinUI 1.4.2, so not an upstream regression) renders `Content` in a second grid row under the 48px icon row with zero bottom padding — producing the gap and the bottom-flush buttons. `InfoBar.ActionButton` only accepts a single `ButtonBase`, so it cannot host the three actions either.

## Fix

Don't fight the template: keep the InfoBar as a pure warning banner, and render the three recovery actions as a horizontal `StackPanel` row directly below it. Both share the same `IsAdapterMissing` visibility binding so they appear and disappear together. The toolchain docs link keeps its own `IsAdapterToolchainMissing` gate as before.

## Verification

- Real GUI run (Skia desktop, Xvfb) with a sandboxed `HOME`/`SHELL`/`PATH` that forces the adapter-missing state: banner title on its own line, message wraps naturally, button row renders below the bar with symmetric ~10 logical-px spacing, all three actions present.
- Pixel measurement before vs. after: the 23 logical-px in-bar dead gap and bottom-flush buttons are gone.
- `AcpSetupWizardViewModelTests`: 60/60 passed.
- Full build: 0 warnings, 0 errors.

Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)