### PR TITLE
feat(acp-setup): let the wizard skip the connection test and persist the verdict

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpConnectionSettingsPage.xaml
@@ -202,12 +202,32 @@
                                                     </Grid>
                                                 </Grid>
 
-                                                <TextBlock Grid.Row="1"
-                                                           Grid.Column="1"
-                                                           Text="{x:Bind EndpointDescription}"
-                                                           Style="{StaticResource SettingsRowDescriptionTextStyle}"
-                                                           TextWrapping="NoWrap"
-                                                           TextTrimming="CharacterEllipsis"/>
+                                                <Grid Grid.Row="1"
+                                                      Grid.Column="1"
+                                                      ColumnDefinitions="*,Auto"
+                                                      ColumnSpacing="10">
+                                                    <TextBlock Text="{x:Bind EndpointDescription}"
+                                                               Style="{StaticResource SettingsRowDescriptionTextStyle}"
+                                                               TextWrapping="NoWrap"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                    <!-- Verification and connection are independent facts: an
+                                                         unverified profile may still be connected successfully. -->
+                                                    <StackPanel Grid.Column="1"
+                                                                Orientation="Horizontal"
+                                                                Spacing="4"
+                                                                VerticalAlignment="Center"
+                                                                Visibility="{x:Bind IsUnverified, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                                AutomationProperties.AutomationId="Acp.Profile.Unverified">
+                                                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                  Glyph="&#xE7BA;"
+                                                                  FontSize="12"
+                                                                  Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                                                  AutomationProperties.AccessibilityView="Raw"/>
+                                                        <TextBlock x:Uid="Acp_ProfileUnverified"
+                                                                   Style="{StaticResource SettingsRowDescriptionTextStyle}"
+                                                                   Foreground="{ThemeResource SystemFillColorCautionBrush}"/>
+                                                    </StackPanel>
+                                                </Grid>
 
                                                 <Grid Grid.RowSpan="2"
                                                       Grid.Column="2"

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -32,7 +32,9 @@
                             <TextBlock x:Name="AcpSetupStepPosition"
                                        Text="{x:Bind ViewModel.StepPositionText, Mode=OneWay}"
                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       AutomationProperties.AutomationId="AcpSetup.StepPosition"
+                                       AutomationProperties.LiveSetting="Polite"/>
                         </StackPanel>
 
                         <!-- Operation failure surface, shared by every command. -->
@@ -558,12 +560,24 @@
                         <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8" Margin="0,8,0,24">
                             <Button x:Name="AcpSetupBackStepButton"
                                     x:Uid="AcpSetup_Back"
-                                    Command="{x:Bind ViewModel.GoBackCommand}"/>
-                            <Button x:Name="AcpSetupNextStepButton"
-                                    Grid.Column="2"
-                                    x:Uid="AcpSetup_Next"
-                                    Style="{StaticResource AccentButtonStyle}"
-                                    Command="{x:Bind ViewModel.GoNextCommand}"/>
+                                    Command="{x:Bind ViewModel.GoBackCommand}"
+                                    AutomationProperties.AutomationId="AcpSetup.Back"/>
+                            <StackPanel Grid.Column="2"
+                                        Orientation="Horizontal"
+                                        Spacing="8">
+                                <!-- Skipping a test is a secondary choice with a durable consequence.
+                                     Keep the native default button appearance subordinate to Next. -->
+                                <Button x:Name="AcpSetupSkipTestButton"
+                                        x:Uid="AcpSetup_SkipTest"
+                                        Command="{x:Bind ViewModel.SkipTestCommand}"
+                                        Visibility="{x:Bind ViewModel.IsSkipTestVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                        AutomationProperties.AutomationId="AcpSetup.SkipTest"/>
+                                <Button x:Name="AcpSetupNextStepButton"
+                                        x:Uid="AcpSetup_Next"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        Command="{x:Bind ViewModel.GoNextCommand}"
+                                        AutomationProperties.AutomationId="AcpSetup.Next"/>
+                            </StackPanel>
                         </Grid>
                     </StackPanel>
                 </controls:ResponsiveContentHost.Child>

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -789,6 +789,9 @@
   <data name="Acp_ProfileReconnect.Text" xml:space="preserve">
     <value>Reconnect</value>
   </data>
+  <data name="Acp_ProfileUnverified.Text" xml:space="preserve">
+    <value>Unverified</value>
+  </data>
   <data name="Acp_ProfileConnect.Text" xml:space="preserve">
     <value>Connect</value>
   </data>
@@ -844,13 +847,13 @@
     <value>Detect your agent, install the ACP adapter, fill in launch parameters, verify the connection, and save it as a profile.</value>
   </data>
   <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
-    <value>1. Choose an agent</value>
+    <value>Choose an agent</value>
   </data>
   <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
     <value>Detect again</value>
   </data>
   <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
-    <value>2. Check components</value>
+    <value>Check components</value>
   </data>
   <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
     <value>Install adapter</value>
@@ -865,19 +868,25 @@
     <value>Set up toolchain</value>
   </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
-    <value>3. Launch parameters</value>
+    <value>Launch parameters</value>
   </data>
   <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
     <value>Command preview</value>
   </data>
   <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
-    <value>4. Test connection</value>
+    <value>Test connection</value>
   </data>
   <data name="AcpSetup_RunTest.Content" xml:space="preserve">
     <value>Run test</value>
   </data>
+  <data name="AcpSetup_SkipTest.Content" xml:space="preserve">
+    <value>Skip test</value>
+  </data>
+  <data name="AcpSetup_SkipTest.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Continue without testing. The saved profile will be marked unverified.</value>
+  </data>
   <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
-    <value>5. Save profile</value>
+    <value>Save profile</value>
   </data>
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>Back</value>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1375,13 +1375,13 @@
     <value>Detect your agent, install the ACP adapter, fill in launch parameters, verify the connection, and save it as a profile.</value>
   </data>
   <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
-    <value>1. Choose an agent</value>
+    <value>Choose an agent</value>
   </data>
   <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
     <value>Detect again</value>
   </data>
   <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
-    <value>2. Check components</value>
+    <value>Check components</value>
   </data>
   <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
     <value>Install adapter</value>
@@ -1396,19 +1396,25 @@
     <value>Set up toolchain</value>
   </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
-    <value>3. Launch parameters</value>
+    <value>Launch parameters</value>
   </data>
   <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
     <value>Command preview</value>
   </data>
   <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
-    <value>4. Test connection</value>
+    <value>Test connection</value>
   </data>
   <data name="AcpSetup_RunTest.Content" xml:space="preserve">
     <value>Run test</value>
   </data>
+  <data name="AcpSetup_SkipTest.Content" xml:space="preserve">
+    <value>Skip test</value>
+  </data>
+  <data name="AcpSetup_SkipTest.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Continue without testing. The saved profile will be marked unverified.</value>
+  </data>
   <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
-    <value>5. Save profile</value>
+    <value>Save profile</value>
   </data>
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>Back</value>
@@ -1529,6 +1535,9 @@
   </data>
   <data name="Acp_ProfileReconnect.Text" xml:space="preserve">
     <value>Reconnect</value>
+  </data>
+  <data name="Acp_ProfileUnverified.Text" xml:space="preserve">
+    <value>Unverified</value>
   </data>
   <data name="Acp_ProfilesAdd.Content" xml:space="preserve">
     <value>New profile</value>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -714,6 +714,9 @@
   <data name="Acp_ProfileReconnect.Text" xml:space="preserve">
     <value>重新连接</value>
   </data>
+  <data name="Acp_ProfileUnverified.Text" xml:space="preserve">
+    <value>未验证</value>
+  </data>
   <data name="Acp_ProfileConnect.Text" xml:space="preserve">
     <value>连接</value>
   </data>
@@ -769,13 +772,13 @@
     <value>按步骤检测 Agent、安装 ACP 适配器、填写启动参数并验证连接，最后保存为配置。</value>
   </data>
   <data name="AcpSetup_AgentsTitle.Text" xml:space="preserve">
-    <value>1. 选择 Agent</value>
+    <value>选择 Agent</value>
   </data>
   <data name="AcpSetup_DetectAgents.Content" xml:space="preserve">
     <value>重新检测</value>
   </data>
   <data name="AcpSetup_ComponentsTitle.Text" xml:space="preserve">
-    <value>2. 检查组件</value>
+    <value>检查组件</value>
   </data>
   <data name="AcpSetup_InstallAdapter.Content" xml:space="preserve">
     <value>一键安装适配器</value>
@@ -790,19 +793,25 @@
     <value>安装工具链</value>
   </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
-    <value>3. 启动参数</value>
+    <value>启动参数</value>
   </data>
   <data name="AcpSetup_CommandPreviewLabel.Text" xml:space="preserve">
     <value>启动命令预览</value>
   </data>
   <data name="AcpSetup_TestTitle.Text" xml:space="preserve">
-    <value>4. 测试连接</value>
+    <value>测试连接</value>
   </data>
   <data name="AcpSetup_RunTest.Content" xml:space="preserve">
     <value>开始测试</value>
   </data>
+  <data name="AcpSetup_SkipTest.Content" xml:space="preserve">
+    <value>跳过测试</value>
+  </data>
+  <data name="AcpSetup_SkipTest.AutomationProperties.HelpText" xml:space="preserve">
+    <value>不测试并继续。保存后的配置会标记为未验证。</value>
+  </data>
   <data name="AcpSetup_SaveTitle.Text" xml:space="preserve">
-    <value>5. 保存配置</value>
+    <value>保存配置</value>
   </data>
   <data name="AcpSetup_Back.Content" xml:space="preserve">
     <value>上一步</value>

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using SalmonEgg.Domain.Models;
 using SalmonEgg.Domain.Models.AcpSetup;
 
 namespace SalmonEgg.Application.Services.AcpSetup;
@@ -40,6 +41,13 @@ public sealed class AcpSetupDraft
 
     /// <summary>Profile name the configuration is saved under.</summary>
     public required string ProfileName { get; init; }
