### PR TITLE
fix(tests): prevent ChatViewModel cancellation from aborting test host

### DIFF
--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -2008,9 +2008,32 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
     private Task ApplyCurrentStoreProjectionAsync(long? activationVersion = null)
         => ApplyCurrentStoreProjectionAsync(activationVersion, CancellationToken.None);
 
+    /// <summary>
+    /// Projects the current store state onto the bindable surface.
+    /// The projection is guarded by a token linking the caller token with the store-subscription
+    /// lifetime token (<see cref="_storeStateCts"/>), which is cancelled on <see cref="Dispose"/>.
+    /// Lifetime cancellation means "this ViewModel is gone, so the projection is moot" — a normal
+    /// terminal condition, not a fault — and therefore completes quietly. Caller-owned cancellation
+    /// still surfaces as <see cref="OperationCanceledException"/>, because the caller that supplied
+    /// the token owns its observation.
+    /// </summary>
     private async Task ApplyCurrentStoreProjectionAsync(
         long? activationVersion,
         CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await ApplyCurrentStoreProjectionCoreAsync(activationVersion, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Store-subscription lifetime ended (ViewModel disposed); nothing left to project.
+        }
+    }
+
+    private async Task ApplyCurrentStoreProjectionCoreAsync(
+        long? activationVersion,
+        CancellationToken cancellationToken)
     {
         var storeProjectionToken = _storeStateCts?.Token ?? CancellationToken.None;
         using var linkedProjectionCts = cancellationToken.CanBeCanceled && storeProjectionToken.CanBeCanceled

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -613,6 +613,92 @@ public partial class ChatViewModelTests
     }
 
     [Fact]
