### PR TITLE
fix(acp): propagate request cancellation to peers

### DIFF
--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -954,20 +954,25 @@ namespace SalmonEgg.Acp.Client
             var requestIdStr = request.Id?.ToString() ?? string.Empty;
             var tcs = new TaskCompletionSource<JsonRpcResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             _pendingRequests[requestIdStr] = tcs;
-            var dispatched = false;
+            var requestWriteStarted = false;
             var retainPendingRequest = false;
 
             try
             {
                 var json = _parser.SerializeMessage(request);
                 ClearLastTransportError();
+                cancellationToken.ThrowIfCancellationRequested();
+                // Once the transport call begins, a pipe/socket implementation may have written
+                // some or all of the frame before observing its token. Treat it as potentially
+                // delivered for cancellation purposes: skipping $/cancel_request here would leave
+                // a peer running an operation the caller has already abandoned.
+                requestWriteStarted = true;
                 var sent = await _transport.SendMessageAsync(json, cancellationToken).ConfigureAwait(false);
                 if (!sent)
                 {
                     throw new InvalidOperationException(CreateTransportSendFailureMessage(request.Method));
                 }
 
-                dispatched = true;
                 using var cancellationRegistration = cancellationToken.Register(
                     static state => ((TaskCompletionSource<JsonRpcResponse>)state!).TrySetCanceled(),
                     tcs);
@@ -996,7 +1001,7 @@ namespace SalmonEgg.Acp.Client
                 // for the original request (possibly -32800), and OnMessageReceived owns removing
                 // that correlation entry. Do not use the caller's already-cancelled token here —
                 // cancelling a request must itself reach the peer.
-                if (dispatched && AcpRequestId.TryFromEnvelopeId(request.Id, out var requestId))
+                if (requestWriteStarted && AcpRequestId.TryFromEnvelopeId(request.Id, out var requestId))
                 {
                     retainPendingRequest = true;
                     await SendCancelRequestNotificationAsync(requestId).ConfigureAwait(false);

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -954,6 +954,8 @@ namespace SalmonEgg.Acp.Client
             var requestIdStr = request.Id?.ToString() ?? string.Empty;
             var tcs = new TaskCompletionSource<JsonRpcResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             _pendingRequests[requestIdStr] = tcs;
+            var dispatched = false;
+            var retainPendingRequest = false;
 
             try
             {
@@ -965,6 +967,7 @@ namespace SalmonEgg.Acp.Client
                     throw new InvalidOperationException(CreateTransportSendFailureMessage(request.Method));
                 }
 
+                dispatched = true;
                 using var cancellationRegistration = cancellationToken.Register(
                     static state => ((TaskCompletionSource<JsonRpcResponse>)state!).TrySetCanceled(),
                     tcs);
@@ -987,6 +990,18 @@ namespace SalmonEgg.Acp.Client
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 AcpActivitySources.MarkCancelled(activity);
+
+                // A caller can abandon its own await immediately, but the matching response still
+                // belongs in _pendingRequests: ACP requires the peer to send a terminal response
+                // for the original request (possibly -32800), and OnMessageReceived owns removing
+                // that correlation entry. Do not use the caller's already-cancelled token here —
+                // cancelling a request must itself reach the peer.
+                if (dispatched && AcpRequestId.TryFromEnvelopeId(request.Id, out var requestId))
+                {
+                    retainPendingRequest = true;
+                    await SendCancelRequestNotificationAsync(requestId).ConfigureAwait(false);
+                }
+
                 throw new OperationCanceledException(cancellationToken);
             }
             catch (TaskCanceledException ex)
@@ -1010,7 +1025,55 @@ namespace SalmonEgg.Acp.Client
             }
             finally
             {
-                _pendingRequests.TryRemove(requestIdStr, out _);
+                if (!retainPendingRequest)
+                {
+                    _pendingRequests.TryRemove(requestIdStr, out _);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends the protocol-level <c>$/cancel_request</c> notification for an already dispatched
+        /// outbound request.
+        /// </summary>
+        /// <remarks>
+        /// This is deliberately best-effort: ACP permits a peer to ignore <c>$/</c> notifications,
+        /// so a failed cancellation notification must not turn a caller's cancellation into a second
+        /// user-facing error. The original request remains pending until its terminal response or a
+        /// disconnect resolves it.
+        /// </remarks>
+        private async Task SendCancelRequestNotificationAsync(AcpRequestId requestId)
+        {
+            if (!_transport.IsConnected)
+            {
+                return;
+            }
+
+            try
+            {
+                var notification = new JsonRpcNotification(
+                    CancelRequestParams.Method,
+                    ToElement(
+                        new CancelRequestParams(requestId),
+                        AcpJsonContext.Default.CancelRequestParams));
+                var sent = await _transport.SendMessageAsync(_parser.SerializeMessage(notification)).ConfigureAwait(false);
+                if (!sent)
+                {
+                    _logger.Log(
+                        AcpClientLogLevel.Warning,
+                        "CANCEL_REQUEST_SEND_FAILED",
+                        $"Failed to send $/cancel_request for request {requestId}.",
+                        nameof(SendCancelRequestNotificationAsync));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(
+                    AcpClientLogLevel.Warning,
+                    "CANCEL_REQUEST_SEND_FAILED",
+                    $"Failed to send $/cancel_request for request {requestId}: {ex.Message}",
+                    nameof(SendCancelRequestNotificationAsync),
+                    ex);
             }
         }
 
@@ -1101,9 +1164,21 @@ namespace SalmonEgg.Acp.Client
                 {
                     var responseIdStr = response.Id?.ToString() ?? string.Empty;
                     // Match the pending request.
-                    if (_pendingRequests.TryRemove(responseIdStr, out var tcs))
+                    if (_pendingRequests.TryRemove(responseIdStr, out var tcs)
+                        && !tcs.TrySetResult(response))
                     {
-                        tcs.TrySetResult(response);
+                        // The entry was still correlated, so the only thing that can already have
+                        // completed it is the caller's own cancellation: this is the terminal
+                        // response ACP requires the peer to send for a cancelled request (a partial
+                        // result, or -32800). Nobody is awaiting it, so record the outcome and let
+                        // the removal above close the correlation rather than dropping it silently.
+                        _logger.Log(
+                            AcpClientLogLevel.Information,
+                            "CANCELLED_REQUEST_SETTLED",
+                            response.IsError
+                                ? $"Cancelled request {responseIdStr} was settled by the peer with error {response.Error!.Code} ({JsonRpcErrorCode.GetErrorMessage(response.Error.Code)})."
+                                : $"Cancelled request {responseIdStr} was settled by the peer with a result.",
+                            nameof(OnMessageReceived));
                     }
                 }
 

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcError.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcError.cs
@@ -116,5 +116,19 @@ namespace SalmonEgg.Acp.JsonRpc
         {
             return JsonRpcErrorCode.IsAcpErrorCode(Code);
         }
+
+        /// <summary>
+        /// Determines whether this error reports a cancelled request (<c>-32800</c>), the terminal
+        /// response a peer sends for a request cancelled via <c>$/cancel_request</c>.
+        /// </summary>
+        /// <returns><c>true</c> if the error code is <see cref="JsonRpcErrorCode.Cancelled"/>.</returns>
+        /// <remarks>
+        /// Neither <see cref="IsStandardError"/> nor <see cref="IsAcpError"/> covers this code; see
+        /// <see cref="JsonRpcErrorCode.IsCancelledErrorCode"/> for why it is its own category.
+        /// </remarks>
+        public bool IsCancelled()
+        {
+            return JsonRpcErrorCode.IsCancelledErrorCode(Code);
+        }
     }
 }

--- a/src/SalmonEgg.Acp/JsonRpc/JsonRpcErrorCode.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/JsonRpcErrorCode.cs
@@ -41,6 +41,23 @@ namespace SalmonEgg.Acp.JsonRpc
 
         #endregion
 
+        #region JSON-RPC reserved codes outside the standard band
+
+        /// <summary>
+        /// -32800: Request cancelled
+        /// The method's execution was aborted, either because the caller sent
+        /// <c>$/cancel_request</c> or because of resource constraints or shutdown.
+        /// </summary>
+        /// <remarks>
+        /// Lives in the JSON-RPC reserved range (-32768 to -32000) but outside the standard
+        /// -32700..-32603 band, so it is neither a standard code nor an ACP extension code. Kept as
+        /// its own category rather than widening either band, which would silently reclassify every
+        /// unassigned code in between.
+        /// </remarks>
+        public const int Cancelled = -32800;
+
+        #endregion
+
         #region ACP extension error codes
 
         /// <summary>
@@ -108,6 +125,22 @@ namespace SalmonEgg.Acp.JsonRpc
         }
 
         /// <summary>
