### PR TITLE
fix(transport): preflight the agent command before starting the stdio process

### DIFF
--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
@@ -49,6 +49,14 @@ internal sealed record LauncherInvocation(
     internal bool ResolvedToExistingFile { get; init; }
 
     /// <summary>
+    /// Whether the resolution found the command by searching PATH (as opposed to the command naming
+    /// its own location, or being unlaunchable as given). The preflight reads this to pick its
+    /// message instead of re-inspecting the string for separators — the same drift the existence
+    /// verdict is kept off it for.
+    /// </summary>
+    internal bool SearchedOnPath { get; init; }
+
+    /// <summary>
     /// The directories the resolver searched before giving up. Diagnostics only — never user-facing.
     /// </summary>
     internal IReadOnlyList<string> SearchedDirectories { get; init; } = Array.Empty<string>();
@@ -92,6 +100,7 @@ internal sealed record LauncherInvocation(
                 ResolvedCommand: resolvedCommand)
             {
                 ResolvedToExistingFile = resolution.ResolvedToExistingFile,
+                SearchedOnPath = resolution.SearchedOnPath,
                 SearchedDirectories = resolution.SearchedDirectories,
             };
         }
@@ -99,6 +108,7 @@ internal sealed record LauncherInvocation(
         return new LauncherInvocation(resolvedCommand, trimmedArguments, resolvedCommand)
         {
             ResolvedToExistingFile = resolution.ResolvedToExistingFile,
+            SearchedOnPath = resolution.SearchedOnPath,
             SearchedDirectories = resolution.SearchedDirectories,
         };
     }

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/LauncherInvocation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace SalmonEgg.Infrastructure.Transport;
 
@@ -41,28 +42,87 @@ internal sealed record LauncherInvocation(
         : StringComparison.Ordinal;
 
     /// <summary>
+    /// Whether <see cref="ResolvedCommand"/> named a file that actually existed at resolution time.
+    /// Judged by the same resolver that produced the command, so the preflight and the process start
+    /// can never disagree about what "on PATH" means.
+    /// </summary>
+    internal bool ResolvedToExistingFile { get; init; }
+
+    /// <summary>
+    /// The directories the resolver searched before giving up. Diagnostics only — never user-facing.
+    /// </summary>
+    internal IReadOnlyList<string> SearchedDirectories { get; init; } = Array.Empty<string>();
+
+    /// <summary>
     /// Normalizes <paramref name="command"/> and <paramref name="arguments"/> into something
     /// <c>CreateProcess</c> accepts, resolving the command against PATH and wrapping a batch launcher in
     /// the command interpreter.
     /// </summary>
-    public static LauncherInvocation Create(string? command, IReadOnlyList<string>? arguments)
+    /// <remarks>
+    /// The resolution runs against the PATH the child will actually get: <paramref name="environment"/>
+    /// when the caller configured one (it replaces the inherited block entirely), otherwise the current
+    /// process's. Resolving against anything else would let the preflight clear a command that
+    /// <c>ApplyTo</c> will then fail to launch — or the reverse.
+    /// </remarks>
+    public static LauncherInvocation Create(
+        string? command,
+        IReadOnlyList<string>? arguments,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         var trimmedCommand = (command ?? string.Empty).Trim();
         var trimmedArguments = arguments is null
             ? Array.Empty<string>()
             : arguments.Select(argument => (argument ?? string.Empty).Trim()).ToArray();
 
-        var resolvedCommand = StdioCommandResolver.Resolve(trimmedCommand);
+        var effectivePath = ResolveEffectivePath(environment);
+        var resolution = StdioCommandResolver.TryResolve(
+            trimmedCommand,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            Environment.CurrentDirectory,
+            effectivePath,
+            Environment.GetEnvironmentVariable("PATHEXT"));
+
+        var resolvedCommand = resolution.Command;
 
         if (IsBatchLauncher(resolvedCommand))
         {
             return new LauncherInvocation(
                 FileName: "cmd.exe",
                 Arguments: new[] { "/c", resolvedCommand }.Concat(trimmedArguments).ToArray(),
-                ResolvedCommand: resolvedCommand);
+                ResolvedCommand: resolvedCommand)
+            {
+                ResolvedToExistingFile = resolution.ResolvedToExistingFile,
+                SearchedDirectories = resolution.SearchedDirectories,
+            };
         }
 
-        return new LauncherInvocation(resolvedCommand, trimmedArguments, resolvedCommand);
+        return new LauncherInvocation(resolvedCommand, trimmedArguments, resolvedCommand)
+        {
+            ResolvedToExistingFile = resolution.ResolvedToExistingFile,
+            SearchedDirectories = resolution.SearchedDirectories,
+        };
+    }
+
+    /// <summary>
+    /// The PATH the child will inherit from <paramref name="environment"/> — the configured value in
+    /// full, since ApplyTo only ever prepends to it. Windows environment dictionaries compare keys
+    /// case-insensitively, but this is also built from arbitrary dictionaries, so the lookup stays
+    /// insensitive everywhere.
+    /// </summary>
+    private static string? ResolveEffectivePath(IReadOnlyDictionary<string, string>? environment)
+    {
+        if (environment is not null)
+        {
+            foreach (var key in environment.Keys)
+            {
+                if (string.Equals(key, "PATH", StringComparison.OrdinalIgnoreCase))
+                {
+                    return environment[key];
+                }
+            }
+        }
+
+        return Environment.GetEnvironmentVariable("PATH");
     }
 
     /// <summary>

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandPreflight.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandPreflight.cs
@@ -21,18 +21,15 @@ internal static class StdioCommandPreflight
     /// <see cref="LauncherInvocation.FileName"/>: a batch launcher is wrapped in <c>cmd.exe</c>, which
     /// always exists, so the underlying command is the only thing worth judging.
     /// </remarks>