+
+    /// <summary>
+    /// Verification fact attached to this draft. The wizard sets this to <c>Verified</c> after a
+    /// successful end-to-end test, or <c>Unverified</c> when the user explicitly skips that step.
+    /// Leaving it as <c>Unknown</c> is reserved for callers that have not made either claim.
+    /// </summary>
+    public ProfileVerification Verification { get; init; } = ProfileVerification.Unknown;
 
     /// <summary>
     /// User-supplied paths for commands the catalog names by executable name.

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -192,7 +192,8 @@ public sealed class AcpSetupWizardOrchestrator
             Transport = TransportType.Stdio,
             StdioCommand = launchPlan.Command,
             StdioArguments = new List<string>(launchPlan.Arguments),
-            StdioEnvironment = new Dictionary<string, string>(launchPlan.Environment, StringComparer.Ordinal)
+            StdioEnvironment = new Dictionary<string, string>(launchPlan.Environment, StringComparer.Ordinal),
+            Verification = draft.Verification
         };
     }
 }

--- a/src/SalmonEgg.Domain/Models/ProfileVerification.cs
+++ b/src/SalmonEgg.Domain/Models/ProfileVerification.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace SalmonEgg.Domain.Models
+{
+    /// <summary>
+    /// Whether a connection profile's launch configuration has been proven to start and speak ACP.
+    /// </summary>
+    /// <remarks>
+    /// Three states rather than a boolean, for the same reason
+    /// <see cref="AcpSetup.AcpComponentAvailability"/> separates <c>Missing</c> from
+    /// <c>Undetermined</c>: never having asked is not the same answer as having asked and been told no.
+    ///
+    /// <see cref="Unknown"/> is first so it is <c>default</c>. Profiles written before this state
+    /// existed, and profiles created by the CLI or the profile editor — neither of which runs a
+    /// connectivity test — land here, and a profile that was never offered a test must not be shown as
+    /// one the user declined to test.
+    /// </remarks>
+    public enum ProfileVerificationState
+    {
+        /// <summary>No verdict was ever recorded for this profile.</summary>
+        Unknown,
+
+        /// <summary>The profile was offered a connectivity test and saved without passing one.</summary>
+        Unverified,
+
+        /// <summary>The profile passed an end-to-end connectivity test before it was saved.</summary>
+        Verified
+    }
+
+    /// <summary>
+    /// A profile's verification verdict together with when it was reached.
+    /// </summary>
+    /// <remarks>
+    /// One value rather than a state field beside a nullable timestamp, because those two can disagree:
+    /// a stale timestamp left behind by an earlier pass would outlive the verdict it belonged to, and a
+    /// <see cref="ProfileVerificationState.Verified"/> profile with no timestamp cannot say how old its
+    /// evidence is. The factories below are the only way to build one, so neither combination is
+    /// representable.
+    ///
+    /// <c>default</c> is <see cref="Unknown"/>, so a profile constructed without mentioning verification
+    /// — every CLI and profile-editor profile — is correct without the constructor having to know this
+    /// type exists.
+    /// </remarks>
+    public readonly record struct ProfileVerification
+    {
+        private ProfileVerification(ProfileVerificationState state, DateTimeOffset? verifiedAtUtc)
+        {
+            State = state;
+            VerifiedAtUtc = verifiedAtUtc;
+        }
+
+        public ProfileVerificationState State { get; }
+
+        /// <summary>
+        /// When the passing test ran, in UTC. Non-null exactly when
+        /// <see cref="State"/> is <see cref="ProfileVerificationState.Verified"/>.
+        /// </summary>
+        public DateTimeOffset? VerifiedAtUtc { get; }
+
+        /// <summary>No verdict was ever recorded. Also the value of <c>default</c>.</summary>
+        public static ProfileVerification Unknown => default;
+
+        /// <summary>The user was offered a test and saved the profile without passing one.</summary>
+        public static ProfileVerification Unverified
+            => new(ProfileVerificationState.Unverified, verifiedAtUtc: null);
+
+        /// <summary>A test passed at <paramref name="verifiedAtUtc"/>.</summary>
+        public static ProfileVerification Verified(DateTimeOffset verifiedAtUtc)
+            => new(ProfileVerificationState.Verified, verifiedAtUtc.ToUniversalTime());
+
+        public bool IsVerified => State == ProfileVerificationState.Verified;
+
+        /// <summary>
+        /// True only for a profile that was offered a test and saved anyway.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately false for <see cref="Unknown"/>. This is what a warning affordance binds to, and
+        /// an <see cref="Unknown"/> profile has no evidence either way — warning about it would put a
+        /// mark on every profile that predates this state.
+        /// </remarks>
+        public bool IsUnverified => State == ProfileVerificationState.Unverified;
+    }
+}

--- a/src/SalmonEgg.Domain/Models/ServerConfiguration.cs
+++ b/src/SalmonEgg.Domain/Models/ServerConfiguration.cs
@@ -70,6 +70,19 @@ namespace SalmonEgg.Domain.Models
         /// </summary>
         public int ConnectionTimeout { get; set; } = AcpConnectionTimeoutPolicy.DefaultSeconds;
 
+        /// <summary>
+        /// 该配置是否通过过端到端连通性测试。
+        /// </summary>
+        /// <remarks>
+        /// 默认 <see cref="ProfileVerification.Unknown"/>：只有明确记录过判定的写入方才会改动它，
+        /// 因此 CLI、配置编辑器与本状态出现之前写下的 profile 都不会被回溯标记。
+        ///
+        /// 极性是有意如此——"已验证"是需要显式写入的正面事实。若某天旧版本客户端丢弃了这个字段，
+        /// profile 退化为 <see cref="ProfileVerificationState.Unknown"/>，最坏结果是少一句提醒；
+        /// 反向的布尔设计则会让未验证配置凭空自称已验证。
+        /// </remarks>
+        public ProfileVerification Verification { get; set; } = ProfileVerification.Unknown;
+
         public string EndpointDisplay
         {
             get

--- a/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/ConfigurationManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -20,7 +21,7 @@ namespace SalmonEgg.Infrastructure.Storage;
 public sealed class ConfigurationManager : IConfigurationService, IConfigurationRecoveryService
 {
     /// <summary>本程序写入 server 配置时使用的 schema 版本。</summary>
-    public const int CurrentServerConfigurationSchemaVersion = 3;
+    public const int CurrentServerConfigurationSchemaVersion = 4;
 
     private const int CurrentSchemaVersion = CurrentServerConfigurationSchemaVersion;
 
@@ -575,6 +576,8 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
             StdioArguments = config.StdioArguments?.ToList() ?? new List<string>(),
             StdioEnvironment = ToYamlStdioEnvironment(config.StdioEnvironment),
             ConnectionTimeoutSeconds = config.ConnectionTimeout,
+            Verification = VerificationToString(config.Verification.State),
+            VerifiedAtUtc = config.Verification.VerifiedAtUtc?.ToString("O", CultureInfo.InvariantCulture),
             Authentication = new AuthenticationYamlV1 { Mode = mode },
             Proxy = new ProxyYamlV1
             {
@@ -596,7 +599,8 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
             StdioArguments = yamlModel.StdioArguments ?? new List<string>(),
             StdioEnvironment = CloneStdioEnvironment(yamlModel.StdioEnvironment),
             Transport = TransportFromString(yamlModel.Transport),
-            ConnectionTimeout = AcpConnectionTimeoutPolicy.ResolveSeconds(yamlModel.ConnectionTimeoutSeconds)
+            ConnectionTimeout = AcpConnectionTimeoutPolicy.ResolveSeconds(yamlModel.ConnectionTimeoutSeconds),
+            Verification = VerificationFromYaml(yamlModel.Verification, yamlModel.VerifiedAtUtc)
         };
 
         var proxyMode = ProxyModeFromYaml(yamlModel.Proxy);
@@ -767,6 +771,60 @@ public sealed class ConfigurationManager : IConfigurationService, IConfiguration
             _ when proxy.Enabled => ProxyMode.Custom,
             _ => ProxyConfig.DefaultMode
         };
+    }
+
+    /// <summary>
+    /// Projects a verification verdict onto its on-disk token, or null when there is no verdict to write.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ProfileVerificationState.Unknown"/> maps to null rather than to an <c>unknown</c>
+    /// token so <c>OmitNull</c> drops the key: absence on disk and "no verdict recorded" are the same
+    /// statement, and writing one for every untested profile would add a redundant business-content key
+    /// to the cloud-sync fingerprint. A schema_version 3 file still advances to version 4 when saved.
+    /// </remarks>
+    private static string? VerificationToString(ProfileVerificationState state) =>
+        state switch
+        {
+            ProfileVerificationState.Verified => "verified",
+            ProfileVerificationState.Unverified => "unverified",
+            _ => null
+        };
+
+    /// <summary>
+    /// Reads a verification verdict, resolving anything it cannot fully substantiate to
+    /// <see cref="ProfileVerification.Unknown"/>.
+    /// </summary>
+    /// <remarks>
+    /// Permissive in the same direction as <see cref="TransportFromString"/>: an unrecognized token from
+    /// a newer build falls back instead of making the profile unreadable. The fallback is
+    /// <see cref="ProfileVerification.Unknown"/> rather than
+    /// <see cref="ProfileVerification.Unverified"/> because a token we do not understand is not a
+    /// verdict, and treating it as one would warn about a profile that may well have passed.
+    ///
+    /// <c>verified</c> additionally needs a parseable timestamp. The domain type cannot represent a pass
+    /// without one, and honouring a hand-edited <c>verification: verified</c> with no evidence would let
+    /// a profile claim it was proven at a moment nobody can name.
+    /// </remarks>
+    private static ProfileVerification VerificationFromYaml(string? state, string? verifiedAtUtc)
+    {
+        var token = (state ?? string.Empty).Trim().ToLowerInvariant();
+        if (token == "unverified")
+        {
+            return ProfileVerification.Unverified;
+        }
+
+        if (token != "verified")
+        {
+            return ProfileVerification.Unknown;
+        }
+
+        return DateTimeOffset.TryParse(
+            verifiedAtUtc,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out var passedAt)
+            ? ProfileVerification.Verified(passedAt)
+            : ProfileVerification.Unknown;
     }
 
     private string GetServerYamlPath(string id)