+        /// Determines whether an error code reports a cancelled request.
+        /// </summary>
+        /// <param name="code">The error code.</param>
+        /// <returns>true if the code is <see cref="Cancelled"/>.</returns>
+        /// <remarks>
+        /// A single code rather than a band, and deliberately not folded into
+        /// <see cref="IsStandardErrorCode"/> or <see cref="IsAcpErrorCode"/>: -32800 sits between
+        /// them, so extending either range to reach it would also swallow codes neither
+        /// specification has assigned.
+        /// </remarks>
+        public static bool IsCancelledErrorCode(int code)
+        {
+            return code == Cancelled;
+        }
+
+        /// <summary>
         /// Gets the standard error message for an error code.
         /// </summary>
         /// <param name="code">The error code.</param>
@@ -121,6 +154,7 @@ namespace SalmonEgg.Acp.JsonRpc
                 MethodNotFound => "Method not found",
                 InvalidParams => "Invalid params",
                 InternalError => "Internal error",
+                Cancelled => "Request cancelled",
                 PermissionDenied => "Permission denied",
                 ResourceNotFound => "Resource not found",
                 MethodNotAllowed => "Method not allowed",

--- a/src/SalmonEgg.Acp/Protocol/CancelRequestTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/CancelRequestTypes.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SalmonEgg.Acp.Protocol
+{
+    /// <summary>
+    /// Which of the three JSON-RPC request-id forms an <see cref="AcpRequestId"/> carries.
+    /// </summary>
+    public enum AcpRequestIdKind
+    {
+        /// <summary>The JSON-RPC <c>null</c> request id.</summary>
+        Null = 0,
+
+        /// <summary>A numeric JSON-RPC request id.</summary>
+        Number = 1,
+
+        /// <summary>A string JSON-RPC request id.</summary>
+        String = 2
+    }
+
+    /// <summary>
+    /// A JSON-RPC request id: <c>null</c>, a number, or a string.
+    /// </summary>
+    /// <remarks>
+    /// Modeled as a union rather than a single numeric type because the ACP <c>RequestId</c> schema
+    /// is a union of all three forms, and JSON-RPC 2.0 requires a responder to echo back the very
+    /// same value. Collapsing it to <see cref="long"/> would reject a peer's string ids, and
+    /// re-encoding a number through <see cref="long"/> would rewrite unusual-but-legal numeric
+    /// tokens — either way the echoed id would no longer correlate. The numeric form therefore
+    /// keeps its raw token text, and <see cref="TryGetNumber"/> exposes the int64 view the schema
+    /// documents for the ordinary case.
+    /// </remarks>
+    [JsonConverter(typeof(AcpRequestIdJsonConverter))]
+    public readonly struct AcpRequestId : IEquatable<AcpRequestId>
+    {
+        /// <summary>
+        /// For <see cref="AcpRequestIdKind.String"/> the string value; for
+        /// <see cref="AcpRequestIdKind.Number"/> the raw JSON numeric token.
+        /// </summary>
+        private readonly string? _raw;
+
+        private AcpRequestId(AcpRequestIdKind kind, string? raw)
+        {
+            Kind = kind;
+            _raw = raw;
+        }
+
+        /// <summary>
+        /// The JSON-RPC <c>null</c> request id, which is also the <c>default</c> value.
+        /// </summary>
+        public static AcpRequestId Null => default;
+
+        /// <summary>
+        /// Creates a numeric request id.
+        /// </summary>
+        /// <param name="value">The numeric id.</param>
+        public static AcpRequestId FromNumber(long value)
+            => new(AcpRequestIdKind.Number, value.ToString(CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// Creates a string request id.
+        /// </summary>
+        /// <param name="value">The string id.</param>
+        public static AcpRequestId FromString(string value)
+            => new(AcpRequestIdKind.String, value ?? throw new ArgumentNullException(nameof(value)));
+
+        /// <summary>
+        /// Which of the three request-id forms this value carries.
+        /// </summary>
+        public AcpRequestIdKind Kind { get; }
+
+        /// <summary>
+        /// Gets the numeric value when this id is a number that fits in an <see cref="long"/>.
+        /// </summary>
+        /// <param name="value">The numeric value, or <c>0</c> when this id is not such a number.</param>
+        /// <returns><c>true</c> when a numeric value was produced.</returns>
+        public bool TryGetNumber(out long value)
+        {
+            if (Kind == AcpRequestIdKind.Number
+                && long.TryParse(_raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            {
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the string value when this id is a string.
+        /// </summary>
+        /// <param name="value">The string value, or <c>null</c> when this id is not a string.</param>
+        /// <returns><c>true</c> when a string value was produced.</returns>
+        public bool TryGetString(out string? value)
+        {
+            if (Kind == AcpRequestIdKind.String)
+            {
+                value = _raw ?? string.Empty;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Projects a JSON-RPC envelope id, whose CLR shape depends on how it was produced or parsed,
+        /// onto this union.
+        /// </summary>
+        /// <param name="envelopeId">The envelope id value.</param>
+        /// <param name="requestId">The projected request id.</param>
+        /// <returns><c>false</c> when the value is none of the three legal forms (for example a boolean).</returns>
+        /// <remarks>
+        /// A locally issued id arrives here as a CLR integer, while a parsed one arrives as a
+        /// <see cref="JsonElement"/>; both must land on the same wire form so an echoed id still
+        /// correlates.
+        /// </remarks>
+        public static bool TryFromEnvelopeId(object? envelopeId, out AcpRequestId requestId)
+        {
+            switch (envelopeId)
+            {
+                case null:
+                    requestId = Null;
+                    return true;
+                case string text:
+                    requestId = FromString(text);
+                    return true;
+                case byte or sbyte or short or ushort or int or uint or long:
+                    requestId = FromNumber(Convert.ToInt64(envelopeId, CultureInfo.InvariantCulture));
+                    return true;
+                case ulong unsigned:
+                    // Outside int64 the raw token is still the faithful wire form.
+                    requestId = new AcpRequestId(
+                        AcpRequestIdKind.Number,
+                        unsigned.ToString(CultureInfo.InvariantCulture));
+                    return true;
+                case JsonElement { ValueKind: JsonValueKind.Null }:
+                    requestId = Null;
+                    return true;
+                case JsonElement { ValueKind: JsonValueKind.String } stringElement:
+                    requestId = FromString(stringElement.GetString() ?? string.Empty);
+                    return true;
+                case JsonElement { ValueKind: JsonValueKind.Number } numberElement:
+                    requestId = new AcpRequestId(AcpRequestIdKind.Number, numberElement.GetRawText());
+                    return true;
+                default:
+                    requestId = Null;
+                    return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals(AcpRequestId other)
+            => Kind == other.Kind && string.Equals(_raw, other._raw, StringComparison.Ordinal);
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is AcpRequestId other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+            => HashCode.Combine(Kind, _raw is null ? 0 : StringComparer.Ordinal.GetHashCode(_raw));
+
+        /// <summary>
+        /// Determines whether two request ids carry the same form and value.
+        /// </summary>
+        public static bool operator ==(AcpRequestId left, AcpRequestId right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two request ids differ in form or value.
+        /// </summary>
+        public static bool operator !=(AcpRequestId left, AcpRequestId right) => !left.Equals(right);
+
+        /// <summary>
+        /// Renders the id for diagnostics. Not a wire form: a string id and the numeric token that
+        /// spells the same characters render identically.
+        /// </summary>
+        public override string ToString() => Kind == AcpRequestIdKind.Null ? "null" : _raw ?? string.Empty;
+
+        /// <summary>
+        /// Writes this id as its JSON-RPC wire form.
+        /// </summary>
+        internal void Write(Utf8JsonWriter writer)
+        {
+            switch (Kind)
+            {
+                case AcpRequestIdKind.Number:
+                    // The raw token, not a re-encoded number: writing through a CLR numeric type
+                    // would normalise the text and break correlation with the original request.
+                    writer.WriteRawValue(_raw ?? "0");
+                    break;
+                case AcpRequestIdKind.String:
+                    writer.WriteStringValue(_raw ?? string.Empty);
+                    break;
+                default:
+                    writer.WriteNullValue();
+                    break;
+            }
+        }
+    }
+
+    internal sealed class AcpRequestIdJsonConverter : JsonConverter<AcpRequestId>
+    {
+        public override AcpRequestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return AcpRequestId.Null;
+                case JsonTokenType.String:
+                    return AcpRequestId.FromString(reader.GetString() ?? string.Empty);
+                case JsonTokenType.Number:
+                    using (var document = JsonDocument.ParseValue(ref reader))
+                    {
+                        return AcpRequestId.TryFromEnvelopeId(document.RootElement.Clone(), out var numeric)
+                            ? numeric
+                            : throw new JsonException("JSON-RPC request id must be null, a number, or a string.");
+                    }
+
+                default:
+                    // The type contract is not relaxed: a boolean, object, or array id is illegal in
+                    // JSON-RPC 2.0 and stays an error rather than being coerced.
+                    throw new JsonException("JSON-RPC request id must be null, a number, or a string.");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, AcpRequestId value, JsonSerializerOptions options)
+            => value.Write(writer);
+    }
+
+    /// <summary>
+    /// Parameters of the <c>$/cancel_request</c> notification, sent by whichever side issued a
+    /// request to ask that it be cancelled.
+    /// </summary>
+    /// <remarks>
+    /// A protocol-level notification: the <c>$/</c> prefix marks it implementation dependent, and
+    /// the receiver is free to ignore it. When the receiver does honour it, the specification still
+    /// requires a terminal response to the original request — either a valid result or the
+    /// <see cref="JsonRpc.JsonRpcErrorCode.Cancelled"/> error.
+    /// </remarks>
+    public sealed record CancelRequestParams : AcpProtocolObject
+    {
+        /// <summary>
+        /// The JSON-RPC method name of the notification these parameters belong to.
+        /// </summary>
+        public const string Method = "$/cancel_request";
+
+        /// <summary>
+        /// The id of the request to cancel (required).
+        /// </summary>
+        [JsonPropertyName("requestId")]
+        public AcpRequestId RequestId { get; init; }
+
+        /// <summary>
+        /// Creates empty cancellation parameters.
+        /// </summary>
+        public CancelRequestParams()
+        {
+        }
+
+        /// <summary>
+        /// Creates cancellation parameters for the given request id.
+        /// </summary>
+        /// <param name="requestId">The id of the request to cancel.</param>
+        public CancelRequestParams(AcpRequestId requestId)
+        {
+            RequestId = requestId;
+        }
+    }
+}

--- a/src/SalmonEgg.Acp/PublicSurface.Types.txt
+++ b/src/SalmonEgg.Acp/PublicSurface.Types.txt
@@ -45,6 +45,8 @@ SalmonEgg.Acp.Plan.PlanEntryStatus
 SalmonEgg.Acp.Protocol.AcpMetaJson
 SalmonEgg.Acp.Protocol.AcpProtocolObject
 SalmonEgg.Acp.Protocol.AcpProtocolVersion
+SalmonEgg.Acp.Protocol.AcpRequestId
+SalmonEgg.Acp.Protocol.AcpRequestIdKind
 SalmonEgg.Acp.Protocol.AgentAuthCapabilities
 SalmonEgg.Acp.Protocol.AgentCapabilities
 SalmonEgg.Acp.Protocol.AgentInfo
@@ -65,6 +67,7 @@ SalmonEgg.Acp.Protocol.AvailableCommand
 SalmonEgg.Acp.Protocol.AvailableCommandInput
 SalmonEgg.Acp.Protocol.AvailableCommandsUpdate
 SalmonEgg.Acp.Protocol.BooleanConfigOptionCapabilities
+SalmonEgg.Acp.Protocol.CancelRequestParams
 SalmonEgg.Acp.Protocol.ClientCapabilities
 SalmonEgg.Acp.Protocol.ClientCapabilityDefaults
 SalmonEgg.Acp.Protocol.ClientCapabilityMetadata

--- a/src/SalmonEgg.Acp/Serialization/AcpJsonContext.cs
+++ b/src/SalmonEgg.Acp/Serialization/AcpJsonContext.cs
@@ -60,6 +60,8 @@ namespace SalmonEgg.Acp.Serialization;
 [JsonSerializable(typeof(SessionSetConfigOptionParams))]
 [JsonSerializable(typeof(SessionSetConfigOptionResponse))]
 [JsonSerializable(typeof(SessionCancelParams))]
+[JsonSerializable(typeof(CancelRequestParams))]
+[JsonSerializable(typeof(AcpRequestId))]
 [JsonSerializable(typeof(AuthenticateParams))]
 [JsonSerializable(typeof(AuthenticateResponse))]
 [JsonSerializable(typeof(LogoutParams))]

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpErrorClassifier.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpErrorClassifier.cs
@@ -6,6 +6,9 @@ namespace SalmonEgg.Presentation.Core.Services.Chat;
 
 public static class AcpErrorClassifier
 {
+    public static bool IsRequestCancelled(Exception ex) =>
+        ex is AcpException acp && acp.ErrorCode == JsonRpcErrorCode.Cancelled;
+
     public static bool IsAuthenticationRequired(Exception ex) =>
         ex is AcpException acp && acp.ErrorCode == JsonRpcErrorCode.AuthenticationRequired;
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -930,7 +930,7 @@ public partial class ChatViewModel
         // rapid session switching, not a real failure. Log it at Information and stop before surfacing
         // any user-facing failure, so these do not masquerade as [ERR] "Switching session failed".
         var superseded = !_conversationActivationOutcomePublisher.CanPublish(activationVersion);
-        var canceled = ex is OperationCanceledException;
+        var canceled = ex is OperationCanceledException || AcpErrorClassifier.IsRequestCancelled(ex);
         if (superseded || canceled)
         {
             Logger.LogInformation(

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
@@ -84,6 +84,10 @@ public partial class ChatViewModel
             await BindLocalConversationToRemoteSessionAsync(localConversationId, response.SessionId).ConfigureAwait(false);
             await ApplyCreatedSessionProjectionAsync(localConversationId, response).ConfigureAwait(true);
         }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(ex, "Create session was cancelled by the peer");
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to create session");
@@ -142,6 +146,13 @@ public partial class ChatViewModel
         catch (OperationCanceledException)
         {
             // User-cancelled; keep input cleared.
+            await PreemptivelyCancelTurnAsync(promptContext.ConversationId, promptContext.TurnId).ConfigureAwait(true);
+        }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            // The peer settled the prompt with JSON-RPC -32800. ACP cancellation is terminal but
+            // not a user-actionable failure, so it follows the same state path as caller-token
+            // cancellation rather than leaving a persistent failure callout.
             await PreemptivelyCancelTurnAsync(promptContext.ConversationId, promptContext.TurnId).ConfigureAwait(true);
         }
         catch (Exception ex)
@@ -1413,6 +1424,11 @@ public partial class ChatViewModel
                     mode.ModeId).ConfigureAwait(true);
             }
         }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(ex, "Mode switch was cancelled by the peer");
+            await ApplyCurrentStoreProjectionAsync().ConfigureAwait(true);
+        }
         catch (Exception ex) when (AcpErrorClassifier.IsRemoteSessionNotFound(ex))
         {
             // The remote session no longer exists on the agent side.
@@ -1500,6 +1516,11 @@ public partial class ChatViewModel
                 activeBinding.RemoteSessionId!,
                 modelValue).ConfigureAwait(true);
         }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(ex, "Model switch was cancelled by the peer");
+            await ApplyCurrentStoreProjectionAsync().ConfigureAwait(true);
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to switch model");
@@ -1559,6 +1580,10 @@ public partial class ChatViewModel
                 await _chatService.CancelSessionAsync(cancelParams);
             }
         }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(ex, "Session cancellation was acknowledged as cancelled by the peer");
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to cancel session");
@@ -1602,6 +1627,10 @@ public partial class ChatViewModel
             await _chatStore.Dispatch(new ResetConversationRuntimeStatesAction()).ConfigureAwait(false);
             _panelStateCoordinator.ClearAskUserRequests();
             PendingAskUserRequest = null;
+        }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(ex, "Disconnect was cancelled by the peer");
         }
         catch (Exception ex)
         {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.RemoteConversationLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.RemoteConversationLifecycle.cs
@@ -610,6 +610,24 @@ public partial class ChatViewModel
         }
         catch (Exception ex)
         {
+            if (AcpErrorClassifier.IsRequestCancelled(ex))
+            {
+                // A peer's -32800 is the terminal acknowledgement of cancellation, not a load
+                // fault. Release the temporary buffering lease but preserve the existing runtime
+                // projection and avoid publishing a failure callout that would outlive the action.
+                Logger.LogInformation(
+                    ex,
+                    "Remote hydration was cancelled by the peer. ConversationId={ConversationId} RemoteSessionId={RemoteSessionId}",
+                    conversationId,
+                    binding.RemoteSessionId);
+                ReleaseBufferedUpdatesAfterInterruptedHydration(
+                    adapter,
+                    hydrationAttemptId,
+                    ownsRecoveryLease,
+                    "RemoteHydrationPeerCancelled");
+                return false;
+            }
+
             if (IsActivationContextStale(activationVersion, cancellationToken))
             {
                 Logger.LogInformation(
@@ -1760,6 +1778,13 @@ public partial class ChatViewModel
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested || _disposed)
         {
+        }
+        catch (Exception ex) when (AcpErrorClassifier.IsRequestCancelled(ex))
+        {
+            Logger.LogInformation(
+                ex,
+                "Remote WebSocket recovery was cancelled by the peer. ConversationId={ConversationId}",
+                conversationId);
         }
         catch (Exception ex)
         {

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientRequestCancellationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientRequestCancellationTests.cs
@@ -114,6 +114,33 @@ public sealed class AcpClientRequestCancellationTests
     }
 
     [Fact]
+    public async Task RequestWriteInProgress_WhenCallerCancels_SendsCancelRequestBecauseThePeerMayAlreadyHaveTheFrame()
+    {
+        using var client = await CreateInitializedClientAsync();
+        var writeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex("session/new"), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>(async (message, token) =>
+            {
+                _sent.Enqueue(message); // Represents bytes accepted by the real pipe/socket.
+                writeStarted.TrySetResult();
+                await releaseWrite.Task.ConfigureAwait(false);
+                token.ThrowIfCancellationRequested();
+                return true;
+            });
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await writeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await cancellation.CancelAsync();
+        releaseWrite.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        await WaitForSentNotificationAsync(CancelRequestParams.Method);
+    }
+
+    [Fact]
     public async Task UndispatchedRequest_WhenCancelledBeforeTheSendSucceeds_SendsNoCancelRequest()
     {
         // Nothing reached the peer, so there is no request for it to cancel.

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientRequestCancellationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientRequestCancellationTests.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Mcp;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+/// <summary>
+/// Outbound request cancellation. ACP puts <c>$/cancel_request</c> on the side that issued the
+/// request: abandoning a local await leaves the peer running, so anything with side effects (a
+/// terminal, a file write) keeps going after the user has cancelled.
+/// </summary>
+/// <remarks>
+/// These assert the wire payload, not just local state — a client that merely stops waiting looks
+/// identical from the outside, which is exactly the defect.
+/// </remarks>
+public sealed class AcpClientRequestCancellationTests
+{
+    private static readonly string AbsoluteCwd = Path.GetFullPath(Path.Combine(
+        Path.GetTempPath(),
+        "salmon-egg-tests",
+        "cancel-request"));
+
+    private readonly Mock<IAcpTransport> _transportMock = new();
+    private readonly Mock<IAcpClientLogger> _loggerMock = new();
+    private readonly MessageParser _parser = new();
+    private readonly ConcurrentQueue<string> _sent = new();
+
+    public AcpClientRequestCancellationTests()
+    {
+        _transportMock.SetupGet(t => t.IsConnected).Returns(true);
+        _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex(@"cancel_request"), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((message, _) =>
+            {
+                _sent.Enqueue(message);
+                return Task.FromResult(true);
+            });
+    }
+
+    [Fact]
+    public async Task DispatchedRequest_WhenCallerCancels_SendsCancelRequestCarryingTheOriginalId()
+    {
+        using var client = await CreateInitializedClientAsync();
+        SetupSilentSend("session/new");
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await WaitForSentMethodAsync("session/new");
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        var request = Assert.Single(SentRequests("session/new"));
+        var cancel = await WaitForSentNotificationAsync(CancelRequestParams.Method);
+        Assert.Equal(
+            request.RootElement.GetProperty("id").GetRawText(),
+            cancel.RootElement.GetProperty("params").GetProperty("requestId").GetRawText());
+    }
+
+    [Fact]
+    public async Task CancelRequest_IsAProtocolLevelNotificationWithNoId()
+    {
+        using var client = await CreateInitializedClientAsync();
+        SetupSilentSend("session/new");
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await WaitForSentMethodAsync("session/new");
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        var cancel = await WaitForSentNotificationAsync(CancelRequestParams.Method);
+
+        // A notification, not a request: carrying an id would make the peer owe us a response.
+        Assert.Equal("2.0", cancel.RootElement.GetProperty("jsonrpc").GetString());
+        Assert.False(cancel.RootElement.TryGetProperty("id", out _));
+        Assert.Equal("$/cancel_request", cancel.RootElement.GetProperty("method").GetString());
+    }
+
+    [Fact]
+    public async Task CancelRequest_IsSentForEveryRequestMethod_NotOnlyPrompts()
+    {
+        // session/cancel already covered the prompt turn. The gap was every other outbound request,
+        // so the behaviour has to live on the shared send path rather than one method.
+        using var client = await CreateInitializedClientAsync(
+            new AgentCapabilities(loadSession: true));
+        SetupSilentSend("session/load");
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = client.LoadSessionAsync(
+            new SessionLoadParams("session-1", AbsoluteCwd, new List<McpServer>()),
+            cancellation.Token);
+        await WaitForSentMethodAsync("session/load");
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        var request = Assert.Single(SentRequests("session/load"));
+        var cancel = await WaitForSentNotificationAsync(CancelRequestParams.Method);
+        Assert.Equal(
+            request.RootElement.GetProperty("id").GetRawText(),
+            cancel.RootElement.GetProperty("params").GetProperty("requestId").GetRawText());
+    }
+
+    [Fact]
+    public async Task UndispatchedRequest_WhenCancelledBeforeTheSendSucceeds_SendsNoCancelRequest()
+    {
+        // Nothing reached the peer, so there is no request for it to cancel.
+        using var client = await CreateInitializedClientAsync();
+        _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex("session/new"), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((message, token) =>
+            {
+                _sent.Enqueue(message);
+                return Task.FromCanceled<bool>(new CancellationToken(canceled: true));
+            });
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token));
+
+        Assert.Empty(SentNotifications(CancelRequestParams.Method));
+    }
+
+    [Fact]
+    public async Task DisconnectedTransport_WhenCallerCancels_SendsNoCancelRequest()
+    {
+        using var client = await CreateInitializedClientAsync();
+        SetupSilentSend("session/new");
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await WaitForSentMethodAsync("session/new");
+
+        // The connection dropped while the request was in flight; a cancellation notification has
+        // nowhere to go and must not become a second error surface.
+        _transportMock.SetupGet(t => t.IsConnected).Returns(false);
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        Assert.Empty(SentNotifications(CancelRequestParams.Method));
+    }
+
+    [Fact]
+    public async Task FailedCancelRequestSend_DoesNotSurfaceAsAClientError()
+    {
+        // '$/' notifications are explicitly ignorable, so failing to deliver one is not a fault the
+        // user can act on — and the failure surface holds such a message until the next success.
+        using var client = await CreateInitializedClientAsync();
+        var errors = new List<string>();
+        client.ErrorOccurred += (_, error) =>
+        {
+            lock (errors)
+            {
+                errors.Add(error);
+            }
+        };
+
+        SetupSilentSend("session/new");
+        _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex(@"cancel_request"), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("socket closed"));
+
+        using var cancellation = new CancellationTokenSource();
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await WaitForSentMethodAsync("session/new");
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        string[] surfaced;
+        lock (errors)
+        {
+            surfaced = [.. errors];
+        }
+
+        Assert.Empty(surfaced);
+        _loggerMock.Verify(
+            logger => logger.Log(
+                AcpClientLogLevel.Warning,
+                "CANCEL_REQUEST_SEND_FAILED",
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Exception?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelledErrorResponse_ArrivingAfterCancellation_IsAbsorbedWithoutAClientError()
+    {
+        // ACP requires the peer to send a terminal response for the cancelled request. Our pending
+        // table has to be able to receive -32800 rather than have it land as an unmatched frame or
+        // an error the user sees.
+        using var client = await CreateInitializedClientAsync();
+        var errors = new List<string>();
+        client.ErrorOccurred += (_, error) =>
+        {
+            lock (errors)
+            {
+                errors.Add(error);
+            }
+        };
+
+        SetupSilentSend("session/new");
+        using var cancellation = new CancellationTokenSource();
+        var pending = client.CreateSessionAsync(new SessionNewParams(AbsoluteCwd, null), cancellation.Token);
+        await WaitForSentMethodAsync("session/new");
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        await WaitForSentNotificationAsync(CancelRequestParams.Method);
+
+        var requestId = Assert.Single(SentRequests("session/new")).RootElement.GetProperty("id").GetRawText();
+        RaiseTransportMessage(
+            "{\"jsonrpc\":\"2.0\",\"id\":" + requestId + ",\"error\":{\"code\":-32800,\"message\":\"Request cancelled\"}}");
+
+        await WaitForLoggedCodeAsync("CANCELLED_REQUEST_SETTLED");
+
+        string[] surfaced;
+        lock (errors)
+        {
+            surfaced = [.. errors];
+        }
+
+        Assert.Empty(surfaced);
+    }
+
+    private async Task<AcpClient> CreateInitializedClientAsync(AgentCapabilities? capabilities = null)
+    {
+        var client = new AcpClient(_transportMock.Object, _loggerMock.Object);
+        _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex("initialize"), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((message, _) =>
+            {
+                _sent.Enqueue(message);
+                var request = _parser.ParseRequest(message);
+                RaiseTransportMessage(_parser.SerializeMessage(new JsonRpcResponse(
+                    request.Id,
+                    JsonSerializer.SerializeToElement(
+                        new InitializeResponse(
+                            AcpProtocolVersion.V1,
+                            new AgentInfo("TestAgent", "1.0.0"),
+                            capabilities ?? new AgentCapabilities()),
+                        AcpJsonContext.Default.InitializeResponse))));
+                return Task.FromResult(true);
+            });
+
+        await client.InitializeAsync(new InitializeParams(
+            new ClientInfo("Test", "1.0.0"),
+            new ClientCapabilities())
+        {
+            ProtocolVersion = AcpProtocolVersion.V1
+        });
+
+        return client;
+    }
+
+    /// <summary>
+    /// Accepts the request but never answers it, so it is genuinely in flight when the caller
+    /// cancels.
+    /// </summary>
+    private void SetupSilentSend(string methodPattern)
+        => _transportMock
+            .Setup(t => t.SendMessageAsync(It.IsRegex(methodPattern), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((message, _) =>
+            {
+                _sent.Enqueue(message);
+                return Task.FromResult(true);
+            });
+
+    private void RaiseTransportMessage(string message)
+        => _transportMock.Raise(
+            t => t.MessageReceived += null,
+            new AcpTransportMessageReceivedEventArgs(message));
+
+    private JsonDocument[] SentFrames(string method)
+        => _sent
+            .Select(static message => JsonDocument.Parse(message))
+            .Where(document =>
+                document.RootElement.TryGetProperty("method", out var sentMethod)
+                && string.Equals(sentMethod.GetString(), method, StringComparison.Ordinal))
+            .ToArray();
+
+    private JsonDocument[] SentRequests(string method)
+        => SentFrames(method)
+            .Where(static document => document.RootElement.TryGetProperty("id", out _))
+            .ToArray();
+
+    private JsonDocument[] SentNotifications(string method)
+        => SentFrames(method)
+            .Where(static document => !document.RootElement.TryGetProperty("id", out _))
+            .ToArray();
+
+    private Task WaitForSentMethodAsync(string method)
+        => WaitAsync(() => SentFrames(method).Length > 0, $"a sent '{method}' frame");
+
+    private async Task<JsonDocument> WaitForSentNotificationAsync(string method)
+    {
+        await WaitAsync(() => SentNotifications(method).Length > 0, $"a sent '{method}' notification");
+        return Assert.Single(SentNotifications(method));
+    }
+
+    private Task WaitForLoggedCodeAsync(string code)
+        => WaitAsync(
+            () =>
+            {
+                try
+                {
+                    _loggerMock.Verify(
+                        logger => logger.Log(
+                            It.IsAny<AcpClientLogLevel>(),
+                            code,
+                            It.IsAny<string>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<Exception?>()),
+                        Times.AtLeastOnce);
+                    return true;
+                }
+                catch (MockException)
+                {
+                    return false;
+                }
+            },
+            $"log entry '{code}'");
+
+    private static async Task WaitAsync(Func<bool> condition, string description)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException($"Timed out waiting for {description}.");
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/JsonRpc/JsonRpcErrorCodeTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/JsonRpc/JsonRpcErrorCodeTests.cs
@@ -1,0 +1,66 @@
+using SalmonEgg.Acp.JsonRpc;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.JsonRpc;
+
+/// <summary>
+/// Locks the classification of <c>-32800</c> (Cancelled). ACP lists it alongside the JSON-RPC
+/// standard codes and the ACP extension codes, but it belongs to neither band, so it needs its own
+/// category rather than a widened range.
+/// </summary>
+public sealed class JsonRpcErrorCodeTests
+{
+    [Fact]
+    public void Cancelled_UsesTheCodeTheSpecificationAssigns()
+    {
+        Assert.Equal(-32800, JsonRpcErrorCode.Cancelled);
+    }
+
+    [Fact]
+    public void Cancelled_IsNeitherAStandardNorAnAcpExtensionCode()
+    {
+        // The point of the dedicated predicate: -32800 sits between the two bands, so widening
+        // either one to reach it would also swallow codes no specification has assigned.
+        Assert.False(JsonRpcErrorCode.IsStandardErrorCode(JsonRpcErrorCode.Cancelled));
+        Assert.False(JsonRpcErrorCode.IsAcpErrorCode(JsonRpcErrorCode.Cancelled));
+        Assert.True(JsonRpcErrorCode.IsCancelledErrorCode(JsonRpcErrorCode.Cancelled));
+    }
+
+    [Theory]
+    [InlineData(JsonRpcErrorCode.ParseError)]
+    [InlineData(JsonRpcErrorCode.InternalError)]
+    [InlineData(JsonRpcErrorCode.AuthenticationRequired)]
+    [InlineData(JsonRpcErrorCode.CapabilityNotSupported)]
+    [InlineData(-32799)]
+    [InlineData(-32801)]
+    public void IsCancelledErrorCode_RejectsEveryOtherCode(int code)
+    {
+        Assert.False(JsonRpcErrorCode.IsCancelledErrorCode(code));
+    }
+
+    [Fact]
+    public void GetErrorMessage_ForCancelled_DoesNotFallBackToUnknown()
+    {
+        // The reported symptom: a compliant peer answers -32800 and the client renders
+        // "Unknown error (code: -32800)", which cannot be told apart from a real failure.
+        var message = JsonRpcErrorCode.GetErrorMessage(JsonRpcErrorCode.Cancelled);
+
+        Assert.Equal("Request cancelled", message);
+        Assert.DoesNotContain("Unknown", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonRpcError_ClassifiesCancelledSeparatelyFromBothBands()
+    {
+        var cancelled = new JsonRpcError(
+            JsonRpcErrorCode.Cancelled,
+            JsonRpcErrorCode.GetErrorMessage(JsonRpcErrorCode.Cancelled));
+
+        Assert.True(cancelled.IsCancelled());
+        Assert.False(cancelled.IsStandardError());
+        Assert.False(cancelled.IsAcpError());
+
+        // A neighbouring code must not be mistaken for a cancellation.
+        Assert.False(new JsonRpcError(JsonRpcErrorCode.InternalError, "boom").IsCancelled());
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Protocol/CancelRequestTypesTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Protocol/CancelRequestTypesTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.Protocol;
+
+/// <summary>
+/// Locks the <c>$/cancel_request</c> payload against the ACP <c>CancelRequestNotification</c>
+/// schema, whose only required field is a <c>RequestId</c> — itself a union of <c>null</c>, a
+/// number, and a string. JSON-RPC 2.0 requires the responder to echo the same id back, so every
+/// form has to survive the round trip unchanged.
+/// </summary>
+public sealed class CancelRequestTypesTests
+{
+    [Fact]
+    public void NumericRequestId_RoundTripsAsANumber()
+    {
+        var json = Serialize(new CancelRequestParams(AcpRequestId.FromNumber(42)));
+
+        using var document = JsonDocument.Parse(json);
+        var requestId = document.RootElement.GetProperty("requestId");
+        Assert.Equal(JsonValueKind.Number, requestId.ValueKind);
+        Assert.Equal(42, requestId.GetInt64());
+
+        var roundTripped = Deserialize(json);
+        Assert.Equal(AcpRequestIdKind.Number, roundTripped.RequestId.Kind);
+        Assert.True(roundTripped.RequestId.TryGetNumber(out var value));
+        Assert.Equal(42, value);
+        Assert.Equal(AcpRequestId.FromNumber(42), roundTripped.RequestId);
+    }
+
+    [Fact]
+    public void StringRequestId_RoundTripsAsAStringAndIsNotConfusedWithANumber()
+    {
+        // A string id is legal, and an agent that issues "7" must get "7" back — not 7.
+        var json = Serialize(new CancelRequestParams(AcpRequestId.FromString("7")));
+
+        using var document = JsonDocument.Parse(json);
+        var requestId = document.RootElement.GetProperty("requestId");
+        Assert.Equal(JsonValueKind.String, requestId.ValueKind);
+        Assert.Equal("7", requestId.GetString());
+
+        var roundTripped = Deserialize(json);
+        Assert.Equal(AcpRequestIdKind.String, roundTripped.RequestId.Kind);
+        Assert.True(roundTripped.RequestId.TryGetString(out var text));
+        Assert.Equal("7", text);
+        Assert.NotEqual(AcpRequestId.FromNumber(7), roundTripped.RequestId);
+        Assert.False(roundTripped.RequestId.TryGetNumber(out _));
+    }
+
+    [Fact]
+    public void NullRequestId_RoundTripsAsExplicitNull()
+    {
+        var json = Serialize(new CancelRequestParams(AcpRequestId.Null));
+
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.TryGetProperty("requestId", out var requestId));
+        Assert.Equal(JsonValueKind.Null, requestId.ValueKind);
+
+        Assert.Equal(AcpRequestIdKind.Null, Deserialize(json).RequestId.Kind);
+    }
+
+    [Fact]
+    public void NumericRequestId_BeyondInt64_KeepsItsRawTokenSoTheEchoStillCorrelates()
+    {
+        // Re-encoding through a CLR numeric type would rewrite the token; the peer would then be
+        // unable to match our cancellation against the request it issued.
+        const string Raw = "123456789012345678901234567890";
+        var roundTripped = Deserialize($"{{\"requestId\":{Raw}}}");
+
+        Assert.Equal(AcpRequestIdKind.Number, roundTripped.RequestId.Kind);
+        Assert.False(roundTripped.RequestId.TryGetNumber(out _));
+
+        using var document = JsonDocument.Parse(Serialize(roundTripped));
+        Assert.Equal(Raw, document.RootElement.GetProperty("requestId").GetRawText());
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("{}")]
+    [InlineData("[1]")]
+    public void NonUnionRequestId_RemainsATypeError(string wire)
+    {
+        // Protocol looseness is not extended past what the specification allows: JSON-RPC 2.0
+        // permits exactly null, a number, or a string as an id.
+        Assert.ThrowsAny<JsonException>(() => Deserialize($"{{\"requestId\":{wire}}}"));
+    }
+
+    [Fact]
+    public void Meta_RoundTripsAlongsideTheRequestId()
+    {
+        var json = Serialize(new CancelRequestParams(AcpRequestId.FromNumber(9))
+        {
+            Meta = new Dictionary<string, object?> { ["traceparent"] = "00-abc-def-01" }
+        });
+
+        var roundTripped = Deserialize(json);
+        Assert.NotNull(roundTripped.Meta);
+        Assert.True(roundTripped.Meta!.TryGetValue("traceparent", out var traceparent));
+        Assert.Equal("00-abc-def-01", Assert.IsType<JsonElement>(traceparent).GetString());
+        Assert.Equal(AcpRequestId.FromNumber(9), roundTripped.RequestId);
+    }
+
+    [Theory]
+    [InlineData(1L)]
+    [InlineData((int)2)]
+    [InlineData((short)3)]
+    public void TryFromEnvelopeId_ProjectsLocallyIssuedIntegerIdsOntoTheNumberForm(object envelopeId)
+    {
+        // Locally issued ids are CLR integers while parsed ones are JsonElement; both must land on
+        // the same wire form or the echoed id would not correlate.
+        Assert.True(AcpRequestId.TryFromEnvelopeId(envelopeId, out var requestId));
+        Assert.Equal(AcpRequestIdKind.Number, requestId.Kind);
+        Assert.True(requestId.TryGetNumber(out var value));
+        Assert.Equal(Convert.ToInt64(envelopeId), value);
+    }
+
+    [Fact]
+    public void TryFromEnvelopeId_ProjectsParsedElementsOntoTheSameFormsAsLocalValues()
+    {
+        Assert.True(AcpRequestId.TryFromEnvelopeId(Element("11"), out var number));
+        Assert.Equal(AcpRequestId.FromNumber(11), number);
+
+        Assert.True(AcpRequestId.TryFromEnvelopeId(Element("\"abc\""), out var text));
+        Assert.Equal(AcpRequestId.FromString("abc"), text);
+
+        Assert.True(AcpRequestId.TryFromEnvelopeId(Element("null"), out var missing));
+        Assert.Equal(AcpRequestId.Null, missing);
+
+        Assert.True(AcpRequestId.TryFromEnvelopeId(null, out var nullReference));
+        Assert.Equal(AcpRequestId.Null, nullReference);
+    }
+
+    [Fact]
+    public void TryFromEnvelopeId_RejectsFormsJsonRpcDoesNotAllow()
+    {
+        Assert.False(AcpRequestId.TryFromEnvelopeId(true, out _));
+        Assert.False(AcpRequestId.TryFromEnvelopeId(Element("true"), out _));
+        Assert.False(AcpRequestId.TryFromEnvelopeId(Element("{}"), out _));
+    }
+
+    [Fact]
+    public void Method_IsTheProtocolLevelNotificationName()
+    {
+        // The '$/' prefix is what marks the notification implementation dependent, so the receiver
+        // is free to ignore it; losing the prefix would turn it into an ordinary ACP method.
+        Assert.Equal("$/cancel_request", CancelRequestParams.Method);
+    }
+
+    private static JsonElement Element(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static string Serialize(CancelRequestParams @params)
+        => JsonSerializer.Serialize(@params, AcpJsonContext.Default.CancelRequestParams);
+
+    private static CancelRequestParams Deserialize(string json)
+        => JsonSerializer.Deserialize(json, AcpJsonContext.Default.CancelRequestParams)!;
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCancelRequestFullStackTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCancelRequestFullStackTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Transport;
+
+/// <summary>
+/// Runs the production stdio chain against a real peer process and inspects the peer's stdin log.
+/// This proves the cancellation frame crosses the actual pipe, rather than only reaching a mock
+/// transport in the ACP SDK tests.
+/// </summary>
+public sealed class StdioCancelRequestFullStackTests
+{
+    [Fact]
+    public async Task CallerCancelsDispatchedRequest_SendsMatchingCancelNotificationOverRealStdioPipe()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Uses /bin/sh and mktemp-style POSIX shell syntax.");
+
+        var directory = Path.Combine(Path.GetTempPath(), $"salmon-egg-cancel-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var scriptPath = Path.Combine(directory, "agent.sh");
+        var framesPath = Path.Combine(directory, "received.ndjson");
+        await File.WriteAllTextAsync(scriptPath, BuildAgentScript(framesPath), TestContext.Current.CancellationToken);
+        // Redundant with the skip above at run time, but the platform analyzer cannot see through
+        // Assert.SkipWhen, so the Unix-only call needs a guard it does understand.
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                scriptPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        try
+        {
+            using var transport = new StdioTransport("/bin/sh", [scriptPath]);
+            using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            Assert.True(await transport.ConnectAsync(TestContext.Current.CancellationToken));
+
+            await client.InitializeAsync(
+                new InitializeParams(new ClientInfo("test", "1.0"), new ClientCapabilities())
+                {
+                    ProtocolVersion = AcpProtocolVersion.V1
+                },
+                TestContext.Current.CancellationToken);
+
+            using var cancellation = new CancellationTokenSource();
+            var request = client.CreateSessionAsync(
+                new SessionNewParams(Path.GetFullPath(directory), null),
+                cancellation.Token);
+            await WaitForMethodAsync(framesPath, "session/new");
+            await cancellation.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+            await WaitForMethodAsync(framesPath, CancelRequestParams.Method);
+
+            var frames = await ReadFramesAsync(framesPath);
+            var original = Assert.Single(frames, frame => frame.GetProperty("method").GetString() == "session/new");
+            var cancel = Assert.Single(frames, frame => frame.GetProperty("method").GetString() == CancelRequestParams.Method);
+
+            Assert.False(cancel.TryGetProperty("id", out _));
+            Assert.Equal(
+                original.GetProperty("id").GetRawText(),
+                cancel.GetProperty("params").GetProperty("requestId").GetRawText());
+
+            await transport.DisconnectAsync();
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+
+    private static string BuildAgentScript(string framesPath)
+    {
+        var quotedPath = framesPath.Replace("'", "'\\''", StringComparison.Ordinal);
+        return "#!/bin/sh\n"
+            + "while IFS= read -r frame; do\n"
+            + "  printf '%s\\n' \"$frame\" >> '" + quotedPath + "'\n"
+            + "  case \"$frame\" in\n"
+            + "    *'\"method\":\"initialize\"'*)\n"
+            + "      id=$(printf '%s' \"$frame\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n"
+            + "      printf '{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"protocolVersion\":1,\"agentInfo\":{\"name\":\"test-agent\",\"version\":\"1.0\"},\"agentCapabilities\":{}}}\\n' \"$id\"\n"
+            + "      ;;\n"
+            + "    *'\"method\":\"$/cancel_request\"'*)\n"
+            + "      # Keep the process open until the client tears it down. The production transport\n"
+            + "      # owns cleanup and kills the whole child tree at DisconnectAsync.\n"
+            + "      ;;\n"
+            + "  esac\n"
+            + "done\n";
+    }
+
+    private static async Task WaitForMethodAsync(string framesPath, string method)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(framesPath)
+                && (await File.ReadAllTextAsync(framesPath, TestContext.Current.CancellationToken))
+                    .Contains($"\"method\":\"{method}\"", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(25, TestContext.Current.CancellationToken);
+        }
+
+        throw new TimeoutException($"Timed out waiting for real stdio peer to receive '{method}'.");
+    }
+
+    private static async Task<JsonElement[]> ReadFramesAsync(string framesPath)
+    {
+        var lines = await File.ReadAllLinesAsync(framesPath, TestContext.Current.CancellationToken);
+        var frames = new JsonElement[lines.Length];
+        for (var index = 0; index < lines.Length; index++)
+        {
+            using var document = JsonDocument.Parse(lines[index]);
+            frames[index] = document.RootElement.Clone();
+        }
+
+        return frames;
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/WebSocketCancelRequestFullStackTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/WebSocketCancelRequestFullStackTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Network;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Transport;
+
+/// <summary>
+/// Exercises the complete WebSocket production chain with a real loopback WebSocket server:
+/// socket → network adapter → domain adapter → ACP client. Unlike a mock, the server sees the
+/// actual masked client frames after the WebSocket library has serialized them.
+/// </summary>
+public sealed class WebSocketCancelRequestFullStackTests
+{
+    [Fact]
+    public async Task CallerCancelsDispatchedRequest_SendsMatchingCancelNotificationOverWebSocket()
+    {
+        await using var peer = new CancelRequestWebSocketPeer();
+        using var socket = new WebSocketTransport(Log.Logger, connectTimeout: TimeSpan.FromSeconds(10));
+        using var network = new NetworkTransportAdapter(socket, peer.Url);
+        using var transport = new DomainAcpTransportAdapter(network);
+        using var client = new AcpClient(transport);
+
+        Assert.True(await network.ConnectAsync(TestContext.Current.CancellationToken));
+        await client.InitializeAsync(
+            new InitializeParams(new ClientInfo("test", "1.0"), new ClientCapabilities())
+            {
+                ProtocolVersion = AcpProtocolVersion.V1
+            },
+            TestContext.Current.CancellationToken);
+
+        using var cancellation = new CancellationTokenSource();
+        var request = client.CreateSessionAsync(
+            new SessionNewParams(Path.GetFullPath(Path.GetTempPath()), null),
+            cancellation.Token);
+        await peer.WaitForMethodAsync("session/new", TestContext.Current.CancellationToken);
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+        await peer.WaitForMethodAsync(CancelRequestParams.Method, TestContext.Current.CancellationToken);
+
+        var original = peer.SingleFrame("session/new");
+        var cancel = peer.SingleFrame(CancelRequestParams.Method);
+        Assert.False(cancel.TryGetProperty("id", out _));
+        Assert.Equal(
+            original.GetProperty("id").GetRawText(),
+            cancel.GetProperty("params").GetProperty("requestId").GetRawText());
+
+        await network.DisconnectAsync();
+    }
+
+    private sealed class CancelRequestWebSocketPeer : IAsyncDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly ConcurrentQueue<JsonElement> _frames = new();
+        private readonly TaskCompletionSource _connected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly CancellationTokenSource _stop = new();
+        private readonly Task _serveTask;
+
+        public CancelRequestWebSocketPeer()
+        {
+            var port = ReserveLoopbackPort();
+            Url = $"ws://127.0.0.1:{port}/acp/";
+            _listener.Prefixes.Add($"http://127.0.0.1:{port}/acp/");
+            _listener.Start();
+            _serveTask = ServeAsync();
+        }
+
+        public string Url { get; }
+
+        public async Task WaitForMethodAsync(string method, CancellationToken cancellationToken)
+        {
+            await _connected.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (DateTime.UtcNow < deadline)
+            {
+                foreach (var frame in _frames)
+                {
+                    if (frame.TryGetProperty("method", out var candidate)
+                        && string.Equals(candidate.GetString(), method, StringComparison.Ordinal))
+                    {
+                        return;
+                    }
+                }
+
+                await Task.Delay(20, cancellationToken);
+            }
+
+            throw new TimeoutException($"Timed out waiting for WebSocket peer to receive '{method}'.");
+        }
+
+        public JsonElement SingleFrame(string method)
+        {
+            JsonElement? result = null;
+            foreach (var frame in _frames)
+            {
+                if (frame.TryGetProperty("method", out var candidate)
+                    && string.Equals(candidate.GetString(), method, StringComparison.Ordinal))
+                {
+                    Assert.Null(result);
+                    result = frame;
+                }
+            }
+
+            return Assert.IsType<JsonElement>(result);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _stop.Cancel();
+            _listener.Close();
+            try { await _serveTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+            _stop.Dispose();
+        }
+
+        private async Task ServeAsync()
+        {
+            try
+            {
+                var context = await _listener.GetContextAsync().WaitAsync(_stop.Token).ConfigureAwait(false);
+                Assert.True(context.Request.IsWebSocketRequest);
+                var webSocketContext = await context.AcceptWebSocketAsync(null).ConfigureAwait(false);
+                using var socket = webSocketContext.WebSocket;
+                _connected.TrySetResult();
+                var buffer = new byte[16 * 1024];
+
+                while (!_stop.IsCancellationRequested && socket.State == WebSocketState.Open)
+                {
+                    var received = await socket.ReceiveAsync(buffer, _stop.Token).ConfigureAwait(false);
+                    if (received.MessageType == WebSocketMessageType.Close)
+                    {
+                        return;
+                    }
+
+                    Assert.True(received.EndOfMessage);
+                    var message = Encoding.UTF8.GetString(buffer, 0, received.Count);
+                    using var document = JsonDocument.Parse(message);
+                    var frame = document.RootElement.Clone();
+                    _frames.Enqueue(frame);
+
+                    if (frame.TryGetProperty("method", out var method)
+                        && string.Equals(method.GetString(), "initialize", StringComparison.Ordinal))
+                    {
+                        var id = frame.GetProperty("id").GetRawText();
+                        var response = "{\"jsonrpc\":\"2.0\",\"id\":" + id
+                            + ",\"result\":{\"protocolVersion\":1,\"agentInfo\":{\"name\":\"test-agent\",\"version\":\"1.0\"},\"agentCapabilities\":{}}}";
+                        var bytes = Encoding.UTF8.GetBytes(response);
+                        await socket.SendAsync(bytes, WebSocketMessageType.Text, true, _stop.Token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (HttpListenerException) when (_stop.IsCancellationRequested)
+            {
+            }
+            catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+            {
+            }
+        }
+
+        private static int ReserveLoopbackPort()
+        {
+            using var reservation = new TcpListener(IPAddress.Loopback, 0);
+            reservation.Start();
+            return ((IPEndPoint)reservation.LocalEndpoint).Port;
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpErrorClassifierTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpErrorClassifierTests.cs
@@ -7,6 +7,23 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat;
 
 public sealed class AcpErrorClassifierTests
 {
+    [Fact]
+    public void IsRequestCancelled_WhenCancelledErrorCode_ReturnsTrue()
+    {
+        var ex = new AcpException(JsonRpcErrorCode.Cancelled, "Request cancelled");
+
+        Assert.True(AcpErrorClassifier.IsRequestCancelled(ex));
+    }
+
+    [Theory]
+    [InlineData(JsonRpcErrorCode.InternalError)]
+    [InlineData(JsonRpcErrorCode.PermissionDenied)]
+    [InlineData(JsonRpcErrorCode.ResourceNotFound)]
+    public void IsRequestCancelled_WhenErrorIsNotCancelled_ReturnsFalse(int errorCode)
+    {
+        Assert.False(AcpErrorClassifier.IsRequestCancelled(new AcpException(errorCode, "not cancelled")));
+    }
+
     [Theory]
     [InlineData(JsonRpcErrorCode.ResourceNotFound)]
     public void IsRemoteSessionNotFound_WhenKnownErrorCodes_ReturnsTrue(int errorCode)

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -8290,6 +8290,53 @@ public partial class ChatViewModelTests
     }
 
     [Fact]
+    public async Task SendPromptAsync_WhenPeerSettlesWithCancelledError_ProjectsCancelledTurnWithoutFailure()
+    {
+        var syncContext = new QueueingSynchronizationContext();
+        var commands = new Mock<IAcpConnectionCommands>(MockBehavior.Strict);
+        commands.Setup(x => x.EnsureRemoteSessionAsync(
+                It.IsAny<IAcpChatCoordinatorSink>(),
+                It.IsAny<Func<CancellationToken, Task<bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AcpRemoteSessionResult("remote-1", new SessionNewResponse("remote-1"), false));
+        commands.Setup(x => x.DispatchPromptToRemoteSessionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<IAcpChatCoordinatorSink>(),
+                It.IsAny<Func<CancellationToken, Task<bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, string, string?, IAcpChatCoordinatorSink, Func<CancellationToken, Task<bool>>, CancellationToken>(
+                async (_, _, _, sink, _, cancellationToken) =>
+                {
+                    await sink.NotifyPromptRequestDispatchedAsync(cancellationToken);
+                    throw new AcpException(JsonRpcErrorCode.Cancelled, "Request cancelled");
+                });
+
+        await using var fixture = CreateViewModel(syncContext, acpConnectionCommands: commands.Object);
+        var viewModel = fixture.ViewModel;
+        await AwaitWithSynchronizationContextAsync(syncContext, viewModel.ReplaceChatServiceAsync(CreateConnectedChatService().Object, TestContext.Current.CancellationToken));
+        await fixture.UpdateStateAsync(state => state with
+        {
+            HydratedConversationId = "conv-1",
+            Bindings = ImmutableDictionary<string, ConversationBindingSlice>.Empty
+        });
+        await fixture.DispatchConnectionAsync(new SetConnectionPhaseAction(ConnectionPhase.Connected));
+        await WaitForQueueingPromptReadyAsync(syncContext, fixture, "conv-1", "cancelled by peer");
+
+        await AwaitWithSynchronizationContextAsync(syncContext, viewModel.SendPromptCommand.ExecuteAsync(null));
+        syncContext.RunAll();
+
+        var state = await fixture.GetStateAsync();
+        Assert.Equal(ChatTurnPhase.Cancelled, state.ActiveTurn!.Phase);
+        Assert.True(string.IsNullOrWhiteSpace(state.ActiveTurn.FailureMessage));
+        Assert.False(viewModel.IsTurnFailureVisible);
+        Assert.True(string.IsNullOrWhiteSpace(viewModel.TurnFailureMessage));
+        Assert.True(string.IsNullOrWhiteSpace(viewModel.ErrorMessage));
+        Assert.False(viewModel.ShowTransientNotification);
+    }
+
+    [Fact]
     public async Task CancelPromptCommand_WhenSubmitIsCancelledBeforeDispatch_DoesNotSendPrompt()
     {
         var syncContext = new QueueingSynchronizationContext();


### PR DESCRIPTION
## Summary
- add ACP $/cancel_request modeling with lossless request-id forms
- notify peers when outbound request cancellation races transport writes
- classify peer -32800 responses as cancellation instead of persistent UI failure

## Validation
- SalmonEgg.Acp.Tests: 378 passed
- SalmonEgg.Presentation.Core.Tests: 3291 passed
- SalmonEgg.Infrastructure.Tests: 728 passed, 6 environment/platform skips
- real stdio and WebSocket transports both exercised end to end
- the Unix-only chmod in the new stdio test is guarded for CA1416, which the
  platform analyzer cannot infer from Assert.SkipWhen; reproduced and cleared
  locally with the same `dotnet format --verify-no-changes` the gate runs
- post-rebase builds and diff checks passed

Target branch: develop. Branch is rebased onto the latest origin/develop with a
linear, single-parent history, so it rebase-merges cleanly.