-    public static string? BuildMissingCommandError(LauncherInvocation invocation, bool isWindows)
+    public static string? BuildMissingCommandError(LauncherInvocation invocation)
     {
         if (invocation.ResolvedToExistingFile)
         {
             return null;
         }
 
-        return HasDirectoryComponent(invocation.ResolvedCommand, isWindows)
-            ? $"The configured agent command '{invocation.ResolvedCommand}' does not exist. Check the path in the agent configuration."
-            : $"Agent command '{invocation.ResolvedCommand}' was not found on PATH. Install the agent or configure the full path to its executable.";
+        return invocation.SearchedOnPath
+            ? $"Agent command '{invocation.ResolvedCommand}' was not found on PATH. Install the agent or configure the full path to its executable."
+            : $"The configured agent command '{invocation.ResolvedCommand}' does not exist. Check the path in the agent configuration.";
     }
-
-    private static bool HasDirectoryComponent(string command, bool isWindows)
-        => command.Contains('/') || (isWindows && command.Contains('\\'));
 }

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandPreflight.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandPreflight.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+
+namespace SalmonEgg.Infrastructure.Transport;
+
+/// <summary>
+/// The preflight that runs before <c>Process.Start</c>: it answers, from the single resolution the
+/// launcher invocation already carries, whether the configured command could even be started — and if
+/// not, says so in words the user can act on instead of forwarding the raw Win32 error ("系统找不到
+/// 指定的文件") that <c>CreateProcess</c> would produce.
+/// </summary>
+internal static class StdioCommandPreflight
+{
+    /// <summary>
+    /// Returns an actionable error message when the invocation's resolved command does not name an
+    /// existing file, or null when the command is startable as resolved. Pure — the existence verdict
+    /// was made by <see cref="StdioCommandResolver"/> at resolution time; nothing is probed here.
+    /// </summary>
+    /// <remarks>
+    /// The verdict is read off <see cref="LauncherInvocation.ResolvedCommand"/>, not
+    /// <see cref="LauncherInvocation.FileName"/>: a batch launcher is wrapped in <c>cmd.exe</c>, which
+    /// always exists, so the underlying command is the only thing worth judging.
+    /// </remarks>
+    public static string? BuildMissingCommandError(LauncherInvocation invocation, bool isWindows)
+    {
+        if (invocation.ResolvedToExistingFile)
+        {
+            return null;
+        }
+
+        return HasDirectoryComponent(invocation.ResolvedCommand, isWindows)
+            ? $"The configured agent command '{invocation.ResolvedCommand}' does not exist. Check the path in the agent configuration."
+            : $"Agent command '{invocation.ResolvedCommand}' was not found on PATH. Install the agent or configure the full path to its executable.";
+    }
+
+    private static bool HasDirectoryComponent(string command, bool isWindows)
+        => command.Contains('/') || (isWindows && command.Contains('\\'));
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandResolver.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandResolver.cs
@@ -5,9 +5,22 @@ using System.Runtime.InteropServices;
 
 namespace SalmonEgg.Infrastructure.Transport;
 
+/// <summary>
+/// One command resolution: what to launch, whether it names a file that exists, whether PATH was
+/// searched to reach that verdict, and where it looked.
+/// </summary>
+/// <param name="Command">The command to launch, resolved exactly as <see cref="StdioCommandResolver.Resolve(string)"/> reports it.</param>
+/// <param name="ResolvedToExistingFile">Whether <paramref name="Command"/> names a file that exists.</param>
+/// <param name="SearchedOnPath">
+/// Whether the command was a name looked up across directories rather than a location given outright.
+/// The resolver already decided this to pick its search strategy, so callers read it here instead of
+/// re-inspecting the string for separators.
+/// </param>
+/// <param name="SearchedDirectories">Where the lookup went. Diagnostics only — never user-facing.</param>
 internal sealed record StdioCommandResolution(
     string Command,
     bool ResolvedToExistingFile,
+    bool SearchedOnPath,
     IReadOnlyList<string> SearchedDirectories);
 
 internal static class StdioCommandResolver
@@ -31,10 +44,10 @@ internal static class StdioCommandResolver
         => TryResolve(command, isWindows, currentDirectory, pathEnvironment, pathExtensions).Command;
 
     /// <summary>
-    /// Resolves a command the same way <see cref="Resolve"/> does, and additionally reports whether
-    /// the resolved command names a file that actually exists, plus the directories that were
-    /// searched. The preflight and the process start must both consume this one resolution — a
-    /// second resolver with different rules is exactly the drift this exists to prevent.
+    /// Resolves a command the same way <see cref="Resolve(string)"/> does, and additionally reports
+    /// whether the resolved command names a file that actually exists. The preflight and the process
+    /// start must both consume this one resolution — a second resolver applying its own rules is
+    /// exactly the drift this exists to prevent.
     /// </summary>
     internal static StdioCommandResolution TryResolve(
         string command,
@@ -42,14 +55,9 @@ internal static class StdioCommandResolver
         string currentDirectory,
         string? pathEnvironment,
         string? pathExtensions)
-    {
-        if (isWindows)
-        {
-            return TryResolveWindows(command, currentDirectory, pathEnvironment, pathExtensions);
-        }
-
-        return TryResolveUnix(command, currentDirectory, pathEnvironment);
-    }
+        => isWindows
+            ? TryResolveWindows(command, currentDirectory, pathEnvironment, pathExtensions)
+            : TryResolveUnix(command, currentDirectory, pathEnvironment);
 
     private static StdioCommandResolution TryResolveWindows(
         string command,
@@ -57,49 +65,46 @@ internal static class StdioCommandResolver
         string? pathEnvironment,
         string? pathExtensions)
     {
-        // An explicit path, an empty command, or a name that already carries an extension is
-        // returned as-is by Resolve; the first two are never launchable as given, and the last one
-        // CreateProcess looks up by its literal name (PATHEXT is not applied), so the literal name
-        // is what existence has to be judged against.
-        if (string.IsNullOrWhiteSpace(command)
-            || command.IndexOfAny(['/', '\\']) >= 0)
+        if (string.IsNullOrWhiteSpace(command))
         {
-            return new StdioCommandResolution(command, File.Exists(Path.Combine(currentDirectory, command)), Array.Empty<string>());
+            return Unlaunchable(command);
         }
 
+        if (command.IndexOfAny(['/', '\\']) >= 0)
+        {
+            return ExplicitLocation(command, currentDirectory);
+        }
+
+        var pathDirectories = SplitDirectories(pathEnvironment, ';');
+        var searched = WithCurrentDirectoryFirst(currentDirectory, pathDirectories);
+
+        // CreateProcess does not apply PATHEXT to a name that already carries an extension, so the
+        // literal name is the only candidate that could launch — and the command stays unchanged,
+        // as it always has.
         if (Path.HasExtension(command))
         {
-            var literalSearch = SearchDirectories(currentDirectory, pathEnvironment, ';');
-            return new StdioCommandResolution(
-                command,
-                File.Exists(Path.Combine(currentDirectory, command)) || FindOnPath(command, literalSearch) is not null,
-                literalSearch);
+            return new StdioCommandResolution(command, Exists(command, searched), SearchedOnPath: true, searched);
         }
-
-        var pathDirectories = (pathEnvironment ?? string.Empty)
-            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        // The current directory is searched first (mirroring CreateProcess), so it leads the trail.
-        var searched = SearchDirectories(currentDirectory, pathEnvironment, ';');
 
         foreach (var extension in ResolveWindowsPathExtensions(pathExtensions))
         {
             var candidate = string.IsNullOrEmpty(extension) ? command : command + extension;
+
+            // The current directory is searched first, and a hit there keeps the relative name: the
+            // child inherits that directory, so the name still resolves, and rewriting it to an
+            // absolute path would change long-standing behaviour for no gain.
             if (File.Exists(Path.Combine(currentDirectory, candidate)))
             {
-                return Found(candidate, searched);
+                return new StdioCommandResolution(candidate, true, SearchedOnPath: true, searched);
             }
 
-            foreach (var directory in pathDirectories)
+            if (Locate(candidate, pathDirectories) is { } located)
             {
-                var candidatePath = Path.Combine(directory, candidate);
-                if (File.Exists(candidatePath))
-                {
-                    return Found(candidatePath, searched);
-                }
+                return new StdioCommandResolution(located, true, SearchedOnPath: true, searched);
             }
         }
 
-        return new StdioCommandResolution(command, false, searched);
+        return new StdioCommandResolution(command, false, SearchedOnPath: true, searched);
     }
 
     private static StdioCommandResolution TryResolveUnix(
@@ -107,45 +112,54 @@ internal static class StdioCommandResolver
         string currentDirectory,
         string? pathEnvironment)
     {
-        // Command is returned unchanged (the OS execvp does the PATH search at start time), but
-        // existence is still reported so the preflight can fail fast with an actionable message.
-        // A relative path is judged against the parent process's current directory: on Unix,
-        // Process.Start execs the file before changing to ProcessStartInfo.WorkingDirectory.
         if (string.IsNullOrWhiteSpace(command))
         {
-            return new StdioCommandResolution(command, false, Array.Empty<string>());
+            return Unlaunchable(command);
         }
 
         if (command.Contains('/'))
         {
-            return new StdioCommandResolution(command, File.Exists(Path.Combine(currentDirectory, command)), Array.Empty<string>());
+            return ExplicitLocation(command, currentDirectory);
         }
 
-        var searched = SearchDirectories(currentDirectory, pathEnvironment, ':');
-        return new StdioCommandResolution(
-            command,
-            File.Exists(Path.Combine(currentDirectory, command)) || FindOnPath(command, searched) is not null,
-            searched);
+        // The command is handed to the OS unchanged — execvp does the PATH search at start time — so
+        // only the existence verdict is added here, over the directories execvp would consult.
+        var searched = WithCurrentDirectoryFirst(currentDirectory, SplitDirectories(pathEnvironment, ':'));
+        return new StdioCommandResolution(command, Exists(command, searched), SearchedOnPath: true, searched);
     }
 
-    private static StdioCommandResolution Found(string resolvedCommand, IReadOnlyList<string> searchedDirectories)
-        => new(resolvedCommand, true, searchedDirectories);
+    /// <summary>A command that names its own location: that one place decides, so nothing is searched.</summary>
+    /// <remarks>
+    /// A relative location is judged against the parent process's current directory rather than the
+    /// configured working directory, because that is where both platforms look: Windows resolves it
+    /// before applying the start info, and on Unix the file is exec'd before the chdir.
+    /// </remarks>
+    private static StdioCommandResolution ExplicitLocation(string command, string currentDirectory)
+        => new(command, File.Exists(Path.Combine(currentDirectory, command)), SearchedOnPath: false, []);
 
-    private static IReadOnlyList<string> SearchDirectories(
+    /// <summary>A command that could never launch as given, so no lookup is attempted.</summary>
+    private static StdioCommandResolution Unlaunchable(string command)
+        => new(command, false, SearchedOnPath: false, []);
+
+    private static string[] SplitDirectories(string? pathEnvironment, char separator)
+        => (pathEnvironment ?? string.Empty)
+            .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static IReadOnlyList<string> WithCurrentDirectoryFirst(
         string currentDirectory,
-        string? pathEnvironment,
-        char separator)
+        IReadOnlyList<string> pathDirectories)
     {
-        var directories = new List<string> { currentDirectory };
-        directories.AddRange(
-            (pathEnvironment ?? string.Empty)
-            .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-        return directories;
+        var searched = new List<string>(pathDirectories.Count + 1) { currentDirectory };
+        searched.AddRange(pathDirectories);
+        return searched;
     }
 
-    private static string? FindOnPath(string command, IReadOnlyList<string> searchedDirectories)
+    private static bool Exists(string command, IReadOnlyList<string> directories)
+        => Locate(command, directories) is not null;
+
+    private static string? Locate(string command, IReadOnlyList<string> directories)
     {
-        foreach (var directory in searchedDirectories)
+        foreach (var directory in directories)
         {
             var candidatePath = Path.Combine(directory, command);
             if (File.Exists(candidatePath))

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandResolver.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioCommandResolver.cs
@@ -5,6 +5,11 @@ using System.Runtime.InteropServices;
 
 namespace SalmonEgg.Infrastructure.Transport;
 
+internal sealed record StdioCommandResolution(
+    string Command,
+    bool ResolvedToExistingFile,
+    IReadOnlyList<string> SearchedDirectories);
+
 internal static class StdioCommandResolver
 {
     private const string DefaultWindowsPathExtensions = ".COM;.EXE;.BAT;.CMD";
@@ -23,28 +28,65 @@ internal static class StdioCommandResolver
         string currentDirectory,
         string? pathEnvironment,
         string? pathExtensions)
+        => TryResolve(command, isWindows, currentDirectory, pathEnvironment, pathExtensions).Command;
+
+    /// <summary>
+    /// Resolves a command the same way <see cref="Resolve"/> does, and additionally reports whether
+    /// the resolved command names a file that actually exists, plus the directories that were
+    /// searched. The preflight and the process start must both consume this one resolution — a
+    /// second resolver with different rules is exactly the drift this exists to prevent.
+    /// </summary>
+    internal static StdioCommandResolution TryResolve(
+        string command,
+        bool isWindows,
+        string currentDirectory,
+        string? pathEnvironment,
+        string? pathExtensions)
     {
-        if (string.IsNullOrWhiteSpace(command)
-            || command.IndexOfAny(['/', '\\']) >= 0
-            || Path.HasExtension(command)
-            || !isWindows)
+        if (isWindows)
         {
-            return command;
+            return TryResolveWindows(command, currentDirectory, pathEnvironment, pathExtensions);
         }
 
-        if (File.Exists(Path.Combine(currentDirectory, command)))
+        return TryResolveUnix(command, currentDirectory, pathEnvironment);
+    }
+
+    private static StdioCommandResolution TryResolveWindows(
+        string command,
+        string currentDirectory,
+        string? pathEnvironment,
+        string? pathExtensions)
+    {
+        // An explicit path, an empty command, or a name that already carries an extension is
+        // returned as-is by Resolve; the first two are never launchable as given, and the last one
+        // CreateProcess looks up by its literal name (PATHEXT is not applied), so the literal name
+        // is what existence has to be judged against.
+        if (string.IsNullOrWhiteSpace(command)
+            || command.IndexOfAny(['/', '\\']) >= 0)
         {
-            return command;
+            return new StdioCommandResolution(command, File.Exists(Path.Combine(currentDirectory, command)), Array.Empty<string>());
+        }
+
+        if (Path.HasExtension(command))
+        {
+            var literalSearch = SearchDirectories(currentDirectory, pathEnvironment, ';');
+            return new StdioCommandResolution(
+                command,
+                File.Exists(Path.Combine(currentDirectory, command)) || FindOnPath(command, literalSearch) is not null,
+                literalSearch);
         }
 
         var pathDirectories = (pathEnvironment ?? string.Empty)
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        // The current directory is searched first (mirroring CreateProcess), so it leads the trail.
+        var searched = SearchDirectories(currentDirectory, pathEnvironment, ';');
+
         foreach (var extension in ResolveWindowsPathExtensions(pathExtensions))
         {
             var candidate = string.IsNullOrEmpty(extension) ? command : command + extension;
             if (File.Exists(Path.Combine(currentDirectory, candidate)))
             {
-                return candidate;
+                return Found(candidate, searched);
             }
 
             foreach (var directory in pathDirectories)
@@ -52,12 +94,67 @@ internal static class StdioCommandResolver
                 var candidatePath = Path.Combine(directory, candidate);
                 if (File.Exists(candidatePath))
                 {
-                    return candidatePath;
+                    return Found(candidatePath, searched);
                 }
             }
         }
 
-        return command;
+        return new StdioCommandResolution(command, false, searched);
+    }
+
+    private static StdioCommandResolution TryResolveUnix(
+        string command,
+        string currentDirectory,
+        string? pathEnvironment)
+    {
+        // Command is returned unchanged (the OS execvp does the PATH search at start time), but
+        // existence is still reported so the preflight can fail fast with an actionable message.
+        // A relative path is judged against the parent process's current directory: on Unix,
+        // Process.Start execs the file before changing to ProcessStartInfo.WorkingDirectory.
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return new StdioCommandResolution(command, false, Array.Empty<string>());
+        }
+
+        if (command.Contains('/'))
+        {
+            return new StdioCommandResolution(command, File.Exists(Path.Combine(currentDirectory, command)), Array.Empty<string>());
+        }
+
+        var searched = SearchDirectories(currentDirectory, pathEnvironment, ':');
+        return new StdioCommandResolution(
+            command,
+            File.Exists(Path.Combine(currentDirectory, command)) || FindOnPath(command, searched) is not null,
+            searched);
+    }
+
+    private static StdioCommandResolution Found(string resolvedCommand, IReadOnlyList<string> searchedDirectories)
+        => new(resolvedCommand, true, searchedDirectories);
+
+    private static IReadOnlyList<string> SearchDirectories(
+        string currentDirectory,
+        string? pathEnvironment,
+        char separator)
+    {
+        var directories = new List<string> { currentDirectory };
+        directories.AddRange(
+            (pathEnvironment ?? string.Empty)
+            .Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        return directories;
+    }
+
+    private static string? FindOnPath(string command, IReadOnlyList<string> searchedDirectories)
+    {
+        foreach (var directory in searchedDirectories)
+        {
+            var candidatePath = Path.Combine(directory, command);
+            if (File.Exists(candidatePath))
+            {
+                return candidatePath;
+            }
+        }
+
+        return null;
     }
 
     private static IEnumerable<string> ResolveWindowsPathExtensions(string? pathExtensions)

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
@@ -140,7 +140,7 @@ namespace SalmonEgg.Infrastructure.Transport
             {
                 // 在启动进程前按同一份解析结果自查：命令根本不存在时，给用户一句能照着做的报错，
                 // 而不是转发 CreateProcess 的原始 Win32 异常。纯只读判定（解析期已判完），不 spawn。
-                if (StdioCommandPreflight.BuildMissingCommandError(_invocation, OperatingSystem.IsWindows()) is { } preflightError)
+                if (StdioCommandPreflight.BuildMissingCommandError(_invocation) is { } preflightError)
                 {
                     _logger.Warning(
                         "Agent command not found during preflight. Command={Command} SearchedDirectories={SearchedDirectories}",

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
@@ -72,12 +72,13 @@ namespace SalmonEgg.Infrastructure.Transport
             IReadOnlyDictionary<string, string>? environment = null)
         {
             // 命令解析、.cmd/.bat 包装与启动器目录上 PATH 都由 LauncherInvocation 统一负责，
-            // 使 ACP 向导的探测/安装与本传输走同一套规则。
-            _invocation = LauncherInvocation.Create(command, args);
+            // 使 ACP 向导的探测/安装与本传输走同一套规则。解析用配置环境覆盖后的生效 PATH，
+            // 与 ApplyTo 写入子进程的执行 PATH 同源，预检结论因此与启动行为一致。
+            _environment = NormalizeEnvironment(environment);
+            _invocation = LauncherInvocation.Create(command, args, _environment);
             _workingDirectory = ResolveWorkingDirectory(_invocation.ResolvedCommand);
 
             _encoding = NormalizeTransportEncoding(encoding ?? Encoding.UTF8);
-            _environment = NormalizeEnvironment(environment);
         }
 
         /// <summary>
@@ -137,6 +138,18 @@ namespace SalmonEgg.Infrastructure.Transport
 
             try
             {
+                // 在启动进程前按同一份解析结果自查：命令根本不存在时，给用户一句能照着做的报错，
+                // 而不是转发 CreateProcess 的原始 Win32 异常。纯只读判定（解析期已判完），不 spawn。
+                if (StdioCommandPreflight.BuildMissingCommandError(_invocation, OperatingSystem.IsWindows()) is { } preflightError)
+                {
+                    _logger.Warning(
+                        "Agent command not found during preflight. Command={Command} SearchedDirectories={SearchedDirectories}",
+                        _invocation.ResolvedCommand,
+                        _invocation.SearchedDirectories);
+                    OnErrorOccurred(new TransportErrorEventArgs(preflightError, kind: TransportErrorKind.ProcessStartFailed));
+                    return false;
+                }
+
                 _readCts = new CancellationTokenSource();
 
                 var processInfo = CreateProcessStartInfo();

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandPreflightTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandPreflightTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Transport;
+
+public sealed class StdioCommandPreflightTests
+{
+    [Fact]
+    public void BuildMissingCommandError_BareNameMiss_SaysNotFoundOnPath()
+    {
+        var invocation = new LauncherInvocation(
+            "absent-agent",
+            [],
+            "absent-agent")
+        {
+            ResolvedToExistingFile = false,
+            SearchedDirectories = ["/usr/bin"],
+        };
+
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false);
+
+        Assert.NotNull(error);
+        Assert.Contains("not found on PATH", error, StringComparison.Ordinal);
+        Assert.Contains("absent-agent", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildMissingCommandError_ExplicitPathMissing_SaysDoesNotExist()
+    {
+        var invocation = new LauncherInvocation(
+            @"C:\tools\absent-agent.exe",
+            [],
+            @"C:\tools\absent-agent.exe")
+        {
+            ResolvedToExistingFile = false,
+        };
+
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: true);
+
+        Assert.NotNull(error);
+        Assert.Contains("does not exist", error, StringComparison.Ordinal);
+        Assert.Contains(@"C:\tools\absent-agent.exe", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildMissingCommandError_NonWindowsExplicitPathMissing_SaysDoesNotExist()
+    {
+        var invocation = new LauncherInvocation(
+            "tools/agent",
+            [],
+            "tools/agent")
+        {
+            ResolvedToExistingFile = false,
+        };
+
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false);
+
+        Assert.NotNull(error);
+        Assert.Contains("does not exist", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildMissingCommandError_ResolvedToExistingFile_ReturnsNull()
+    {
+        var invocation = new LauncherInvocation(
+            "/usr/bin/agent",
+            [],
+            "/usr/bin/agent")
+        {
+            ResolvedToExistingFile = true,
+        };
+
+        Assert.Null(StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false));
+    }
+
+    [Fact]
+    public void BuildMissingCommandError_BatchLauncherWrappedInCmdExe_StillJudgesUnderlyingCommand()
+    {
+        // A .cmd launcher is wrapped as cmd.exe /c, so FileName always exists and must not clear the
+        // check: the batch file the user configured is what is actually missing.
+        var invocation = new LauncherInvocation(
+            "cmd.exe",
+            ["/c", @"C:\tools\absent-agent.cmd"],
+            @"C:\tools\absent-agent.cmd")
+        {
+            ResolvedToExistingFile = false,
+        };
+
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: true);
+
+        Assert.NotNull(error);
+        Assert.Contains("does not exist", error, StringComparison.Ordinal);
+        Assert.Contains(@"C:\tools\absent-agent.cmd", error, StringComparison.Ordinal);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandPreflightTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandPreflightTests.cs
@@ -8,7 +8,7 @@ namespace SalmonEgg.Infrastructure.Tests.Transport;
 public sealed class StdioCommandPreflightTests
 {
     [Fact]
-    public void BuildMissingCommandError_BareNameMiss_SaysNotFoundOnPath()
+    public void BuildMissingCommandError_SearchedOnPath_SaysNotFoundOnPath()
     {
         var invocation = new LauncherInvocation(
             "absent-agent",
@@ -16,10 +16,11 @@ public sealed class StdioCommandPreflightTests
             "absent-agent")
         {
             ResolvedToExistingFile = false,
+            SearchedOnPath = true,
             SearchedDirectories = ["/usr/bin"],
         };
 
-        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false);
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation);
 
         Assert.NotNull(error);
         Assert.Contains("not found on PATH", error, StringComparison.Ordinal);
@@ -27,7 +28,7 @@ public sealed class StdioCommandPreflightTests
     }
 
     [Fact]
-    public void BuildMissingCommandError_ExplicitPathMissing_SaysDoesNotExist()
+    public void BuildMissingCommandError_ExplicitLocation_SaysDoesNotExist()
     {
         var invocation = new LauncherInvocation(
             @"C:\tools\absent-agent.exe",
@@ -37,7 +38,7 @@ public sealed class StdioCommandPreflightTests
             ResolvedToExistingFile = false,
         };
 
-        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: true);
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation);
 
         Assert.NotNull(error);
         Assert.Contains("does not exist", error, StringComparison.Ordinal);
@@ -45,17 +46,20 @@ public sealed class StdioCommandPreflightTests
     }
 
     [Fact]
-    public void BuildMissingCommandError_NonWindowsExplicitPathMissing_SaysDoesNotExist()
+    public void BuildMissingCommandError_UnlaunchableCommand_SaysDoesNotExist()
     {
+        // A blank or otherwise unlaunchable command never went near PATH, so the "install the agent"
+        // advice would be wrong; the location wording is the safer of the two.
         var invocation = new LauncherInvocation(
-            "tools/agent",
+            " ",
             [],
-            "tools/agent")
+            " ")
         {
             ResolvedToExistingFile = false,
+            SearchedOnPath = false,
         };
 
-        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false);
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation);
 
         Assert.NotNull(error);
         Assert.Contains("does not exist", error, StringComparison.Ordinal);
@@ -72,7 +76,7 @@ public sealed class StdioCommandPreflightTests
             ResolvedToExistingFile = true,
         };
 
-        Assert.Null(StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: false));
+        Assert.Null(StdioCommandPreflight.BuildMissingCommandError(invocation));
     }
 
     [Fact]
@@ -88,7 +92,7 @@ public sealed class StdioCommandPreflightTests
             ResolvedToExistingFile = false,
         };
 