+    public async Task ChatModeSelection_WhenViewModelIsDisposedMidFlight_DoesNotEscapeCancellationToTheThreadPool()
+    {
+        // Regression: SelectChatModeDisplayCommand dispatches SetModeCommand as fire-and-forget,
+        // so AsyncRelayCommand rethrows any fault on the thread pool (async void). Disposing the
+        // ViewModel while the failure-recovery projection is still queued used to surface the
+        // store-subscription lifetime cancellation as an unhandled TaskCanceledException, which
+        // aborts the whole test host (SIGABRT) instead of failing a single test.
+        var escaped = new List<Exception>();
+        var previousContext = SynchronizationContext.Current;
+        var syncContext = new QueueingSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(new EscapedExceptionRecordingSynchronizationContext(escaped));
+        try
+        {
+            var fixture = CreateViewModel(syncContext, localizer: new TestCoreStringLocalizer());
+            var viewModel = fixture.ViewModel;
+            var chatService = CreateConnectedChatService();
+            chatService
+                .Setup(service => service.SetSessionModeAsync(It.IsAny<SessionSetModeParams>()))
+                .ThrowsAsync(new InvalidOperationException("mode-denied"));
+            viewModel.ReplaceChatService(chatService.Object);
+
+            await fixture.UpdateStateAsync(state => state with
+            {
+                HydratedConversationId = "conv-1",
+                Bindings = ImmutableDictionary<string, ConversationBindingSlice>.Empty
+                    .Add("conv-1", new ConversationBindingSlice("conv-1", "remote-1", "profile-1")),
+                ConversationSessionStates = ImmutableDictionary<string, ConversationSessionStateSlice>.Empty
+                    .Add("conv-1", new ConversationSessionStateSlice(
+                        ImmutableList.Create(
+                            new ConversationModeOptionSnapshot
+                            {
+                                ModeId = "code",
+                                ModeName = "Code",
+                                Description = string.Empty
+                            },
+                            new ConversationModeOptionSnapshot
+                            {
+                                ModeId = "ask",
+                                ModeName = "Ask",
+                                Description = string.Empty
+                            }),
+                        SelectedModeId: "code",
+                        ConfigOptions: ImmutableList<ConversationConfigOptionSnapshot>.Empty,
+                        ShowConfigOptionsPanel: false,
+                        AvailableCommands: ImmutableList<ConversationAvailableCommandSnapshot>.Empty,
+                        SessionInfo: null,
+                        Usage: null))
+            });
+            SetCurrentSessionId(viewModel, "conv-1");
+            SetCurrentRemoteSessionId(viewModel, "remote-1");
+            viewModel.IsConnected = true;
+            viewModel.IsSessionActive = true;
+            await fixture.ApplyCurrentStoreProjectionAsync();
+            syncContext.RunAll();
+
+            var ask = viewModel.ChatModeSelectorItems.Single(item => item.SemanticValue == "ask");
+            viewModel.SelectChatModeDisplayCommand.Execute(ask);
+
+            // Pump until the remote failure is published, which leaves the recovery projection
+            // parked on the UI queue while the store-subscription token is still alive.
+            await WaitForConditionAsync(() =>
+            {
+                syncContext.RunAll();
+                return Task.FromResult(viewModel.HasConversationOperationFailure);
+            });
+            await WaitForConditionAsync(() => Task.FromResult(syncContext.PendingCount > 0));
+
+            await fixture.DisposeAsync();
+            syncContext.RunAll();
+
+            var modeCommandTask = viewModel.SetModeCommand.ExecutionTask;
+            if (modeCommandTask is not null)
+            {
+                await WaitForConditionAsync(() => Task.FromResult(modeCommandTask.IsCompleted));
+            }
+
+            Assert.False(modeCommandTask?.IsFaulted);
+            Assert.Empty(escaped);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+    }
+
+    [Fact]
     public async Task LanguageChanged_WhenAuthenticationHintIsHeld_ReprojectsLocalizedMessage()
     {
         // Arrange
@@ -5170,6 +5256,47 @@ public partial class ChatViewModelTests
         runtimeState.IsSessionActivationInProgress = false;
 
         Assert.True(projectedAvailability[^1]);
+    }
+
+    /// <summary>
+    /// Stands in for the app's real dispatcher context so that anything an <c>async void</c>
+    /// continuation rethrows (notably <see cref="CommunityToolkit.Mvvm.Input.AsyncRelayCommand"/>'s
+    /// fire-and-forget rethrow) is recorded instead of tearing down the test host.
+    /// </summary>
+    private sealed class EscapedExceptionRecordingSynchronizationContext : SynchronizationContext
+    {
+        private readonly List<Exception> _escaped;
+
+        public EscapedExceptionRecordingSynchronizationContext(List<Exception> escaped)
+            => _escaped = escaped;
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            ArgumentNullException.ThrowIfNull(d);
+
+            ThreadPool.UnsafeQueueUserWorkItem(
+                _ =>
+                {
+                    try
+                    {
+                        d(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        lock (_escaped)
+                        {
+                            _escaped.Add(ex);
+                        }
+                    }
+                },
+                null);
+        }
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            ArgumentNullException.ThrowIfNull(d);
+            d(state);
+        }
     }
 
     private sealed class QueueingSynchronizationContext : SynchronizationContext, IUiDispatcher

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/VoiceInputDiagnosticsProbeViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/VoiceInputDiagnosticsProbeViewModelTests.cs
@@ -291,28 +291,32 @@ public sealed class VoiceInputDiagnosticsProbeViewModelTests
     public async Task StartProbeAsync_WhenActivationArrivesBeforeDeniedFlowSettles_RetriesAfterProbeBecomesIdle()
     {
         var activationSource = new FakeApplicationActivationSignalSource();
-        var dispatcher = new BufferedActionUiDispatcher();
+        var authorizationHelpEntered = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeAuthorizationHelp = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var service = new FakeVoiceInputService
         {
             PermissionResult = new VoiceInputPermissionResult(
                 VoiceInputPermissionStatus.Denied,
                 "Enable speech access",
-                RequiresAuthorization: true)
+                RequiresAuthorization: true),
+            OnAuthorizationHelpRequestedAsync = async cancellationToken =>
+            {
+                authorizationHelpEntered.TrySetResult(null);
+                return await completeAuthorizationHelp.Task.WaitAsync(cancellationToken);
+            }
         };
-        service.OnAuthorizationHelpRequested = () =>
-        {
-            dispatcher.BufferNextAction();
-        };
-        var viewModel = CreateViewModel(service, dispatcher: dispatcher, activationSource: activationSource);
+        var viewModel = CreateViewModel(service, activationSource: activationSource);
 
-        await viewModel.StartProbeCommand.ExecuteAsync(null);
+        var initialStart = viewModel.StartProbeCommand.ExecuteAsync(null);
+        await authorizationHelpEntered.Task;
 
         Assert.Equal(1, service.AuthorizationHelpRequestCount);
         Assert.True(viewModel.IsRunning);
 
         service.PermissionResult = VoiceInputPermissionResult.Granted();
         activationSource.RaiseActivated();
