### PR TITLE
build(acp): 给版本天花板废弃专属诊断 id 并升级为错误

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,14 @@
     <!-- Suppress SDK preview banner to keep build output clean -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
+    <!-- AGENTS.md requires that production code never reference the modeled-version ceiling
+         (AcpProtocolVersion.Latest / HighestModeled) - only SalmonEgg.Acp itself enables
+         TreatWarningsAsErrors, so without this the rule would be a warning everywhere else and
+         nothing would stop an app project from shipping a reference to a draft ceiling. The id is
+         AcpProtocolVersion.LatestRenamedDiagnosticId; AcpProtocolVersionGateTests asserts the two
+         stay in step, because a mismatch would silently disarm this gate rather than fail. -->
+    <WarningsAsErrors>$(WarningsAsErrors);SEACP001</WarningsAsErrors>
+
     <!-- MinVer 6.0.0 treats an empty MinVerTagPrefix as "ignore every tag", so the v* namespace
          must be declared here. The ACP SDK project overrides it with acp-sdk-v for its own line. -->
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
+++ b/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
@@ -35,8 +35,17 @@ namespace SalmonEgg.Acp.Protocol
         /// <summary>
         /// Deprecated alias for <see cref="HighestModeled"/>.
         /// </summary>
-        [Obsolete(LatestRenamedMessage)]
+        [Obsolete(LatestRenamedMessage, DiagnosticId = LatestRenamedDiagnosticId)]
         public const int Latest = HighestModeled;
+
+        /// <summary>
+        /// Diagnostic id reported when source references <see cref="Latest"/>. A dedicated id is the
+        /// point of this deprecation: CS0618 covers every obsolete member at once, so it can only be
+        /// escalated or suppressed wholesale, while this id lets the repository escalate exactly the
+        /// "production code must not reference the modeled-version ceiling" rule to an error (see
+        /// WarningsAsErrors in Directory.Build.props) without touching any other deprecation.
+        /// </summary>
+        internal const string LatestRenamedDiagnosticId = "SEACP001";
 
         /// <summary>
         /// Obsoletion text for <see cref="Latest"/>. Named so the deprecation contract can be

--- a/tests/SalmonEgg.Acp.Tests/Architecture/AcpProtocolVersionGateTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Architecture/AcpProtocolVersionGateTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using SalmonEgg.Acp.Protocol;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.Architecture;
+
+/// <summary>
+/// Guards the wiring that turns the <see cref="AcpProtocolVersion.Latest"/> deprecation into a
+/// repository-wide error. AGENTS.md requires that production code never reference the
+/// modeled-version ceiling, and only SalmonEgg.Acp itself sets TreatWarningsAsErrors: every other
+/// project would treat a reference to the draft ceiling as a warning. The escalation therefore
+/// lives in Directory.Build.props, keyed by the diagnostic id declared next to the attribute.
+/// </summary>
+public sealed class AcpProtocolVersionGateTests
+{
+    // Scope note: this asserts that the escalation is declared, not that a compilation observes it.
+    // Proving the latter needs a throwaway project that references Latest without suppression, which
+    // belongs to the gate scripts rather than to an in-process test. What it does catch is the
+    // failure mode that would otherwise be silent - renaming the id on one side only, which disarms
+    // the gate without breaking any build.
+    [Fact]
+    public void DirectoryBuildProps_EscalatesTheLatestCeilingDiagnostic()
+    {
+        var props = XDocument.Load(FindRepositoryProps());
+
+        var escalated = props
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "WarningsAsErrors")
+            .SelectMany(static element => element.Value.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            .Select(static id => id.Trim())
+            .ToArray();
+
+        Assert.Contains(AcpProtocolVersion.LatestRenamedDiagnosticId, escalated);
+    }
+
+    private static string FindRepositoryProps()
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "Directory.Build.props"));
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        throw new FileNotFoundException($"Repository Directory.Build.props was not found at {path}.");
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Serialization/AcpJsonContextTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Serialization/AcpJsonContextTests.cs
@@ -256,7 +256,8 @@ public sealed class AcpJsonContextTests
 
     // "Latest" shipped in SalmonEgg.Acp 1.0.0, so package validation forbids removing it: the rename
     // has to keep the old constant as an obsolete alias. Reading it through reflection rather than
-    // source keeps this assertion from tripping the SDK's warnings-as-errors on CS0618.
+    // source keeps this assertion from tripping the deprecation, which Directory.Build.props
+    // escalates to an error repository-wide.
     [Fact]
     public void AcpProtocolVersion_Latest_IsObsoleteAliasOfHighestModeled()
     {
@@ -273,6 +274,12 @@ public sealed class AcpJsonContextTests
         Assert.Equal(AcpProtocolVersion.LatestRenamedMessage, obsolete.Message);
         Assert.Contains(nameof(AcpProtocolVersion.HighestModeled), obsolete.Message, StringComparison.Ordinal);
         Assert.Contains(nameof(AcpProtocolVersion.Default), obsolete.Message, StringComparison.Ordinal);
+
+        // A dedicated diagnostic id is what makes the "production code must not reference the
+        // modeled-version ceiling" rule enforceable on its own: CS0618 would drag every other
+        // deprecation along when escalated. AcpProtocolVersionGateTests asserts the build actually
+        // escalates this id.
+        Assert.Equal(AcpProtocolVersion.LatestRenamedDiagnosticId, obsolete.DiagnosticId);
     }
 
     [Fact]