--- a/src/SalmonEgg.Infrastructure/Storage/YamlModels/ServerConfigurationYaml.cs
+++ b/src/SalmonEgg.Infrastructure/Storage/YamlModels/ServerConfigurationYaml.cs
@@ -5,7 +5,7 @@ namespace SalmonEgg.Infrastructure.Storage.YamlModels;
 
 internal sealed class ServerConfigurationYaml
 {
-    public int SchemaVersion { get; set; } = 3;
+    public int SchemaVersion { get; set; } = 4;
 
     public string UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow.ToString("O");
 
@@ -35,6 +35,34 @@ internal sealed class ServerConfigurationYaml
     public Dictionary<string, string>? StdioEnvironment { get; set; }
 
     public int ConnectionTimeoutSeconds { get; set; } = AcpConnectionTimeoutPolicy.DefaultSeconds;
+
+    /// <summary>
+    /// Whether this profile's launch configuration was proven to start and speak ACP. Added in
+    /// schema_version 4; absent in v3 and earlier files, which deserialize to null and need no
+    /// migration step.
+    /// </summary>
+    /// <remarks>
+    /// Nullable, and left null for <see cref="ProfileVerificationState.Unknown"/> so <c>OmitNull</c>
+    /// drops the key entirely rather than writing <c>unknown</c>. That keeps the no-verdict wire shape
+    /// minimal and prevents a redundant default key from participating in the cloud-sync fingerprint.
+    /// A schema_version 3 file saved by this build still changes to schema_version 4 by design.
+    ///
+    /// Written as a token rather than the enum's name so the on-disk vocabulary is owned here, the way
+    /// <c>transport</c> and <c>proxy.mode</c> already are. An unrecognized token reads back as
+    /// <see cref="ProfileVerificationState.Unknown"/>: the permissive direction, matching how
+    /// <c>transport</c> falls back instead of refusing the file.
+    /// </remarks>
+    public string? Verification { get; set; }
+
+    /// <summary>
+    /// When the passing test ran, ISO-8601 round-trip in UTC. Non-null only alongside
+    /// <c>verification: verified</c>.
+    /// </summary>
+    /// <remarks>
+    /// A timestamp without a verified verdict is discarded on read rather than honoured, so a
+    /// hand-edited file cannot produce a profile that claims evidence it does not have.
+    /// </remarks>
+    public string? VerifiedAtUtc { get; set; }
 
     public AuthenticationYamlV1 Authentication { get; set; } = new();
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -36,18 +36,21 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     private readonly IUiDispatcher _uiDispatcher;
     private readonly IStringLocalizer<CoreStrings>? _localizer;
     private readonly ILogger<AcpSetupWizardViewModel> _logger;
+    private readonly TimeProvider _timeProvider;
     private bool _suppressAdapterSelectionProbe;
 
     public AcpSetupWizardViewModel(
         AcpSetupWizardOrchestrator orchestrator,
         IUiDispatcher uiDispatcher,
         ILogger<AcpSetupWizardViewModel> logger,
-        IStringLocalizer<CoreStrings>? localizer = null)
+        IStringLocalizer<CoreStrings>? localizer = null,
+        TimeProvider? timeProvider = null)
     {
         _orchestrator = orchestrator ?? throw new ArgumentNullException(nameof(orchestrator));
         _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _localizer = localizer;
+        _timeProvider = timeProvider ?? TimeProvider.System;
 
         foreach (var agent in _orchestrator.Agents)
         {
@@ -92,21 +95,26 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
     [NotifyCanExecuteChangedFor(nameof(GoBackCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SkipTestCommand))]
     [NotifyPropertyChangedFor(nameof(IsOnAgentSelection))]
     [NotifyPropertyChangedFor(nameof(IsOnComponentSetup))]
     [NotifyPropertyChangedFor(nameof(IsOnParameters))]
     [NotifyPropertyChangedFor(nameof(IsOnTest))]
     [NotifyPropertyChangedFor(nameof(IsOnSave))]
+    [NotifyPropertyChangedFor(nameof(IsSkipTestVisible))]
     [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpSetupWizardStep _step = AcpSetupWizardStep.AgentSelection;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(GoBackCommand))]
     [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectAgentsCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
     [NotifyCanExecuteChangedFor(nameof(TestCommand))]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SkipTestCommand))]
     // Cancel is the one command enabled *by* being busy, so it tracks the same flag in the opposite
     // direction rather than needing a signal of its own.
     [NotifyCanExecuteChangedFor(nameof(CancelOperationCommand))]
@@ -114,6 +122,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpSetupAgentRowViewModel? _selectedAgent;
 
     [ObservableProperty]
@@ -127,6 +136,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
+    [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpAdapterDescriptor? _selectedAdapter;
 
     /// <summary>
@@ -139,6 +149,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         AdapterProbe = null;
         AdapterToolchain = null;
         TestResult = null;
+        Verification = ProfileVerification.Unknown;
         Parameters.Clear();
         LaunchCommandPreview = string.Empty;
         AdapterCustomCommand = string.Empty;
@@ -169,6 +180,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
+    [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpComponentProbeResult? _adapterProbe;
 
     /// <summary>
@@ -203,6 +215,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     public bool HasAdapterCustomCommand => !string.IsNullOrWhiteSpace(AdapterCustomCommand);
 
+    partial void OnAdapterCustomCommandChanged(string value)
+    {
+        TestResult = null;
+        Verification = ProfileVerification.Unknown;
+        RefreshLaunchCommandPreview();
+    }
+
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
     private string _profileName = string.Empty;
@@ -212,13 +231,28 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
     [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
     [NotifyPropertyChangedFor(nameof(HasTestResult))]
-    [NotifyPropertyChangedFor(nameof(IsTestSuccessful))]
     [NotifyPropertyChangedFor(nameof(IsTestFailed))]
     [NotifyPropertyChangedFor(nameof(TestFailureStageText))]
     [NotifyPropertyChangedFor(nameof(TestRemediationText))]
     [NotifyPropertyChangedFor(nameof(TestErrorDetail))]
     [NotifyPropertyChangedFor(nameof(HasTestErrorDetail))]
     private AcpSetupTestResult? _testResult;
+
+    /// <summary>
+    /// Authoritative verification verdict for the draft currently on screen.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately one value rather than a successful-test flag beside a skipped-test flag. A
+    /// draft can have only one verdict, and every plan-changing preparation resets it to
+    /// <see cref="ProfileVerification.Unknown"/> before the user can save again.
+    /// </remarks>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SkipTestCommand))]
+    [NotifyPropertyChangedFor(nameof(IsTestSuccessful))]
+    [NotifyPropertyChangedFor(nameof(IsSkipTestVisible))]
+    private ProfileVerification _verification = ProfileVerification.Unknown;
 
     /// <summary>Single-line rendering of the command the wizard will save, for user review.</summary>
     [ObservableProperty]
@@ -252,14 +286,14 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     public bool IsOnSave => Step == AcpSetupWizardStep.Save;
 
-    /// <summary>Human-readable step position ("Step 2 of 5"), so the walk's place is always stated.</summary>
+    /// <summary>
+    /// Human-readable position among the steps that apply to the current draft.
+    /// </summary>
     public string StepPositionText => FormatLocalize(
         "AcpSetup_Step_Position",
         "Step {0} of {1}",
-        (int)Step + 1,
-        TotalSteps);
-
-    private const int TotalSteps = 5;
+        GetApplicableStepPosition(),
+        GetApplicableStepCount());
 
     public bool HasSavedProfile => SavedProfile is not null;
 
@@ -356,7 +390,10 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     public bool HasTestResult => TestResult is not null;
 
-    public bool IsTestSuccessful => TestResult?.IsSuccess == true;
+    public bool IsTestSuccessful => Verification.IsVerified;
+
+    /// <summary>True while the optional test may still be deliberately skipped.</summary>
+    public bool IsSkipTestVisible => IsOnTest && !IsTestSuccessful;
 
     /// <summary>True when the last test failed. Distinct from HasTestResult, which is also
     /// true on success — the failure banner must not open on a passing test.</summary>
@@ -431,7 +468,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 var probe = await _orchestrator
                     .DetectComponentAsync(row.Agent.Runtime, CollectCommandOverrides(), token)
                     .ConfigureAwait(false);
-                await _uiDispatcher.EnqueueAsync(() => row.Runtime = probe).ConfigureAwait(false);
+                await _uiDispatcher
+                    .EnqueueAsync(() =>
+                    {
+                        row.Runtime = probe;
+                        OnPropertyChanged(nameof(StepPositionText));
+                    })
+                    .ConfigureAwait(false);
             },
             CancellationToken.None);
     }
@@ -534,6 +577,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                     {
                         row.Runtime = probe;
                         row.RuntimeToolchain = toolchain;
+                        OnPropertyChanged(nameof(StepPositionText));
                         ReportInstallFailure(install);
                     })
                     .ConfigureAwait(false);
@@ -605,6 +649,12 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             return;
         }
 