-        dispatcher.FlushBufferedActions();
+        completeAuthorizationHelp.TrySetResult(true);
+        await initialStart;
 
         await WaitForConditionAsync(() => Task.FromResult(
             service.StartCount == 2
@@ -376,102 +380,48 @@ public sealed class VoiceInputDiagnosticsProbeViewModelTests
 
     private sealed class TrackingUiDispatcher : IUiDispatcher
     {
-        public bool IsExecutingCallback { get; private set; }
+        private readonly AsyncLocal<int> _callbackDepth = new();
+
+        public bool IsExecutingCallback => _callbackDepth.Value > 0;
 
         public bool HasThreadAccess => false;
 
         public void Enqueue(Action action)
-        {
-            IsExecutingCallback = true;
-            try
-            {
-                action();
-            }
-            finally
-            {
-                IsExecutingCallback = false;
-            }
-        }
+            => Execute(action);
 
         public Task EnqueueAsync(Action action)
         {
-            IsExecutingCallback = true;
-            try
-            {
-                action();
-            }
-            finally
-            {
-                IsExecutingCallback = false;
-            }
-
+            Execute(action);
             return Task.CompletedTask;
         }
 
-        public Task EnqueueAsync(Func<Task> action)
+        public async Task EnqueueAsync(Func<Task> action)
         {
-            IsExecutingCallback = true;
-            try
-            {
-                return AwaitAndResetAsync(action);
-            }
-            catch
-            {
-                IsExecutingCallback = false;
-                throw;
-            }
-        }
-
-        private async Task AwaitAndResetAsync(Func<Task> action)
-        {
+            var previousDepth = _callbackDepth.Value;
+            _callbackDepth.Value = previousDepth + 1;
             try
             {
                 await action();
             }
             finally
             {
-                IsExecutingCallback = false;
+                _callbackDepth.Value = previousDepth;
             }
         }
-    }
 
-    private sealed class BufferedActionUiDispatcher : IUiDispatcher
-    {
-        private Action? _bufferedAction;
-        private bool _bufferNextAction;
-
-        public bool HasThreadAccess => false;
-
-        public void BufferNextAction()
-            => _bufferNextAction = true;
-
-        public void FlushBufferedActions()
+        private void Execute(Action action)
         {
-            var action = _bufferedAction;
-            _bufferedAction = null;
-            action?.Invoke();
-        }
-
-        public void Enqueue(Action action)
-        {
-            EnqueueAsync(action).GetAwaiter().GetResult();
-        }
-
-        public Task EnqueueAsync(Action action)
-        {
-            if (_bufferNextAction)
+            var previousDepth = _callbackDepth.Value;
+            _callbackDepth.Value = previousDepth + 1;
+            try
             {
-                _bufferNextAction = false;
-                _bufferedAction = action;
-                return Task.CompletedTask;
+                action();
             }
-
-            action();
-            return Task.CompletedTask;
+            finally
+            {
+                _callbackDepth.Value = previousDepth;
+            }
         }
-
-        public Task EnqueueAsync(Func<Task> action)
-            => action();
     }
 
     private sealed class FakeVoiceInputService : IVoiceInputService
@@ -493,6 +443,8 @@ public sealed class VoiceInputDiagnosticsProbeViewModelTests
         public bool WasStartCancellationRequestedWhenStopCalled { get; private set; }
 
         public Action? OnAuthorizationHelpRequested { get; set; }
+
+        public Func<CancellationToken, Task<bool>>? OnAuthorizationHelpRequestedAsync { get; set; }
 
         public VoiceInputSessionOptions? LastOptions { get; private set; }
 
@@ -530,6 +482,11 @@ public sealed class VoiceInputDiagnosticsProbeViewModelTests
         public Task<bool> TryRequestAuthorizationHelpAsync(CancellationToken cancellationToken = default)
         {
             AuthorizationHelpRequestCount++;
+            if (OnAuthorizationHelpRequestedAsync is not null)
+            {
+                return OnAuthorizationHelpRequestedAsync(cancellationToken);
+            }
+
             OnAuthorizationHelpRequested?.Invoke();
             return Task.FromResult(true);
         }


### PR DESCRIPTION
## Summary

Fixes #139.

- Treats store-projection cancellation caused by `ChatViewModel.Dispose()` as a normal terminal condition, while preserving caller-owned cancellation and real faults.
- Adds a deterministic regression that previously reproduced the `AsyncRelayCommand` thread-pool rethrow / exit 134 test-host crash.
- Replaces the two VoiceInput test doubles that raced the background signal poller with an `AsyncLocal` dispatcher scope and explicit authorization-help synchronization.

## Verification

- `dotnet build tests/SalmonEgg.Presentation.Core.Tests/SalmonEgg.Presentation.Core.Tests.csproj -c Debug`
- `VoiceInputDiagnosticsProbeViewModelTests`: 10 consecutive runs, each `13/13` passed.
- New Chat cancellation regression: passed.
- Full `SalmonEgg.Presentation.Core.Tests`:
  - before rebase: 2 runs, each `3278/3278` passed
  - after rebasing onto current `develop`: `3286/3286` passed
- Reverse verification: disabling the lifecycle-cancellation guard restored the original `TaskCanceledException`, exit 134, and `failed: 0 / total: 0` host-abort signature.

The branch was rebased directly onto the latest `origin/develop` before the final full-suite run, so it is currently fast-forward mergeable unless `develop` advances again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