### PR DESCRIPTION
## 问题

AGENTS.md §11 要求生产代码不得引用版本天花板（`AcpProtocolVersion.Latest` / `HighestModeled`），但这条规则**此前没有门禁**。

`Latest` 上的 `[Obsolete]` 报的是 `CS0618` —— 所有过时成员共用的公共号码。而只有 `SalmonEgg.Acp` 自己开了 `TreatWarningsAsErrors`（`SalmonEgg.Acp.csproj:12`），根 `Directory.Build.props` 没开、`code-quality.yml:114` 也不加 `warnaserror`。所以任何 app 工程引用草案天花板只是一条黄警告，不会红。

想把 `CS0618` 整体升级成错误又不行 —— 会连坐仓库里所有无关的过时成员。

## 改动

给这条废弃一个**专属诊断 id** `SEACP001`（`AcpProtocolVersion.LatestRenamedDiagnosticId`），并在根 `Directory.Build.props` 用 `<WarningsAsErrors>` 精确升级这一个 id。

新增 `AcpProtocolVersionGateTests` 守两处 id 不漂移 —— 单侧改名会**静默解除**门禁而不会让任何构建失败，这是唯一需要断言的失败模式。测试注释里写明了它的作用域：断言"升级已声明"，不断言"某次编译观察到了它"（后者需要一个引用 `Latest` 且不抑制的一次性工程，属门禁脚本而非进程内测试）。

同时扩展既有 `AcpProtocolVersion_Latest_IsObsoleteAliasOfHighestModeled` 断言 `DiagnosticId`。

4 个文件、+26 −2 行，加一个 52 行的新门禁测试。

## 验证

| 项 | 结果 |
|---|---|
| 完整 ACP SDK 门禁 6 步（`run-acp-sdk-gates.sh Release`，`ACP_PACKAGE_BASELINE_VERSION=1.0.0`） | 全绿，exit 0 |
| pack 阶段 ApiCompat 对 1.0.0 基线 | 通过（属性差异不算破坏，`EnableRuleAttributesMustMatch` 默认关闭） |
| `SalmonEgg.Acp.Tests` 全量 | 461 / 0 失败 |
| `dotnet format --verify-no-changes`（SDK + 测试工程） | 均 exit 0 |
| 下游 `SalmonEgg.Application`、`SalmonEgg.Infrastructure` 编译 | Build succeeded，未被新的 `WarningsAsErrors` 误伤 |

**反向验证（三条，都实跑）**

1. 临时往测试工程塞一行不抑制的 `AcpProtocolVersion.Latest` 引用 → `error SEACP001` + `Build FAILED`（探针已删除，未进提交）。证明门禁真有牙。
2. 把 props 里的 id 改成 `SEACP999` → `AcpProtocolVersionGateTests` 转红（`Assert.Contains() Failure`）。
3. 摘掉 `[Obsolete]` 的 `DiagnosticId` → 契约测试转红（`Assert.Equal() Failure`）。

## 范围说明

本 PR **只做**这一件无争议的事。同一轮审查开出的两个高优 issue 都不在此 PR 内：

- **#165** 草案面标记为实验性 + 封堵 `AcpJsonContext` 旁路。有硬时限（打 `acp-sdk-v*` tag 前免费）。它会用 `SEACP002` —— `SEACP001` 已被本 PR 占用。
- **#166** v1 通道泄漏 v2 wire（读路径无闸门 / 四族无写闸门 / structured diff 破坏 round-trip）。

#166 不在此 PR 的原因是它**依赖 #165 里一个尚未决定的子项**：7 个 v2 判别子留在 `[JsonDerivedType]` 还是搬进 `SessionUpdateParamsJsonConverter`。读方向目前**没有任何版本上下文**（`AcpProtocolWriteContext.Enter` 全仓唯一调用点是 `AcpClient.cs:2486`，在写方向的 `ToElement` 里；`FromElement` 是 static 且不带版本），所以修 #166 的第一步是造一个读上下文 —— 而它的形状随那个子项决策二选一，另一种是废码。

## 相关

- issue #149（ACP v2 draft 缺口清账）的「建议 1：把 `Latest` 的语义在命名上说清」由 PR #160 完成；本 PR 补上它缺的门禁。
- AGENTS.md §11「草案协议的生产默认与能力门控」。