+        // A previous passing result belongs to the previous test run. Clear its verdict before starting
+        // another attempt so cancellation, failure, or an exception can never leave stale proof attached to
+        // the draft.
+        TestResult = null;
+        Verification = ProfileVerification.Unknown;
+
         await RunOperationAsync(
             async token =>
             {
@@ -613,6 +663,9 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                     .EnqueueAsync(() =>
                     {
                         TestResult = result;
+                        Verification = result.IsSuccess
+                            ? ProfileVerification.Verified(_timeProvider.GetUtcNow())
+                            : ProfileVerification.Unknown;
                         ApplyValidationMessages(result);
                     })
                     .ConfigureAwait(false);
@@ -622,11 +675,37 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     private bool CanTest() => !IsBusy && SelectedAdapter is not null;
 
+    /// <summary>
+    /// Deliberately accepts an untested draft and moves to naming it. This is distinct from automatic step
+    /// folding: folding omits a step that has no work, while this command records a user decision with a
+    /// durable <see cref="ProfileVerification.Unverified"/> verdict.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanSkipTest))]
+    private void SkipTest()
+    {
+        if (!CanSkipTest())
+        {
+            return;
+        }
+
+        Verification = ProfileVerification.Unverified;
+        PrepareSave();
+        Step = AcpSetupWizardStep.Save;
+    }
+
+    private bool CanSkipTest()
+        => !IsBusy
+            && IsOnTest
+            && !IsTestSuccessful
+            && SelectedAgent is not null
+            && SelectedAdapter is not null;
+
     [RelayCommand(CanExecute = nameof(CanSave))]
     private async Task SaveAsync(CancellationToken cancellationToken)
     {
-        // RelayCommand invocation does not consult CanExecute, so the rule is restated here: a
-        // profile that never passed the test must not reach the connection list looking verified.
+        // RelayCommand invocation does not consult CanExecute, so the rule is restated here. The draft must
+        // carry either a passing test verdict or the explicit decision made by SkipTest; Unknown is never a
+        // saveable answer.
         if (!CanSave())
         {
             return;
@@ -647,13 +726,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Saving requires a successful test. The issue's acceptance criteria put the test before the save,
-    /// and a profile saved without one would appear in the connection list as if it had been verified.
-    /// </summary>
+    /// <summary>Saving requires an explicit verification verdict and the dedicated save step.</summary>
     private bool CanSave()
         => !IsBusy
-            && IsTestSuccessful
+            && IsOnSave
+            && Verification.State != ProfileVerificationState.Unknown
             && SelectedAdapter is not null
             && !string.IsNullOrWhiteSpace(ProfileName);
 
@@ -662,16 +739,33 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanGoNext))]
     private async Task GoNextAsync(CancellationToken cancellationToken)
     {
+        // AsyncRelayCommand can still be invoked directly while CanExecute is false. Keep the transition
+        // guard inside the handler so a missing runtime/adapter cannot be bypassed by a stale binding.
+        if (!CanGoNext())
+        {
+            return;
+        }
+
         switch (Step)
         {
             case AcpSetupWizardStep.AgentSelection:
                 PrepareComponentSetup();
-                Step = AcpSetupWizardStep.ComponentSetup;
                 await DetectAdapterAsync(cancellationToken).ConfigureAwait(false);
+
+                // Detection is preparation, not presentation. Only a conclusively no-op component step is
+                // folded; a missing, undetermined, failed, or cancelled probe remains visible and keeps the
+                // same blocking rule as an ordinary visit to that step.
+                if (IsStepApplicable(AcpSetupWizardStep.ComponentSetup)
+                    || !CanAdvanceFromComponentSetup())
+                {
+                    Step = AcpSetupWizardStep.ComponentSetup;
+                    break;
+                }
+
+                AdvancePastComponentSetup();
                 break;
             case AcpSetupWizardStep.ComponentSetup:
-                PrepareParameters();
-                Step = AcpSetupWizardStep.Parameters;
+                AdvancePastComponentSetup();
                 break;
             case AcpSetupWizardStep.Parameters:
                 if (!TryPrepareTest())
@@ -694,30 +788,145 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     private bool CanGoNext() => !IsBusy && Step switch
     {
         AcpSetupWizardStep.AgentSelection => SelectedAgent is not null,
-        // Only a probe that positively found nothing blocks the walk; "undetermined" does not.
-        AcpSetupWizardStep.ComponentSetup =>
-            SelectedAdapter is not null
-                && SelectedAgent?.IsMissing != true
-                && AdapterProbe is not null
-                && !IsAdapterMissing,
+        AcpSetupWizardStep.ComponentSetup => CanAdvanceFromComponentSetup(),
         AcpSetupWizardStep.Parameters => true,
         AcpSetupWizardStep.Test => IsTestSuccessful,
         _ => false
     };
 
+    /// <summary>
+    /// The component gate shared by a rendered visit and an automatically folded visit. Keeping one gate is
+    /// what prevents folding from becoming a second, weaker route around a missing runtime or adapter.
+    /// </summary>
+    private bool CanAdvanceFromComponentSetup()
+        => SelectedAdapter is not null
+            && SelectedAgent?.IsMissing != true
+            && AdapterProbe is not null
+            && !IsAdapterMissing;
+
+    private void AdvancePastComponentSetup()
+    {
+        PrepareParameters();
+        if (IsStepApplicable(AcpSetupWizardStep.Parameters))
+        {
+            Step = AcpSetupWizardStep.Parameters;
+            return;
+        }
+
+        // A hidden Parameters step still owns default-value projection and validation. Preparing it above
+        // keeps the launch plan identical to the one produced when the same template has a visible form.
+        if (TryPrepareTest())
+        {
+            Step = AcpSetupWizardStep.Test;
+        }
+    }
+
     [RelayCommand(CanExecute = nameof(CanGoBack))]
     private void GoBack()
     {
-        if (Step == AcpSetupWizardStep.AgentSelection)
+        var previous = FindPreviousApplicableStep();
+        if (IsBusy || previous is null)
         {
             return;
         }
 
-        Step = (AcpSetupWizardStep)((int)Step - 1);
+        Step = previous.Value;
         ErrorMessage = string.Empty;
     }
 
-    private bool CanGoBack() => Step != AcpSetupWizardStep.AgentSelection;
+    private bool CanGoBack() => !IsBusy && FindPreviousApplicableStep() is not null;
+
+    /// <summary>
+    /// Returns whether a step has user-visible work for the current draft. No skipped-step collection is
+    /// stored: applicability is derived from the authoritative catalog, selection, and probe facts every
+    /// time, so changing an adapter cannot leave stale navigation state behind.
+    /// </summary>
+    private bool IsStepApplicable(AcpSetupWizardStep step) => step switch
+    {
+        AcpSetupWizardStep.ComponentSetup => IsComponentSetupApplicable(),
+        AcpSetupWizardStep.Parameters => IsParametersStepApplicable(),
+        _ => true
+    };
+
+    private bool IsComponentSetupApplicable()
+    {
+        var agentRow = SelectedAgent;
+        if (agentRow is null || agentRow.IsMissing)
+        {
+            return true;
+        }
+
+        var agent = agentRow.Agent;
+        var adapter = SelectedAdapter ?? agent.ResolveRecommendedAdapter();
+        if (adapter is null || agent.Adapters.Count != 1)
+        {
+            // Selecting among alternatives is work even when the recommended adapter itself is built in.
+            return true;
+        }
+
+        if (SelectedAdapter is null)
+        {
+            // Before entering the walk, the catalog can already prove that a sole built-in adapter needs no
+            // setup. External adapters wait for their probe, whose result may carry actionable diagnostics.
+            return adapter.Component.Distribution != AcpDistributionKind.BuiltIn;
+        }
+
+        // Once prepared, only a positive BuiltIn verdict is safe to fold. Null/Undetermined remains visible;
+        // "could not tell" is not the same fact as "nothing to do".
+        return AdapterProbe?.Availability != AcpComponentAvailability.BuiltIn;
+    }
+
+    private bool IsParametersStepApplicable()
+    {
+        var adapter = SelectedAdapter ?? SelectedAgent?.Agent.ResolveRecommendedAdapter();
+        // Before an agent is selected, keep the complete five-step shape. Once selected, the launch
+        // template itself is authoritative about whether a form exists.
+        return adapter is null || adapter.LaunchTemplate.Parameters.Count > 0;
+    }
+
+    private AcpSetupWizardStep? FindPreviousApplicableStep()
+    {
+        for (var value = (int)Step - 1; value >= (int)AcpSetupWizardStep.AgentSelection; value--)
+        {
+            var candidate = (AcpSetupWizardStep)value;
+            if (IsStepApplicable(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private int GetApplicableStepPosition()
+    {
+        var position = 0;
+        for (var value = (int)AcpSetupWizardStep.AgentSelection; value <= (int)Step; value++)
+        {
+            if (IsStepApplicable((AcpSetupWizardStep)value))
+            {
+                position++;
+            }
+        }
+
+        return Math.Max(position, 1);
+    }
+
+    private int GetApplicableStepCount()
+    {
+        var count = 0;
+        for (var value = (int)AcpSetupWizardStep.AgentSelection;
+             value <= (int)AcpSetupWizardStep.Save;
+             value++)
+        {
+            if (IsStepApplicable((AcpSetupWizardStep)value))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
 
     // ── Step preparation ────────────────────────────────────────────────────
 
@@ -753,6 +962,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     {
         Parameters.Clear();
         TestResult = null;
+        Verification = ProfileVerification.Unknown;
         var template = SelectedAdapter?.LaunchTemplate;
         if (template is null)
         {
@@ -763,7 +973,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         foreach (var definition in template.Parameters)
         {
             Parameters.Add(
-                new AcpSetupParameterRowViewModel(definition, RefreshLaunchCommandPreview, _localizer));
+                new AcpSetupParameterRowViewModel(definition, OnParameterValueChanged, _localizer));
         }
 
         RefreshLaunchCommandPreview();
@@ -789,6 +999,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         }
 
         TestResult = null;
+        Verification = ProfileVerification.Unknown;
         RefreshLaunchCommandPreview();
         return true;
     }
@@ -799,6 +1010,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         {
             ProfileName = SelectedAgent.DisplayName;
         }
+    }
+
+    private void OnParameterValueChanged()
+    {
+        TestResult = null;
+        Verification = ProfileVerification.Unknown;
+        RefreshLaunchCommandPreview();
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────
@@ -856,7 +1074,8 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             Adapter = adapter,
             ParameterValues = CollectParameterValues(),
             CommandOverrides = CollectCommandOverrides(),
-            ProfileName = string.IsNullOrWhiteSpace(ProfileName) ? agent.DisplayName : ProfileName.Trim()
+            ProfileName = string.IsNullOrWhiteSpace(ProfileName) ? agent.DisplayName : ProfileName.Trim(),
+            Verification = Verification
         };
     }
 
@@ -931,6 +1150,8 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 row.Runtime = state.Runtime;
             }
         }
+
+        OnPropertyChanged(nameof(StepPositionText));
     }
 
     private void ApplyViolations(IReadOnlyList<AcpSetupParameterViolation> violations)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AgentProfileItemViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AgentProfileItemViewModel.cs
@@ -107,6 +107,12 @@ public sealed partial class AgentProfileItemViewModel : ObservableObject, IDispo
     public string TransportGlyph => AcpTransportGlyph.Resolve(_profile.Transport);
 
     /// <summary>
+    /// True only when the setup wizard explicitly offered a connection test and the user skipped it.
+    /// Unknown profiles stay visually neutral so older and externally-created profiles are not mislabeled.
+    /// </summary>
+    public bool IsUnverified => _profile.Verification.IsUnverified;
+
+    /// <summary>
     /// Short status string suitable for a badge or subtitle.
     /// </summary>
     public string StatusLabel => IsConnecting && _transitionKind == ConnectionTransitionKind.Reconnecting
@@ -184,6 +190,7 @@ public sealed partial class AgentProfileItemViewModel : ObservableObject, IDispo
         Name = profile.Name;
         EndpointDescription = BuildEndpointDescription(profile);
         OnPropertyChanged(nameof(TransportGlyph));
+        OnPropertyChanged(nameof(IsUnverified));
     }
 
     internal void ReprojectLocalizedState()

--- a/tests/SalmonEgg.Domain.Tests/Models/ProfileVerificationTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/ProfileVerificationTests.cs
@@ -1,0 +1,86 @@
+using System;
+using SalmonEgg.Domain.Models;
+using Xunit;
+
+namespace SalmonEgg.Domain.Tests.Models;
+
+/// <summary>
+/// Pins the three-state verification contract that the connection list's warning affordance and the
+/// setup wizard's save step both read.
+/// </summary>
+/// <remarks>
+/// The distinction under test is <see cref="ProfileVerificationState.Unknown"/> versus
+/// <see cref="ProfileVerificationState.Unverified"/>. Collapsing the two — the shape a boolean would
+/// force — puts a "not verified" mark on every profile written before this state existed and on every
+/// profile the CLI or the profile editor creates, none of which were ever offered a test.
+/// </remarks>
+public sealed class ProfileVerificationTests
+{
+    [Fact]
+    public void FreshProfile_IsUnknown_SoNothingIsRetroactivelyFlagged()
+    {
+        var profile = new ServerConfiguration();
+
+        Assert.Equal(ProfileVerificationState.Unknown, profile.Verification.State);
+        // Both false: an unasked question is neither a pass nor a refusal, and the warning
+        // affordance binds to IsUnverified.
+        Assert.False(profile.Verification.IsVerified);
+        Assert.False(profile.Verification.IsUnverified);
+        Assert.Null(profile.Verification.VerifiedAtUtc);
+    }
+
+    /// <summary>
+    /// <c>default</c> has to be <see cref="ProfileVerification.Unknown"/> on its own, not only because
+    /// <see cref="ServerConfiguration"/> happens to initialize the property. Any writer that builds a
+    /// configuration without mentioning verification — and every writer outside the wizard does — gets
+    /// this value.
+    /// </summary>
+    [Fact]
+    public void Default_IsUnknown_WithoutAnyInitializer()
+    {
+        Assert.Equal(ProfileVerification.Unknown, default(ProfileVerification));
+        Assert.Equal(ProfileVerificationState.Unknown, default(ProfileVerification).State);
+    }
+
+    [Fact]
+    public void Unverified_CarriesNoTimestamp_SoNoStaleEvidenceSurvivesTheVerdict()
+    {
+        var verification = ProfileVerification.Unverified;
+
+        Assert.Equal(ProfileVerificationState.Unverified, verification.State);
+        Assert.True(verification.IsUnverified);
+        Assert.False(verification.IsVerified);
+        Assert.Null(verification.VerifiedAtUtc);
+    }
+
+    [Fact]
+    public void Verified_CarriesTheMomentItPassed()
+    {
+        var passedAt = new DateTimeOffset(2026, 8, 30, 12, 0, 0, TimeSpan.Zero);
+
+        var verification = ProfileVerification.Verified(passedAt);
+
+        Assert.Equal(ProfileVerificationState.Verified, verification.State);
+        Assert.True(verification.IsVerified);
+        Assert.False(verification.IsUnverified);
+        Assert.Equal(passedAt, verification.VerifiedAtUtc);
+    }
+
+    /// <summary>
+    /// The timestamp is normalized to UTC on the way in, so two profiles verified at the same instant in
+    /// different time zones compare equal and persist identically.
+    /// </summary>
+    [Fact]
+    public void Verified_NormalizesTheTimestampToUtc()
+    {
+        var localised = new DateTimeOffset(2026, 8, 30, 20, 0, 0, TimeSpan.FromHours(8));
+
+        var verification = ProfileVerification.Verified(localised);
+
+        Assert.Equal(TimeSpan.Zero, verification.VerifiedAtUtc!.Value.Offset);
+        Assert.Equal(localised.UtcDateTime, verification.VerifiedAtUtc!.Value.UtcDateTime);
+        Assert.Equal(
+            ProfileVerification.Verified(localised.ToOffset(TimeSpan.FromHours(-5))),
+            verification);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigContentFingerprintTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigContentFingerprintTests.cs
@@ -95,6 +95,36 @@ public sealed class ConfigContentFingerprintTests : IDisposable
             _fingerprint.ComputeFromPackage(late, includeSecrets: false));
     }
 
+    [Fact]
+    public void ComputeFromPackage_VerificationVerdictChangesFingerprint()
+    {
+        const string profileWithoutVerdict = """
+            schema_version: 4
+            id: verification-fingerprint-001
+            name: Verification Fingerprint
+            transport: websocket
+            server_url: ws://localhost:8080
+            connection_timeout_seconds: 10
+            """;
+        var unknown = CreatePackageWithConfigFile("servers/verification-fingerprint-001.yaml", profileWithoutVerdict);
+        var unverified = CreatePackageWithConfigFile(
+            "servers/verification-fingerprint-001.yaml",
+            profileWithoutVerdict + Environment.NewLine + "verification: unverified" + Environment.NewLine);
+        var verified = CreatePackageWithConfigFile(
+            "servers/verification-fingerprint-001.yaml",
+            profileWithoutVerdict + Environment.NewLine +
+            "verification: verified" + Environment.NewLine +
+            "verified_at_utc: 2026-08-30T12:15:30.0000000+00:00" + Environment.NewLine);
+
+        var unknownFingerprint = _fingerprint.ComputeFromPackage(unknown, includeSecrets: false);
+        var unverifiedFingerprint = _fingerprint.ComputeFromPackage(unverified, includeSecrets: false);
+        var verifiedFingerprint = _fingerprint.ComputeFromPackage(verified, includeSecrets: false);
+
+        Assert.NotEqual(unknownFingerprint, unverifiedFingerprint);
+        Assert.NotEqual(unknownFingerprint, verifiedFingerprint);
+        Assert.NotEqual(unverifiedFingerprint, verifiedFingerprint);
+    }
+
     private static byte[] CreatePackageWithManifestTime(string appYamlBody, DateTimeOffset createdAtUtc)
     {
         using var stream = new MemoryStream();
@@ -103,6 +133,17 @@ public sealed class ConfigContentFingerprintTests : IDisposable
             var manifest = $$"""{"schemaVersion":1,"appId":"SalmonEgg","createdAtUtc":"{{createdAtUtc:O}}","files":["app.yaml"]}""";
             WriteEntry(archive, "manifest.json", manifest);
             WriteEntry(archive, "files/config/app.yaml", $"schema_version: 2{Environment.NewLine}{appYamlBody}{Environment.NewLine}");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreatePackageWithConfigFile(string relativePath, string content)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteEntry(archive, $"files/config/{relativePath}", content);
         }
 
         return stream.ToArray();

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigSchemaVersionContractTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigSchemaVersionContractTests.cs
@@ -16,7 +16,7 @@ namespace SalmonEgg.Infrastructure.Tests.Storage;
 ///
 /// Bumping a version deliberately means updating the number here in the same commit, and adding a
 /// load test for the previous version's files: purely additive keys need no migration (see
-/// <c>ConfigurationManagerTests.LoadConfigurationAsync_WithSchemaVersion2File_HydratesEmptyEnvironmentWithoutMigration</c>),
+/// <c>ConfigurationManagerTests.LoadConfigurationAsync_WithSchemaVersion3File_DefaultsVerificationToUnknown</c>),
 /// while a rename or a semantic change does.
 /// </remarks>
 public sealed class ConfigSchemaVersionContractTests
@@ -24,7 +24,7 @@ public sealed class ConfigSchemaVersionContractTests
     [Fact]
     public void ServerConfigurationSchemaVersion_IsPinnedToTheCurrentContract()
     {
-        Assert.Equal(3, ConfigurationManager.CurrentServerConfigurationSchemaVersion);
+        Assert.Equal(4, ConfigurationManager.CurrentServerConfigurationSchemaVersion);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Storage/ConfigurationManagerTests.cs
@@ -270,6 +270,143 @@ public sealed class ConfigurationManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadConfigurationAsync_WithSchemaVersion3File_DefaultsVerificationToUnknown()
+    {
+        const string configId = "schema-v3-no-verification-001";
+        var path = GetServerYamlPath(configId);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(
+            path,
+            """
+            schema_version: 3
+            id: schema-v3-no-verification-001
+            name: Legacy Profile
+            transport: websocket
+            server_url: ws://localhost:8080
+            connection_timeout_seconds: 10
+            authentication:
+              mode: none
+            proxy:
+              mode: system
+            """, TestContext.Current.CancellationToken);
+
+        var loaded = await _configManager.LoadConfigurationAsync(configId);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(ProfileVerification.Unknown, loaded!.Verification);
+    }
+
+    [Fact]
+    public async Task SaveConfigurationAsync_WithUnknownVerification_OmitsVerificationKeys()
+    {
+        var config = CreateTestConfiguration("verification-unknown-001");
+        config.Verification = ProfileVerification.Unknown;
+
+        await _configManager.SaveConfigurationAsync(config);
+
+        var yaml = await File.ReadAllTextAsync(GetServerYamlPath(config.Id), TestContext.Current.CancellationToken);
+        Assert.DoesNotContain("verification:", yaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("verified_at_utc:", yaml, StringComparison.Ordinal);
+
+        var loaded = await _configManager.LoadConfigurationAsync(config.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(ProfileVerification.Unknown, loaded!.Verification);
+    }
+
+    [Fact]
+    public async Task SaveConfigurationAsync_WithUnverifiedVerification_RoundTripsWithoutTimestamp()
+    {
+        var config = CreateTestConfiguration("verification-unverified-001");
+        config.Verification = ProfileVerification.Unverified;
+
+        await _configManager.SaveConfigurationAsync(config);
+
+        var yaml = await File.ReadAllTextAsync(GetServerYamlPath(config.Id), TestContext.Current.CancellationToken);
+        Assert.Contains("verification: unverified", yaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("verified_at_utc:", yaml, StringComparison.Ordinal);
+
+        var loaded = await _configManager.LoadConfigurationAsync(config.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(ProfileVerification.Unverified, loaded!.Verification);
+    }
+
+    [Fact]
+    public async Task SaveConfigurationAsync_WithVerifiedVerification_RoundTripsUtcTimestamp()
+    {
+        var config = CreateTestConfiguration("verification-verified-001");
+        var passedAt = new DateTimeOffset(2026, 8, 30, 20, 15, 30, TimeSpan.FromHours(8));
+        config.Verification = ProfileVerification.Verified(passedAt);
+
+        await _configManager.SaveConfigurationAsync(config);
+
+        var yaml = await File.ReadAllTextAsync(GetServerYamlPath(config.Id), TestContext.Current.CancellationToken);
+        Assert.Contains("verification: verified", yaml, StringComparison.Ordinal);
+        Assert.Contains("verified_at_utc:", yaml, StringComparison.Ordinal);
+
+        var loaded = await _configManager.LoadConfigurationAsync(config.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(config.Verification, loaded!.Verification);
+        Assert.Equal(TimeSpan.Zero, loaded.Verification.VerifiedAtUtc!.Value.Offset);
+    }
+
+    [Fact]
+    public async Task LoadConfigurationAsync_WithUnknownVerificationToken_DefaultsToUnknown()
+    {
+        const string configId = "verification-future-token-001";
+        var path = GetServerYamlPath(configId);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(
+            path,
+            """
+            schema_version: 4
+            id: verification-future-token-001
+            name: Future Verification
+            transport: websocket
+            server_url: ws://localhost:8080
+            connection_timeout_seconds: 10
+            verification: conditionally_verified
+            verified_at_utc: 2026-08-30T12:15:30.0000000+00:00
+            authentication:
+              mode: none
+            proxy:
+              mode: system
+            """, TestContext.Current.CancellationToken);
+
+        var loaded = await _configManager.LoadConfigurationAsync(configId);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(ProfileVerification.Unknown, loaded!.Verification);
+    }
+
+    [Fact]
+    public async Task LoadConfigurationAsync_WithVerifiedVerdictButMissingTimestamp_DefaultsToUnknown()
+    {
+        const string configId = "verification-missing-timestamp-001";
+        var path = GetServerYamlPath(configId);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(
+            path,
+            """
+            schema_version: 4
+            id: verification-missing-timestamp-001
+            name: Missing Verification Evidence
+            transport: websocket
+            server_url: ws://localhost:8080
+            connection_timeout_seconds: 10
+            verification: verified
+            authentication:
+              mode: none
+            proxy:
+              mode: system
+            """, TestContext.Current.CancellationToken);
+
+        var loaded = await _configManager.LoadConfigurationAsync(configId);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(ProfileVerification.Unknown, loaded!.Verification);
+    }
+
+    [Fact]
     public async Task TransportPersistence_WritesAndReadsCanonicalStreamableHttp()
     {
         var config = CreateTestConfiguration("streamable-http-001");

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpConnectionSettingsViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpConnectionSettingsViewModelTests.cs
@@ -1024,6 +1024,36 @@ public sealed class AcpConnectionSettingsViewModelTests
     }
 
     [Fact]
+    public void ProfileVerificationProjection_OnlyExplicitSkipShowsWarningAndRefreshes()
+    {
+        var registry = new InMemoryAcpConnectionSessionRegistry();
+        using var item = CreateAgentProfileItem("profile-a", registry, new TestConnectionCommands());
+        var changed = new List<string?>();
+        item.PropertyChanged += (_, args) => changed.Add(args.PropertyName);
+
+        Assert.False(item.IsUnverified);
+
+        item.UpdateProfile(new ServerConfiguration
+        {
+            Id = "profile-a",
+            Name = "profile-a",
+            Verification = ProfileVerification.Unverified
+        });
+
+        Assert.True(item.IsUnverified);
+        Assert.Contains(nameof(AgentProfileItemViewModel.IsUnverified), changed);
+
+        item.UpdateProfile(new ServerConfiguration
+        {
+            Id = "profile-a",
+            Name = "profile-a",
+            Verification = ProfileVerification.Verified(DateTimeOffset.UtcNow)
+        });
+
+        Assert.False(item.IsUnverified);
+    }
+
+    [Fact]
     public void ApplyConnectionToggleRequestCommand_WhenConnectIsPending_UsesConnectingLabelAndKeepsAuthoritativeSwitchState()
     {
         var registry = new InMemoryAcpConnectionSessionRegistry();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpConnectionSettingsXamlTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpConnectionSettingsXamlTests.cs
@@ -211,6 +211,7 @@ public sealed class AcpConnectionSettingsXamlTests
         string[] requiredResources =
         [
             "Acp_ProfileReconnect.Text",
+            "Acp_ProfileUnverified.Text",
             "AgentProfileEditor_CurrentConnectionSavedNoticeMessage"
         ];
 
@@ -268,6 +269,31 @@ public sealed class AcpConnectionSettingsXamlTests
         Assert.Contains("<MenuFlyout>", xaml, StringComparison.Ordinal);
         AssertProfileMenuItem(document, "Acp_ProfileEdit", "\uE70F");
         AssertProfileMenuItem(document, "Acp_ProfileDelete", "\uE74D");
+    }
+
+    [Fact]
+    public void AcpConnectionSettingsPage_ProfileList_ProjectsUnverifiedSeparatelyFromConnectionState()
+    {
+        var xaml = LoadFile(@"SalmonEgg\SalmonEgg\Presentation\Views\Settings\AcpConnectionSettingsPage.xaml");
+        var document = XDocument.Parse(xaml);
+        var unverified = Assert.Single(document.Descendants(), element =>
+            string.Equals(
+                (string?)element.Attribute("AutomationProperties.AutomationId"),
+                "Acp.Profile.Unverified",
+                StringComparison.Ordinal));
+
+        Assert.Equal(
+            "{x:Bind IsUnverified, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}",
+            (string?)unverified.Attribute("Visibility"));
+        Assert.Contains(unverified.Descendants(), element =>
+            string.Equals(element.Name.LocalName, "TextBlock", StringComparison.Ordinal)
+            && string.Equals(
+                element.Attributes().FirstOrDefault(attribute => attribute.Name.LocalName == "Uid")?.Value,
+                "Acp_ProfileUnverified",
+                StringComparison.Ordinal));
+
+        Assert.Contains("Visibility=\"{x:Bind IsStableConnected, Mode=OneWay", xaml, StringComparison.Ordinal);
+        Assert.Contains("Visibility=\"{x:Bind IsStableDisconnected, Mode=OneWay", xaml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -409,7 +409,8 @@ internal static class AcpSetupWizardFixtures
         IAcpSetupConnectivityTester connectivityTester,
         IConfigurationService configurationService,
         IStringLocalizer<CoreStrings>? localizer = null,
-        IUiDispatcher? uiDispatcher = null)
+        IUiDispatcher? uiDispatcher = null,
+        TimeProvider? timeProvider = null)
         => new(
             new AcpSetupWizardOrchestrator(
                 catalog,
@@ -422,7 +423,8 @@ internal static class AcpSetupWizardFixtures
             // what the real WinUI one does: every marshalled write lands later, on another thread.
             uiDispatcher ?? new ImmediateUiDispatcher(),
             NullLogger<AcpSetupWizardViewModel>.Instance,
-            localizer);
+            localizer,
+            timeProvider);
 
     /// <summary>The healthy-machine answer most tests walk against.</summary>
     public static class WellKnownResults

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardViewModelTests.cs
@@ -290,12 +290,13 @@ public sealed class AcpSetupWizardViewModelTests
         // The launcher the plan runs is the adapter's, not the runtime's, so the override belongs here.
         Assert.Equal("npx", wizard.AdapterProbeCommand);
         wizard.AdapterCustomCommand = customNpx;
-        await wizard.GoNextCommand.ExecuteAsync(null); // -> Parameters
+        await wizard.DetectAdapterCommand.ExecuteAsync(null);
+        Assert.True(wizard.IsAdapterUsable);
+        await wizard.GoNextCommand.ExecuteAsync(null); // -> Test; the empty parameter step is folded
 
         // The preview a user reviews before testing must already show the path they supplied.
         Assert.StartsWith(customNpx, wizard.LaunchCommandPreview, StringComparison.Ordinal);
 
-        await wizard.GoNextCommand.ExecuteAsync(null); // -> Test
         await wizard.TestCommand.ExecuteAsync(null);
         Assert.True(wizard.IsTestSuccessful);
         // What was tested carries the override too, so the verdict is about the real command.
@@ -363,9 +364,11 @@ public sealed class AcpSetupWizardViewModelTests
     /// Built-in is now its own state, separate from "installed", so the step can say why it is satisfied.
     /// </summary>
     [Fact]
-    public async Task BuiltInAdapter_ReportsBuiltIn_NotInstalled_AndAllowsAdvance()
+    public async Task BuiltInAdapter_WhenItIsTheOnlyChoice_AutoSkipsComponentSetup()
     {
-        var agent = AcpSetupWizardFixtures.Agent(adapters: AcpSetupWizardFixtures.BuiltInAdapter());
+        var parameter = AcpSetupWizardFixtures.Parameter("--model", defaultValue: "sonnet");
+        var agent = AcpSetupWizardFixtures.Agent(
+            adapters: AcpSetupWizardFixtures.BuiltInAdapter(parameters: parameter));
         var wizard = CreateWizardFor(
             agent,
             ProbeForInstalledRuntime(),
@@ -375,13 +378,26 @@ public sealed class AcpSetupWizardViewModelTests
         wizard.SelectedAgent = Assert.Single(wizard.Agents);
         await wizard.GoNextCommand.ExecuteAsync(null);
 
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
         Assert.True(wizard.IsAdapterBuiltIn);
         Assert.False(wizard.IsAdapterInstalled);
         Assert.False(wizard.IsAdapterMissing);
         Assert.False(wizard.IsAdapterUndetermined);
+        Assert.Equal("sonnet", Assert.Single(wizard.Parameters).Value);
         // A built-in adapter has no launcher to name, so the override disclosure stays hidden.
         Assert.False(wizard.HasAdapterProbeCommand);
         Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Parameters_WhenTemplateIsEmpty_AutoSkipsToTestAfterPreparingThePlan()
+    {
+        var (wizard, _, _) = await WalkToTestStepAsync();
+
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        Assert.Empty(wizard.Parameters);
+        Assert.Contains(AcpSetupWizardFixtures.AdapterPackage, wizard.LaunchCommandPreview, StringComparison.Ordinal);
+        Assert.True(wizard.IsSkipTestVisible);
     }
 
     /// <summary>
@@ -592,11 +608,11 @@ public sealed class AcpSetupWizardViewModelTests
         var zh = new MutableTestCoreStringLocalizer();
         zh.Set("zh-Hans", "AcpSetup_Step_Position", "第 {0} 步，共 {1} 步");
         var (wizardZh, _, _) = await WalkToComponentSetupAsync(localizer: zh);
-        Assert.Equal("第 2 步，共 5 步", wizardZh.StepPositionText);
+        Assert.Equal("第 2 步，共 4 步", wizardZh.StepPositionText);
 
         // Without a localizer the fallback template formats, so the position is still stated.
         var (wizardFallback, _, _) = await WalkToComponentSetupAsync(localizer: null);
-        Assert.Equal("Step 2 of 5", wizardFallback.StepPositionText);
+        Assert.Equal("Step 2 of 4", wizardFallback.StepPositionText);
     }
 
     [Fact]
@@ -619,6 +635,11 @@ public sealed class AcpSetupWizardViewModelTests
         Assert.True(wizard.IsAdapterMissing);
         Assert.Contains("/test/bin/npm", wizard.AdapterProbeDetail, StringComparison.Ordinal);
         Assert.False(wizard.GoNextCommand.CanExecute(null));
+
+        // A stale binding can still invoke an async command directly. The handler must keep the same gate
+        // as CanExecute, otherwise automatic folding would become a back door around a missing adapter.
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
 
         // Installing flips the package answer; the orchestrator re-probes after the install.
         installer.OnInstall = _ => probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, true);
@@ -665,7 +686,8 @@ public sealed class AcpSetupWizardViewModelTests
     [Fact]
     public async Task GoBack_RewindsOneStepAtATime_AndClearsErrorSurface()
     {
-        var (wizard, tester, configuration) = await WalkToTestAsync();
+        var parameter = AcpSetupWizardFixtures.Parameter("--model", defaultValue: "sonnet");
+        var (wizard, tester, configuration) = await WalkToTestAsync(parameters: new[] { parameter });
 
         wizard.ErrorMessage = "boom";
         wizard.GoBackCommand.Execute(null);
@@ -681,21 +703,72 @@ public sealed class AcpSetupWizardViewModelTests
     }
 
     [Fact]
+    public async Task GoBack_WhenIntermediateStepsWereFolded_ReturnsToThePreviousVisibleStep()
+    {
+        var wizard = CreateWizard();
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        Assert.Equal("Step 2 of 3", wizard.StepPositionText);
+
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        Assert.False(wizard.GoBackCommand.CanExecute(null));
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+    }
+
+    [Fact]
     public async Task Test_SuccessfulHandshake_UnlocksSaveAndCarriesPlan()
     {
-        var (wizard, tester, configuration) = await WalkToTestStepAsync();
+        var verifiedAt = new DateTimeOffset(2026, 8, 30, 12, 34, 56, TimeSpan.Zero);
+        var (wizard, tester, configuration) = await WalkToTestStepAsync(
+            timeProvider: new FixedTimeProvider(verifiedAt));
 
         await wizard.TestCommand.ExecuteAsync(null);
 
         Assert.True(wizard.IsTestSuccessful);
+        Assert.Equal(ProfileVerificationState.Verified, wizard.Verification.State);
+        Assert.Equal(verifiedAt, wizard.Verification.VerifiedAtUtc);
         Assert.Equal(1, tester.TestCount);
         // The walk adapter is npx-packaged, so the plan launches through npx.
         Assert.NotNull(tester.LastPlan);
-        Assert.Equal("npx", tester.LastPlan!.Command);
+        Assert.Equal("/usr/bin/npx", tester.LastPlan!.Command);
         Assert.Contains(AcpSetupWizardFixtures.AdapterPackage, tester.LastPlan!.Arguments, StringComparer.Ordinal);
         // The name is still empty at this point, so save stays locked until the user names it.
         Assert.False(wizard.SaveCommand.CanExecute(null));
         Assert.True(wizard.GoNextCommand.CanExecute(null));
+        Assert.False(wizard.IsSkipTestVisible);
+        Assert.False(wizard.SkipTestCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task SkipTest_RecordsUnverifiedAndAllowsSavingWithoutRunningTheTester()
+    {
+        var (wizard, tester, configuration) = await WalkToTestStepAsync();
+
+        Assert.Equal(ProfileVerificationState.Unknown, wizard.Verification.State);
+        Assert.True(wizard.IsSkipTestVisible);
+        Assert.True(wizard.SkipTestCommand.CanExecute(null));
+
+        wizard.SkipTestCommand.Execute(null);
+
+        Assert.Equal(AcpSetupWizardStep.Save, wizard.Step);
+        Assert.Equal("Test Agent", wizard.ProfileName);
+        Assert.Equal(ProfileVerificationState.Unverified, wizard.Verification.State);
+        Assert.Null(wizard.Verification.VerifiedAtUtc);
+        Assert.False(wizard.IsSkipTestVisible);
+        Assert.Equal(0, tester.TestCount);
+        Assert.True(wizard.SaveCommand.CanExecute(null));
+
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        var saved = Assert.Single(configuration.Saved);
+        Assert.Equal(ProfileVerificationState.Unverified, saved.Verification.State);
+        Assert.Null(saved.Verification.VerifiedAtUtc);
     }
 
     [Fact]
@@ -822,7 +895,9 @@ public sealed class AcpSetupWizardViewModelTests
     [Fact]
     public async Task Save_AfterSuccessfulTest_PersistsStdioProfileShape()
     {
-        var (wizard, tester, configuration) = await WalkToTestAsync();
+        var verifiedAt = new DateTimeOffset(2026, 8, 30, 1, 2, 3, TimeSpan.Zero);
+        var (wizard, tester, configuration) = await WalkToTestAsync(
+            timeProvider: new FixedTimeProvider(verifiedAt));
 
         await wizard.GoNextCommand.ExecuteAsync(null); // → Save; name prefilled from the agent
         Assert.Equal("Test Agent", wizard.ProfileName);
@@ -833,23 +908,56 @@ public sealed class AcpSetupWizardViewModelTests
         Assert.Same(saved, wizard.SavedProfile);
         Assert.Equal("Test Agent", saved.Name);
         Assert.Equal(TransportType.Stdio, saved.Transport);
-        Assert.Equal("npx", saved.StdioCommand);
+        Assert.Equal("/usr/bin/npx", saved.StdioCommand);
         Assert.Contains(AcpSetupWizardFixtures.AdapterPackage, saved.StdioArguments!, StringComparer.Ordinal);
+        Assert.Equal(ProfileVerificationState.Verified, saved.Verification.State);
+        Assert.Equal(verifiedAt, saved.Verification.VerifiedAtUtc);
         Assert.True(wizard.IsOnSave);
     }
 
     [Fact]
-    public async Task Save_RequiresSuccessfulTest_EvenWhenInvokedDirectly()
+    public async Task Save_RequiresAnExplicitVerdict_EvenWhenInvokedDirectly()
     {
         var (wizard, tester, configuration) = await WalkToTestStepAsync();
 
-        Assert.False(wizard.SaveCommand.CanExecute(null), "an untested draft must not be savable");
+        Assert.False(wizard.SaveCommand.CanExecute(null), "a draft with no test or skip verdict must not be savable");
 
         // Direct invocation bypasses CanExecute, so the handler itself must hold the line too.
         await wizard.SaveCommand.ExecuteAsync(null);
 
         Assert.Empty(configuration.Saved);
         Assert.Equal(0, tester.TestCount);
+    }
+
+    [Fact]
+    public async Task ParameterChange_AfterPassingTest_ClearsTheVerifiedVerdict()
+    {
+        var parameter = AcpSetupWizardFixtures.Parameter("--model", defaultValue: "sonnet");
+        var (wizard, _, _) = await WalkToTestAsync(parameters: new[] { parameter });
+        Assert.True(wizard.IsTestSuccessful);
+
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
+        Assert.Single(wizard.Parameters).Value = "opus";
+
+        Assert.Equal(ProfileVerificationState.Unknown, wizard.Verification.State);
+        Assert.False(wizard.IsTestSuccessful);
+        Assert.False(wizard.SaveCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task AdapterOverrideChange_AfterPassingTest_ClearsTheVerifiedVerdict()
+    {
+        var (wizard, _, _) = await WalkToTestAsync();
+        Assert.True(wizard.IsTestSuccessful);
+
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        wizard.AdapterCustomCommand = "/opt/node/bin/npx";
+
+        Assert.Equal(ProfileVerificationState.Unknown, wizard.Verification.State);
+        Assert.False(wizard.IsTestSuccessful);
+        Assert.False(wizard.SaveCommand.CanExecute(null));
     }
 
     [Fact]
@@ -942,6 +1050,7 @@ public sealed class AcpSetupWizardViewModelTests
         MutableTestCoreStringLocalizer? localizer = null)
     {
         var probe = ProbeForInstalledRuntime();
+        ConfigurePackagedAdapterProbe(probe);
         var packagedAdapter = AcpSetupWizardFixtures.PackagedAdapter(
             parameters: parameters ?? Array.Empty<AcpSetupParameterDefinition>());
         return WalkToParametersAsync(probe, packagedAdapter, localizer);
@@ -961,16 +1070,41 @@ public sealed class AcpSetupWizardViewModelTests
         wizard.SelectedAgent = wizard.Agents[0];
         await wizard.GoNextCommand.ExecuteAsync(null); // → ComponentSetup
         await wizard.GoNextCommand.ExecuteAsync(null); // → Parameters
+        Assert.Equal(AcpSetupWizardStep.Parameters, wizard.Step);
         return (wizard, tester, configuration);
     }
 
     /// <summary>Walks to the Test step without running the test.</summary>
     private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToTestStepAsync(
         AcpSetupParameterDefinition[]? parameters = null,
-        MutableTestCoreStringLocalizer? localizer = null)
+        MutableTestCoreStringLocalizer? localizer = null,
+        TimeProvider? timeProvider = null)
     {
-        var (wizard, tester, configuration) = await WalkToParametersAsync(parameters, localizer);
-        await wizard.GoNextCommand.ExecuteAsync(null); // → Test
+        var probe = ProbeForInstalledRuntime();
+        ConfigurePackagedAdapterProbe(probe);
+        var adapter = AcpSetupWizardFixtures.PackagedAdapter(
+            parameters: parameters ?? Array.Empty<AcpSetupParameterDefinition>());
+        var agent = AcpSetupWizardFixtures.Agent(adapters: adapter);
+        var tester = new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success());
+        var configuration = new RecordingConfigurationService();
+        var wizard = CreateWizardFor(
+            agent,
+            probe,
+            new StubComponentInstaller(),
+            localizer,
+            tester,
+            configuration,
+            timeProvider);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[0];
+        await wizard.GoNextCommand.ExecuteAsync(null); // → ComponentSetup
+        await wizard.GoNextCommand.ExecuteAsync(null); // → Parameters or Test when the form is empty
+        if (wizard.IsOnParameters)
+        {
+            await wizard.GoNextCommand.ExecuteAsync(null); // → Test
+        }
+
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
         return (wizard, tester, configuration);
     }
 
@@ -980,9 +1114,10 @@ public sealed class AcpSetupWizardViewModelTests
     /// </summary>
     private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> WalkToTestAsync(
         AcpSetupParameterDefinition[]? parameters = null,
-        MutableTestCoreStringLocalizer? localizer = null)
+        MutableTestCoreStringLocalizer? localizer = null,
+        TimeProvider? timeProvider = null)
     {
-        var walked = await WalkToTestStepAsync(parameters, localizer);
+        var walked = await WalkToTestStepAsync(parameters, localizer, timeProvider);
         await walked.Wizard.TestCommand.ExecuteAsync(null);
         return walked;
     }
@@ -1283,6 +1418,12 @@ public sealed class AcpSetupWizardViewModelTests
         return probe;
     }
 
+    private static void ConfigurePackagedAdapterProbe(StubExecutableProbe probe)
+    {
+        probe.SetExecutable("npx", "/usr/bin/npx");
+        probe.SetNodePackage(AcpSetupWizardFixtures.AdapterPackage, installed: true);
+    }
+
     private static AcpSetupWizardViewModel CreateWizard(
         StubExecutableProbe? probe = null,
         StubComponentInstaller? installer = null,
@@ -1295,14 +1436,16 @@ public sealed class AcpSetupWizardViewModelTests
         StubComponentInstaller installer,
         MutableTestCoreStringLocalizer? localizer,
         StubConnectivityTester? tester = null,
-        RecordingConfigurationService? configuration = null)
+        RecordingConfigurationService? configuration = null,
+        TimeProvider? timeProvider = null)
         => AcpSetupWizardFixtures.CreateWizard(
             new StubAgentCatalog(agent),
             probe,
             installer,
             tester ?? new StubConnectivityTester(AcpSetupWizardFixtures.WellKnownResults.Success()),
             configuration ?? new RecordingConfigurationService(),
-            localizer);
+            localizer,
+            timeProvider: timeProvider);
 
     // ── Missing toolchain ───────────────────────────────────────────────────
 
@@ -1545,5 +1688,10 @@ public sealed class AcpSetupWizardViewModelTests
         Assert.True(wizard.IsAdapterBuiltIn);
         Assert.False(wizard.IsAdapterToolchainMissing);
         Assert.Empty(wizard.AdapterToolchainMissingText);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+using static SalmonEgg.Presentation.Core.Tests.Ui.XamlComplianceTestHelpers;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+public sealed class AcpSetupWizardXamlTests
+{
+    private const string WizardPath = "SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml";
+
+    [Fact]
+    public void Navigation_ExposesSecondarySkipAndAnnouncesDynamicStepPosition()
+    {
+        var document = XDocument.Parse(LoadXaml(WizardPath));
+
+        var skip = FindByName(document, "AcpSetupSkipTestButton");
+        Assert.Equal("AcpSetup_SkipTest", AttributeByLocalName(skip, "Uid"));
+        Assert.Equal("{x:Bind ViewModel.SkipTestCommand}", skip.Attribute("Command")?.Value);
+        Assert.Equal(
+            "{x:Bind ViewModel.IsSkipTestVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}",
+            skip.Attribute("Visibility")?.Value);
+        Assert.Equal("AcpSetup.SkipTest", skip.Attribute("AutomationProperties.AutomationId")?.Value);
+        Assert.Null(skip.Attribute("Style"));
+
+        var next = FindByName(document, "AcpSetupNextStepButton");
+        Assert.Equal("{StaticResource AccentButtonStyle}", next.Attribute("Style")?.Value);
+        Assert.Equal("AcpSetup.Next", next.Attribute("AutomationProperties.AutomationId")?.Value);
+        Assert.Equal(
+            "AcpSetup.Back",
+            FindByName(document, "AcpSetupBackStepButton").Attribute("AutomationProperties.AutomationId")?.Value);
+
+        var position = FindByName(document, "AcpSetupStepPosition");
+        Assert.Equal("{x:Bind ViewModel.StepPositionText, Mode=OneWay}", position.Attribute("Text")?.Value);
+        Assert.Equal("Polite", position.Attribute("AutomationProperties.LiveSetting")?.Value);
+        Assert.Equal("AcpSetup.StepPosition", position.Attribute("AutomationProperties.AutomationId")?.Value);
+    }
+
+    [Fact]
+    public void LocalizedStepTitles_DoNotClaimFixedOrdinalsWhenStepsCanBeSkipped()
+    {
+        string[] resourceFiles =
+        [
+            "SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw",
+            "SalmonEgg/SalmonEgg/Strings/en/Resources.resw",
+            "SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw"
+        ];
+        string[] titleKeys =
+        [
+            "AcpSetup_AgentsTitle.Text",
+            "AcpSetup_ComponentsTitle.Text",
+            "AcpSetup_ParametersTitle.Text",
+            "AcpSetup_TestTitle.Text",
+            "AcpSetup_SaveTitle.Text"
+        ];
+        string[] skipKeys =
+        [
+            "AcpSetup_SkipTest.Content",
+            "AcpSetup_SkipTest.AutomationProperties.HelpText"
+        ];
+
+        foreach (var resourceFile in resourceFiles)
+        {
+            var resources = XDocument.Parse(LoadText(resourceFile));
+            var values = resources.Descendants("data").ToDictionary(
+                data => (string)data.Attribute("name")!,
+                data => data.Element("value")?.Value ?? string.Empty,
+                StringComparer.Ordinal);
+
+            foreach (var key in titleKeys)
+            {
+                Assert.True(values.TryGetValue(key, out var value), $"{resourceFile} must define {key}.");
+                Assert.DoesNotMatch(@"^\d+\.", value);
+            }
+
+            foreach (var key in skipKeys)
+            {
+                Assert.True(values.TryGetValue(key, out var value), $"{resourceFile} must define {key}.");
+                Assert.False(string.IsNullOrWhiteSpace(value), $"{resourceFile} must localize {key}.");
+            }
+        }
+    }
+
+    private static XElement FindByName(XDocument document, string name)
+        => Assert.Single(document.Descendants(), element =>
+            string.Equals(AttributeByLocalName(element, "Name"), name, StringComparison.Ordinal));
+
+    private static string? AttributeByLocalName(XElement element, string localName)
+        => element.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, localName, StringComparison.Ordinal))
+            ?.Value;
+}


### PR DESCRIPTION
Closes #136

## Summary

Three linear commits, each independently buildable and green:

1. **Persist a three-state verification verdict** — `ProfileVerification` (Unknown / Unverified / Verified + passing timestamp) on `ServerConfiguration`, mapped additively through the YAML schema so v3 files load unchanged and `Unknown` still writes no verification keys. The verdict is business content: changing it moves the cloud-sync fingerprint.
2. **Wizard skip-test + stale-verdict invalidation** — the test step offers Skip, which lands on Save with an explicit `Unverified` verdict (`Unknown` remains a non-saveable non-answer). Applicable steps are resolved live from draft/template/probe facts, and every launch-field mutation (parameters, adapter override, re-detection, agent change) clears a stale verdict before it can be saved.
3. **UI surface** — native secondary Skip button on the test step, polite live-region step announcements, and an `Unverified` hint in the connection list shown only for explicitly-unverified profiles (legacy / externally-created `Unknown` profiles stay visually neutral). Strings in en / en-US / zh-Hans.

## Test evidence

- **Per-commit (rebase-merge safety)**: verified in a clean worktree — commit 1: Domain 88/88 + Infrastructure 703/703; commit 2: Application 120/120 + wizard VM 65/65. Every commit in the stack compiles and its tests pass on its own.
- **Tip**: Presentation.Core 3273/3273; Desktop (`net10.0-desktop`) XAML compile with 0 warnings; fingerprint / schema-contract suites green.
- Branch is three linear commits directly on top of `origin/main` (`b90b77aa`), no merge commits — rebase merge applies cleanly with no conflicts.

## Note

Two pre-existing flaky behaviors in the full Presentation.Core suite (test-host crash via an escaped `ChatViewModel` cancellation, and two load-sensitive VoiceInput probe tests) were diagnosed and reproduced on clean HEAD — tracked separately in #139, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)