### PR TITLE
fix(start): constrain draft error InfoBar to composer content width

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Start/StartView.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Start/StartView.xaml
@@ -176,6 +176,8 @@
             <InfoBar x:Name="StartDraftErrorInfoBar"
                      Grid.Row="0"
                      Margin="12,0,12,0"
+                     HorizontalAlignment="Center"
+                     MaxWidth="{x:Bind models:UiLayout.ContentMaxWidth, Mode=OneTime}"
                      Severity="Error"
                      IsOpen="{x:Bind ViewModel.HasStartSessionDraftError, Mode=OneWay}"
                      Message="{x:Bind ViewModel.StartSessionDraftErrorMessage, Mode=OneWay}" />


### PR DESCRIPTION
## Summary
- 开始页草稿错误 InfoBar 没有宽度上限,宽窗口下横贯全屏,与下方 `MaxWidth=900` 居中的输入框明显错位
- 给 InfoBar 绑定与 `ChatInputArea` 相同的单一布局事实源 `UiLayout.ContentMaxWidth` 并居中
- VSM 两个高度状态的 Margin(紧凑 12 / 舒适 24)保留,窄窗口行为不变

## Verification
- `net10.0-desktop` 构建通过,0 警告 0 错误
- `x:Bind models:UiLayout.ContentMaxWidth` 写法照抄 `ChatInputArea` 既有先例

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)