-        var error = StdioCommandPreflight.BuildMissingCommandError(invocation, isWindows: true);
+        var error = StdioCommandPreflight.BuildMissingCommandError(invocation);
 
         Assert.NotNull(error);
         Assert.Contains("does not exist", error, StringComparison.Ordinal);

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandResolverTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandResolverTests.cs
@@ -25,6 +25,7 @@ public sealed class StdioCommandResolverTests
 
             Assert.Equal(commandPath, resolution.Command);
             Assert.True(resolution.ResolvedToExistingFile);
+            Assert.True(resolution.SearchedOnPath);
             Assert.Equal([Path.GetTempPath(), commandDirectory], resolution.SearchedDirectories);
         }
         finally
@@ -50,6 +51,7 @@ public sealed class StdioCommandResolverTests
 
             Assert.Equal("absent-agent", resolution.Command);
             Assert.False(resolution.ResolvedToExistingFile);
+            Assert.True(resolution.SearchedOnPath);
             // The trail covers the current directory and every PATH entry, so a log line can say
             // where the name was looked for.
             Assert.Equal([Path.GetTempPath(), first, second], resolution.SearchedDirectories);
@@ -211,6 +213,9 @@ public sealed class StdioCommandResolverTests
 
         Assert.Equal(@"tools\agent.exe", resolution.Command);
         Assert.False(resolution.ResolvedToExistingFile);
