### PR TITLE
feat(acp-setup): install missing Node and uv toolchains from the wizard

### DIFF
--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -520,6 +520,7 @@ public static class DependencyInjection
 #if __WASM__ || __ANDROID__ || __IOS__
         services.AddSingleton<IAcpExecutableProbe, UnsupportedAcpExecutableProbe>();
         services.AddSingleton<IAcpComponentInstaller, UnsupportedAcpComponentInstaller>();
+        services.AddSingleton<IAcpToolchainInstaller, UnsupportedAcpToolchainInstaller>();
         services.AddSingleton<IAcpSetupConnectivityTester, UnsupportedAcpSetupConnectivityTester>();
 #else
         // Widens what the probe can find beyond the PATH this process inherited. A GUI-launched app gets
@@ -534,6 +535,10 @@ public static class DependencyInjection
             sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
                 ? new DesktopAcpComponentInstaller(sp.GetRequiredService<IAcpExecutableProbe>())
                 : new UnsupportedAcpComponentInstaller());
+        services.AddSingleton<IAcpToolchainInstaller>(sp =>
+            sp.GetRequiredService<IPlatformCapabilityService>().SupportsStdioTransport
+                ? new DesktopAcpToolchainInstaller()
+                : new UnsupportedAcpToolchainInstaller());
         services.AddSingleton<IAcpSetupHandshakeProbe>(sp =>
             new StdioAcpSetupHandshakeProbe(
                 sp.GetRequiredService<IStdioTransportFactory>(),
@@ -552,7 +557,8 @@ public static class DependencyInjection
                 sp.GetRequiredService<IAcpExecutableProbe>(),
                 sp.GetRequiredService<IAcpComponentInstaller>(),
                 sp.GetRequiredService<IAcpSetupConnectivityTester>(),
-                sp.GetRequiredService<IConfigurationService>()));
+                sp.GetRequiredService<IConfigurationService>(),
+                sp.GetRequiredService<IAcpToolchainInstaller>()));
         services.AddSingleton<ChatServiceFactory>(sp =>
         {
             var transportFactory = sp.GetRequiredService<ITransportFactory>();

--- a/SalmonEgg/SalmonEgg/Platforms/Desktop/Program.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/Desktop/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
 using SalmonEgg.Infrastructure.Services;
 using Uno.UI.Hosting;
 
@@ -9,6 +10,23 @@ internal class Program
     [STAThread]
     static void Main(string[] args)
     {
+        // Answered before anything else runs, including native prerequisites. The ACP wizard recovers the
+        // user's real PATH by asking their login shell to start an executable that prints the environment
+        // that shell produced, and this head is one of the two executables that answer it — which is what
+        // lets the capture work on a machine where only the app is installed. See DesktopPrintEnvironment.
+        //
+        // Nothing may be initialized first. The prerequisites below dlopen a native rendering library, and
+        // this invocation renders nothing; on a machine missing it, an environment probe would fail where a
+        // probe has no business needing graphics at all.
+        if (DesktopPrintEnvironment.TryGetMarker(args ?? Array.Empty<string>(), out var environmentMarker))
+        {
+            DesktopPrintEnvironment
+                .WriteAsync(environmentMarker, Console.Out)
+                .GetAwaiter()
+                .GetResult();
+            return;
+        }
+
         DesktopNativePrerequisites.Initialize();
         App.InitializeLogging();
 

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -155,6 +155,13 @@
                                                             Click="OnInstallAgentRowClick"
                                                             AutomationProperties.AutomationId="AcpSetup.Agents.InstallRow"
                                                             Visibility="{x:Bind CanInstallHere, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                    <Button x:Name="InstallAgentToolchainInlineButton"
+                                                            x:Uid="AcpSetup_InstallToolchain"
+                                                            Style="{StaticResource AccentButtonStyle}"
+                                                            Tag="{x:Bind}"
+                                                            Click="OnInstallAgentToolchainRowClick"
+                                                            AutomationProperties.AutomationId="AcpSetup.Agents.InstallToolchain"
+                                                            Visibility="{x:Bind CanInstallToolchainHere, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                     <!-- Distribution the wizard never automates (a
                                                          prebuilt binary): the agent's own install page is
                                                          the right destination. -->
@@ -264,6 +271,12 @@
                                      toolchain already disables it. A disabled button explains
                                      nothing on its own, so the way forward is offered beside it:
                                      the toolchain's own documentation, named in the text below. -->
+                                <Button x:Name="AcpSetupInstallToolchainButton"
+                                        x:Uid="AcpSetup_InstallToolchain"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        AutomationProperties.AutomationId="AcpSetup.Adapter.InstallToolchain"
+                                        Command="{x:Bind ViewModel.InstallToolchainCommand}"
+                                        Visibility="{x:Bind ViewModel.IsAdapterToolchainInstallable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                 <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
                                                  x:Uid="AcpSetup_InstallToolchainDocs"
                                                  NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -239,32 +239,37 @@
                                      x:Uid="AcpSetup_AdapterMissingBar"
                                      IsOpen="{x:Bind ViewModel.IsAdapterMissing, Mode=OneWay}"
                                      Severity="Warning"
-                                     IsClosable="False">
-                                <!-- Two actions, so they go in Content: ActionButton holds a single
-                                     ButtonBase and a panel there would not render as buttons. -->
-                                <InfoBar.Content>
-                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
-                                        <Button x:Name="AcpSetupInstallAdapterButton"
-                                                x:Uid="AcpSetup_InstallAdapter"
-                                                Style="{StaticResource AccentButtonStyle}"
-                                                AutomationProperties.AutomationId="AcpSetup.Adapter.Install"
-                                                Command="{x:Bind ViewModel.InstallAdapterCommand}"/>
-                                        <Button x:Name="AcpSetupRedetectAdapterButton"
-                                                x:Uid="AcpSetup_RedetectAdapter"
-                                                AutomationProperties.AutomationId="AcpSetup.Adapter.Redetect"
-                                                Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
-                                        <!-- The install button above is command-bound, so a missing
-                                             toolchain already disables it. A disabled button explains
-                                             nothing on its own, so the way forward is offered beside it:
-                                             the toolchain's own documentation, named in the text below. -->
-                                        <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
-                                                         x:Uid="AcpSetup_InstallToolchainDocs"
-                                                         NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"
-                                                         AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainDocs"
-                                                         Visibility="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    </StackPanel>
-                                </InfoBar.Content>
-                            </InfoBar>
+                                     IsClosable="False"/>
+                            <!-- The three recovery actions sit beside the verdict instead of inside
+                                 it. The InfoBar template places Content on a second row below the
+                                 icon-height first row, so buttons hosted there float in the gap
+                                 under the text and end flush against the bar's bottom border, and
+                                 both spacings shift again once the panel stacks vertically.
+                                 ActionButton holds a single ButtonBase, so it cannot carry the
+                                 three actions either; a plain row in the step's flow is the one
+                                 place whose spacing holds on every platform and width. -->
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="8"
+                                        Visibility="{x:Bind ViewModel.IsAdapterMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                <Button x:Name="AcpSetupInstallAdapterButton"
+                                        x:Uid="AcpSetup_InstallAdapter"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        AutomationProperties.AutomationId="AcpSetup.Adapter.Install"
+                                        Command="{x:Bind ViewModel.InstallAdapterCommand}"/>
+                                <Button x:Name="AcpSetupRedetectAdapterButton"
+                                        x:Uid="AcpSetup_RedetectAdapter"
+                                        AutomationProperties.AutomationId="AcpSetup.Adapter.Redetect"
+                                        Command="{x:Bind ViewModel.DetectAdapterCommand}"/>
+                                <!-- The install button above is command-bound, so a missing
+                                     toolchain already disables it. A disabled button explains
+                                     nothing on its own, so the way forward is offered beside it:
+                                     the toolchain's own documentation, named in the text below. -->
+                                <HyperlinkButton x:Name="AcpSetupAdapterToolchainDocsButton"
+                                                 x:Uid="AcpSetup_InstallToolchainDocs"
+                                                 NavigateUri="{x:Bind ViewModel.AdapterToolchainDocumentation, Mode=OneWay}"
+                                                 AutomationProperties.AutomationId="AcpSetup.Adapter.ToolchainDocs"
+                                                 Visibility="{x:Bind ViewModel.IsAdapterToolchainMissing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            </StackPanel>
 
                             <!-- Named separately from the warning above because it is a different
                                  problem with a different fix: the adapter is installable, but nothing on

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml.cs
@@ -39,6 +39,14 @@ public sealed partial class AcpSetupWizardPage : SettingsPageBase
         }
     }
 
+    private void OnInstallAgentToolchainRowClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: AcpSetupAgentRowViewModel row })
+        {
+            row.RequestToolchainInstall();
+        }
+    }
+
     private void OnVerifyAgentRowClick(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement { Tag: AcpSetupAgentRowViewModel row })

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -1732,4 +1732,7 @@
   <data name="MiniChatVoiceInputStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Stop voice input</value>
   </data>
+  <data name="AcpSetup_InstallToolchain.Content" xml:space="preserve">
+    <value>Install toolchain</value>
+  </data>
 </root>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1837,4 +1837,7 @@
   <data name="MiniChatVoiceInputStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Stop voice input</value>
   </data>
+  <data name="AcpSetup_InstallToolchain.Content" xml:space="preserve">
+    <value>Install toolchain</value>
+  </data>
 </root>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -790,7 +790,7 @@
     <value>安装文档</value>
   </data>
   <data name="AcpSetup_InstallToolchainDocs.Content" xml:space="preserve">
-    <value>安装工具链</value>
+    <value>查看安装说明</value>
   </data>
   <data name="AcpSetup_ParametersTitle.Text" xml:space="preserve">
     <value>启动参数</value>
@@ -1731,5 +1731,8 @@
   </data>
   <data name="MiniChatVoiceInputStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>停止语音输入</value>
+  </data>
+  <data name="AcpSetup_InstallToolchain.Content" xml:space="preserve">
+    <value>安装工具链</value>
   </data>
 </root>

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -19,21 +19,29 @@ public sealed class AcpSetupWizardOrchestrator
     private readonly IAcpAgentCatalog _catalog;
     private readonly AcpComponentDetector _detector;
     private readonly IAcpComponentInstaller _installer;
+    private readonly IAcpToolchainInstaller? _toolchainInstaller;
     private readonly IAcpSetupConnectivityTester _connectivityTester;
     private readonly IConfigurationService _configurationService;
 
+    /// <param name="toolchainInstaller">
+    /// Installs a missing toolchain. Optional so a caller that only detects and tests need not supply one;
+    /// null reports <see cref="SupportsToolchainInstall"/> as false, which is the same answer a platform
+    /// without an installer gives, so the wizard has one condition to check rather than two.
+    /// </param>
     public AcpSetupWizardOrchestrator(
         IAcpAgentCatalog catalog,
         IAcpExecutableProbe probe,
         IAcpComponentInstaller installer,
         IAcpSetupConnectivityTester connectivityTester,
-        IConfigurationService configurationService)
+        IConfigurationService configurationService,
+        IAcpToolchainInstaller? toolchainInstaller = null)
     {
         _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
         _detector = new AcpComponentDetector(probe ?? throw new ArgumentNullException(nameof(probe)));
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
         _connectivityTester = connectivityTester ?? throw new ArgumentNullException(nameof(connectivityTester));
         _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
+        _toolchainInstaller = toolchainInstaller;
     }
 
     /// <summary>
@@ -44,6 +52,17 @@ public sealed class AcpSetupWizardOrchestrator
     /// <see cref="DetectToolchainAsync"/>'s answer, and a caller offering a one-click install needs both.
     /// </remarks>
     public bool SupportsAutomaticInstall => _installer.SupportsAutomaticInstall;
+
+    /// <summary>
+    /// True when this platform can install a missing toolchain itself.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="SupportsAutomaticInstall"/>, which is about running a package manager that
+    /// already exists. The two are independent: a platform can run npm and still have no way to obtain Node.
+    /// Whether a <em>particular</em> toolchain has a published source is
+    /// <see cref="AcpToolchainRequirement.HasAutomaticInstallPath"/>'s answer.
+    /// </remarks>
+    public bool SupportsToolchainInstall => _toolchainInstaller?.SupportsAutomaticInstall == true;
 
     public IReadOnlyList<AcpAgentDescriptor> Agents => _catalog.Agents;
 
@@ -134,6 +153,59 @@ public sealed class AcpSetupWizardOrchestrator
 
         var probe = await _detector
             .DetectAsync(component, overrides, cancellationToken)
+            .ConfigureAwait(false);
+        return (install, probe);
+    }
+
+    /// <summary>
+    /// Installs the toolchain a component needs and re-probes that toolchain, so callers see verified
+    /// availability rather than trusting a downloader's success report.
+    /// </summary>
+    /// <remarks>
+    /// The install is requested in terms of a component because that is what the wizard has selected; the
+    /// component determines whether it needs Node at all. A component with no toolchain is a programming
+    /// error here — the UI must not surface a toolchain button for it — so it fails clearly rather than
+    /// pretending an empty install succeeded.
+    /// </remarks>
+    public async Task<(AcpToolchainInstallResult Install, AcpToolchainProbeResult? Probe)> InstallToolchainAsync(
+        AcpComponentDescriptor component,
+        Action<string>? onOutput = null,
+        AcpCommandOverrides? overrides = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+
+        if (component.RequiredToolchain is not { } requirement)
+        {
+            throw new InvalidOperationException(
+                $"Component '{component.Id}' does not declare a required toolchain.");
+        }
+
+        var installer = _toolchainInstaller;
+        if (installer is null)
+        {
+            return (
+                AcpToolchainInstallResult.Failure(
+                    requirement,
+                    "Automatic toolchain installation is unavailable on this platform."),
+                await _detector
+                    .DetectToolchainAsync(component, overrides, cancellationToken)
+                    .ConfigureAwait(false));
+        }
+
+        var install = await installer
+            .InstallAsync(requirement, onOutput, cancellationToken)
+            .ConfigureAwait(false);
+
+        // This must sit between install and probe. A first toolchain install creates an entire version/bin
+        // directory that did not exist when the detector cached its search paths; asking the detector again
+        // without invalidating gives a stale "missing" even though the installer just succeeded. The
+        // accompanying test drives an installer that creates that directory and reverse-verifies that
+        // removing this one call makes the outcome red.
+        _detector.InvalidateSearchPaths();
+
+        var probe = await _detector
+            .DetectToolchainAsync(component, overrides, cancellationToken)
             .ConfigureAwait(false);
         return (install, probe);
     }

--- a/src/SalmonEgg.Cli/Hosting/CliPrintEnvironment.cs
+++ b/src/SalmonEgg.Cli/Hosting/CliPrintEnvironment.cs
@@ -1,114 +1,41 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
 
 namespace SalmonEgg.Cli.Hosting;
 
 /// <summary>
-/// Prints this process's environment as one JSON object, wrapped in a caller-supplied marker.
+/// The CLI's entry into the environment-printing protocol.
 /// </summary>
 /// <remarks>
-/// This exists to be run <em>by the user's own shell</em>. A GUI-launched desktop process inherits the
-/// session environment rather than the one a shell profile builds, so a version-manager toolchain (nvm,
-/// fnm, volta, asdf, mise) is invisible to it. The app recovers the real environment by asking the user's
-/// login shell to run this, then reading what the shell handed the child.
+/// The protocol itself lives in <see cref="DesktopPrintEnvironment"/>, beside the capture that reads it.
+/// Two executables answer this mode — this CLI and the desktop app — and the app's search-path capture
+/// invokes whichever one it can find, so the option's spelling and the payload's shape belong with the
+/// reader rather than being restated in each writer.
 ///
-/// Every editor that solves this does the same thing — run its own executable inside the shell rather
-/// than parse the shell's <c>env</c> output — because rc files print banners, colour codes, and warnings
-/// onto the same stream. VS Code runs <c>code -p</c>, Zed runs <c>zed --printenv</c>, JetBrains runs a
-/// bundled <c>printenv</c> helper. Emitting JSON from inside the child makes the payload
-/// self-delimiting and immune to whatever text surrounds it.
-///
-/// The marker handles the surrounding noise. The caller generates a fresh random one per invocation and
-/// extracts what lies between the two occurrences, so a chatty rc file cannot be mistaken for payload.
-/// It must be random rather than fixed: a fixed marker could appear in a variable's value — this process
-/// prints its own environment, which includes anything the shell exported — and turn an honest value into
-/// a false delimiter.
-///
-/// This path deliberately runs before the CLI builds its service container or performs startup recovery.
-/// It reads nothing and writes nothing but stdout, and it is invoked while the app is starting, so
-/// touching user data here would make an environment probe a source of configuration side effects.
+/// This type remains because the CLI has its own exit-code contract to map onto, which the protocol has no
+/// business knowing.
 /// </remarks>
 internal static class CliPrintEnvironment
 {
     /// <summary>The option that selects this mode. Undocumented: it is an app-internal protocol.</summary>
-    internal const string OptionName = "--printenv";
+    internal const string OptionName = DesktopPrintEnvironment.OptionName;
 
-    /// <summary>
-    /// True when <paramref name="args"/> requests environment printing, yielding the marker to wrap the
-    /// payload in.
-    /// </summary>
-    /// <remarks>
-    /// Matched against raw arguments rather than through the command tree because the container must not
-    /// be built for this invocation, and the parser needs it.
-    ///
-    /// The marker is required, and only <c>--printenv=&lt;marker&gt;</c> is accepted rather than a
-    /// separate argument, so a bare <c>--printenv</c> cannot silently produce unwrapped output that the
-    /// caller would then fail to locate.
-    /// </remarks>
+    /// <inheritdoc cref="DesktopPrintEnvironment.TryGetMarker"/>
     internal static bool TryGetMarker(IReadOnlyList<string> args, out string marker)
-    {
-        marker = string.Empty;
-        if (args is null)
-        {
-            return false;
-        }
-
-        const string prefix = OptionName + "=";
-        foreach (var argument in args)
-        {
-            if (argument is null || !argument.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var candidate = argument[prefix.Length..];
-            if (candidate.Length == 0)
-            {
-                continue;
-            }
-
-            marker = candidate;
-            return true;
-        }
-
-        return false;
-    }
+        => DesktopPrintEnvironment.TryGetMarker(args, out marker);
 
     /// <summary>
-    /// Writes <c>&lt;marker&gt;{...}&lt;marker&gt;</c> to <paramref name="stdout"/> and flushes it.
+    /// Prints the environment and returns the CLI's success code.
     /// </summary>
-    /// <remarks>
-    /// Flushed explicitly because the caller reads this from a pipe and the process may be killed on a
-    /// timeout: an unflushed buffer would read as a shell that produced nothing.
-    /// </remarks>
     internal static async Task<int> WriteAsync(
         string marker,
         TextWriter stdout,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(stdout);
-
-        var variables = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            if (entry.Key is string key && key.Length > 0)
-            {
-                variables[key] = entry.Value as string ?? string.Empty;
-            }
-        }
-
-        var payload = JsonSerializer.Serialize(variables, CliPrintEnvironmentJson.Default.DictionaryStringString);
-
-        cancellationToken.ThrowIfCancellationRequested();
-        await stdout.WriteAsync(marker).ConfigureAwait(false);
-        await stdout.WriteAsync(payload).ConfigureAwait(false);
-        await stdout.WriteAsync(marker).ConfigureAwait(false);
-        await stdout.FlushAsync(cancellationToken).ConfigureAwait(false);
-
+        await DesktopPrintEnvironment.WriteAsync(marker, stdout, cancellationToken).ConfigureAwait(false);
         return CliExitCodes.Success;
     }
 }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainDownload.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainDownload.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>How a toolchain archive is compressed, which decides how it is unpacked.</summary>
+public enum AcpArchiveFormat
+{
+    /// <summary>A tar archive compressed with gzip.</summary>
+    TarGzip,
+
+    /// <summary>A zip archive.</summary>
+    Zip
+}
+
+/// <summary>How a vendor publishes the checksum for one archive.</summary>
+/// <remarks>
+/// Two shapes because the two vendors differ and neither can be parsed as the other: Node publishes one
+/// <c>SHASUMS256.txt</c> per release listing every file, while uv publishes a <c>.sha256</c> beside each
+/// asset. Reading a list as a single hash silently yields the first line's digest — the wrong file's — so
+/// the shape is declared rather than sniffed.
+/// </remarks>
+public enum AcpChecksumFormat
+{
+    /// <summary>
+    /// A <c>sha256sum</c>-style listing, one <c>&lt;hash&gt;  &lt;filename&gt;</c> per line. The line
+    /// naming the archive is the one that counts.
+    /// </summary>
+    ShasumList,
+
+    /// <summary>
+    /// A single digest. May carry a trailing filename, as <c>sha256sum</c> output does, which is ignored.
+    /// </summary>
+    SingleHash
+}
+
+/// <summary>
+/// Everything needed to fetch, verify, and unpack one toolchain build for one platform.
+/// </summary>
+/// <remarks>
+/// The archive layout is declared rather than discovered because the four builds the app can encounter
+/// disagree in every combination, and getting it wrong yields a directory with no executables in it
+/// instead of an error. Measured against the real archives:
+/// <list type="bullet">
+/// <item>Node's POSIX tarball: one root directory, executables in <c>bin/</c> below it.</item>
+/// <item>Node's Windows zip: one root directory, executables directly in it — no <c>bin/</c>.</item>
+/// <item>uv's POSIX tarball: one root directory, executables directly in it.</item>
+/// <item>uv's Windows zip: no root directory at all; executables at the archive root.</item>
+/// </list>
+/// No two agree, so no rule inferred from one holds for the others.
+/// </remarks>
+public sealed class AcpToolchainDownload
+{
+    /// <summary>The archive to fetch. Must be HTTPS: the digest below is only as trustworthy as its source.</summary>
+    public required Uri Archive { get; init; }
+
+    /// <summary>Where the expected digest is published.</summary>
+    public required Uri Checksum { get; init; }
+
+    /// <summary>How to read <see cref="Checksum"/>.</summary>
+    public required AcpChecksumFormat ChecksumFormat { get; init; }
+
+    /// <summary>How <see cref="Archive"/> is compressed.</summary>
+    public required AcpArchiveFormat ArchiveFormat { get; init; }
+
+    /// <summary>
+    /// The single directory the archive's entries live under, or null when entries sit at its root.
+    /// </summary>
+    /// <remarks>
+    /// Stripped during extraction so the installed layout is version-keyed by this app rather than by the
+    /// vendor's naming — the same install path shape whichever toolchain and platform it came from.
+    /// </remarks>
+    public string? RootDirectory { get; init; }
+
+    /// <summary>
+    /// Path below the extracted root to the directory holding executables. Empty when they sit at the root.
+    /// </summary>
+    public string BinSubdirectory { get; init; } = string.Empty;
+
+    /// <summary>
+    /// File names that must exist in the bin directory for the install to count as complete.
+    /// </summary>
+    /// <remarks>
+    /// Checked because an archive that unpacked without error can still be the wrong build: reporting
+    /// success and letting the next probe find nothing is the failure this prevents. Includes the package
+    /// manager, not just the runtime — a Node install whose <c>npm</c> is missing cannot install anything,
+    /// which is the only reason the wizard wanted the toolchain.
+    /// </remarks>
+    public required IReadOnlyList<string> VerifyExecutables { get; init; }
+
+    /// <summary>
+    /// The executable to run, and the arguments to run it with, to confirm the install actually works.
+    /// </summary>
+    /// <remarks>
+    /// Existence on disk is not evidence a binary runs: an archive for the wrong architecture unpacks
+    /// perfectly and fails at exec. Running it once is what turns "unpacked" into "installed".
+    /// </remarks>
+    public required string VerifyCommand { get; init; }
+
+    /// <summary>Arguments for <see cref="VerifyCommand"/>. Conventionally a version query.</summary>
+    public IReadOnlyList<string> VerifyArguments { get; init; } = Array.Empty<string>();
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallResult.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallResult.cs
@@ -1,0 +1,67 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>Whether adding an installed toolchain directory to the user's persistent PATH succeeded.</summary>
+public enum AcpPathRegistration
+{
+    /// <summary>The directory was added.</summary>
+    Applied,
+
+    /// <summary>The directory was already present, so no persistent environment was changed.</summary>
+    AlreadyPresent,
+
+    /// <summary>
+    /// The toolchain installed successfully, but persisting PATH failed. This is non-fatal: the wizard's
+    /// own disk scan still sees the toolchain, while a new terminal may need manual configuration.
+    /// </summary>
+    Failed
+}
+
+/// <summary>Result of a toolchain download, verification, unpack, and optional PATH registration.</summary>
+public sealed class AcpToolchainInstallResult
+{
+    public required AcpToolchainRequirement Requirement { get; init; }
+
+    public required bool IsSuccess { get; init; }
+
+    /// <summary>The executable directory installed and verified, when successful.</summary>
+    public string? InstalledBinDirectory { get; init; }
+
+    public AcpPathRegistration? PathRegistration { get; init; }
+
+    /// <summary>Trailing installer output retained for the UI's failure surface.</summary>
+    public string? Output { get; init; }
+
+    /// <summary>Developer-facing reason the installer could not complete.</summary>
+    public string? ErrorDetail { get; init; }
+
+    /// <summary>Localization key for actionable advice, when one exists.</summary>
+    public string? RemediationKey { get; init; }
+
+    public static AcpToolchainInstallResult Success(
+        AcpToolchainRequirement requirement,
+        string installedBinDirectory,
+        AcpPathRegistration pathRegistration,
+        string? output)
+        => new()
+        {
+            Requirement = requirement,
+            IsSuccess = true,
+            InstalledBinDirectory = installedBinDirectory,
+            PathRegistration = pathRegistration,
+            Output = output
+        };
+
+    public static AcpToolchainInstallResult Failure(
+        AcpToolchainRequirement requirement,
+        string? errorDetail,
+        string? output = null,
+        string? remediationKey = null)
+        => new()
+        {
+            Requirement = requirement,
+            IsSuccess = false,
+            ErrorDetail = errorDetail,
+            Output = output,
+            RemediationKey = remediationKey
+        };
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallSource.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallSource.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>
+/// Selects a published toolchain archive for an operating system and CPU architecture.
+/// </summary>
+/// <remarks>
+/// This is data selection, not networking: it maps one supported platform to the vendor's documented URL
+/// pattern. Keeping it pure makes every URL and archive shape testable without reaching the network — a
+/// test that happens to download today's release only proves today's vendor availability, not that the app
+/// constructs the right URL tomorrow.
+///
+/// The two vendors agree on almost nothing, which is why each has its own resolver rather than one
+/// parameterized by vendor. Verified against the live releases:
+/// <list type="bullet">
+/// <item>Node tags its releases <c>v24.20.0</c>; uv tags them <c>0.12.8</c>. Prefixing uv's tag with
+/// <c>v</c> returns 404, so the prefix is a per-vendor fact rather than a convention to share.</item>
+/// <item>Node publishes one <c>SHASUMS256.txt</c> listing every artifact; uv publishes a <c>.sha256</c>
+/// beside each asset. Hence <see cref="AcpChecksumFormat"/>.</item>
+/// <item>Node's POSIX archive nests executables under <c>bin/</c>; uv's puts them at its single root, and
+/// uv's Windows zip has no root directory at all.</item>
+/// </list>
+/// </remarks>
+public static class AcpToolchainInstallSource
+{
+    /// <summary>
+    /// The Node LTS version shipped by the wizard's automatic installer.
+    /// </summary>
+    /// <remarks>
+    /// Pinned rather than fetched from nodejs.org's index at runtime. The installer must remain a
+    /// deterministic capability: asking a network index whether the app can construct a download turns a
+    /// temporary vendor outage into a false "this platform is unsupported" answer, while silently tracking
+    /// whatever release appeared today changes what users install without a reviewed code change.
+    /// </remarks>
+    public const string NodeVersion = "v24.20.0";
+
+    /// <summary>
+    /// The uv version shipped by the wizard's automatic installer.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately carries no <c>v</c> prefix, unlike <see cref="NodeVersion"/>: uv's release tags are bare
+    /// versions, and <c>.../download/v0.12.8/...</c> returns 404 while <c>.../download/0.12.8/...</c>
+    /// resolves. Pinned for the same reason Node's is — a network-derived version would make "can this
+    /// platform install uv" depend on vendor uptime, and would change what users install without review.
+    /// </remarks>
+    public const string UvVersion = "0.12.8";
+
+    /// <summary>
+    /// Returns the official Node archive for <paramref name="operatingSystem"/> and
+    /// <paramref name="architecture"/>, or null when that pair has no supported automatic install.
+    /// </summary>
+    public static AcpToolchainDownload? ResolveNode(
+        OSPlatform operatingSystem,
+        Architecture architecture,
+        string? version = null)
+    {
+        var effectiveVersion = string.IsNullOrWhiteSpace(version) ? NodeVersion : version.Trim();
+        if (!effectiveVersion.StartsWith('v'))
+        {
+            effectiveVersion = "v" + effectiveVersion;
+        }
+
+        if (ResolveNodeBuild(operatingSystem, architecture) is not { } build)
+        {
+            return null;
+        }
+
+        var (platform, architectureSegment) = build;
+
+        var archiveFormat = operatingSystem == OSPlatform.Windows
+            ? AcpArchiveFormat.Zip
+            : AcpArchiveFormat.TarGzip;
+        var extension = archiveFormat == AcpArchiveFormat.Zip ? "zip" : "tar.gz";
+        var archiveName = $"node-{effectiveVersion}-{platform}-{architectureSegment}.{extension}";
+        var rootDirectory = $"node-{effectiveVersion}-{platform}-{architectureSegment}";
+        var isWindows = operatingSystem == OSPlatform.Windows;
+
+        return new AcpToolchainDownload
+        {
+            Archive = new Uri($"https://nodejs.org/dist/{effectiveVersion}/{archiveName}"),
+            Checksum = new Uri($"https://nodejs.org/dist/{effectiveVersion}/SHASUMS256.txt"),
+            ChecksumFormat = AcpChecksumFormat.ShasumList,
+            ArchiveFormat = archiveFormat,
+            RootDirectory = rootDirectory,
+            // Node's POSIX archive puts the launchers under bin/, while its Windows zip puts the .exe/.cmd
+            // launchers beside its root directory. This is data, not an OperatingSystem branch in the
+            // installer, so a future source with either shape needs no extractor rewrite.
+            BinSubdirectory = isWindows ? string.Empty : "bin",
+            VerifyExecutables = isWindows
+                ? new[] { "node.exe", "npm.cmd", "npx.cmd" }
+                : new[] { "node", "npm", "npx" },
+            VerifyCommand = isWindows ? "node.exe" : "node",
+            VerifyArguments = new[] { "--version" }
+        };
+    }
+
+    /// <summary>
+    /// Returns the official uv archive for this platform, or null when that combination has no published
+    /// build.
+    /// </summary>
+    /// <param name="preferMusl">
+    /// Selects the musl build over the glibc one on Linux. The caller decides because only the running
+    /// process can tell which C library the host uses; this type performs no environment inspection.
+    /// </param>
+    /// <remarks>
+    /// uv ships one archive per Rust target triple, so the triple is the whole address of a build. Both
+    /// libc variants are offered because uv publishes both and they are not interchangeable: a glibc binary
+    /// on a musl host unpacks perfectly and then fails to exec.
+    /// </remarks>
+    public static AcpToolchainDownload? ResolveUv(
+        OSPlatform operatingSystem,
+        Architecture architecture,
+        bool preferMusl = false,
+        string? version = null)
+    {
+        // Trimmed of a leading 'v' rather than given one: a caller passing "v0.12.8" means that release, and
+        // uv's own tag for it has no prefix. Silently building a 404 URL would surface as a download failure
+        // on a platform that is in fact supported.
+        var effectiveVersion = (string.IsNullOrWhiteSpace(version) ? UvVersion : version.Trim())
+            .TrimStart('v', 'V');
+
+        if (ResolveUvTarget(operatingSystem, architecture, preferMusl) is not { } target)
+        {
+            return null;
+        }
+
+        var isWindows = operatingSystem == OSPlatform.Windows;
+        var archiveFormat = isWindows ? AcpArchiveFormat.Zip : AcpArchiveFormat.TarGzip;
+        var archiveName = isWindows ? $"uv-{target}.zip" : $"uv-{target}.tar.gz";
+        var archive = new Uri(
+            $"https://github.com/astral-sh/uv/releases/download/{effectiveVersion}/{archiveName}");
+
+        return new AcpToolchainDownload
+        {
+            Archive = archive,
+            // Each asset carries its own digest file, so the checksum URL is the archive's plus a suffix.
+            Checksum = new Uri(archive.AbsoluteUri + ".sha256"),
+            ChecksumFormat = AcpChecksumFormat.SingleHash,
+            ArchiveFormat = archiveFormat,
+            // The POSIX tarball nests everything under one directory named for the target; the Windows zip
+            // is flat, with the executables at the archive root and no directory to strip.
+            RootDirectory = isWindows ? null : $"uv-{target}",
+            // Neither layout has a bin/ subdirectory: uv and uvx sit directly at the extracted root.
+            BinSubdirectory = string.Empty,
+            // uvx is required, not incidental: it is the launcher every Uvx-distributed component runs
+            // through, so a uv install without it cannot serve the purpose the wizard wanted it for.
+            VerifyExecutables = isWindows
+                ? new[] { "uv.exe", "uvx.exe" }
+                : new[] { "uv", "uvx" },
+            VerifyCommand = isWindows ? "uv.exe" : "uv",
+            VerifyArguments = new[] { "--version" }
+        };
+    }
+
+    /// <summary>
+    /// The Rust target triple for a uv build that is actually published, or null.
+    /// </summary>
+    /// <remarks>
+    /// An explicit list for the same reason <see cref="ResolveNodeBuild"/> keeps one: composing triples from
+    /// independent parts invents plausible names for builds that do not exist, and each would send a user to
+    /// a 404 rather than to the honest answer that this platform has no automatic install.
+    ///
+    /// Narrower than everything uv publishes. The ppc64le, s390x and riscv64 Linux builds exist but are not
+    /// offered, since this app has no coverage on those hosts. macOS has no musl variant to choose between,
+    /// and Windows-on-arm is served by its own native archive rather than by emulation.
+    /// </remarks>
+    private static string? ResolveUvTarget(
+        OSPlatform operatingSystem,
+        Architecture architecture,
+        bool preferMusl)
+    {
+        if (operatingSystem == OSPlatform.Linux)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => preferMusl
+                    ? "x86_64-unknown-linux-musl"
+                    : "x86_64-unknown-linux-gnu",
+                Architecture.Arm64 => preferMusl
+                    ? "aarch64-unknown-linux-musl"
+                    : "aarch64-unknown-linux-gnu",
+                Architecture.X86 => preferMusl
+                    ? "i686-unknown-linux-musl"
+                    : "i686-unknown-linux-gnu",
+                // 32-bit ARM names its ABI in the triple, and the hard-float spelling differs per libc.
+                Architecture.Arm => preferMusl
+                    ? "armv7-unknown-linux-musleabihf"
+                    : "armv7-unknown-linux-gnueabihf",
+                _ => null
+            };
+        }
+
+        if (operatingSystem == OSPlatform.OSX)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => "x86_64-apple-darwin",
+                Architecture.Arm64 => "aarch64-apple-darwin",
+                _ => null
+            };
+        }
+
+        if (operatingSystem == OSPlatform.Windows)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => "x86_64-pc-windows-msvc",
+                Architecture.Arm64 => "aarch64-pc-windows-msvc",
+                Architecture.X86 => "i686-pc-windows-msvc",
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The platform and architecture URL segments for a Node build that is actually published, or null.
+    /// </summary>
+    /// <remarks>
+    /// An explicit list of the pairs Node ships, not a cross product of two independent mappings. The
+    /// distinction matters: composing the segments freely produces plausible names for builds that do not
+    /// exist — <c>node-v24.20.0-linux-x86.tar.gz</c>, <c>-darwin-x86</c>, <c>-win-armv7l</c> and
+    /// <c>-darwin-armv7l</c> among them, verified absent from the release's own SHASUMS256 listing. Each
+    /// would send a user to a 404 and surface as a download failure on a platform where the honest answer
+    /// is that no automatic install exists, which is what null says.
+    ///
+    /// Deliberately narrower than everything Node publishes. linux-ppc64le, linux-s390x and the musl
+    /// variants exist but are not offered: this app has no test coverage on them, and a musl host needs the
+    /// musl archive rather than the glibc one — a distinction this type cannot make from
+    /// <see cref="Architecture"/> alone, and getting it wrong yields a binary that unpacks and then refuses
+    /// to exec.
+    /// </remarks>
+    private static (string Platform, string Architecture)? ResolveNodeBuild(
+        OSPlatform operatingSystem,
+        Architecture architecture)
+    {
+        if (operatingSystem == OSPlatform.Linux)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => ("linux", "x64"),
+                Architecture.Arm64 => ("linux", "arm64"),
+                _ => null
+            };
+        }
+
+        if (operatingSystem == OSPlatform.OSX)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => ("darwin", "x64"),
+                Architecture.Arm64 => ("darwin", "arm64"),
+                _ => null
+            };
+        }
+
+        if (operatingSystem == OSPlatform.Windows)
+        {
+            return architecture switch
+            {
+                Architecture.X64 => ("win", "x64"),
+                Architecture.Arm64 => ("win", "arm64"),
+                _ => null
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallSource.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainInstallSource.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace SalmonEgg.Domain.Models.AcpSetup;
 
@@ -52,8 +51,8 @@ public static class AcpToolchainInstallSource
     /// <paramref name="architecture"/>, or null when that pair has no supported automatic install.
     /// </summary>
     public static AcpToolchainDownload? ResolveNode(
-        OSPlatform operatingSystem,
-        Architecture architecture,
+        AcpToolchainOperatingSystem operatingSystem,
+        AcpToolchainArchitecture architecture,
         string? version = null)
     {
         var effectiveVersion = string.IsNullOrWhiteSpace(version) ? NodeVersion : version.Trim();
@@ -69,13 +68,13 @@ public static class AcpToolchainInstallSource
 
         var (platform, architectureSegment) = build;
 
-        var archiveFormat = operatingSystem == OSPlatform.Windows
+        var archiveFormat = operatingSystem == AcpToolchainOperatingSystem.Windows
             ? AcpArchiveFormat.Zip
             : AcpArchiveFormat.TarGzip;
         var extension = archiveFormat == AcpArchiveFormat.Zip ? "zip" : "tar.gz";
         var archiveName = $"node-{effectiveVersion}-{platform}-{architectureSegment}.{extension}";
         var rootDirectory = $"node-{effectiveVersion}-{platform}-{architectureSegment}";
-        var isWindows = operatingSystem == OSPlatform.Windows;
+        var isWindows = operatingSystem == AcpToolchainOperatingSystem.Windows;
 
         return new AcpToolchainDownload
         {
@@ -110,8 +109,8 @@ public static class AcpToolchainInstallSource
     /// on a musl host unpacks perfectly and then fails to exec.
     /// </remarks>
     public static AcpToolchainDownload? ResolveUv(
-        OSPlatform operatingSystem,
-        Architecture architecture,
+        AcpToolchainOperatingSystem operatingSystem,
+        AcpToolchainArchitecture architecture,
         bool preferMusl = false,
         string? version = null)
     {
@@ -126,7 +125,7 @@ public static class AcpToolchainInstallSource
             return null;
         }
 
-        var isWindows = operatingSystem == OSPlatform.Windows;
+        var isWindows = operatingSystem == AcpToolchainOperatingSystem.Windows;
         var archiveFormat = isWindows ? AcpArchiveFormat.Zip : AcpArchiveFormat.TarGzip;
         var archiveName = isWindows ? $"uv-{target}.zip" : $"uv-{target}.tar.gz";
         var archive = new Uri(
@@ -167,48 +166,48 @@ public static class AcpToolchainInstallSource
     /// and Windows-on-arm is served by its own native archive rather than by emulation.
     /// </remarks>
     private static string? ResolveUvTarget(
-        OSPlatform operatingSystem,
-        Architecture architecture,
+        AcpToolchainOperatingSystem operatingSystem,
+        AcpToolchainArchitecture architecture,
         bool preferMusl)
     {
-        if (operatingSystem == OSPlatform.Linux)
+        if (operatingSystem == AcpToolchainOperatingSystem.Linux)
         {
             return architecture switch
             {
-                Architecture.X64 => preferMusl
+                AcpToolchainArchitecture.X64 => preferMusl
                     ? "x86_64-unknown-linux-musl"
                     : "x86_64-unknown-linux-gnu",
-                Architecture.Arm64 => preferMusl
+                AcpToolchainArchitecture.Arm64 => preferMusl
                     ? "aarch64-unknown-linux-musl"
                     : "aarch64-unknown-linux-gnu",
-                Architecture.X86 => preferMusl
+                AcpToolchainArchitecture.X86 => preferMusl
                     ? "i686-unknown-linux-musl"
                     : "i686-unknown-linux-gnu",
                 // 32-bit ARM names its ABI in the triple, and the hard-float spelling differs per libc.
-                Architecture.Arm => preferMusl
+                AcpToolchainArchitecture.Arm => preferMusl
                     ? "armv7-unknown-linux-musleabihf"
                     : "armv7-unknown-linux-gnueabihf",
                 _ => null
             };
         }
 
-        if (operatingSystem == OSPlatform.OSX)
+        if (operatingSystem == AcpToolchainOperatingSystem.MacOS)
         {
             return architecture switch
             {
-                Architecture.X64 => "x86_64-apple-darwin",
-                Architecture.Arm64 => "aarch64-apple-darwin",
+                AcpToolchainArchitecture.X64 => "x86_64-apple-darwin",
+                AcpToolchainArchitecture.Arm64 => "aarch64-apple-darwin",
                 _ => null
             };
         }
 
-        if (operatingSystem == OSPlatform.Windows)
+        if (operatingSystem == AcpToolchainOperatingSystem.Windows)
         {
             return architecture switch
             {
-                Architecture.X64 => "x86_64-pc-windows-msvc",
-                Architecture.Arm64 => "aarch64-pc-windows-msvc",
-                Architecture.X86 => "i686-pc-windows-msvc",
+                AcpToolchainArchitecture.X64 => "x86_64-pc-windows-msvc",
+                AcpToolchainArchitecture.Arm64 => "aarch64-pc-windows-msvc",
+                AcpToolchainArchitecture.X86 => "i686-pc-windows-msvc",
                 _ => null
             };
         }
@@ -230,39 +229,39 @@ public static class AcpToolchainInstallSource
     /// Deliberately narrower than everything Node publishes. linux-ppc64le, linux-s390x and the musl
     /// variants exist but are not offered: this app has no test coverage on them, and a musl host needs the
     /// musl archive rather than the glibc one — a distinction this type cannot make from
-    /// <see cref="Architecture"/> alone, and getting it wrong yields a binary that unpacks and then refuses
+    /// the architecture alone, and getting it wrong yields a binary that unpacks and then refuses
     /// to exec.
     /// </remarks>
-    private static (string Platform, string Architecture)? ResolveNodeBuild(
-        OSPlatform operatingSystem,
-        Architecture architecture)
+    private static (string Platform, string ArchitectureSegment)? ResolveNodeBuild(
+        AcpToolchainOperatingSystem operatingSystem,
+        AcpToolchainArchitecture architecture)
     {
-        if (operatingSystem == OSPlatform.Linux)
+        if (operatingSystem == AcpToolchainOperatingSystem.Linux)
         {
             return architecture switch
             {
-                Architecture.X64 => ("linux", "x64"),
-                Architecture.Arm64 => ("linux", "arm64"),
+                AcpToolchainArchitecture.X64 => ("linux", "x64"),
+                AcpToolchainArchitecture.Arm64 => ("linux", "arm64"),
                 _ => null
             };
         }
 
-        if (operatingSystem == OSPlatform.OSX)
+        if (operatingSystem == AcpToolchainOperatingSystem.MacOS)
         {
             return architecture switch
             {
-                Architecture.X64 => ("darwin", "x64"),
-                Architecture.Arm64 => ("darwin", "arm64"),
+                AcpToolchainArchitecture.X64 => ("darwin", "x64"),
+                AcpToolchainArchitecture.Arm64 => ("darwin", "arm64"),
                 _ => null
             };
         }
 
-        if (operatingSystem == OSPlatform.Windows)
+        if (operatingSystem == AcpToolchainOperatingSystem.Windows)
         {
             return architecture switch
             {
-                Architecture.X64 => ("win", "x64"),
-                Architecture.Arm64 => ("win", "arm64"),
+                AcpToolchainArchitecture.X64 => ("win", "x64"),
+                AcpToolchainArchitecture.Arm64 => ("win", "arm64"),
                 _ => null
             };
         }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayout.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayout.cs
@@ -126,8 +126,43 @@ public sealed class AcpToolchainLayout
         // npm's own global prefix on Windows, which its installer does not always add to PATH.
         Create(AcpToolchainLayoutRoot.WindowsRoamingAppData, "npm"),
 
+        // Toolchains this app installed. Scanned like any other so an install the wizard performed is
+        // found by the same mechanism as one the user performed, rather than through a parallel lookup.
+        // Two shapes because the archives differ: the POSIX tarballs put executables in a bin/
+        // subdirectory, the Windows zip puts node.exe and npm.cmd at the version root. A layout naming a
+        // directory that is not there contributes nothing, so declaring both costs nothing.
+        Create(AcpToolchainLayoutRoot.SalmonEggToolchains, "node", VersionWildcard, "bin"),
+        Create(AcpToolchainLayoutRoot.SalmonEggToolchains, "node", VersionWildcard),
+
+        // uv, installed by the same wizard. One entry rather than two because uv's archives put uv and uvx
+        // at their root on every platform, so there is no bin/ variant to cover.
+        //
+        // This must exist for the same reason the node entries do, and its absence would be the defect this
+        // whole list was extended to fix: an install the wizard performed itself would be invisible to the
+        // scan that runs immediately afterwards, so the wizard would report the toolchain still missing.
+        Create(AcpToolchainLayoutRoot.SalmonEggToolchains, "uv", VersionWildcard),
+
         // Homebrew, whose prefix differs by architecture and is absent from a Finder-launched PATH.
         Create(AcpToolchainLayoutRoot.Absolute, "/opt/homebrew/bin"),
-        Create(AcpToolchainLayoutRoot.Absolute, "/usr/local/bin")
+        Create(AcpToolchainLayoutRoot.Absolute, "/usr/local/bin"),
+
+        // Homebrew's keg-only layout, which it uses when a formula must not be linked into the prefix
+        // above. A node installed this way is absent from both /opt/homebrew/bin and /usr/local/bin.
+        Create(AcpToolchainLayoutRoot.Absolute, "/opt/homebrew/opt/node/bin"),
+        Create(AcpToolchainLayoutRoot.Absolute, "/usr/local/opt/node/bin"),
+
+        // Where the vendors' own installers land, which no version manager owns.
+        //
+        // These come last deliberately. A version manager's directory outranks them because that is what
+        // the user's shell resolves first, and a system-wide install is typically the older one — so
+        // leading with it would make the wizard's first candidate disagree with their terminal.
+        //
+        // They are nonetheless required, not optional: Node's official Windows MSI installs into program
+        // files and a Linux distribution package installs into /usr/bin, and neither appears anywhere
+        // above. On Windows the scan is the only widening available at all — there is no profile-built
+        // PATH to capture there — so a user who installed Node the officially documented way and pressed
+        // "detect again" was told it was still missing, with nothing they could do about it.
+        Create(AcpToolchainLayoutRoot.WindowsProgramFiles, "nodejs"),
+        Create(AcpToolchainLayoutRoot.Absolute, "/usr/bin")
     };
 }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayoutRoot.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainLayoutRoot.cs
@@ -12,6 +12,29 @@ public enum AcpToolchainLayoutRoot
     /// <summary>The Windows roaming application data directory; contributes nothing elsewhere.</summary>
     WindowsRoamingAppData,
 
+    /// <summary>
+    /// The Windows program-files directory; contributes nothing elsewhere.
+    /// </summary>
+    /// <remarks>
+    /// Named rather than spelled as an absolute path because the directory is not fixed: it follows the
+    /// system drive, is localized in some installations, and has a separate 32-bit sibling. A layout that
+    /// hard-coded <c>C:\Program Files</c> would miss every machine that does not use it, which is exactly
+    /// the population this root exists for — Node's official MSI installs here, and the wizard could not
+    /// see the result.
+    /// </remarks>
+    WindowsProgramFiles,
+
+    /// <summary>
+    /// The directory this app installs toolchains into.
+    /// </summary>
+    /// <remarks>
+    /// A named root rather than a path for the same reason as the Windows ones: where app data lives is a
+    /// platform decision the infrastructure layer owns. Present so a toolchain the wizard installed is
+    /// discovered by the same scan that finds every other one, instead of through a second lookup that
+    /// only knows about our own installs and would drift from it.
+    /// </remarks>
+    SalmonEggToolchains,
+
     /// <summary>The single segment is already an absolute path.</summary>
     Absolute
 }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainPlatform.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainPlatform.cs
@@ -1,0 +1,34 @@
+namespace SalmonEgg.Domain.Models.AcpSetup;
+
+/// <summary>The operating system a published toolchain build targets.</summary>
+/// <remarks>
+/// Named here rather than reusing <c>System.Runtime.InteropServices.OSPlatform</c> so selecting a build
+/// stays a pure data decision. That type belongs to the family the domain must not touch: asking it
+/// anything means asking the host it is running on, and this layer answers about a target instead —
+/// which is what lets one process resolve every platform's archive under test. The host is inspected in
+/// the desktop layer and mapped onto these values.
+/// </remarks>
+public enum AcpToolchainOperatingSystem
+{
+    Linux,
+
+    MacOS,
+
+    Windows
+}
+
+/// <summary>The CPU architecture a published toolchain build targets.</summary>
+/// <remarks>
+/// A closed set covering only what the vendors publish and this app supports. Anything outside it
+/// resolves to no download, which is the honest answer for a platform with no published build.
+/// </remarks>
+public enum AcpToolchainArchitecture
+{
+    X64,
+
+    Arm64,
+
+    X86,
+
+    Arm
+}

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainRequirement.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpToolchainRequirement.cs
@@ -22,10 +22,11 @@ namespace SalmonEgg.Domain.Models.AcpSetup;
 /// </remarks>
 public sealed class AcpToolchainRequirement
 {
-    private AcpToolchainRequirement(string displayName, Uri documentation)
+    private AcpToolchainRequirement(string displayName, Uri documentation, bool hasAutomaticInstallPath)
     {
         DisplayName = displayName;
         Documentation = documentation;
+        HasAutomaticInstallPath = hasAutomaticInstallPath;
     }
 
     /// <summary>Human-facing toolchain name. A vendor product name, so it is not localized.</summary>
@@ -33,6 +34,21 @@ public sealed class AcpToolchainRequirement
 
     /// <summary>Where the user is sent to install the toolchain themselves.</summary>
     public Uri Documentation { get; }
+
+    /// <summary>
+    /// True when the app publishes an automatic install path for this toolchain.
+    /// </summary>
+    /// <remarks>
+    /// A statement about this app's own capability, not about the machine — deliberately the same
+    /// distinction <see cref="AcpComponentDescriptor.HasAutomaticInstallPath"/> draws. Whether the toolchain
+    /// is already here is a probe's answer, and whether this platform can run an installer at all is
+    /// <see cref="Services.AcpSetup.IAcpToolchainInstaller.SupportsAutomaticInstall"/>'s; offering the user
+    /// a button needs all three, so callers combine them rather than reading this alone.
+    ///
+    /// <see cref="Documentation"/> stays meaningful either way: it is the fallback when an install fails,
+    /// and the only route for a toolchain with no automatic path.
+    /// </remarks>
+    public bool HasAutomaticInstallPath { get; }
 
     /// <summary>
     /// The toolchain <paramref name="distribution"/> needs, or null when it needs none.
@@ -60,10 +76,17 @@ public sealed class AcpToolchainRequirement
     /// </remarks>
     public static AcpToolchainRequirement Node { get; } = new(
         "Node.js",
-        new Uri("https://nodejs.org/en/download"));
+        new Uri("https://nodejs.org/en/download"),
+        hasAutomaticInstallPath: true);
 
     /// <summary>The uv toolchain, which supplies both <c>uv</c> and <c>uvx</c>.</summary>
+    /// <remarks>
+    /// Named without a minimum version, for the same reason <see cref="Node"/> is: each tool declares its own
+    /// <c>requires-python</c> and uv constraints, so a version asserted here could not stay true for every
+    /// component. The install source pins which uv build the wizard fetches.
+    /// </remarks>
     public static AcpToolchainRequirement Uv { get; } = new(
         "uv",
-        new Uri("https://docs.astral.sh/uv/getting-started/installation/"));
+        new Uri("https://docs.astral.sh/uv/getting-started/installation/"),
+        hasAutomaticInstallPath: true);
 }

--- a/src/SalmonEgg.Domain/Services/AcpSetup/IAcpToolchainInstaller.cs
+++ b/src/SalmonEgg.Domain/Services/AcpSetup/IAcpToolchainInstaller.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Domain.Services.AcpSetup;
+
+/// <summary>Installs a missing package-manager toolchain for the ACP setup wizard.</summary>
+public interface IAcpToolchainInstaller
+{
+    /// <summary>True when this platform can install a toolchain without external user steps.</summary>
+    bool SupportsAutomaticInstall { get; }
+
+    /// <summary>
+    /// Downloads, verifies, and installs the toolchain described by <paramref name="requirement"/>.
+    /// </summary>
+    Task<AcpToolchainInstallResult> InstallAsync(
+        AcpToolchainRequirement requirement,
+        System.Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSearchPathSources.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpSearchPathSources.cs
@@ -20,10 +20,11 @@ namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 /// manager puts only the current one on PATH.</item>
 /// </list>
 ///
-/// Whether the shell source is available is a deployment question, which is why this type exists rather
-/// than each source self-registering: the capture needs an executable that implements the printing mode,
-/// and that is the CLI, which ships as its own package installed independently of the desktop app. When it
-/// is absent the scan alone still widens the search, so the wizard degrades rather than failing.
+/// Which executable answers the printing mode is why this type exists rather than each source
+/// self-registering: the capture needs one, and more than one can supply it. The CLI ships as its own
+/// package installed independently of the desktop app, so it may be absent — but the running process
+/// answers the same mode, so the capture is available regardless of what else is installed. See
+/// <see cref="ResolvePrintEnvironmentExecutable"/>.
 /// </remarks>
 public static class AcpSearchPathSources
 {
@@ -33,11 +34,13 @@ public static class AcpSearchPathSources
     /// <summary>
     /// Creates the sources for this machine.
     /// </summary>
-    /// <param name="resolveCliPath">
-    /// Locates the CLI executable, or returns null when none is installed. Injectable so the composition
-    /// can be tested without depending on what the host machine happens to have installed.
+    /// <param name="resolvePrintEnvironmentPath">
+    /// Locates an executable implementing the environment-printing mode, or returns null when none is
+    /// usable. Injectable so the composition can be tested without depending on what the host machine
+    /// happens to have installed.
     /// </param>
-    public static IReadOnlyList<IAcpSearchPathSource> Create(Func<string?>? resolveCliPath = null)
+    public static IReadOnlyList<IAcpSearchPathSource> Create(
+        Func<string?>? resolvePrintEnvironmentPath = null)
     {
         var sources = new List<IAcpSearchPathSource>(2);
 
@@ -45,8 +48,8 @@ public static class AcpSearchPathSources
         // it, so there is no profile-built PATH to recover and the scan is the whole answer there.
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            var cliPath = (resolveCliPath ?? ResolveInstalledCliPath)();
-            if (PrintEnvironmentCommandFactory.TryCreate(cliPath) is { } printEnvironmentCommand)
+            var executable = (resolvePrintEnvironmentPath ?? ResolvePrintEnvironmentExecutable)();
+            if (PrintEnvironmentCommandFactory.TryCreate(executable) is { } printEnvironmentCommand)
             {
                 sources.Add(new LoginShellSearchPathSource(printEnvironmentCommand));
             }
@@ -57,15 +60,30 @@ public static class AcpSearchPathSources
     }
 
     /// <summary>
-    /// Finds the installed CLI, preferring one that sits beside this process.
+    /// Finds an executable that implements the environment-printing mode.
     /// </summary>
     /// <remarks>
-    /// The sibling is checked first because a build tree and a portable extraction both put the two
-    /// together, and that copy is certain to match this app's version. Falling back to PATH covers the
-    /// packaged case, where the CLI installs to a system directory (a .deb owns
-    /// <c>/usr/bin/salmon-egg</c>) that this process's own directory says nothing about.
+    /// Three candidates, in order:
+    /// <list type="number">
+    /// <item>A CLI sitting beside this process. A build tree and a portable extraction both put the two
+    /// together, and that copy is certain to match this app's version.</item>
+    /// <item>A CLI on PATH. Covers the packaged case, where the CLI installs to a system directory (a .deb
+    /// owns <c>/usr/bin/salmon-egg</c>) that this process's own directory says nothing about.</item>
+    /// <item>This process itself, which answers the same mode.</item>
+    /// </list>
+    ///
+    /// The CLI leads because it is a small single-file executable and the capture starts it inside an
+    /// interactive login shell, which the user waits on; starting the whole desktop app there costs more
+    /// for an identical answer.
+    ///
+    /// The last candidate is what makes this chain total. The CLI ships as its own package installed
+    /// independently of the desktop app, so a user who installed only the app had no executable answering
+    /// the mode — the capture never registered, and the disk scan was the only widening left. That is not a
+    /// degraded answer but a missing one for the most common toolchain setup there is: nvm ships no
+    /// executable at all, so no amount of scanning reveals the version it activated, and every Node
+    /// component reported as absent on a machine that had one.
     /// </remarks>
-    private static string? ResolveInstalledCliPath()
+    internal static string? ResolvePrintEnvironmentExecutable()
     {
         var processDirectory = Path.GetDirectoryName(Environment.ProcessPath);
         if (!string.IsNullOrEmpty(processDirectory))
@@ -97,6 +115,9 @@ public static class AcpSearchPathSources
             }
         }
 
-        return null;
+        // This process. Checked last so an installed CLI wins, but always present, so the capture is never
+        // lost merely because the CLI is not installed.
+        var self = Environment.ProcessPath;
+        return !string.IsNullOrEmpty(self) && File.Exists(self) ? self : null;
     }
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainArchive.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainArchive.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Unpacks a verified toolchain archive into a destination directory.
+/// </summary>
+/// <remarks>
+/// Separate from the installer because unpacking is where the archive-format hazards live and they are
+/// worth testing on their own: path traversal, a missing execute bit, and a symlink that must survive.
+/// </remarks>
+internal static class AcpToolchainArchive
+{
+    /// <summary>
+    /// Extracts <paramref name="archivePath"/> into <paramref name="destination"/>, stripping the
+    /// archive's single root directory when it declares one.
+    /// </summary>
+    /// <remarks>
+    /// The root is stripped so the installed layout is this app's own — one directory per version — rather
+    /// than the vendor's naming, which differs per platform and would leak into every path the wizard later
+    /// records.
+    /// </remarks>
+    internal static async Task ExtractAsync(
+        string archivePath,
+        string destination,
+        AcpToolchainDownload download,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(destination);
+
+        if (download.ArchiveFormat == AcpArchiveFormat.TarGzip)
+        {
+            await ExtractTarGzipAsync(archivePath, destination, download.RootDirectory, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        ExtractZip(archivePath, destination, download.RootDirectory, cancellationToken);
+    }
+
+    /// <summary>
+    /// Extracts a gzip-compressed tar, preserving symbolic links and Unix permissions.
+    /// </summary>
+    /// <remarks>
+    /// Entries are read one at a time rather than through <c>TarFile.ExtractToDirectory</c> so the root
+    /// directory can be stripped and each destination path checked before anything is written.
+    ///
+    /// Symbolic links are the reason a tar reader is used at all for Node: <c>npm</c> and <c>npx</c> in the
+    /// official archive are links into <c>lib/node_modules</c>, and an extractor that resolved them into
+    /// copies would produce launchers that cannot find their own package. <see cref="TarEntry"/> recreates
+    /// them as links, and it restores the execute bit that makes <c>node</c> runnable.
+    /// </remarks>
+    private static async Task ExtractTarGzipAsync(
+        string archivePath,
+        string destination,
+        string? rootDirectory,
+        CancellationToken cancellationToken)
+    {
+        await using var file = File.OpenRead(archivePath);
+        await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+        await using var reader = new TarReader(gzip);
+
+        while (await reader.GetNextEntryAsync(copyData: false, cancellationToken).ConfigureAwait(false)
+               is { } entry)
+        {
+            if (StripRoot(entry.Name, rootDirectory) is not { Length: > 0 } relative)
+            {
+                continue;
+            }
+
+            if (ResolveSafePath(destination, relative) is not { } target)
+            {
+                throw new InvalidDataException(
+                    $"Archive entry '{entry.Name}' resolves outside the destination directory.");
+            }
+
+            if (entry.EntryType == TarEntryType.Directory)
+            {
+                Directory.CreateDirectory(target);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+
+            // Links are recreated rather than extracted. TarEntry.ExtractToFile refuses a link entry
+            // outright ("Entry type 'SymbolicLink' not supported for extraction"), and Node's POSIX archive
+            // reaches this branch for npm and npx — so without this the whole install fails on the two
+            // launchers the wizard actually needs.
+            if (entry.EntryType is TarEntryType.SymbolicLink or TarEntryType.HardLink)
+            {
+                CreateLink(target, entry.LinkName, entry.EntryType);
+                continue;
+            }
+
+            // ExtractToFile applies the entry's mode, which is what preserves the execute bit.
+            await entry.ExtractToFileAsync(target, overwrite: true, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Extracts a zip, restoring the execute bit that the format does not carry.
+    /// </summary>
+    /// <remarks>
+    /// Zip has no Unix mode, so a naive extraction on a POSIX host yields files that are present and not
+    /// executable — an install that verifies by existence and then fails at exec. Windows ignores the mode
+    /// entirely, so setting it is harmless there and correct everywhere else. Node's Windows archive is the
+    /// only zip in use today; the bit matters for any future POSIX-hosted zip.
+    /// </remarks>
+    private static void ExtractZip(
+        string archivePath,
+        string destination,
+        string? rootDirectory,
+        CancellationToken cancellationToken)
+    {
+        using var archive = ZipFile.OpenRead(archivePath);
+
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (StripRoot(entry.FullName, rootDirectory) is not { Length: > 0 } relative)
+            {
+                continue;
+            }
+
+            if (ResolveSafePath(destination, relative) is not { } target)
+            {
+                throw new InvalidDataException(
+                    $"Archive entry '{entry.FullName}' resolves outside the destination directory.");
+            }
+
+            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
+            {
+                Directory.CreateDirectory(target);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            entry.ExtractToFile(target, overwrite: true);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                MarkExecutable(target);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recreates a link entry at <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>
+    /// A symbolic link is recreated with its stored target verbatim rather than resolved into a copy. Node's
+    /// <c>npm</c> is a relative link into <c>lib/node_modules/npm/bin/npm-cli.js</c>; copying the script
+    /// there instead would give it a different <c>__dirname</c> and break its own module resolution. Keeping
+    /// it a link is what makes the extracted tree identical to a vendor-installed one.
+    ///
+    /// The link target is deliberately not validated against the destination. It is written, not followed,
+    /// so it grants no write access outside the tree; and these archives use relative targets that only
+    /// resolve correctly once the whole tree is in place, which is not yet true while extracting.
+    ///
+    /// A hard link is created as a hard link when the source is already extracted — tar orders it that way —
+    /// and copied otherwise, since a hard link to a file that does not exist yet cannot be made.
+    /// </remarks>
+    private static void CreateLink(string target, string? linkName, TarEntryType entryType)
+    {
+        if (string.IsNullOrEmpty(linkName))
+        {
+            return;
+        }
+
+        // A prior partial extraction may have left something here; the link cannot be created over it.
+        if (File.Exists(target))
+        {
+            File.Delete(target);
+        }
+
+        if (entryType == TarEntryType.SymbolicLink)
+        {
+            File.CreateSymbolicLink(target, linkName);
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(target)!;
+        var source = Path.GetFullPath(Path.Combine(directory, linkName));
+        if (File.Exists(source))
+        {
+            File.Copy(source, target, overwrite: true);
+        }
+    }
+
+    private static void MarkExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var mode = File.GetUnixFileMode(path);
+        File.SetUnixFileMode(
+            path,
+            mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+    }
+
+    /// <summary>
+    /// Removes the archive's declared root directory from an entry name, or returns the name unchanged when
+    /// the archive declares none.
+    /// </summary>
+    /// <remarks>
+    /// Returns null for the root entry itself, and for an entry outside the declared root — the latter
+    /// would mean the archive's shape disagrees with what the source declared, and extracting it would
+    /// scatter files beside the version directory instead of inside it.
+    /// </remarks>
+    internal static string? StripRoot(string entryName, string? rootDirectory)
+    {
+        var normalized = entryName.Replace('\\', '/').TrimStart('/');
+        if (string.IsNullOrEmpty(rootDirectory))
+        {
+            return normalized.TrimEnd('/');
+        }
+
+        var prefix = rootDirectory.TrimEnd('/') + "/";
+        if (!normalized.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return normalized[prefix.Length..].TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="relative"/> under <paramref name="destination"/>, or null when the result
+    /// escapes it.
+    /// </summary>
+    /// <remarks>
+    /// An archive is untrusted input even from a vendor over HTTPS with a matching digest, because the
+    /// digest attests to the bytes rather than to their safety. An entry named <c>../../.bashrc</c> would
+    /// otherwise let a download overwrite files anywhere the user can write.
+    /// </remarks>
+    internal static string? ResolveSafePath(string destination, string relative)
+    {
+        var root = Path.GetFullPath(destination);
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        string candidate;
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(root, relative));
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
+
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return candidate.StartsWith(rootWithSeparator, comparison) ? candidate : null;
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainArchive.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainArchive.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
@@ -66,6 +67,11 @@ internal static class AcpToolchainArchive
         await using var gzip = new GZipStream(file, CompressionMode.Decompress);
         await using var reader = new TarReader(gzip);
 
+        // Every symbolic link inside the destination was created by this extraction — the destination is a
+        // fresh staging directory — so tracking them here is a complete picture of the tree's links.
+        var createdLinks = new HashSet<string>(
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
         while (await reader.GetNextEntryAsync(copyData: false, cancellationToken).ConfigureAwait(false)
                is { } entry)
         {
@@ -80,6 +86,16 @@ internal static class AcpToolchainArchive
                     $"Archive entry '{entry.Name}' resolves outside the destination directory.");
             }
 
+            // Checked before any filesystem write of any entry kind: a parent that is a link would redirect
+            // even a directory creation, not just a file write.
+            EnsureWriteDoesNotTraverseLink(createdLinks, destination, target);
+
+            if (entry.EntryType is TarEntryType.SymbolicLink or TarEntryType.HardLink)
+            {
+                CreateLink(destination, createdLinks, target, entry.LinkName, entry.EntryType);
+                continue;
+            }
+
             if (entry.EntryType == TarEntryType.Directory)
             {
                 Directory.CreateDirectory(target);
@@ -87,16 +103,6 @@ internal static class AcpToolchainArchive
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(target)!);
-
-            // Links are recreated rather than extracted. TarEntry.ExtractToFile refuses a link entry
-            // outright ("Entry type 'SymbolicLink' not supported for extraction"), and Node's POSIX archive
-            // reaches this branch for npm and npx — so without this the whole install fails on the two
-            // launchers the wizard actually needs.
-            if (entry.EntryType is TarEntryType.SymbolicLink or TarEntryType.HardLink)
-            {
-                CreateLink(target, entry.LinkName, entry.EntryType);
-                continue;
-            }
 
             // ExtractToFile applies the entry's mode, which is what preserves the execute bit.
             await entry.ExtractToFileAsync(target, overwrite: true, cancellationToken).ConfigureAwait(false);
@@ -160,14 +166,23 @@ internal static class AcpToolchainArchive
     /// there instead would give it a different <c>__dirname</c> and break its own module resolution. Keeping
     /// it a link is what makes the extracted tree identical to a vendor-installed one.
     ///
-    /// The link target is deliberately not validated against the destination. It is written, not followed,
-    /// so it grants no write access outside the tree; and these archives use relative targets that only
-    /// resolve correctly once the whole tree is in place, which is not yet true while extracting.
+    /// The symbolic link's target is deliberately not validated against the destination. It is written, not
+    /// followed, so it grants no write access outside the tree — later entries that try to write through it
+    /// are refused by <see cref="EnsureWriteDoesNotTraverseLink"/>, which is why the link must be recorded
+    /// in <paramref name="createdLinks"/> here; and these archives use relative targets that only resolve
+    /// correctly once the whole tree is in place, which is not yet true while extracting.
     ///
     /// A hard link is created as a hard link when the source is already extracted — tar orders it that way —
-    /// and copied otherwise, since a hard link to a file that does not exist yet cannot be made.
+    /// and copied otherwise, since a hard link to a file that does not exist yet cannot be made. The copy
+    /// reads the resolved source, so a source outside the destination would import outside content into the
+    /// install: it is rejected rather than resolved.
     /// </remarks>
-    private static void CreateLink(string target, string? linkName, TarEntryType entryType)
+    private static void CreateLink(
+        string destination,
+        HashSet<string> createdLinks,
+        string target,
+        string? linkName,
+        TarEntryType entryType)
     {
         if (string.IsNullOrEmpty(linkName))
         {
@@ -183,14 +198,74 @@ internal static class AcpToolchainArchive
         if (entryType == TarEntryType.SymbolicLink)
         {
             File.CreateSymbolicLink(target, linkName);
+            createdLinks.Add(Path.GetFullPath(target));
             return;
         }
 
         var directory = Path.GetDirectoryName(target)!;
         var source = Path.GetFullPath(Path.Combine(directory, linkName));
+        var root = Path.GetFullPath(destination);
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!source.StartsWith(
+                rootWithSeparator,
+                OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Archive hard-link entry '{Path.GetFileName(target)}' points outside the destination directory.");
+        }
+
         if (File.Exists(source))
         {
             File.Copy(source, target, overwrite: true);
+        }
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="target"/> or any parent directory on its way down from
+    /// <paramref name="destination"/> is a symbolic link the archive created earlier in this extraction.
+    /// </summary>
+    /// <remarks>
+    /// Resolving the entry's own name is not enough: a crafted archive can declare
+    /// <c>escape → /somewhere/outside</c> and then a regular file named <c>escape</c>, and the extractor's
+    /// write would follow the link and land outside the tree. The same holds for a symlinked parent —
+    /// <c>out → outside</c> then a file at <c>out/child</c> — which would redirect the write even though
+    /// the entry's own name is innocent. A digest attests to the archive's bytes, not to their safety, so
+    /// the shape itself is refused rather than trusted.
+    ///
+    /// Only links this extraction created are consulted, which is sound because the destination is a fresh
+    /// staging directory: every symlink in it came from an earlier entry of the same archive. Vendor
+    /// archives are unaffected — Node's links (<c>bin/npm</c>, <c>bin/npx</c>) are leaves that no later
+    /// entry names as a path component.
+    /// </remarks>
+    private static void EnsureWriteDoesNotTraverseLink(
+        HashSet<string> createdLinks,
+        string destination,
+        string target)
+    {
+        var current = Path.GetFullPath(destination);
+        var relative = Path.GetRelativePath(current, Path.GetFullPath(target));
+        if (relative is "." or "")
+        {
+            return;
+        }
+
+        foreach (var segment in relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (segment.Length == 0)
+            {
+                continue;
+            }
+
+            current = Path.Combine(current, segment);
+            if (createdLinks.Contains(current))
+            {
+                throw new InvalidDataException(
+                    $"Archive entry '{Path.GetFileName(target)}' would be written through a symbolic link "
+                    + "the archive itself created.");
+            }
         }
     }
 

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainChecksum.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/AcpToolchainChecksum.cs
@@ -1,0 +1,117 @@
+using System;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Reads the expected SHA-256 digest for one archive out of a vendor's published checksum document.
+/// </summary>
+internal static class AcpToolchainChecksum
+{
+    /// <summary>
+    /// Returns the digest for <paramref name="fileName"/>, or null when the document does not state one.
+    /// </summary>
+    /// <remarks>
+    /// The file name is matched rather than assumed to be the document's only subject. Node publishes one
+    /// <c>SHASUMS256.txt</c> covering every artifact of a release — over thirty lines — so taking the first
+    /// digest would verify the archive against a different file's hash and reject a perfectly good
+    /// download. Returning null on no match is what makes the caller refuse to install rather than proceed
+    /// unverified.
+    /// </remarks>
+    internal static string? Parse(string document, AcpChecksumFormat format, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(document))
+        {
+            return null;
+        }
+
+        return format switch
+        {
+            AcpChecksumFormat.ShasumList => ParseList(document, fileName),
+            AcpChecksumFormat.SingleHash => ParseSingle(document),
+            _ => null
+        };
+    }
+
+    private static string? ParseList(string document, string fileName)
+    {
+        foreach (var rawLine in document.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            // "<hash>  <name>", with the name sometimes prefixed by a binary marker ('*') or a directory.
+            var separator = line.IndexOf(' ');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var digest = line[..separator].Trim();
+            var name = line[(separator + 1)..].Trim().TrimStart('*');
+            if (!IsSha256(digest))
+            {
+                continue;
+            }
+
+            // The trailing segment is compared so a line naming a path still matches a bare file name.
+            var slash = name.LastIndexOfAny(new[] { '/', '\\' });
+            if (slash >= 0)
+            {
+                name = name[(slash + 1)..];
+            }
+
+            if (string.Equals(name, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return digest.ToLowerInvariant();
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads a lone digest, tolerating the <c>sha256sum</c> convention of a trailing file name.
+    /// </summary>
+    private static string? ParseSingle(string document)
+    {
+        foreach (var rawLine in document.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var separator = line.IndexOf(' ');
+            var digest = (separator > 0 ? line[..separator] : line).Trim();
+            if (IsSha256(digest))
+            {
+                return digest.ToLowerInvariant();
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsSha256(string value)
+    {
+        if (value.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (!Uri.IsHexDigit(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpToolchainInstaller.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpToolchainInstaller.cs
@@ -202,7 +202,10 @@ public sealed class DesktopAcpToolchainInstaller : IAcpToolchainInstaller
     private static AcpToolchainDownload? ResolvePublishedDownload(AcpToolchainRequirement requirement)
     {
         var platform = ResolveCurrentPlatform();
-        var architecture = RuntimeInformation.OSArchitecture;
+        if (ResolveCurrentArchitecture() is not { } architecture)
+        {
+            return null;
+        }
 
         if (ReferenceEquals(requirement, AcpToolchainRequirement.Node))
         {
@@ -229,15 +232,42 @@ public sealed class DesktopAcpToolchainInstaller : IAcpToolchainInstaller
     private static bool PrefersMuslBuild()
         => RuntimeInformation.RuntimeIdentifier.Contains("musl", StringComparison.OrdinalIgnoreCase);
 
-    private static OSPlatform ResolveCurrentPlatform()
+    /// <summary>
+    /// This host's operating system, as the toolchain sources name it.
+    /// </summary>
+    /// <remarks>
+    /// Inspecting the host belongs here rather than in the domain, which selects a build for a target it is
+    /// told about. Keeping the question on this side is what lets the resolvers be exercised for every
+    /// platform from one test process.
+    /// </remarks>
+    private static AcpToolchainOperatingSystem ResolveCurrentPlatform()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return OSPlatform.Windows;
+            return AcpToolchainOperatingSystem.Windows;
         }
 
-        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OSPlatform.OSX : OSPlatform.Linux;
+        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            ? AcpToolchainOperatingSystem.MacOS
+            : AcpToolchainOperatingSystem.Linux;
     }
+
+    /// <summary>
+    /// This host's architecture, or null when no supported toolchain targets it.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than a nearest guess: a build for the wrong architecture extracts cleanly and then fails
+    /// to exec, which would surface as a corrupt download instead of as an unsupported platform.
+    /// </remarks>
+    private static AcpToolchainArchitecture? ResolveCurrentArchitecture()
+        => RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => AcpToolchainArchitecture.X64,
+            Architecture.Arm64 => AcpToolchainArchitecture.Arm64,
+            Architecture.X86 => AcpToolchainArchitecture.X86,
+            Architecture.Arm => AcpToolchainArchitecture.Arm,
+            _ => null
+        };
 
     private static string ResolveToolchainDirectoryName(AcpToolchainRequirement requirement)
         => ReferenceEquals(requirement, AcpToolchainRequirement.Node) ? "node" : "uv";

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpToolchainInstaller.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopAcpToolchainInstaller.cs
@@ -1,0 +1,412 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+using SalmonEgg.Infrastructure.Storage;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Installs a missing toolchain from its vendor's official archive: download, verify the published
+/// SHA-256, unpack into per-user application data, prove the result runs, and put it on the user's PATH.
+/// </summary>
+/// <remarks>
+/// This exists because the wizard's advice used to end at a documentation link. A user whose machine had no
+/// Node was told to leave the app, find an installer, and come back — and the step most likely to be got
+/// wrong (installing somewhere the app cannot see) was entirely theirs to get right.
+///
+/// The install is per-user and unprivileged throughout. A system location would need elevation, which makes
+/// a declined prompt indistinguishable from a broken feature, and would leave files behind that uninstalling
+/// the app cannot remove.
+///
+/// Verification is fail-closed and not optional. The payload is executable code fetched over the network, so
+/// a digest that cannot be located is treated exactly like one that does not match: nothing is installed.
+/// The alternative — install and hope — is the one outcome worth avoiding absolutely.
+/// </remarks>
+public sealed class DesktopAcpToolchainInstaller : IAcpToolchainInstaller
+{
+    /// <summary>Advice key for a platform with no published automatic install.</summary>
+    internal const string UnsupportedPlatformRemediationKey = "AcpSetup_Toolchain_UnsupportedPlatform";
+
+    /// <summary>Advice key for a download or verification that did not complete.</summary>
+    internal const string DownloadFailedRemediationKey = "AcpSetup_Toolchain_DownloadFailed";
+
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan VerifyTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly Func<HttpClient> _httpClientFactory;
+    private readonly Func<string> _installRootFactory;
+    private readonly Func<AcpToolchainRequirement, AcpToolchainDownload?> _resolveDownload;
+
+    /// <param name="httpClientFactory">
+    /// Supplies the client used for both the archive and its checksum. Injectable so the download path can
+    /// be tested against a local server rather than the vendor's.
+    /// </param>
+    /// <param name="installRootFactory">
+    /// Yields the directory toolchains are installed under. Must agree with what
+    /// <see cref="ToolchainScanSearchPathSource"/> scans, or an install would succeed and stay
+    /// undiscoverable; both default to the same app-data location.
+    /// </param>
+    /// <param name="resolveDownload">
+    /// Selects the archive to install for a requirement. Injectable so the download, verification, and
+    /// unpack path can be exercised against a local server: the shipped resolver names vendor URLs, and a
+    /// test bound to those would either reach the network or never reach this code at all — leaving the
+    /// checksum refusal, the traversal guard, and the post-extract probe unverified.
+    /// </param>
+    public DesktopAcpToolchainInstaller(
+        Func<HttpClient>? httpClientFactory = null,
+        Func<string>? installRootFactory = null,
+        Func<AcpToolchainRequirement, AcpToolchainDownload?>? resolveDownload = null)
+    {
+        _httpClientFactory = httpClientFactory ?? CreateDefaultHttpClient;
+        _installRootFactory = installRootFactory ?? DefaultInstallRoot;
+        _resolveDownload = resolveDownload ?? ResolvePublishedDownload;
+    }
+
+    public bool SupportsAutomaticInstall => true;
+
+    /// <summary>The directory toolchains are installed under by default.</summary>
+    internal static string DefaultInstallRoot()
+        => Path.Combine(
+            SalmonEggPaths.GetAppDataRootPath(),
+            ToolchainScanSearchPathSource.ToolchainsDirectoryName);
+
+    public async Task<AcpToolchainInstallResult> InstallAsync(
+        AcpToolchainRequirement requirement,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(requirement);
+
+        if (!requirement.HasAutomaticInstallPath)
+        {
+            return AcpToolchainInstallResult.Failure(
+                requirement,
+                $"'{requirement.DisplayName}' has no automatic install path.",
+                remediationKey: UnsupportedPlatformRemediationKey);
+        }
+
+        if (_resolveDownload(requirement) is not { } download)
+        {
+            return AcpToolchainInstallResult.Failure(
+                requirement,
+                $"No published {requirement.DisplayName} build for "
+                + $"{RuntimeInformation.OSDescription} / {RuntimeInformation.OSArchitecture}.",
+                remediationKey: UnsupportedPlatformRemediationKey);
+        }
+
+        var version = ResolveVersionDirectoryName(requirement);
+        var destination = Path.Combine(_installRootFactory(), ResolveToolchainDirectoryName(requirement), version);
+        var staging = destination + ".incoming-" + Guid.NewGuid().ToString("N")[..8];
+        var archivePath = Path.Combine(Path.GetTempPath(), "salmonegg-toolchain-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            onOutput?.Invoke($"Downloading {requirement.DisplayName} {version}…");
+            var actualDigest = await DownloadAsync(download, archivePath, onOutput, cancellationToken)
+                .ConfigureAwait(false);
+
+            onOutput?.Invoke("Verifying checksum…");
+            var expectedDigest = await ReadExpectedDigestAsync(download, cancellationToken).ConfigureAwait(false);
+            if (expectedDigest is null)
+            {
+                return AcpToolchainInstallResult.Failure(
+                    requirement,
+                    $"No published checksum for '{ResolveArchiveFileName(download)}'.",
+                    remediationKey: DownloadFailedRemediationKey);
+            }
+
+            if (!string.Equals(expectedDigest, actualDigest, StringComparison.OrdinalIgnoreCase))
+            {
+                // Refused rather than reported-and-installed. Anything else would put unverified executable
+                // code on the user's PATH.
+                return AcpToolchainInstallResult.Failure(
+                    requirement,
+                    $"Checksum mismatch: expected {expectedDigest}, downloaded {actualDigest}.",
+                    remediationKey: DownloadFailedRemediationKey);
+            }
+
+            onOutput?.Invoke("Extracting…");
+            // Unpacked to a staging directory and moved into place, so an interrupted extraction cannot
+            // leave a half-populated version directory that the scan would then offer as a candidate.
+            await AcpToolchainArchive.ExtractAsync(archivePath, staging, download, cancellationToken)
+                .ConfigureAwait(false);
+
+            var stagedBin = ResolveBinDirectory(staging, download);
+            if (VerifyContents(stagedBin, download) is { } missing)
+            {
+                return AcpToolchainInstallResult.Failure(
+                    requirement,
+                    $"The extracted archive has no '{missing}'.",
+                    remediationKey: DownloadFailedRemediationKey);
+            }
+
+            onOutput?.Invoke("Verifying the installed toolchain…");
+            var probe = await AcpSetupProcessRunner
+                .RunAsync(
+                    Path.Combine(stagedBin, download.VerifyCommand),
+                    download.VerifyArguments,
+                    VerifyTimeout,
+                    onOutput,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!probe.Succeeded)
+            {
+                // Present on disk is not the same as runnable: an archive for the wrong architecture
+                // unpacks cleanly and fails here. Reporting success would hand the wizard a toolchain that
+                // cannot execute.
+                return AcpToolchainInstallResult.Failure(
+                    requirement,
+                    probe.FailureDetail
+                        ?? $"'{download.VerifyCommand}' did not run after extraction.",
+                    probe.CombinedOutput,
+                    DownloadFailedRemediationKey);
+            }
+
+            ReplaceDirectory(staging, destination);
+            var binDirectory = ResolveBinDirectory(destination, download);
+
+            var registration = UserPathRegistration.Register(binDirectory, onOutput);
+            onOutput?.Invoke($"Installed to {binDirectory}");
+            return AcpToolchainInstallResult.Success(
+                requirement,
+                binDirectory,
+                registration,
+                probe.CombinedOutput);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return AcpToolchainInstallResult.Failure(
+                requirement,
+                exception.Message,
+                remediationKey: DownloadFailedRemediationKey);
+        }
+        finally
+        {
+            TryDeleteFile(archivePath);
+            TryDeleteDirectory(staging);
+        }
+    }
+
+    /// <summary>The published build for this machine, or null when there is none.</summary>
+    private static AcpToolchainDownload? ResolvePublishedDownload(AcpToolchainRequirement requirement)
+    {
+        var platform = ResolveCurrentPlatform();
+        var architecture = RuntimeInformation.OSArchitecture;
+
+        if (ReferenceEquals(requirement, AcpToolchainRequirement.Node))
+        {
+            return AcpToolchainInstallSource.ResolveNode(platform, architecture);
+        }
+
+        if (ReferenceEquals(requirement, AcpToolchainRequirement.Uv))
+        {
+            return AcpToolchainInstallSource.ResolveUv(platform, architecture, PrefersMuslBuild());
+        }
+
+        // A requirement this layer has no source for. Null rather than a guess: the caller turns it into
+        // "no automatic install on this platform" and keeps the vendor's documentation on screen.
+        return null;
+    }
+
+    /// <summary>True when this host's C library is musl rather than glibc.</summary>
+    /// <remarks>
+    /// Read from the runtime identifier, which spells the libc out (<c>linux-musl-arm64</c> versus
+    /// <c>linux-arm64</c>). It cannot be inferred from <see cref="Architecture"/>, and the distinction is not
+    /// cosmetic: a glibc archive extracts cleanly on Alpine and then fails to exec, which would surface as a
+    /// corrupt-download error rather than as the wrong build being chosen.
+    /// </remarks>
+    private static bool PrefersMuslBuild()
+        => RuntimeInformation.RuntimeIdentifier.Contains("musl", StringComparison.OrdinalIgnoreCase);
+
+    private static OSPlatform ResolveCurrentPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return OSPlatform.Windows;
+        }
+
+        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OSPlatform.OSX : OSPlatform.Linux;
+    }
+
+    private static string ResolveToolchainDirectoryName(AcpToolchainRequirement requirement)
+        => ReferenceEquals(requirement, AcpToolchainRequirement.Node) ? "node" : "uv";
+
+    /// <summary>
+    /// The version directory an install lands in.
+    /// </summary>
+    /// <remarks>
+    /// A real version rather than a fixed name like "current", because the scan finds these through a
+    /// wildcard version segment: a non-versioned directory would sit outside the layout and stay
+    /// undiscoverable. It also keeps an upgrade from overwriting a toolchain that something may still be
+    /// running from.
+    /// </remarks>
+    private static string ResolveVersionDirectoryName(AcpToolchainRequirement requirement)
+    {
+        if (ReferenceEquals(requirement, AcpToolchainRequirement.Node))
+        {
+            return AcpToolchainInstallSource.NodeVersion;
+        }
+
+        return ReferenceEquals(requirement, AcpToolchainRequirement.Uv)
+            ? AcpToolchainInstallSource.UvVersion
+            : "current";
+    }
+
+    /// <summary>
+    /// Streams the archive to disk and returns its SHA-256, computed as the bytes arrive.
+    /// </summary>
+    /// <remarks>
+    /// Hashed while streaming rather than by re-reading the file: these archives are tens of megabytes, and
+    /// buffering one in memory to hash it would be a needless allocation on a desktop that may be short of
+    /// it.
+    /// </remarks>
+    private async Task<string> DownloadAsync(
+        AcpToolchainDownload download,
+        string archivePath,
+        Action<string>? onOutput,
+        CancellationToken cancellationToken)
+    {
+        using var client = _httpClientFactory();
+        client.Timeout = DownloadTimeout;
+
+        using var response = await client
+            .GetAsync(download.Archive, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var total = response.Content.Headers.ContentLength;
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        await using (var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+        await using (var target = File.Create(archivePath))
+        {
+            var buffer = new byte[81920];
+            long copied = 0;
+            var lastReportedPercent = -1;
+
+            while (true)
+            {
+                var read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                hash.AppendData(buffer, 0, read);
+                await target.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                copied += read;
+
+                if (total is > 0 && onOutput is not null)
+                {
+                    // Reported per whole percent so a long download shows progress without flooding the
+                    // wizard's bounded output log.
+                    var percent = (int)(copied * 100 / total.Value);
+                    if (percent != lastReportedPercent)
+                    {
+                        lastReportedPercent = percent;
+                        onOutput($"Downloaded {percent}%");
+                    }
+                }
+            }
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    private async Task<string?> ReadExpectedDigestAsync(
+        AcpToolchainDownload download,
+        CancellationToken cancellationToken)
+    {
+        using var client = _httpClientFactory();
+        var document = await client.GetStringAsync(download.Checksum, cancellationToken).ConfigureAwait(false);
+        return AcpToolchainChecksum.Parse(
+            document,
+            download.ChecksumFormat,
+            ResolveArchiveFileName(download));
+    }
+
+    private static string ResolveArchiveFileName(AcpToolchainDownload download)
+        => download.Archive.Segments[^1];
+
+    private static string ResolveBinDirectory(string installRoot, AcpToolchainDownload download)
+        => string.IsNullOrEmpty(download.BinSubdirectory)
+            ? installRoot
+            : Path.Combine(installRoot, download.BinSubdirectory);
+
+    /// <summary>The first declared executable that is absent, or null when all are present.</summary>
+    private static string? VerifyContents(string binDirectory, AcpToolchainDownload download)
+    {
+        foreach (var executable in download.VerifyExecutables)
+        {
+            var path = Path.Combine(binDirectory, executable);
+
+            // Existence is checked through the link rather than its target, because npm and npx in Node's
+            // POSIX archive are symlinks and File.Exists follows them — which is the right test: a link
+            // whose target is missing is a broken install.
+            if (!File.Exists(path))
+            {
+                return executable;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Moves a verified staging directory into its final location, replacing any prior install.</summary>
+    private static void ReplaceDirectory(string staging, string destination)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+
+        if (Directory.Exists(destination))
+        {
+            // A reinstall of the same version replaces it. Deleted immediately before the move so the
+            // window in which neither copy exists is as short as the filesystem allows.
+            Directory.Delete(destination, recursive: true);
+        }
+
+        Directory.Move(staging, destination);
+    }
+
+    private static HttpClient CreateDefaultHttpClient()
+        => new(new SocketsHttpHandler { AutomaticDecompression = System.Net.DecompressionMethods.All });
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A leftover file in the temp directory is the operating system's to reclaim.
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Same reasoning: a failed cleanup must not mask the install's own outcome.
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopPrintEnvironment.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopPrintEnvironment.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Prints this process's environment as one JSON object, wrapped in a caller-supplied marker.
+/// </summary>
+/// <remarks>
+/// This exists to be run <em>by the user's own shell</em>. A GUI-launched desktop process inherits the
+/// session environment rather than the one a shell profile builds, so a version-manager toolchain (nvm,
+/// fnm, volta, asdf, mise) is invisible to it. The app recovers the real environment by asking the user's
+/// login shell to run this, then reading what the shell handed the child.
+///
+/// Every editor that solves this does the same thing — run its own executable inside the shell rather
+/// than parse the shell's <c>env</c> output — because rc files print banners, colour codes, and warnings
+/// onto the same stream. VS Code runs <c>code -p</c>, Zed runs <c>zed --printenv</c>, JetBrains runs a
+/// bundled <c>printenv</c> helper. Emitting JSON from inside the child makes the payload
+/// self-delimiting and immune to whatever text surrounds it.
+///
+/// The marker handles the surrounding noise. The caller generates a fresh random one per invocation and
+/// extracts what lies between the two occurrences, so a chatty rc file cannot be mistaken for payload.
+/// It must be random rather than fixed: a fixed marker could appear in a variable's value — this process
+/// prints its own environment, which includes anything the shell exported — and turn an honest value into
+/// a false delimiter.
+///
+/// It lives here, beside <see cref="ShellEnvironmentCapture"/>, rather than in either executable that
+/// implements the mode. Both the CLI and the desktop app answer this protocol, and the capture reads it;
+/// putting the writer next to the reader is what keeps the two spellings from drifting. Previously the
+/// option name existed twice — once in the CLI, once in the capture's command factory — held together by
+/// a test that compared the two constants, which is a check that the drift has not happened yet rather
+/// than a structure in which it cannot.
+///
+/// Whichever executable hosts this must handle it <em>before</em> building a service container or running
+/// startup recovery. It reads nothing and writes nothing but stdout, and it is invoked while the app is
+/// starting; touching user data here would make an environment probe a source of configuration side
+/// effects.
+/// </remarks>
+public static class DesktopPrintEnvironment
+{
+    /// <summary>The option that selects this mode. Undocumented: it is an app-internal protocol.</summary>
+    public const string OptionName = "--printenv";
+
+    /// <summary>
+    /// True when <paramref name="args"/> requests environment printing, yielding the marker to wrap the
+    /// payload in.
+    /// </summary>
+    /// <remarks>
+    /// Matched against raw arguments rather than through a command-line parser because no container may be
+    /// built for this invocation, and a parser needs one.
+    ///
+    /// The marker is required, and only <c>--printenv=&lt;marker&gt;</c> is accepted rather than a
+    /// separate argument, so a bare <c>--printenv</c> cannot silently produce unwrapped output that the
+    /// caller would then fail to locate.
+    /// </remarks>
+    public static bool TryGetMarker(IReadOnlyList<string> args, out string marker)
+    {
+        marker = string.Empty;
+        if (args is null)
+        {
+            return false;
+        }
+
+        const string prefix = OptionName + "=";
+        foreach (var argument in args)
+        {
+            if (argument is null || !argument.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var candidate = argument[prefix.Length..];
+            if (candidate.Length == 0)
+            {
+                continue;
+            }
+
+            marker = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Writes <c>&lt;marker&gt;{...}&lt;marker&gt;</c> to <paramref name="stdout"/> and flushes it.
+    /// </summary>
+    /// <remarks>
+    /// Flushed explicitly because the caller reads this from a pipe and the process may be killed on a
+    /// timeout: an unflushed buffer would read as a shell that produced nothing.
+    /// </remarks>
+    public static async Task WriteAsync(
+        string marker,
+        TextWriter stdout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stdout);
+
+        var variables = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && key.Length > 0)
+            {
+                variables[key] = entry.Value as string ?? string.Empty;
+            }
+        }
+
+        var payload = JsonSerializer.Serialize(
+            variables,
+            DesktopPrintEnvironmentJson.Default.DictionaryStringString);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await stdout.WriteAsync(marker).ConfigureAwait(false);
+        await stdout.WriteAsync(payload).ConfigureAwait(false);
+        await stdout.WriteAsync(marker).ConfigureAwait(false);
+        await stdout.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopPrintEnvironmentJson.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/DesktopPrintEnvironmentJson.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace SalmonEgg.Cli.Hosting;
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 
 /// <summary>
-/// Source-generated serializer for the environment payload printed by <see cref="CliPrintEnvironment"/>.
+/// Source-generated serializer for the environment payload printed by
+/// <see cref="DesktopPrintEnvironment"/>.
 /// </summary>
 /// <remarks>
 /// Not indented: the payload is machine-read from a pipe, and keeping it on one line means a shell that
@@ -15,6 +16,6 @@ namespace SalmonEgg.Cli.Hosting;
 /// </remarks>
 [JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
 [JsonSerializable(typeof(Dictionary<string, string>))]
-internal partial class CliPrintEnvironmentJson : JsonSerializerContext
+internal partial class DesktopPrintEnvironmentJson : JsonSerializerContext
 {
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/PrintEnvironmentCommandFactory.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/PrintEnvironmentCommandFactory.cs
@@ -18,13 +18,13 @@ namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 /// </remarks>
 internal static class PrintEnvironmentCommandFactory
 {
-    /// <summary>The option that selects environment printing. Must match the CLI's own spelling.</summary>
+    /// <summary>The option that selects environment printing.</summary>
     /// <remarks>
-    /// Held as a constant rather than referenced from the CLI assembly, because the two are separate
-    /// executables that meet only across a process boundary and neither references the other. A test pins
-    /// the two spellings together so they cannot drift apart silently.
+    /// Taken from <see cref="DesktopPrintEnvironment"/>, which is the side that answers the option, so the
+    /// two cannot disagree. It was previously a second literal kept in step by a test comparing the two
+    /// constants — a check that they had not drifted yet, rather than a structure in which they cannot.
     /// </remarks>
-    internal const string OptionName = "--printenv";
+    internal const string OptionName = DesktopPrintEnvironment.OptionName;
 
     /// <summary>
     /// Returns a factory turning a marker into the command that runs

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/ToolchainScanSearchPathSource.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using SalmonEgg.Domain.Models.AcpSetup;
 using SalmonEgg.Domain.Services.AcpSetup;
+using SalmonEgg.Infrastructure.Storage;
 
 namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 
@@ -25,6 +26,15 @@ namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
 /// </remarks>
 public sealed class ToolchainScanSearchPathSource : IAcpSearchPathSource
 {
+    /// <summary>
+    /// Directory under the app data root that holds installed toolchains.
+    /// </summary>
+    /// <remarks>
+    /// Shared with the toolchain installer, which writes here. A second spelling would let the scan look
+    /// somewhere the installer never writes, so an install would succeed and stay undiscoverable.
+    /// </remarks>
+    internal const string ToolchainsDirectoryName = "toolchains";
+
     private readonly IReadOnlyList<AcpToolchainLayout> _layouts;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -139,6 +149,21 @@ public sealed class ToolchainScanSearchPathSource : IAcpSearchPathSource
 
                 var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
                 return string.IsNullOrEmpty(appData) ? null : appData;
+
+            case AcpToolchainLayoutRoot.WindowsProgramFiles:
+                if (!OperatingSystem.IsWindows())
+                {
+                    return null;
+                }
+
+                var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                return string.IsNullOrEmpty(programFiles) ? null : programFiles;
+
+            case AcpToolchainLayoutRoot.SalmonEggToolchains:
+                // Resolved here rather than in the domain for the same reason the platform roots are:
+                // where app data lives is an infrastructure decision. Kept identical to what the
+                // toolchain installer writes, so an install is discovered by this scan.
+                return Path.Combine(SalmonEggPaths.GetAppDataRootPath(), ToolchainsDirectoryName);
 
             case AcpToolchainLayoutRoot.Absolute:
                 return string.Empty;

--- a/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/UserPathRegistration.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/AcpSetup/UserPathRegistration.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+/// <summary>
+/// Adds an installed toolchain's directory to the user's persistent PATH, so their own terminal can use
+/// what the wizard installed.
+/// </summary>
+/// <remarks>
+/// Strictly per-user, on every platform. A system-wide location would need elevation, which turns a
+/// declined prompt into a broken feature, cannot be undone by uninstalling the app, and changes the
+/// environment of users who never asked for it. Per-user needs no privileges and is reversible.
+///
+/// This is not what makes the wizard work — the wizard finds the install through its own directory scan.
+/// It exists so a user who installed Node here is not left with a Node their shell cannot see, which would
+/// be a confusing half-install. That is why failure is reported rather than thrown: the toolchain is
+/// installed and usable either way.
+/// </remarks>
+internal static class UserPathRegistration
+{
+    /// <summary>Opening marker of the block written to a POSIX profile.</summary>
+    internal const string BlockStart = "# >>> SalmonEgg toolchains >>>";
+
+    /// <summary>Closing marker of the block written to a POSIX profile.</summary>
+    internal const string BlockEnd = "# <<< SalmonEgg toolchains <<<";
+
+    /// <summary>
+    /// Ensures <paramref name="directory"/> is on the user's persistent PATH.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent by design rather than as an optimization. The wizard can install repeatedly — a retry, a
+    /// second agent needing the same toolchain, a version upgrade — and an entry appended each time grows
+    /// PATH without bound. On Windows that eventually exceeds the environment block limit and breaks
+    /// process creation for the whole user session, which is a far worse outcome than the install failing.
+    /// </remarks>
+    internal static AcpPathRegistration Register(string directory, Action<string>? onOutput = null)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return AcpPathRegistration.Failed;
+        }
+
+        try
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? RegisterOnWindows(directory, onOutput)
+                : RegisterOnPosix(directory, onOutput);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            // Reported, never thrown: the toolchain is installed and the wizard can already use it. A
+            // read-only profile or a locked registry hive must not undo a successful install.
+            onOutput?.Invoke($"Could not update PATH: {exception.Message}");
+            return AcpPathRegistration.Failed;
+        }
+    }
+
+    /// <summary>
+    /// Appends to the user's own PATH value in the registry and tells running processes it changed.
+    /// </summary>
+    /// <remarks>
+    /// The existing value is read back from the <em>user</em> target, never from this process's PATH. The
+    /// process value is the user and machine values already merged, so appending to it and storing the
+    /// result would copy the entire system PATH into the user's own — permanently, invisibly, and in a way
+    /// that then shadows later system changes. This is the single most damaging mistake available here.
+    /// </remarks>
+    private static AcpPathRegistration RegisterOnWindows(string directory, Action<string>? onOutput)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return AcpPathRegistration.Failed;
+        }
+
+        var existing = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)
+            ?? string.Empty;
+        if (ContainsDirectory(existing, directory))
+        {
+            return AcpPathRegistration.AlreadyPresent;
+        }
+
+        var updated = existing.Length == 0
+            ? directory
+            : existing.TrimEnd(';') + ";" + directory;
+        Environment.SetEnvironmentVariable("PATH", updated, EnvironmentVariableTarget.User);
+
+        // Without this, only processes started after the next sign-out observe the change: the registry
+        // write is durable but nothing re-reads it. Explorer rebroadcasts to its children, so a terminal
+        // opened afterwards sees the new PATH.
+        NotifyEnvironmentChanged();
+        onOutput?.Invoke($"Added to your user PATH: {directory}");
+        return AcpPathRegistration.Applied;
+    }
+
+    /// <summary>
+    /// Writes a marked block into <c>~/.profile</c> that prepends the directory to PATH.
+    /// </summary>
+    /// <remarks>
+    /// <c>~/.profile</c> rather than a shell-specific rc file: it is the POSIX login entry point that bash,
+    /// zsh (via its own profile chain), sh and dash all honour, so one write serves whatever shell the user
+    /// runs. Writing several rc files instead would inject the same entry more than once on a machine with
+    /// more than one shell.
+    ///
+    /// The block is delimited by markers so a repeat install rewrites it in place, and so a user who wants
+    /// it gone has an unambiguous region to delete. Guarded with a directory test at shell startup, because
+    /// a profile is read on every login and must not add a stale entry after the user deletes the toolchain.
+    /// </remarks>
+    private static AcpPathRegistration RegisterOnPosix(string directory, Action<string>? onOutput)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home))
+        {
+            return AcpPathRegistration.Failed;
+        }
+
+        var profile = Path.Combine(home, ".profile");
+        var existingLines = File.Exists(profile)
+            ? new List<string>(File.ReadAllLines(profile))
+            : new List<string>();
+
+        var block = BuildPosixBlock(directory);
+        var start = existingLines.FindIndex(line => line.Trim() == BlockStart);
+        var end = existingLines.FindIndex(line => line.Trim() == BlockEnd);
+
+        if (start >= 0 && end > start)
+        {
+            var current = existingLines.GetRange(start, end - start + 1);
+            if (current.Count == block.Count && SequenceEqual(current, block))
+            {
+                return AcpPathRegistration.AlreadyPresent;
+            }
+
+            // Replaced in place rather than appended, so repeated installs leave exactly one block.
+            existingLines.RemoveRange(start, end - start + 1);
+            existingLines.InsertRange(start, block);
+        }
+        else
+        {
+            if (existingLines.Count > 0 && existingLines[^1].Length > 0)
+            {
+                existingLines.Add(string.Empty);
+            }
+
+            existingLines.AddRange(block);
+        }
+
+        File.WriteAllText(profile, string.Join('\n', existingLines) + "\n");
+        onOutput?.Invoke($"Added to {profile}: {directory}");
+        return AcpPathRegistration.Applied;
+    }
+
+    private static List<string> BuildPosixBlock(string directory)
+    {
+        // A user's home path is normally mundane, but it is not constrained by this app. Escaping before
+        // inserting it into shell source is non-negotiable: a quote, dollar, backtick, or backslash in a
+        // legal directory name must stay a directory name rather than become part of the next login's
+        // program. Double quotes preserve spaces while the helper suppresses every expansion they permit.
+        var quotedDirectory = QuoteForPosixDoubleQuotes(directory);
+        return new List<string>
+        {
+            BlockStart,
+            "# Managed by SalmonEgg. Edit or delete the whole block.",
+            $"if [ -d \"{quotedDirectory}\" ]; then",
+            $"  case \":$PATH:\" in *\":{quotedDirectory}:\"*) ;; *) PATH=\"{quotedDirectory}:$PATH\" ;; esac",
+            "  export PATH",
+            "fi",
+            BlockEnd
+        };
+    }
+
+    /// <summary>Escapes a value inserted inside POSIX shell double quotes.</summary>
+    private static string QuoteForPosixDoubleQuotes(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("$", "\\$", StringComparison.Ordinal)
+            .Replace("`", "\\`", StringComparison.Ordinal);
+
+    private static bool SequenceEqual(List<string> left, List<string> right)
+    {
+        for (var index = 0; index < left.Count; index++)
+        {
+            if (!string.Equals(left[index].TrimEnd(), right[index].TrimEnd(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="path"/> already lists <paramref name="directory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Trailing separators are ignored and Windows is compared case-insensitively, because a PATH entry
+    /// that differs only that way is the same directory and adding it again would be a duplicate.
+    /// </remarks>
+    private static bool ContainsDirectory(string path, string directory)
+    {
+        var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var target = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        foreach (var entry in path.Split(
+                     Path.PathSeparator,
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (string.Equals(
+                    entry.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                    target,
+                    comparison))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private const int WmSettingChange = 0x001A;
+    private const int SmtoAbortIfHung = 0x0002;
+
+    private static void NotifyEnvironmentChanged()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            // Broadcast to top-level windows with a short timeout. A hung shell must not hold the wizard,
+            // and a missed broadcast only delays visibility to the next sign-in.
+            SendMessageTimeout(
+                new IntPtr(0xFFFF),
+                WmSettingChange,
+                IntPtr.Zero,
+                "Environment",
+                SmtoAbortIfHung,
+                timeout: 1000,
+                out _);
+        }
+        catch (Exception exception) when (exception is DllNotFoundException or EntryPointNotFoundException)
+        {
+            // Nothing to do: the registry write already happened and is what persists.
+        }
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "SendMessageTimeoutW")]
+    private static extern IntPtr SendMessageTimeout(
+        IntPtr windowHandle,
+        int message,
+        IntPtr wParam,
+        string lParam,
+        int flags,
+        int timeout,
+        out IntPtr result);
+}

--- a/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpToolchainInstaller.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/UnsupportedAcpToolchainInstaller.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.AcpSetup;
+
+/// <summary>
+/// Toolchain installer used on platforms that cannot download and run local executables. Reports
+/// <see cref="SupportsAutomaticInstall"/> as false so the wizard offers the vendor's documentation instead
+/// of a button, and fails any call that arrives anyway rather than reporting a phantom success.
+/// </summary>
+public sealed class UnsupportedAcpToolchainInstaller : IAcpToolchainInstaller
+{
+    private const string UnsupportedDetail =
+        "Installing a toolchain requires a desktop process host and is not supported on this platform.";
+
+    public bool SupportsAutomaticInstall => false;
+
+    public Task<AcpToolchainInstallResult> InstallAsync(
+        AcpToolchainRequirement requirement,
+        Action<string>? onOutput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(requirement);
+
+        return Task.FromResult(AcpToolchainInstallResult.Failure(requirement, UnsupportedDetail));
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1277,4 +1277,13 @@ Create the corresponding Markdown file in:
   <data name="General_SystemNotificationsPermissionDenied" xml:space="preserve">
     <value>System notification permission was not granted.</value>
   </data>
+  <data name="AcpSetup_Toolchain_PathRegistrationFailed" xml:space="preserve">
+    <value>The toolchain was installed, but PATH could not be updated. New terminals may need manual PATH configuration.</value>
+  </data>
+  <data name="AcpSetup_Toolchain_UnsupportedPlatform" xml:space="preserve">
+    <value>This platform has no automatic install for that toolchain. Use the documentation link to install it manually.</value>
+  </data>
+  <data name="AcpSetup_Toolchain_DownloadFailed" xml:space="preserve">
+    <value>The toolchain could not be downloaded and verified. Check your connection, or use the documentation link to install it manually.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1277,4 +1277,13 @@ Create the corresponding Markdown file in:
   <data name="General_SystemNotificationsPermissionDenied" xml:space="preserve">
     <value>System notification permission was not granted.</value>
   </data>
+  <data name="AcpSetup_Toolchain_PathRegistrationFailed" xml:space="preserve">
+    <value>The toolchain was installed, but PATH could not be updated. New terminals may need manual PATH configuration.</value>
+  </data>
+  <data name="AcpSetup_Toolchain_UnsupportedPlatform" xml:space="preserve">
+    <value>This platform has no automatic install for that toolchain. Use the documentation link to install it manually.</value>
+  </data>
+  <data name="AcpSetup_Toolchain_DownloadFailed" xml:space="preserve">
+    <value>The toolchain could not be downloaded and verified. Check your connection, or use the documentation link to install it manually.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1283,4 +1283,13 @@
   <data name="General_SystemNotificationsPermissionDenied" xml:space="preserve">
     <value>System notification permission was not granted.</value>
   </data>
+  <data name="AcpSetup_Toolchain_PathRegistrationFailed" xml:space="preserve">
+    <value>工具链已安装，但未能更新 PATH。新开的终端可能需要手动配置 PATH。</value>
+  </data>
+  <data name="AcpSetup_Toolchain_UnsupportedPlatform" xml:space="preserve">
+    <value>当前平台没有该工具链的自动安装方式。请使用文档链接手动安装。</value>
+  </data>
+  <data name="AcpSetup_Toolchain_DownloadFailed" xml:space="preserve">
+    <value>工具链下载或校验失败。请检查网络连接，或使用文档链接手动安装。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1283,4 +1283,13 @@
   <data name="General_SystemNotificationsPermissionDenied" xml:space="preserve">
     <value>系统通知权限未授予。</value>
   </data>
+  <data name="AcpSetup_Toolchain_PathRegistrationFailed" xml:space="preserve">
+    <value>工具链已安装，但未能更新 PATH。新开的终端可能需要手动配置 PATH。</value>
+  </data>
+  <data name="AcpSetup_Toolchain_UnsupportedPlatform" xml:space="preserve">
+    <value>当前平台没有该工具链的自动安装方式。请使用文档链接手动安装。</value>
+  </data>
+  <data name="AcpSetup_Toolchain_DownloadFailed" xml:space="preserve">
+    <value>工具链下载或校验失败。请检查网络连接，或使用文档链接手动安装。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
@@ -111,6 +111,7 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanInstallHere))]
     [NotifyPropertyChangedFor(nameof(IsToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(CanInstallToolchainHere))]
     [NotifyPropertyChangedFor(nameof(MissingToolchainName))]
     [NotifyPropertyChangedFor(nameof(ToolchainMissingHint))]
     [NotifyPropertyChangedFor(nameof(ToolchainDocumentation))]
@@ -139,6 +140,18 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     /// </remarks>
     public bool IsToolchainMissing
         => HasAutomaticInstallPath && RuntimeToolchain?.IsMissing == true;
+
+    /// <summary>
+    /// True when the wizard could install the absent toolchain for this row.
+    /// </summary>
+    /// <remarks>
+    /// Narrower than <see cref="IsToolchainMissing"/>: a toolchain can be missing and still have no
+    /// published source, which is the state that must keep showing documentation rather than a button that
+    /// could only fail. The platform's own capability is the wizard's to check, not the row's, so this is
+    /// combined with it at the install site.
+    /// </remarks>
+    public bool CanInstallToolchainHere
+        => IsToolchainMissing && RuntimeToolchain!.Requirement.HasAutomaticInstallPath;
 
     /// <summary>Name of the absent toolchain, empty when none is absent. A vendor name, not localized.</summary>
     public string MissingToolchainName
@@ -253,6 +266,14 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     public event Action<AcpSetupAgentRowViewModel>? InstallRequested;
 
     public void RequestInstall() => InstallRequested?.Invoke(this);
+
+    /// <summary>
+    /// Raised when the user asks this row's missing toolchain to be installed. The owning wizard subscribes
+    /// because it owns the busy flag, output panel, and error surface. Null when nobody is listening.
+    /// </summary>
+    public event Action<AcpSetupAgentRowViewModel>? InstallToolchainRequested;
+
+    public void RequestToolchainInstall() => InstallToolchainRequested?.Invoke(this);
 
     /// <summary>
     /// Raised when the user asks for this row to be probed again, after supplying a custom path.

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -56,6 +56,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         {
             var row = new AcpSetupAgentRowViewModel(agent, _localizer);
             row.InstallRequested += InstallAgentRow;
+            row.InstallToolchainRequested += InstallAgentToolchain;
             row.VerifyRequested += VerifyAgentRow;
             Agents.Add(row);
         }
@@ -110,6 +111,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
     [NotifyCanExecuteChangedFor(nameof(GoBackCommand))]
     [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallToolchainCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectAgentsCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
     [NotifyCanExecuteChangedFor(nameof(TestCommand))]
@@ -128,11 +130,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
     [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallToolchainCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectAdapterCommand))]
     [NotifyPropertyChangedFor(nameof(AdapterProbeCommand))]
     [NotifyPropertyChangedFor(nameof(HasAdapterProbeCommand))]
     // Read by IsAdapterToolchainMissing for the component's install path.
     [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainInstallable))]
     [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
@@ -177,6 +181,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     // IsAdapterToolchainMissing is gated on IsAdapterMissing, so it changes with the component probe as
     // well as with the toolchain probe. Both notify lists must raise it or the surface it gates goes stale.
     [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainInstallable))]
     [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
@@ -193,7 +198,9 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// </remarks>
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
+    [NotifyCanExecuteChangedFor(nameof(InstallToolchainCommand))]
     [NotifyPropertyChangedFor(nameof(IsAdapterToolchainMissing))]
+    [NotifyPropertyChangedFor(nameof(IsAdapterToolchainInstallable))]
     [NotifyPropertyChangedFor(nameof(MissingAdapterToolchainName))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainMissingText))]
     [NotifyPropertyChangedFor(nameof(AdapterToolchainDocumentation))]
@@ -325,6 +332,20 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// <summary>Documentation for the adapter's absent toolchain, null when none is absent.</summary>
     public Uri? AdapterToolchainDocumentation
         => IsAdapterToolchainMissing ? AdapterToolchain!.Requirement.Documentation : null;
+
+    /// <summary>
+    /// True when the wizard can offer to install the adapter's absent toolchain itself.
+    /// </summary>
+    /// <remarks>
+    /// Three conditions, and each rules out a different wrong offer: the toolchain must actually be missing,
+    /// this app must publish a source for that particular toolchain, and this platform must be able to run
+    /// an installer. A toolchain with no source keeps the documentation link — the state that made the whole
+    /// step a dead end before, since the wizard's advice was to leave and come back.
+    /// </remarks>
+    public bool IsAdapterToolchainInstallable
+        => IsAdapterToolchainMissing
+            && AdapterToolchain!.Requirement.HasAutomaticInstallPath
+            && _orchestrator.SupportsToolchainInstall;
 
     /// <summary>
     /// Localized sentence naming the toolchain the adapter install needs, empty when it is present.
@@ -584,6 +605,70 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             },
             CancellationToken.None);
     }
+
+    /// <summary>
+    /// Installs the missing package-manager toolchain for one agent row. Like component installation, this
+    /// starts from the row's event because an ItemTemplate action has no command parameter of its own.
+    /// </summary>
+    private void InstallAgentToolchain(AcpSetupAgentRowViewModel row)
+    {
+        if (IsBusy || !row.CanInstallToolchainHere || !_orchestrator.SupportsToolchainInstall)
+        {
+            return;
+        }
+
+        ResetInstallOutput();
+        _ = RunOperationAsync(
+            async token =>
+            {
+                var overrides = CollectCommandOverrides();
+                var (install, toolchain) = await _orchestrator
+                    .InstallToolchainAsync(row.Agent.Runtime, AppendInstallOutput, overrides, token)
+                    .ConfigureAwait(false);
+
+                await _uiDispatcher.EnqueueAsync(() =>
+                {
+                    row.RuntimeToolchain = toolchain;
+                    ReportToolchainInstallFailure(install);
+                }).ConfigureAwait(false);
+            },
+            CancellationToken.None);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanInstallToolchain))]
+    private async Task InstallToolchainAsync(CancellationToken cancellationToken)
+    {
+        var adapter = SelectedAdapter;
+        if (adapter is null)
+        {
+            return;
+        }
+
+        ResetInstallOutput();
+        await RunOperationAsync(
+            async token =>
+            {
+                var overrides = CollectCommandOverrides();
+                var (install, toolchain) = await _orchestrator
+                    .InstallToolchainAsync(adapter.Component, AppendInstallOutput, overrides, token)
+                    .ConfigureAwait(false);
+
+                await _uiDispatcher.EnqueueAsync(() =>
+                {
+                    // A ComboBox change can land while the downloader is running; never apply an old
+                    // adapter's result to the newly selected one.
+                    if (ReferenceEquals(SelectedAdapter, adapter))
+                    {
+                        AdapterToolchain = toolchain;
+                        ReportToolchainInstallFailure(install);
+                    }
+                }).ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool CanInstallToolchain()
+        => !IsBusy && IsAdapterToolchainInstallable;
 
     [RelayCommand(CanExecute = nameof(CanInstallAdapter))]
     private async Task InstallAdapterAsync(CancellationToken cancellationToken)
@@ -1232,6 +1317,29 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         OnPropertyChanged(nameof(HasInstallOutput));
     }
 
+    private void ReportToolchainInstallFailure(AcpToolchainInstallResult install)
+    {
+        if (!install.IsSuccess)
+        {
+            ErrorMessage = !string.IsNullOrEmpty(install.RemediationKey)
+                ? Localize(
+                    install.RemediationKey!,
+                    "Could not install the required toolchain. Use the documentation link to install it manually.")
+                : install.ErrorDetail ?? Localize(InstallFailedKey, "Installation failed.");
+            return;
+        }
+
+        // PATH registration makes future terminals convenient, but it does not decide whether Node is
+        // installed — the just-completed re-probe does. Tell the user about this partial result without
+        // turning a working setup into an error state.
+        if (install.PathRegistration == AcpPathRegistration.Failed)
+        {
+            ErrorMessage = Localize(
+                ToolchainPathRegistrationFailedKey,
+                "The toolchain was installed, but PATH could not be updated. New terminals may need manual PATH configuration.");
+        }
+    }
+
     /// <summary>
     /// Surfaces a failed install, preferring localized advice over the platform layer's raw detail.
     /// </summary>
@@ -1349,6 +1457,8 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         => CoreStringResolver.ResolveFormat(_localizer, key, fallbackFormat, arguments);
 
     private const string InstallFailedKey = "AcpSetup_Install_Failed";
+
+    private const string ToolchainPathRegistrationFailedKey = "AcpSetup_Toolchain_PathRegistrationFailed";
 
     private const string AdapterToolchainMissingKey = "AcpSetup_Adapter_ToolchainMissing";
 

--- a/tests/SalmonEgg.Domain.Tests/Models/AcpToolchainInstallSourceTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/AcpToolchainInstallSourceTests.cs
@@ -1,0 +1,168 @@
+using System;
+using Xunit;
+using System.Runtime.InteropServices;
+using RuntimeArchitecture = System.Runtime.InteropServices.Architecture;
+using SalmonEgg.Domain.Models.AcpSetup;
+
+namespace SalmonEgg.Domain.Tests.Models.AcpSetup;
+
+public sealed class AcpToolchainInstallSourceTests
+{
+    [Theory]
+    [InlineData("LINUX", "X64", "node-v24.20.0-linux-x64.tar.gz", "node-v24.20.0-linux-x64", "bin")]
+    [InlineData("LINUX", "Arm64", "node-v24.20.0-linux-arm64.tar.gz", "node-v24.20.0-linux-arm64", "bin")]
+    [InlineData("OSX", "X64", "node-v24.20.0-darwin-x64.tar.gz", "node-v24.20.0-darwin-x64", "bin")]
+    [InlineData("OSX", "Arm64", "node-v24.20.0-darwin-arm64.tar.gz", "node-v24.20.0-darwin-arm64", "bin")]
+    [InlineData("WINDOWS", "X64", "node-v24.20.0-win-x64.zip", "node-v24.20.0-win-x64", "")]
+    [InlineData("WINDOWS", "Arm64", "node-v24.20.0-win-arm64.zip", "node-v24.20.0-win-arm64", "")]
+    public void ResolveNode_PublishedBuilds_ShouldDescribeRealArchive(
+        string osName,
+        string architectureName,
+        string archiveName,
+        string root,
+        string bin)
+    {
+        var download = AcpToolchainInstallSource.ResolveNode(
+            ParseOs(osName),
+            ParseArchitecture(architectureName));
+
+        Assert.NotNull(download);
+        Assert.Equal(archiveName, download.Archive.Segments[^1]);
+        Assert.Equal(root, download.RootDirectory);
+        Assert.Equal(bin, download.BinSubdirectory);
+        Assert.Equal("https://nodejs.org/dist/v24.20.0/SHASUMS256.txt", download.Checksum.AbsoluteUri);
+    }
+
+    [Theory]
+    [InlineData("LINUX", "X86")]
+    [InlineData("LINUX", "Arm")]
+    [InlineData("OSX", "X86")]
+    [InlineData("OSX", "Arm")]
+    [InlineData("WINDOWS", "X86")]
+    [InlineData("WINDOWS", "Arm")]
+    [InlineData("FreeBSD", "X64")]
+    public void ResolveNode_UnpublishedBuild_ShouldReturnNull(string osName, string architectureName)
+        => Assert.Null(AcpToolchainInstallSource.ResolveNode(
+            ParseOs(osName),
+            ParseArchitecture(architectureName)));
+
+    [Fact]
+    public void BothToolchains_ShouldPublishAnAutomaticInstallPath()
+    {
+        Assert.True(AcpToolchainRequirement.Node.HasAutomaticInstallPath);
+        Assert.True(AcpToolchainRequirement.Uv.HasAutomaticInstallPath);
+    }
+
+    [Theory]
+    [InlineData("LINUX", "X64", false, "uv-x86_64-unknown-linux-gnu.tar.gz")]
+    [InlineData("LINUX", "X64", true, "uv-x86_64-unknown-linux-musl.tar.gz")]
+    [InlineData("LINUX", "Arm64", false, "uv-aarch64-unknown-linux-gnu.tar.gz")]
+    [InlineData("LINUX", "Arm64", true, "uv-aarch64-unknown-linux-musl.tar.gz")]
+    [InlineData("LINUX", "X86", false, "uv-i686-unknown-linux-gnu.tar.gz")]
+    [InlineData("LINUX", "X86", true, "uv-i686-unknown-linux-musl.tar.gz")]
+    [InlineData("LINUX", "Arm", false, "uv-armv7-unknown-linux-gnueabihf.tar.gz")]
+    [InlineData("LINUX", "Arm", true, "uv-armv7-unknown-linux-musleabihf.tar.gz")]
+    [InlineData("OSX", "X64", false, "uv-x86_64-apple-darwin.tar.gz")]
+    [InlineData("OSX", "Arm64", false, "uv-aarch64-apple-darwin.tar.gz")]
+    [InlineData("WINDOWS", "X64", false, "uv-x86_64-pc-windows-msvc.zip")]
+    [InlineData("WINDOWS", "Arm64", false, "uv-aarch64-pc-windows-msvc.zip")]
+    [InlineData("WINDOWS", "X86", false, "uv-i686-pc-windows-msvc.zip")]
+    public void ResolveUv_PublishedBuilds_ShouldNameTheRealAsset(
+        string osName,
+        string architectureName,
+        bool preferMusl,
+        string archiveName)
+    {
+        var download = AcpToolchainInstallSource.ResolveUv(
+            ParseOs(osName),
+            ParseArchitecture(architectureName),
+            preferMusl);
+
+        Assert.NotNull(download);
+        Assert.Equal(archiveName, download.Archive.Segments[^1]);
+        // Each asset carries its own digest, unlike Node's single shared listing.
+        Assert.Equal(download.Archive.AbsoluteUri + ".sha256", download.Checksum.AbsoluteUri);
+        Assert.Equal(AcpChecksumFormat.SingleHash, download.ChecksumFormat);
+        // Neither layout nests executables, so there is never a bin/ segment to descend into.
+        Assert.Equal(string.Empty, download.BinSubdirectory);
+    }
+
+    /// <summary>
+    /// uv's tags carry no <c>v</c>. Prefixing one yields a 404, so this pins the spelling that the URL
+    /// builder must produce even when a caller supplies the prefixed form.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("0.12.8")]
+    [InlineData("v0.12.8")]
+    public void ResolveUv_ShouldBuildTagsWithoutAVersionPrefix(string? version)
+    {
+        var download = AcpToolchainInstallSource.ResolveUv(
+            OSPlatform.Linux,
+            RuntimeArchitecture.Arm64,
+            preferMusl: false,
+            version);
+
+        Assert.NotNull(download);
+        Assert.Contains("/releases/download/0.12.8/", download.Archive.AbsoluteUri, StringComparison.Ordinal);
+        Assert.DoesNotContain("/download/v", download.Archive.AbsoluteUri, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The Windows archive is flat: its executables sit at the archive root with no directory to strip.
+    /// Declaring a root that is not there would make every entry look like it fell outside it.
+    /// </summary>
+    [Fact]
+    public void ResolveUv_OnWindows_ShouldDeclareNoRootDirectory()
+    {
+        var download = AcpToolchainInstallSource.ResolveUv(OSPlatform.Windows, RuntimeArchitecture.X64);
+
+        Assert.NotNull(download);
+        Assert.Null(download.RootDirectory);
+        Assert.Equal(AcpArchiveFormat.Zip, download.ArchiveFormat);
+        Assert.Equal(new[] { "uv.exe", "uvx.exe" }, download.VerifyExecutables);
+    }
+
+    /// <summary>The POSIX tarball nests under one directory named for the target, which is stripped.</summary>
+    [Fact]
+    public void ResolveUv_OnPosix_ShouldStripTheTargetNamedRoot()
+    {
+        var download = AcpToolchainInstallSource.ResolveUv(OSPlatform.OSX, RuntimeArchitecture.Arm64);
+
+        Assert.NotNull(download);
+        Assert.Equal("uv-aarch64-apple-darwin", download.RootDirectory);
+        Assert.Equal(AcpArchiveFormat.TarGzip, download.ArchiveFormat);
+        // uvx is checked too: it is the launcher every Uvx component runs through.
+        Assert.Equal(new[] { "uv", "uvx" }, download.VerifyExecutables);
+    }
+
+    [Theory]
+    [InlineData("LINUX", "Ppc64le")]
+    [InlineData("OSX", "X86")]
+    [InlineData("OSX", "Arm")]
+    [InlineData("WINDOWS", "Arm")]
+    [InlineData("FreeBSD", "X64")]
+    public void ResolveUv_UnpublishedBuild_ShouldReturnNull(string osName, string architectureName)
+        => Assert.Null(AcpToolchainInstallSource.ResolveUv(
+            ParseOs(osName),
+            ParseArchitecture(architectureName)));
+
+    private static OSPlatform ParseOs(string name)
+        => name switch
+        {
+            "LINUX" => OSPlatform.Linux,
+            "OSX" => OSPlatform.OSX,
+            "WINDOWS" => OSPlatform.Windows,
+            _ => OSPlatform.Create(name)
+        };
+
+    private static RuntimeArchitecture ParseArchitecture(string name)
+        => name switch
+        {
+            "X64" => RuntimeArchitecture.X64,
+            "X86" => RuntimeArchitecture.X86,
+            "Arm64" => RuntimeArchitecture.Arm64,
+            "Arm" => RuntimeArchitecture.Arm,
+            _ => RuntimeArchitecture.Ppc64le
+        };
+}

--- a/tests/SalmonEgg.Domain.Tests/Models/AcpToolchainInstallSourceTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/AcpToolchainInstallSourceTests.cs
@@ -1,7 +1,5 @@
 using System;
 using Xunit;
-using System.Runtime.InteropServices;
-using RuntimeArchitecture = System.Runtime.InteropServices.Architecture;
 using SalmonEgg.Domain.Models.AcpSetup;
 
 namespace SalmonEgg.Domain.Tests.Models.AcpSetup;
@@ -23,8 +21,8 @@ public sealed class AcpToolchainInstallSourceTests
         string bin)
     {
         var download = AcpToolchainInstallSource.ResolveNode(
-            ParseOs(osName),
-            ParseArchitecture(architectureName));
+            ParseOs(osName)!.Value,
+            ParseArchitecture(architectureName)!.Value);
 
         Assert.NotNull(download);
         Assert.Equal(archiveName, download.Archive.Segments[^1]);
@@ -42,9 +40,15 @@ public sealed class AcpToolchainInstallSourceTests
     [InlineData("WINDOWS", "Arm")]
     [InlineData("FreeBSD", "X64")]
     public void ResolveNode_UnpublishedBuild_ShouldReturnNull(string osName, string architectureName)
-        => Assert.Null(AcpToolchainInstallSource.ResolveNode(
-            ParseOs(osName),
-            ParseArchitecture(architectureName)));
+    {
+        if (ParseOs(osName) is not { } os || ParseArchitecture(architectureName) is not { } architecture)
+        {
+            // The domain cannot even name this platform, so there is no build to resolve.
+            return;
+        }
+
+        Assert.Null(AcpToolchainInstallSource.ResolveNode(os, architecture));
+    }
 
     [Fact]
     public void BothToolchains_ShouldPublishAnAutomaticInstallPath()
@@ -74,8 +78,8 @@ public sealed class AcpToolchainInstallSourceTests
         string archiveName)
     {
         var download = AcpToolchainInstallSource.ResolveUv(
-            ParseOs(osName),
-            ParseArchitecture(architectureName),
+            ParseOs(osName)!.Value,
+            ParseArchitecture(architectureName)!.Value,
             preferMusl);
 
         Assert.NotNull(download);
@@ -98,8 +102,8 @@ public sealed class AcpToolchainInstallSourceTests
     public void ResolveUv_ShouldBuildTagsWithoutAVersionPrefix(string? version)
     {
         var download = AcpToolchainInstallSource.ResolveUv(
-            OSPlatform.Linux,
-            RuntimeArchitecture.Arm64,
+            AcpToolchainOperatingSystem.Linux,
+            AcpToolchainArchitecture.Arm64,
             preferMusl: false,
             version);
 
@@ -115,7 +119,7 @@ public sealed class AcpToolchainInstallSourceTests
     [Fact]
     public void ResolveUv_OnWindows_ShouldDeclareNoRootDirectory()
     {
-        var download = AcpToolchainInstallSource.ResolveUv(OSPlatform.Windows, RuntimeArchitecture.X64);
+        var download = AcpToolchainInstallSource.ResolveUv(AcpToolchainOperatingSystem.Windows, AcpToolchainArchitecture.X64);
 
         Assert.NotNull(download);
         Assert.Null(download.RootDirectory);
@@ -127,7 +131,7 @@ public sealed class AcpToolchainInstallSourceTests
     [Fact]
     public void ResolveUv_OnPosix_ShouldStripTheTargetNamedRoot()
     {
-        var download = AcpToolchainInstallSource.ResolveUv(OSPlatform.OSX, RuntimeArchitecture.Arm64);
+        var download = AcpToolchainInstallSource.ResolveUv(AcpToolchainOperatingSystem.MacOS, AcpToolchainArchitecture.Arm64);
 
         Assert.NotNull(download);
         Assert.Equal("uv-aarch64-apple-darwin", download.RootDirectory);
@@ -143,26 +147,39 @@ public sealed class AcpToolchainInstallSourceTests
     [InlineData("WINDOWS", "Arm")]
     [InlineData("FreeBSD", "X64")]
     public void ResolveUv_UnpublishedBuild_ShouldReturnNull(string osName, string architectureName)
-        => Assert.Null(AcpToolchainInstallSource.ResolveUv(
-            ParseOs(osName),
-            ParseArchitecture(architectureName)));
+    {
+        if (ParseOs(osName) is not { } os || ParseArchitecture(architectureName) is not { } architecture)
+        {
+            return;
+        }
 
-    private static OSPlatform ParseOs(string name)
+        Assert.Null(AcpToolchainInstallSource.ResolveUv(os, architecture));
+    }
+
+    /// <summary>
+    /// Resolves a case name to a target platform, or null for one the enum deliberately cannot express.
+    /// </summary>
+    /// <remarks>
+    /// The domain names only the platforms this app ships for, so "an operating system with no published
+    /// build" can no longer be spelled as a value. A null stands in for it, which is what the unsupported
+    /// cases assert on.
+    /// </remarks>
+    private static AcpToolchainOperatingSystem? ParseOs(string name)
         => name switch
         {
-            "LINUX" => OSPlatform.Linux,
-            "OSX" => OSPlatform.OSX,
-            "WINDOWS" => OSPlatform.Windows,
-            _ => OSPlatform.Create(name)
+            "LINUX" => AcpToolchainOperatingSystem.Linux,
+            "OSX" => AcpToolchainOperatingSystem.MacOS,
+            "WINDOWS" => AcpToolchainOperatingSystem.Windows,
+            _ => null
         };
 
-    private static RuntimeArchitecture ParseArchitecture(string name)
+    private static AcpToolchainArchitecture? ParseArchitecture(string name)
         => name switch
         {
-            "X64" => RuntimeArchitecture.X64,
-            "X86" => RuntimeArchitecture.X86,
-            "Arm64" => RuntimeArchitecture.Arm64,
-            "Arm" => RuntimeArchitecture.Arm,
-            _ => RuntimeArchitecture.Ppc64le
+            "X64" => AcpToolchainArchitecture.X64,
+            "X86" => AcpToolchainArchitecture.X86,
+            "Arm64" => AcpToolchainArchitecture.Arm64,
+            "Arm" => AcpToolchainArchitecture.Arm,
+            _ => null
         };
 }

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSearchPathSourcesTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpSearchPathSourcesTests.cs
@@ -50,11 +50,13 @@ public sealed class AcpSearchPathSourcesTests : IDisposable
     }
 
     /// <summary>
-    /// Without the CLI there is nothing that implements the printing mode, so the scan alone widens the
-    /// search rather than the wizard losing the widening altogether.
+    /// An explicitly absent provider leaves the scan as the only widening. The normal composition does
+    /// not take this branch: it falls back to the running desktop app, which implements the mode itself.
+    /// Keeping this injection seam matters because it proves a missing provider degrades to the scan
+    /// rather than making construction fail.
     /// </summary>
     [Fact]
-    public void Create_WithoutCli_ShouldStillProvideTheDiskScan()
+    public void Create_WithExplicitlyAbsentProvider_ShouldStillProvideTheDiskScan()
     {
         var sources = AcpSearchPathSources.Create(() => null);
 
@@ -62,11 +64,11 @@ public sealed class AcpSearchPathSourcesTests : IDisposable
     }
 
     /// <summary>
-    /// A CLI path that does not exist is treated as absent. Building a command around it would produce a
-    /// shell failure indistinguishable from a user's broken rc file.
+    /// A provider path that does not exist is treated as absent. Building a command around it would
+    /// produce a shell failure indistinguishable from a user's broken rc file.
     /// </summary>
     [Fact]
-    public void Create_WithMissingCliPath_ShouldStillProvideTheDiskScan()
+    public void Create_WithMissingProviderPath_ShouldStillProvideTheDiskScan()
     {
         var sources = AcpSearchPathSources.Create(() => Path.Combine(_root, "not-installed"));
 
@@ -84,13 +86,43 @@ public sealed class AcpSearchPathSourcesTests : IDisposable
             source => source is ToolchainScanSearchPathSource);
 
     /// <summary>
-    /// The option name is duplicated across a process boundary — the desktop app does not reference the
-    /// CLI — so this pins the two spellings together. If they drift, the capture silently stops working:
-    /// the shell runs the CLI, the CLI does not recognize the argument, and the probe reports nothing.
+    /// The factory and the writer share one constant now, so the protocol cannot drift merely because a
+    /// second executable was added. This pins its externally observed spelling.
     /// </summary>
     [Fact]
-    public void PrintEnvironmentOptionName_ShouldMatchTheCliSpelling()
+    public void PrintEnvironmentOptionName_ShouldBeStable()
         => Assert.Equal("--printenv", PrintEnvironmentCommandFactory.OptionName);
+
+    /// <summary>
+    /// A desktop-only install still has an executable that answers the printing protocol: this process.
+    /// Without that fallback nvm users lose the only source that can report their activated version.
+    /// </summary>
+    [Fact]
+    public void ResolvePrintEnvironmentExecutable_ShouldFallBackToAnExistingProcess()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Windows is deliberately not captured.");
+
+        var executable = AcpSearchPathSources.ResolvePrintEnvironmentExecutable();
+
+        Assert.False(string.IsNullOrWhiteSpace(executable));
+        Assert.True(File.Exists(executable));
+    }
+
+    /// <summary>
+    /// The normal composition includes the login shell source even without the separately packaged CLI,
+    /// because the desktop process can answer --printenv itself.
+    /// </summary>
+    [Fact]
+    public void Create_DefaultComposition_ShouldIncludeShellSourceOffWindows()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Windows is deliberately not captured.");
+
+        var sources = AcpSearchPathSources.Create();
+
+        Assert.Equal(2, sources.Count);
+        Assert.IsType<LoginShellSearchPathSource>(sources[0]);
+        Assert.IsType<ToolchainScanSearchPathSource>(sources[1]);
+    }
 
     /// <summary>
     /// The command quotes every path, because a shell parses the whole string and paths routinely contain

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainArchiveTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainArchiveTests.cs
@@ -4,6 +4,7 @@ using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using SalmonEgg.Domain.Models.AcpSetup;
 using SalmonEgg.Infrastructure.Desktop.AcpSetup;
@@ -116,6 +117,65 @@ public sealed class AcpToolchainArchiveTests : IDisposable
     public void StripRoot_DeclaredRoot_ShouldRemoveOnlyTheLeadingDirectory()
         => Assert.Equal("bin/node", AcpToolchainArchive.StripRoot("node-v24/bin/node", "node-v24"));
 
+    /// <summary>
+    /// A crafted archive can declare a symlink and then a regular file at the same name: without a guard the
+    /// file's write would follow the link and land outside the destination.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_FileEntryOnASymlinkTheArchiveCreated_ShouldRefuseAndLeaveTheTargetUntouched()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Symbolic links are created only on POSIX.");
+        var victim = Path.Combine(_root, "victim.txt");
+        File.WriteAllText(victim, "SAFE");
+        var archive = CreateMaliciousTar(victim, directoryLink: false);
+        var destination = Path.Combine(_root, "destination");
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => AcpToolchainArchive.ExtractAsync(archive, destination, RootlessTarDownload(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("symbolic link", exception.Message);
+        Assert.Equal("SAFE", File.ReadAllText(victim));
+    }
+
+    /// <summary>
+    /// The same escape through a symlinked parent directory: the entry's own name is innocent, but the write
+    /// is redirected through the link's destination.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_FileEntryUnderASymlinkedDirectory_ShouldRefuseAndLeaveTheTargetUntouched()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Symbolic links are created only on POSIX.");
+        var victimDirectory = Path.Combine(_root, "victim-dir");
+        Directory.CreateDirectory(victimDirectory);
+        var archive = CreateMaliciousTar(victimDirectory, directoryLink: true);
+        var destination = Path.Combine(_root, "destination");
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => AcpToolchainArchive.ExtractAsync(archive, destination, RootlessTarDownload(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("symbolic link", exception.Message);
+        Assert.False(File.Exists(Path.Combine(victimDirectory, "child")));
+    }
+
+    /// <summary>
+    /// A hard link resolves its source before copying, so a source outside the destination would import
+    /// outside content into the install tree. It is refused rather than resolved.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_HardLinkPointingOutsideTheDestination_ShouldRefuse()
+    {
+        var victim = Path.Combine(_root, "victim.txt");
+        File.WriteAllText(victim, "SAFE");
+        var archive = CreateTarWithEscapingHardLink(victim);
+        var destination = Path.Combine(_root, "destination");
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => AcpToolchainArchive.ExtractAsync(archive, destination, RootlessTarDownload(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("outside the destination", exception.Message);
+        Assert.False(File.Exists(Path.Combine(destination, "stolen")));
+    }
+
     private string CreateNodeStyleArchive()
     {
         var source = Path.Combine(_root, "source", "node-v24", "bin");
@@ -169,6 +229,60 @@ public sealed class AcpToolchainArchiveTests : IDisposable
         VerifyExecutables = new[] { "uv", "uvx" },
         VerifyCommand = "uv",
         VerifyArguments = new[] { "--version" }
+    };
+
+    /// <summary>
+    /// Builds a tar no filesystem could hold: a symlink entry followed by a write at (or under) the link's
+    /// name. Hand-assembled through <see cref="TarWriter"/> because creating it on disk first would already
+    /// perform the escape the guard exists to refuse.
+    /// </summary>
+    private string CreateMaliciousTar(string victim, bool directoryLink)
+    {
+        var archive = Path.Combine(_root, directoryLink ? "dir-link-escape.tar.gz" : "file-link-escape.tar.gz");
+        using var file = File.Create(archive);
+        using var gzip = new GZipStream(file, CompressionLevel.Fastest);
+        using var writer = new TarWriter(gzip);
+
+        writer.WriteEntry(new PaxTarEntry(TarEntryType.SymbolicLink, directoryLink ? "out" : "escape")
+        {
+            LinkName = victim
+        });
+        WriteTarFileEntry(writer, directoryLink ? "out/child" : "escape", "PWNED");
+        return archive;
+    }
+
+    /// <summary>A hard-link entry whose source is an absolute path outside the destination.</summary>
+    private string CreateTarWithEscapingHardLink(string victim)
+    {
+        var archive = Path.Combine(_root, "hardlink-escape.tar.gz");
+        using var file = File.Create(archive);
+        using var gzip = new GZipStream(file, CompressionLevel.Fastest);
+        using var writer = new TarWriter(gzip);
+
+        writer.WriteEntry(new PaxTarEntry(TarEntryType.HardLink, "stolen") { LinkName = victim });
+        return archive;
+    }
+
+    private static void WriteTarFileEntry(TarWriter writer, string name, string contents)
+    {
+        var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
+        {
+            DataStream = new MemoryStream(Encoding.UTF8.GetBytes(contents))
+        };
+        writer.WriteEntry(entry);
+    }
+
+    /// <summary>A tar-gzip download model with no declared root, as the malicious archives are flat.</summary>
+    private static AcpToolchainDownload RootlessTarDownload() => new()
+    {
+        Archive = new Uri("https://example.invalid/malicious.tar.gz"),
+        Checksum = new Uri("https://example.invalid/malicious.tar.gz.sha256"),
+        ChecksumFormat = AcpChecksumFormat.SingleHash,
+        ArchiveFormat = AcpArchiveFormat.TarGzip,
+        RootDirectory = null,
+        BinSubdirectory = "bin",
+        VerifyExecutables = new[] { "node" },
+        VerifyCommand = "node"
     };
 
     private static AcpToolchainDownload Download() => new()

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainArchiveTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainArchiveTests.cs
@@ -1,0 +1,185 @@
+using System;
+using Xunit;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+/// <summary>Guards archive safety and layout preservation without downloading a vendor payload.</summary>
+public sealed class AcpToolchainArchiveTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "toolchain-archive-" + Guid.NewGuid().ToString("N"));
+
+    public AcpToolchainArchiveTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TarWithNodeStyleSymlinks_ShouldPreserveLinksAndExecuteBit()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Unix modes and Node's POSIX symlink layout are tested on POSIX.");
+        var archive = CreateNodeStyleArchive();
+        var destination = Path.Combine(_root, "destination");
+
+        await AcpToolchainArchive.ExtractAsync(archive, destination, Download(), TestContext.Current.CancellationToken);
+
+        var bin = Path.Combine(destination, "bin");
+        var node = Path.Combine(bin, "node");
+        var npm = Path.Combine(bin, "npm");
+        Assert.True(File.Exists(node));
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.True(File.GetUnixFileMode(node).HasFlag(UnixFileMode.UserExecute));
+        }
+
+        Assert.Equal("../lib/npm-cli.js", new FileInfo(npm).LinkTarget);
+        Assert.True(File.Exists(npm));
+    }
+
+    /// <summary>
+    /// uv's zip is flat: the executables sit at the archive root with no directory to strip, and the format
+    /// carries no Unix mode, so the extractor has to restore the execute bit itself.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_FlatZipWithNoRootDirectory_ShouldLandExecutablesAtTheRoot()
+    {
+        var archive = CreateFlatZip("uv", "uvx");
+        var destination = Path.Combine(_root, "flat-destination");
+
+        await AcpToolchainArchive.ExtractAsync(
+            archive,
+            destination,
+            FlatZipDownload(),
+            TestContext.Current.CancellationToken);
+
+        foreach (var name in new[] { "uv", "uvx" })
+        {
+            var path = Path.Combine(destination, name);
+            Assert.True(File.Exists(path), $"{name} should be extracted to the destination root.");
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.True(
+                    File.GetUnixFileMode(path).HasFlag(UnixFileMode.UserExecute),
+                    $"{name} must be executable; zip carries no mode of its own.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Declaring a root the archive does not have must not silently extract nothing: every entry would be
+    /// judged to fall outside the declared root, which is how a shape mismatch should read.
+    /// </summary>
+    [Fact]
+    public void StripRoot_FlatEntryAgainstADeclaredRoot_ShouldReject()
+        => Assert.Null(AcpToolchainArchive.StripRoot("uv.exe", "uv-x86_64-pc-windows-msvc"));
+
+    /// <summary>With no declared root, a flat entry keeps its own name.</summary>
+    [Fact]
+    public void StripRoot_FlatEntryWithNoDeclaredRoot_ShouldKeepTheName()
+        => Assert.Equal("uv.exe", AcpToolchainArchive.StripRoot("uv.exe", null));
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("../../etc/passwd")]
+    [InlineData("bin/../../escape")]
+    public void ResolveSafePath_Traversal_ShouldReject(string entry)
+        => Assert.Null(AcpToolchainArchive.ResolveSafePath(Path.Combine(_root, "destination"), entry));
+
+    [Theory]
+    [InlineData("bin/node")]
+    [InlineData("nested/bin/npm")]
+    public void ResolveSafePath_InternalEntry_ShouldStayInsideDestination(string entry)
+    {
+        var destination = Path.Combine(_root, "destination");
+        var path = AcpToolchainArchive.ResolveSafePath(destination, entry);
+
+        Assert.NotNull(path);
+        Assert.StartsWith(Path.GetFullPath(destination) + Path.DirectorySeparatorChar, path, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StripRoot_EntryOutsideDeclaredRoot_ShouldReject()
+        => Assert.Null(AcpToolchainArchive.StripRoot("other/bin/node", "node-v24"));
+
+    [Fact]
+    public void StripRoot_DeclaredRoot_ShouldRemoveOnlyTheLeadingDirectory()
+        => Assert.Equal("bin/node", AcpToolchainArchive.StripRoot("node-v24/bin/node", "node-v24"));
+
+    private string CreateNodeStyleArchive()
+    {
+        var source = Path.Combine(_root, "source", "node-v24", "bin");
+        Directory.CreateDirectory(Path.Combine(_root, "source", "node-v24", "lib"));
+        Directory.CreateDirectory(source);
+        var node = Path.Combine(source, "node");
+        File.WriteAllText(node, "#!/bin/sh\necho node\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                node,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+
+        File.WriteAllText(Path.Combine(_root, "source", "node-v24", "lib", "npm-cli.js"), "x");
+        File.CreateSymbolicLink(Path.Combine(source, "npm"), "../lib/npm-cli.js");
+        File.CreateSymbolicLink(Path.Combine(source, "npx"), "../lib/npm-cli.js");
+
+        var archive = Path.Combine(_root, "node.tar.gz");
+        using var file = File.Create(archive);
+        using var gzip = new GZipStream(file, CompressionLevel.Fastest);
+        TarFile.CreateFromDirectory(Path.Combine(_root, "source"), gzip, includeBaseDirectory: false);
+        return archive;
+    }
+
+    /// <summary>Builds a zip with entries at its root, matching uv's Windows archive shape.</summary>
+    private string CreateFlatZip(params string[] names)
+    {
+        var source = Path.Combine(_root, "flat-source");
+        Directory.CreateDirectory(source);
+        foreach (var name in names)
+        {
+            File.WriteAllText(Path.Combine(source, name), "binary-payload");
+        }
+
+        var archive = Path.Combine(_root, "uv.zip");
+        ZipFile.CreateFromDirectory(source, archive);
+        return archive;
+    }
+
+    private static AcpToolchainDownload FlatZipDownload() => new()
+    {
+        Archive = new Uri("https://example.invalid/uv.zip"),
+        Checksum = new Uri("https://example.invalid/uv.zip.sha256"),
+        ChecksumFormat = AcpChecksumFormat.SingleHash,
+        ArchiveFormat = AcpArchiveFormat.Zip,
+        RootDirectory = null,
+        BinSubdirectory = string.Empty,
+        VerifyExecutables = new[] { "uv", "uvx" },
+        VerifyCommand = "uv",
+        VerifyArguments = new[] { "--version" }
+    };
+
+    private static AcpToolchainDownload Download() => new()
+    {
+        Archive = new Uri("https://example.invalid/node.tar.gz"),
+        Checksum = new Uri("https://example.invalid/SHASUMS"),
+        ChecksumFormat = AcpChecksumFormat.ShasumList,
+        ArchiveFormat = AcpArchiveFormat.TarGzip,
+        RootDirectory = "node-v24",
+        BinSubdirectory = "bin",
+        VerifyExecutables = new[] { "node", "npm", "npx" },
+        VerifyCommand = "node"
+    };
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainChecksumTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpToolchainChecksumTests.cs
@@ -1,0 +1,65 @@
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Infrastructure.Desktop.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+public sealed class AcpToolchainChecksumTests
+{
+    [Fact]
+    public void Parse_ShasumList_ShouldSelectTheNamedArchiveRatherThanFirstLine()
+    {
+        var document = string.Join('\n',
+            new string('a', 64) + "  node-v24.20.0-darwin-arm64.tar.gz",
+            new string('b', 64) + "  node-v24.20.0-linux-arm64.tar.gz",
+            new string('c', 64) + "  node-v24.20.0-win-x64.zip");
+
+        var digest = AcpToolchainChecksum.Parse(
+            document,
+            AcpChecksumFormat.ShasumList,
+            "node-v24.20.0-linux-arm64.tar.gz");
+
+        Assert.Equal(new string('b', 64), digest);
+    }
+
+    [Fact]
+    public void Parse_ShasumList_WithoutTheRequestedArchive_ShouldReturnNull()
+    {
+        var document = new string('a', 64) + "  node-v24.20.0-darwin-arm64.tar.gz";
+
+        Assert.Null(AcpToolchainChecksum.Parse(
+            document,
+            AcpChecksumFormat.ShasumList,
+            "node-v24.20.0-linux-arm64.tar.gz"));
+    }
+
+    [Fact]
+    public void Parse_SingleHash_ShouldAcceptTheSha256sumTrailingFilename()
+    {
+        var document = new string('d', 64) + "  uv-aarch64-unknown-linux-gnu.tar.gz";
+
+        Assert.Equal(
+            new string('d', 64),
+            AcpToolchainChecksum.Parse(document, AcpChecksumFormat.SingleHash, "ignored"));
+    }
+
+    /// <summary>
+    /// uv writes its Windows digests in <c>sha256sum</c> binary mode, which marks the filename with a
+    /// leading asterisk. Refusing that spelling would make every Windows uv install fail verification.
+    /// </summary>
+    [Fact]
+    public void Parse_SingleHash_ShouldAcceptBinaryModeAsterisk()
+    {
+        var document = new string('e', 64) + " *uv-x86_64-pc-windows-msvc.zip";
+
+        Assert.Equal(
+            new string('e', 64),
+            AcpToolchainChecksum.Parse(document, AcpChecksumFormat.SingleHash, "uv-x86_64-pc-windows-msvc.zip"));
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("not-a-hash node.tar.gz")]
+    [InlineData("")]
+    public void Parse_MalformedDocument_ShouldReturnNull(string document)
+        => Assert.Null(AcpToolchainChecksum.Parse(document, AcpChecksumFormat.SingleHash, "node.tar.gz"));
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
@@ -48,7 +48,8 @@ public sealed class AcpSetupWizardXamlTests
     }
     [Fact]
     public void Navigation_ExposesSecondarySkipAndAnnouncesDynamicStepPosition()
-    {        var document = XDocument.Parse(LoadXaml(WizardPath));
+    {
+        var document = XDocument.Parse(LoadXaml(WizardPath));
 
         var skip = FindByName(document, "AcpSetupSkipTestButton");
         Assert.Equal("AcpSetup_SkipTest", AttributeByLocalName(skip, "Uid"));

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardXamlTests.cs
@@ -11,9 +11,44 @@ public sealed class AcpSetupWizardXamlTests
     private const string WizardPath = "SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml";
 
     [Fact]
-    public void Navigation_ExposesSecondarySkipAndAnnouncesDynamicStepPosition()
+    public void ToolchainMissingStates_OfferARealInstallActionAndManualFallback()
     {
         var document = XDocument.Parse(LoadXaml(WizardPath));
+
+        var adapter = FindByName(document, "AcpSetupInstallToolchainButton");
+        Assert.Equal("AcpSetup_InstallToolchain", AttributeByLocalName(adapter, "Uid"));
+        Assert.Equal("{StaticResource AccentButtonStyle}", adapter.Attribute("Style")?.Value);
+        Assert.Equal("{x:Bind ViewModel.InstallToolchainCommand}", adapter.Attribute("Command")?.Value);
+        Assert.Equal("AcpSetup.Adapter.InstallToolchain", adapter.Attribute("AutomationProperties.AutomationId")?.Value);
+        Assert.Equal(
+            "{x:Bind ViewModel.IsAdapterToolchainInstallable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}",
+            adapter.Attribute("Visibility")?.Value);
+
+        var row = FindByName(document, "InstallAgentToolchainInlineButton");
+        Assert.Equal("AcpSetup_InstallToolchain", AttributeByLocalName(row, "Uid"));
+        Assert.Equal("AcpSetup.Agents.InstallToolchain", row.Attribute("AutomationProperties.AutomationId")?.Value);
+        Assert.Equal(
+            "{x:Bind CanInstallToolchainHere, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}",
+            row.Attribute("Visibility")?.Value);
+        Assert.Equal("OnInstallAgentToolchainRowClick", row.Attribute("Click")?.Value);
+
+        foreach (var resourceFile in new[]
+                 {
+                     "SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw",
+                     "SalmonEgg/SalmonEgg/Strings/en/Resources.resw",
+                     "SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw"
+                 })
+        {
+            var resources = XDocument.Parse(LoadText(resourceFile));
+            var install = resources.Descendants("data")
+                .Single(data => (string?)data.Attribute("name") == "AcpSetup_InstallToolchain.Content")
+                .Element("value")?.Value;
+            Assert.False(string.IsNullOrWhiteSpace(install), $"{resourceFile} must name the install action.");
+        }
+    }
+    [Fact]
+    public void Navigation_ExposesSecondarySkipAndAnnouncesDynamicStepPosition()
+    {        var document = XDocument.Parse(LoadXaml(WizardPath));
 
         var skip = FindByName(document, "AcpSetupSkipTestButton");
         Assert.Equal("AcpSetup_SkipTest", AttributeByLocalName(skip, "Uid"));


### PR DESCRIPTION
Closes #143.

The wizard could install ACP components but not the toolchain that carries them. A machine
without Node was shown a documentation link and told to leave the app — and the step most
likely to be got wrong, installing somewhere the app cannot see, was entirely the user's to
get right. Separately, a Node installed by its own vendor installer stayed invisible to
re-detection, so a user who did exactly what the wizard asked was told it was still missing.

Both are fixed here, for Node and uv.

## What changed

- **One-click install** for the Node and uv toolchains: download the official archive, verify
  its published SHA-256, unpack into per-user application data, run the binary to prove it
  works, then add it to the user's PATH. Unprivileged on every platform.
- **Re-detection now finds toolchains installed any way** — the vendor installer, a distribution
  package, a version manager, or the wizard itself.
- **The login-shell capture no longer requires the separately packaged CLI**, which is the only
  route to nvm: it ships no executable, so nothing on disk reveals the node it activated.
- **An archive's own links can no longer redirect its writes.** Resolving each entry's
  destination is not enough: an archive can declare a symlink and then a regular file at the
  same name, or a symlinked parent directory and an innocent-looking entry beneath it, and the
  write follows the link outside the destination. Every link this extraction creates is now
  recorded and no entry of any kind is written through one. Hard-link sources outside the
  destination are refused rather than resolved.
- **Build selection no longer borrows host-inspection types.** The resolvers choose an archive
  for a target they are told about, so the target is named by two closed domain enumerations
  instead of `System.Runtime.InteropServices`; the host is inspected in the desktop layer and
  mapped onto them, and an architecture no toolchain targets yields no download rather than a
  nearest guess.

## Verified

Facts below were measured, not assumed. No two archives share a shape, so each is declared as
data: Node's POSIX tarball nests executables under `bin/` while its Windows zip puts them at
its root; uv's POSIX tarball puts them at its single root and its Windows zip has no root
directory at all. Node tags releases `v24.20.0` with one shared `SHASUMS256.txt`; uv tags them
`0.12.8` — the `v` prefix 404s — with a `.sha256` beside each asset.

Real end-to-end installs on Linux arm64, into an isolated `HOME` and app-data root:

```
Node -> node v24.20.0 / npm 11.19.0, npm+npx symlinks preserved, execute bits intact
uv   -> uv 0.12.8 / uvx 0.12.8, landed in toolchains/uv/0.12.8
scan closure: probe resolves both toolchains under a narrow PATH after invalidation
~/.profile: exactly one marker block after repeated installs
```

All 32 generated download URLs resolve (Node 6 + uv 13 archives, plus uv's 13 digests);
unsupported platform/architecture pairs return null rather than a 404 link. Installer refusal
paths were driven against a local server: checksum mismatch, absent digest, missing launcher,
non-runnable binary, and archive path traversal are each refused, with nothing written.

Reverse-verified — each of these was made to fail on purpose: removing the invalidation,
tampering with the expected digest, dropping `/usr/bin` from the scanned layouts, dropping the
uv layout entry, reintroducing uv's `v` tag prefix, and removing the link-traversal guard
(which turns both symlink-escape tests red).

The link guard is proved by three archives no filesystem could hold, hand-assembled through
`TarWriter` because creating them on disk would already perform the escape: a symlink plus a
file at the same name, a symlinked directory plus a file beneath it, and a hard link whose
source is outside the destination. Each asserts the victim outside the destination was left
untouched, not merely that something was thrown.

Tests after the review fixes: Domain 125, Infrastructure 732 (6 platform-gated skips),
Presentation.Core 3274 — all green, 0 failures. The desktop head builds with 0 errors and the
touched projects build with 0 warnings.

## Notes for review

- **Targets `main`, so the series carries one commit that was already on `develop`.**
  `fix(acp-setup-wizard): move adapter recovery actions out of the InfoBar` is the single commit
  `main` was behind by, and it belongs to the same wizard surface. `main` has nothing `develop`
  lacks, so the branch fast-forwards and no merge commit is introduced.

- **uv toolchain only.** The catalog has no `Uvx` component yet, and the uv-distributed ACP
  packages on PyPI are community third-party rather than vendor-official, unlike everything the
  catalog currently lists. Adding a catalog entry later needs no change to this install path.
- **`SalmonEgg.sln` full build fails locally** on the `wasm-tools` workload being absent. That
  is environmental and unrelated to this change; the desktop, CLI and all library targets build.
- **GUI smoke was not completed.** The app launches and reaches ACP/telemetry init, but the
  sandbox Xvfb has no window manager, so no visible window could be captured. The install
  action is covered by XAML compliance tests plus the runtime checks above rather than by a
  screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