+        // An explicit location is judged at that one place — no PATH was searched, so the
+        // preflight must say "does not exist", not "install the agent".
+        Assert.False(resolution.SearchedOnPath);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandResolverTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioCommandResolverTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.IO;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Infrastructure.Tests.Transport;
+
+public sealed class StdioCommandResolverTests
+{
+    [Fact]
+    public void TryResolve_WindowsBareNameHitOnPath_ReportsFound()
+    {
+        var commandDirectory = CreateCommandDirectory();
+        var commandPath = Path.Combine(commandDirectory, "npm.cmd");
+        File.WriteAllText(commandPath, "@echo off");
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "npm",
+                isWindows: true,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: commandDirectory,
+                pathExtensions: ".com;.exe;.cmd");
+
+            Assert.Equal(commandPath, resolution.Command);
+            Assert.True(resolution.ResolvedToExistingFile);
+            Assert.Equal([Path.GetTempPath(), commandDirectory], resolution.SearchedDirectories);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_WindowsBareNameMiss_ReportsNotFoundWithTrail()
+    {
+        var first = CreateCommandDirectory();
+        var second = CreateCommandDirectory();
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "absent-agent",
+                isWindows: true,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: $"{first};{second}",
+                pathExtensions: ".EXE;.CMD");
+
+            Assert.Equal("absent-agent", resolution.Command);
+            Assert.False(resolution.ResolvedToExistingFile);
+            // The trail covers the current directory and every PATH entry, so a log line can say
+            // where the name was looked for.
+            Assert.Equal([Path.GetTempPath(), first, second], resolution.SearchedDirectories);
+        }
+        finally
+        {
+            Directory.Delete(first, recursive: true);
+            Directory.Delete(second, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_WindowsPathextOrdering_DotExeBeforeDotCmd()
+    {
+        var commandDirectory = CreateCommandDirectory();
+        // Both extensions exist; PATHEXT order must decide, not filesystem order. File names are
+        // written in the extension's own case: on a case-sensitive test filesystem that is the only
+        // way to exercise resolution as Windows's case-insensitive File.Exists would see it.
+        File.WriteAllText(Path.Combine(commandDirectory, "agent.EXE"), "exe");
+        File.WriteAllText(Path.Combine(commandDirectory, "agent.CMD"), "@echo off");
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "agent",
+                isWindows: true,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: commandDirectory,
+                pathExtensions: ".EXE;.CMD");
+
+            Assert.Equal(Path.Combine(commandDirectory, "agent.EXE"), resolution.Command);
+            Assert.True(resolution.ResolvedToExistingFile);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_WindowsBareNameWithExtension_SearchesLiteralNameNotPathext()
+    {
+        var commandDirectory = CreateCommandDirectory();
+        // CreateProcess does not apply PATHEXT to a name that already carries an extension: only the
+        // literal file would launch, so only the literal file counts as found. A differently-named
+        // file under the same PATHEXT family must not satisfy the check.
+        File.WriteAllText(Path.Combine(commandDirectory, "agent.cmd"), "@echo off");
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "agent.exe",
+                isWindows: true,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: commandDirectory,
+                pathExtensions: ".EXE;.CMD");
+
+            Assert.Equal("agent.exe", resolution.Command);
+            Assert.False(resolution.ResolvedToExistingFile);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_WindowsBareNameWithExtension_FoundViaLiteralSearch()
+    {
+        var commandDirectory = CreateCommandDirectory();
+        File.WriteAllText(Path.Combine(commandDirectory, "agent.exe"), "exe");
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "agent.exe",
+                isWindows: true,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: commandDirectory,
+                pathExtensions: ".EXE;.CMD");
+
+            Assert.Equal("agent.exe", resolution.Command);
+            Assert.True(resolution.ResolvedToExistingFile);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_NonWindowsBareName_CommandUnchangedButExistenceReported()
+    {
+        var commandDirectory = CreateCommandDirectory();
+        var commandPath = Path.Combine(commandDirectory, "agent-bin");
+        File.WriteAllText(commandPath, "#!/bin/sh\n");
+
+        try
+        {
+            var resolution = StdioCommandResolver.TryResolve(
+                "agent-bin",
+                isWindows: false,
+                currentDirectory: Path.GetTempPath(),
+                pathEnvironment: commandDirectory,
+                pathExtensions: null);
+
+            // Non-Windows resolution still leaves bare commands to the OS PATH lookup; the addition
+            // is the existence verdict, which the preflight reads.
+            Assert.Equal("agent-bin", resolution.Command);
+            Assert.True(resolution.ResolvedToExistingFile);
+            Assert.Equal([Path.GetTempPath(), commandDirectory], resolution.SearchedDirectories);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_NonWindowsBareNameMiss_ReportsNotFound()
+    {
+        var resolution = StdioCommandResolver.TryResolve(
+            "absent-agent",
+            isWindows: false,
+            currentDirectory: Path.GetTempPath(),
+            pathEnvironment: string.Empty,
+            pathExtensions: null);
+
+        Assert.Equal("absent-agent", resolution.Command);
+        Assert.False(resolution.ResolvedToExistingFile);
+    }
+
+    [Theory]
+    [InlineData("/definitely/not/a/real/binary")]
+    [InlineData("./absent-agent")]
+    [InlineData("tools/agent")]
+    public void TryResolve_NonWindowsExplicitPathMissing_ReportsNotFound(string command)
+    {
+        var resolution = StdioCommandResolver.TryResolve(
+            command,
+            isWindows: false,
+            currentDirectory: Path.GetTempPath(),
+            pathEnvironment: null,
+            pathExtensions: null);
+
+        Assert.Equal(command, resolution.Command);
+        Assert.False(resolution.ResolvedToExistingFile);
+    }
+
+    [Fact]
+    public void TryResolve_WindowsExplicitPathMissing_ReportsNotFound()
+    {
+        var resolution = StdioCommandResolver.TryResolve(
+            @"tools\agent.exe",
+            isWindows: true,
+            currentDirectory: Path.GetTempPath(),
+            pathEnvironment: null,
+            pathExtensions: null);
+
+        Assert.Equal(@"tools\agent.exe", resolution.Command);
+        Assert.False(resolution.ResolvedToExistingFile);
+    }
+
+    [Fact]
+    public void TryResolve_EmptyCommand_ReportsNotFound()
+    {
+        var resolution = StdioCommandResolver.TryResolve(
+            "  ",
+            isWindows: true,
+            currentDirectory: Path.GetTempPath(),
+            pathEnvironment: null,
+            pathExtensions: null);
+
+        Assert.Equal("  ", resolution.Command);
+        Assert.False(resolution.ResolvedToExistingFile);
+    }
+
+    private static string CreateCommandDirectory()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "stdio-command-resolver-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioTransportConnectionTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioTransportConnectionTests.cs
@@ -262,6 +262,62 @@ public sealed class StdioTransportConnectionTests
         }
     }
 
+    [Fact]
+    public void Create_WithConfiguredPathOverride_ResolvesAgainstOverrideNotProcessPath()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        // The command exists only in the directory the caller puts on the child's PATH. Resolution
+        // has to run against that effective PATH — against the process PATH it would report missing
+        // and the preflight would refuse to start a command that would actually have worked.
+        var commandDirectory = Path.Combine(Path.GetTempPath(), "stdio-transport-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(commandDirectory);
+        File.WriteAllText(Path.Combine(commandDirectory, "agent.cmd"), "@echo off");
+
+        try
+        {
+            using var transport = new StdioTransport(
+                "agent",
+                [],
+                environment: new Dictionary<string, string> { ["PATH"] = commandDirectory });
+
+            var startInfo = transport.CreateProcessStartInfo();
+
+            Assert.Equal("cmd.exe", startInfo.FileName);
+            Assert.Equal(["/c", Path.Combine(commandDirectory, "agent.cmd")], startInfo.ArgumentList);
+        }
+        finally
+        {
+            Directory.Delete(commandDirectory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("/definitely/not/a/real/binary-", "does not exist")]
+    [InlineData("definitely-not-a-real-agent-command-", "not found on PATH")]
+    public async Task ConnectAsync_WhenCommandMissing_PreflightFailsFast(string commandPrefix, string expectedPhrase)
+    {
+        // The old path forwarded CreateProcess's raw Win32 error ("Unable to start process: ...
+        // 系统找不到指定的文件"). The preflight must answer instead, in words the user can act on,
+        // with the same ProcessStartFailed classification the caller already handles.
+        var command = commandPrefix + Guid.NewGuid().ToString("N");
+        var errors = new List<TransportErrorEventArgs>();
+        using var transport = new StdioTransport(command, []);
+        transport.ErrorOccurred += (_, error) => errors.Add(error);
+
+        var connected = await transport.ConnectAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(connected);
+        var error = Assert.Single(errors);
+        Assert.Equal(TransportErrorKind.ProcessStartFailed, error.Kind);
+        Assert.Contains(expectedPhrase, error.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains(command, error.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unable to start process", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
     private static (string Command, string[] Args) CreateImmediateFailureCommand(string stderrMessage)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
## Summary

Closes #164

When the configured agent command does not resolve to an existing file, `StdioTransport` used to forward CreateProcess's raw Win32 error ("Unable to start process ... The system cannot find the file specified"), which gives the user nothing to act on. The preflight now answers first, from the one resolution the launcher invocation already carries:

- an explicit path that is missing → *"The configured agent command 'X' does not exist. Check the path in the agent configuration."*
- a bare name → *"Agent command 'X' was not found on PATH. Install the agent or configure the full path to its executable."*

The search trail goes to structured logging only, never the user-facing message.

## Design notes

- **Single owner**: the preflight and the process start consume the same resolution — `StdioCommandResolver.TryResolve` now also reports existence (Windows: PATHEXT search plus the literal-name lookup an extension-carrying command gets; Unix: cwd plus `:`-separated PATH, leaving bare names to execvp). No second resolver.
- **Latent inconsistency fixed**: `LauncherInvocation.Create` now resolves against the effective PATH — the configured `StdioEnvironment` override when present — which is the same PATH `ApplyTo` hands the child. A command found only via a configured PATH override no longer risks a false "not found" verdict.
- **Zero intrusion**: no new exception types, no new contracts, no change to the published SDK public surface; the wizard's tri-state probing path is untouched. Errors reuse the existing `TransportErrorKind.ProcessStartFailed` channel.

## Testing

- 17 new tests (`StdioCommandResolverTests`, `StdioCommandPreflightTests`, extended `StdioTransportConnectionTests`); 4 transport test classes 42/42 green; full `SalmonEgg.Infrastructure.Tests` 748 passed / 6 skipped.
- Reverse verification (AGENTS.md): short-circuiting the preflight branch turned 2 tests red; misreporting not-found as found in the resolver turned 3 tests red; both restored to green.
- `dotnet format --verify-no-changes` clean on both touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)