### PR TITLE
feat(chat): register imported remote session cwd as remote directory

### DIFF
--- a/src/SalmonEgg.Presentation.Core/Services/Chat/RemoteDirectoryRegistrar.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/RemoteDirectoryRegistrar.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Presentation.ViewModels.Settings;
+
+namespace SalmonEgg.Presentation.Core.Services.Chat;
+
+/// <summary>
+/// Registers an imported remote session's working directory as a remote-directory project so the
+/// conversation survives restart: project affinity, the navigation project list and recovery all
+/// resolve against <see cref="AgentRemoteDirectories"/>, and an unregistered cwd falls out of the
+/// project tree entirely once the runtime session is gone.
+/// </summary>
+public interface IRemoteDirectoryRegistrar
+{
+    /// <summary>
+    /// Ensures <paramref name="remoteCwd"/> is backed by a configured remote directory and that the
+    /// directory is a navigation project member. Existing entries win: a path that already has a
+    /// directory keeps its id, display name and membership state. Returns the id of the directory
+    /// backing <paramref name="remoteCwd"/>, or null when the path could not be registered.
+    /// </summary>
+    string? EnsureRegistered(string remoteCwd);
+}
+
+/// <inheritdoc />
+public sealed class RemoteDirectoryRegistrar : IRemoteDirectoryRegistrar
+{
+    private readonly AppPreferencesViewModel _preferences;
+
+    public RemoteDirectoryRegistrar(AppPreferencesViewModel preferences)
+    {
+        _preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
+    }
+
+    public string? EnsureRegistered(string remoteCwd)
+    {
+        var normalizedCwd = RemotePathEquivalence.Normalize(remoteCwd);
+        if (string.IsNullOrWhiteSpace(normalizedCwd) || !ProtocolPathRules.IsAbsolutePath(normalizedCwd))
+        {
+            return null;
+        }
+
+        var directories = _preferences.AgentRemoteDirectories;
+        AgentRemoteDirectory? existing = null;
+        for (var i = 0; i < directories.Count; i++)
+        {
+            if (PathsEqual(directories[i]?.RemotePath, normalizedCwd))
+            {
+                existing = directories[i];
+                break;
+            }
+        }
+
+        string directoryId;
+        if (existing is null)
+        {
+            directoryId = Guid.NewGuid().ToString("N");
+            _preferences.AgentRemoteDirectories.Add(new AgentRemoteDirectory
+            {
+                DirectoryId = directoryId,
+                DisplayName = string.Empty,
+                RemotePath = normalizedCwd
+            });
+        }
+        else
+        {
+            directoryId = existing.DirectoryId?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(directoryId))
+            {
+                return null;
+            }
+        }
+
+        if (!_preferences.NavigationRemoteDirectoryIds.Contains(directoryId, StringComparer.Ordinal))
+        {
+            _preferences.NavigationRemoteDirectoryIds.Add(directoryId);
+        }
+
+        return directoryId;
+    }
+
+    private static bool PathsEqual(string? left, string? right) => RemotePathEquivalence.Equals(left, right);
+}

--- a/src/SalmonEgg.Presentation.Core/Services/ProjectAffinity/ProjectAffinityResolver.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/ProjectAffinity/ProjectAffinityResolver.cs
@@ -356,41 +356,10 @@ public sealed class ProjectAffinityResolver : IProjectAffinityResolver
         return path[root.Length] == '/';
     }
 
-    private static string NormalizePath(string? path)
-    {
-        var trimmed = NormalizeToken(path);
-        if (string.IsNullOrWhiteSpace(trimmed))
-        {
-            return string.Empty;
-        }
+    // Delegates keep the call sites unchanged while the algorithm lives in one place.
+    private static string NormalizePath(string? path) => RemotePathEquivalence.Normalize(path);
 
-        var normalized = trimmed.Replace('\\', '/');
-        normalized = normalized.TrimEnd('/');
-        return normalized;
-    }
-
-    private static bool PathsEqual(string left, string right)
-    {
-        var comparison = UsesCaseInsensitivePathSemantics(left) || UsesCaseInsensitivePathSemantics(right)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        return string.Equals(left, right, comparison);
-    }
-
-    private static bool UsesCaseInsensitivePathSemantics(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        return ProtocolPathRules.IsAbsolutePath(path)
-            && (path.StartsWith(@"\\", StringComparison.Ordinal)
-                || (path.Length >= 3
-                    && char.IsLetter(path[0])
-                    && path[1] == ':'
-                    && path[2] == '/'));
-    }
+    private static bool PathsEqual(string left, string right) => RemotePathEquivalence.Equals(left, right);
 
     private static string? NormalizeToken(string? value)
     {

--- a/src/SalmonEgg.Presentation.Core/Services/RemotePathEquivalence.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/RemotePathEquivalence.cs
@@ -1,0 +1,61 @@
+using System;
+using SalmonEgg.Acp.Protocol;
+
+namespace SalmonEgg.Presentation.Core.Services;
+
+/// <summary>
+/// Equivalence semantics for remote agent paths (ACP cwd / additionalDirectories /
+/// AgentRemoteDirectory.RemotePath). Remote paths are compared as forward-slash absolute
+/// strings with trailing separators removed; case-insensitivity applies only where the
+/// path shape carries Windows drive/UNC semantics (see
+/// <see cref="UsesCaseInsensitivePathSemantics"/>). Local filesystem paths must not run
+/// through this type: <see cref="System.IO.Path"/> resolution would rewrite remote POSIX
+/// paths against the local platform.
+/// </summary>
+public static class RemotePathEquivalence
+{
+    /// <summary>
+    /// Normalizes a remote path for comparison and persistence: trimmed, backslashes
+    /// folded to forward slashes, trailing separators removed. Empty input normalizes to
+    /// the empty string.
+    /// </summary>
+    public static string Normalize(string? path)
+    {
+        var trimmed = path?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return string.Empty;
+        }
+
+        return trimmed.Replace('\\', '/').TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Remote-path equality: equal after <see cref="Normalize"/>, case-insensitive only
+    /// when either side carries Windows drive/UNC semantics.
+    /// </summary>
+    public static bool Equals(string? left, string? right)
+    {
+        var normalizedLeft = Normalize(left);
+        var normalizedRight = Normalize(right);
+        var comparison = UsesCaseInsensitivePathSemantics(normalizedLeft) || UsesCaseInsensitivePathSemantics(normalizedRight)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(normalizedLeft, normalizedRight, comparison);
+    }
+
+    private static bool UsesCaseInsensitivePathSemantics(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        return ProtocolPathRules.IsAbsolutePath(path)
+            && (path.StartsWith(@"\\", StringComparison.Ordinal)
+                || (path.Length >= 3
+                    && char.IsLetter(path[0])
+                    && path[1] == ':'
+                    && path[2] == '/'));
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -1275,6 +1275,29 @@ public partial class ChatViewModel
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
+            // The conversation must survive restart on its own, so the cwd has to outlive the
+            // runtime session too: register it as a remote-directory project. Best-effort — a
+            // registration failure must not turn an otherwise successful import into an error.
+            try
+            {
+                var registeredDirectoryId = _remoteDirectoryRegistrar.EnsureRegistered(request.RemoteSessionCwd);
+                if (string.IsNullOrEmpty(registeredDirectoryId))
+                {
+                    Logger.LogWarning(
+                        "Skipped remote directory registration for imported session. remoteSessionId={RemoteSessionId} remoteCwd={RemoteCwd}",
+                        request.RemoteSessionId,
+                        request.RemoteSessionCwd);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Failed to register remote directory for imported session. remoteSessionId={RemoteSessionId} remoteCwd={RemoteCwd}",
+                    request.RemoteSessionId,
+                    request.RemoteSessionCwd);
+            }
+
             return new DiscoverRemoteSessionOpenResult(true, localConversationId, null);
         }
         catch (OperationCanceledException)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -1359,6 +1359,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
     private readonly IAppLanguageService? _languageService;
     private readonly IUiInteractionService? _uiInteractionService;
     private readonly IAiContentReportLauncher? _aiContentReportLauncher;
+    private readonly IRemoteDirectoryRegistrar _remoteDirectoryRegistrar;
 
     public ChatViewModel(
         IChatStore chatStore,
@@ -1400,7 +1401,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         IAppLanguageService? languageService = null,
         IUiInteractionService? uiInteractionService = null,
         IAiContentReportLauncher? aiContentReportLauncher = null,
-        IShellLayoutMetricsSink? shellLayoutMetricsSink = null)
+        IShellLayoutMetricsSink? shellLayoutMetricsSink = null,
+        IRemoteDirectoryRegistrar? remoteDirectoryRegistrar = null)
         : base(logger)
     {
         _chatStore = chatStore ?? throw new ArgumentNullException(nameof(chatStore));
@@ -1412,6 +1414,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         _shellLayoutMetricsSink = shellLayoutMetricsSink;
         _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
         _preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
+        _remoteDirectoryRegistrar = remoteDirectoryRegistrar ?? new RemoteDirectoryRegistrar(preferences);
         _acpProfiles = acpProfiles ?? throw new ArgumentNullException(nameof(acpProfiles));
         _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _miniWindowCoordinator = miniWindowCoordinator ?? throw new ArgumentNullException(nameof(miniWindowCoordinator));

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpConnectionSettingsViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpConnectionSettingsViewModel.cs
@@ -643,40 +643,7 @@ public sealed partial class AcpConnectionSettingsViewModel : ObservableObject, I
         }
     }
 
-    private static bool PathsEqual(string? left, string? right)
-    {
-        var normalizedLeft = NormalizePath(left);
-        var normalizedRight = NormalizePath(right);
-        var comparison = UsesCaseInsensitivePathSemantics(normalizedLeft) || UsesCaseInsensitivePathSemantics(normalizedRight)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        return string.Equals(normalizedLeft, normalizedRight, comparison);
-    }
-
-    private static string NormalizePath(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return string.Empty;
-        }
-
-        return path.Trim().Replace('\\', '/').TrimEnd('/');
-    }
-
-    private static bool UsesCaseInsensitivePathSemantics(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        return ProtocolPathRules.IsAbsolutePath(path)
-            && (path.StartsWith(@"\\", StringComparison.Ordinal)
-                || (path.Length >= 3
-                    && char.IsLetter(path[0])
-                    && path[1] == ':'
-                    && path[2] == '/'));
-    }
+    private static bool PathsEqual(string? left, string? right) => RemotePathEquivalence.Equals(left, right);
 
     private void RefreshRemoteDirectoryCommandStates()
     {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AppPreferencesViewModel.cs
@@ -1152,40 +1152,7 @@ public partial class AppPreferencesViewModel : ObservableObject, IApplicationNot
         return -1;
     }
 
-    private static bool PathsEqual(string? left, string? right)
-    {
-        var normalizedLeft = NormalizePath(left);
-        var normalizedRight = NormalizePath(right);
-        var comparison = UsesCaseInsensitivePathSemantics(normalizedLeft) || UsesCaseInsensitivePathSemantics(normalizedRight)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        return string.Equals(normalizedLeft, normalizedRight, comparison);
-    }
-
-    private static string NormalizePath(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return string.Empty;
-        }
-
-        return path.Trim().Replace('\\', '/').TrimEnd('/');
-    }
-
-    private static bool UsesCaseInsensitivePathSemantics(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        return ProtocolPathRules.IsAbsolutePath(path)
-            && (path.StartsWith(@"\\", StringComparison.Ordinal)
-                || (path.Length >= 3
-                    && char.IsLetter(path[0])
-                    && path[1] == ':'
-                    && path[2] == '/'));
-    }
+    private static bool PathsEqual(string? left, string? right) => RemotePathEquivalence.Equals(left, right);
 
     private static ObservableCollection<AppLanguageOptionViewModel> CreateLanguageOptions()
         => new(AppLanguageCatalog.SupportedOptions.Select(option =>

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -3254,6 +3254,44 @@ public partial class ChatViewModelTests
             snapshot.SessionInfo?.AdditionalDirectories);
         Assert.Equal("remote-session-1", binding?.RemoteSessionId);
         Assert.Equal("profile-1", binding?.BoundProfileId);
+
+        // The import must register the cwd as a remote-directory project so the conversation
+        // survives a restart (issue #176): without it, recovery fails once the runtime session
+        // is gone and the path is unknown to project affinity.
+        var directory = Assert.Single(fixture.Preferences.AgentRemoteDirectories);
+        Assert.Equal("C:/remote/workspace", directory.RemotePath);
+        Assert.Contains(directory.DirectoryId, fixture.Preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public async Task OpenDiscoveredRemoteSessionAsync_ImportingEquivalentCwdTwice_ReusesRegisteredDirectory()
+    {
+        await using var fixture = CreateViewModel();
+        await fixture.Workspace.RestoreAsync(TestContext.Current.CancellationToken);
+        var switcher = (IConversationSessionSwitcher)fixture.ViewModel;
+
+        var first = await switcher.OpenDiscoveredRemoteSessionAsync(
+            new DiscoverRemoteSessionOpenRequest(
+                "remote-session-1",
+                "/home/user/project",
+                "profile-1",
+                "Remote Session",
+                null),
+            TestContext.Current.CancellationToken);
+        var second = await switcher.OpenDiscoveredRemoteSessionAsync(
+            new DiscoverRemoteSessionOpenRequest(
+                "remote-session-2",
+                "/home/user/project/",
+                "profile-1",
+                "Remote Session",
+                null),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(first.Succeeded, first.ErrorMessage);
+        Assert.True(second.Succeeded, second.ErrorMessage);
+        var directory = Assert.Single(fixture.Preferences.AgentRemoteDirectories);
+        Assert.Equal("/home/user/project", directory.RemotePath);
+        Assert.Single(fixture.Preferences.NavigationRemoteDirectoryIds);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Services/Chat/RemoteDirectoryRegistrarTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Services/Chat/RemoteDirectoryRegistrarTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Localization;
+using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+using SalmonEgg.Presentation.Core.Tests.TestDoubles;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.Services;
+using SalmonEgg.Presentation.ViewModels.Settings;
+using Xunit;
+
+namespace SalmonEgg.Presentation.Core.Tests.Services.Chat;
+
+public sealed class RemoteDirectoryRegistrarTests
+{
+    [Fact]
+    public void EnsureRegistered_NewPath_AddsDirectoryAndNavigationMembership()
+    {
+        var preferences = CreatePreferences();
+
+        var directoryId = CreateRegistrar(preferences).EnsureRegistered("/home/user/project-a");
+
+        Assert.False(string.IsNullOrWhiteSpace(directoryId));
+        var directory = Assert.Single(preferences.AgentRemoteDirectories);
+        Assert.Equal(directoryId, directory.DirectoryId);
+        Assert.Equal("/home/user/project-a", directory.RemotePath);
+        Assert.Equal(string.Empty, directory.DisplayName);
+        Assert.Contains(directoryId, preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public void EnsureRegistered_EquivalentPath_ReusesExistingDirectory()
+    {
+        var preferences = CreatePreferences();
+        var existing = new AgentRemoteDirectory
+        {
+            DirectoryId = "existing-id",
+            DisplayName = "Project A",
+            RemotePath = "/home/user/project-a/"
+        };
+        preferences.AgentRemoteDirectories.Add(existing);
+        var directoryCountBefore = preferences.AgentRemoteDirectories.Count;
+
+        var directoryId = CreateRegistrar(preferences).EnsureRegistered("/home/user/project-a");
+
+        Assert.Equal("existing-id", directoryId);
+        Assert.Equal(directoryCountBefore, preferences.AgentRemoteDirectories.Count);
+        Assert.Equal("Project A", preferences.AgentRemoteDirectories.Single().DisplayName);
+        Assert.Contains("existing-id", preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public void EnsureRegistered_ExistingDirectoryNotInNavigation_AddsMembershipOnly()
+    {
+        var preferences = CreatePreferences();
+        preferences.AgentRemoteDirectories.Add(new AgentRemoteDirectory
+        {
+            DirectoryId = "existing-id",
+            DisplayName = "Project A",
+            RemotePath = "/home/user/project-a"
+        });
+
+        var directoryId = CreateRegistrar(preferences).EnsureRegistered("/home/user/project-a");
+
+        Assert.Equal("existing-id", directoryId);
+        Assert.Contains("existing-id", preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public void EnsureRegistered_DuplicateCall_IsIdempotent()
+    {
+        var preferences = CreatePreferences();
+        var registrar = CreateRegistrar(preferences);
+
+        var firstId = registrar.EnsureRegistered("/home/user/project-a");
+        var secondId = registrar.EnsureRegistered("/home/user/project-a");
+
+        Assert.Equal(firstId, secondId);
+        Assert.Single(preferences.AgentRemoteDirectories);
+        Assert.Single(preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public void EnsureRegistered_WindowsPath_CaseInsensitiveMatchReusesExisting()
+    {
+        var preferences = CreatePreferences();
+        preferences.AgentRemoteDirectories.Add(new AgentRemoteDirectory
+        {
+            DirectoryId = "windows-id",
+            RemotePath = "C:/Users/user/project"
+        });
+
+        var directoryId = CreateRegistrar(preferences).EnsureRegistered(@"c:\Users\user\project");
+
+        Assert.Equal("windows-id", directoryId);
+        Assert.Single(preferences.AgentRemoteDirectories);
+    }
+
+    [Fact]
+    public void EnsureRegistered_RelativePath_IsRejected()
+    {
+        var preferences = CreatePreferences();
+
+        var directoryId = CreateRegistrar(preferences).EnsureRegistered("relative/path");
+
+        Assert.Null(directoryId);
+        Assert.Empty(preferences.AgentRemoteDirectories);
+        Assert.Empty(preferences.NavigationRemoteDirectoryIds);
+    }
+
+    [Fact]
+    public void EnsureRegistered_NullOrWhitespace_IsRejected()
+    {
+        var preferences = CreatePreferences();
+        var registrar = CreateRegistrar(preferences);
+
+        Assert.Null(registrar.EnsureRegistered(null!));
+        Assert.Null(registrar.EnsureRegistered("   "));
+        Assert.Empty(preferences.AgentRemoteDirectories);
+    }
+
+    private static RemoteDirectoryRegistrar CreateRegistrar(AppPreferencesViewModel preferences)
+        => new(preferences);
+
+    private static AppPreferencesViewModel CreatePreferences()
+    {
+        var appSettingsService = new Mock<IAppSettingsService>();
+        appSettingsService.Setup(s => s.LoadAsync()).ReturnsAsync(new AppSettings());
+        var startupService = new Mock<IAppStartupService>();
+        startupService.SetupGet(s => s.IsSupported).Returns(false);
+        var languageService = new Mock<IAppLanguageService>();
+        var capabilities = new Mock<IPlatformCapabilityService>();
+        var uiRuntime = new Mock<IUiRuntimeService>();
+        var prefsLogger = new Mock<ILogger<AppPreferencesViewModel>>();
+
+        return new AppPreferencesViewModel(
+            appSettingsService.Object,
+            startupService.Object,
+            languageService.Object,
+            capabilities.Object,
+            uiRuntime.Object,
+            Mock.Of<IUiInteractionService>(),
+            new TestCoreStringLocalizer(),
+            prefsLogger.Object,
+            new ImmediateUiDispatcher(),
+            TestSystemNotificationService.Instance);
+    }
+}


### PR DESCRIPTION
## Problem

An imported remote session only loaded until the app restarted. The cwd lived in the runtime `SessionManager` (pure memory) and in the conversation snapshot, but the session was invisible to project affinity: no `AgentRemoteDirectory` backed the path, so after a restart recovery resolved no remote-directory project and failed with `MissingRemoteSessionCwd`.

Closes #176

## Fix (Option A: register on import)

- New `IRemoteDirectoryRegistrar` (`RemoteDirectoryRegistrar`): on a successful `OpenDiscoveredRemoteSessionAsync`, registers the cwd as an `AgentRemoteDirectory` and adds it to `NavigationRemoteDirectoryIds`.
  - Best-effort: a registration failure is logged and never turns a successful import into an error.
  - Existing entries win: a path that already has a directory keeps its id, display name and navigation-membership state.
  - Equivalent paths dedupe (trailing slash / backslash / Windows case-insensitive semantics).
- Persistence is free: the settings VM's existing `CollectionChanged` → debounced save pipeline picks up the new directory and membership.

## Refactor (dedup while here)

The remote path normalization/equality algorithm existed as four private copies (`ProjectAffinityResolver`, `AppPreferencesViewModel`, `AcpConnectionSettingsViewModel`, and the new registrar). Collapsed into a single shared `RemotePathEquivalence`; the resolvers keep thin delegating helpers so call sites are untouched. Net −33 lines in touched sources.

## Tests

- New `RemoteDirectoryRegistrarTests` (7): register + membership, existing-directory reuse (path equivalence incl. Windows case-insensitivity), membership-only add, idempotent repeat, relative/blank rejection.
- Extended `ChatViewModelTests` import coverage (348 passing): import now asserts the cwd was registered and its directory joined navigation; new test proves importing an equivalent cwd twice reuses one directory.
- `ProjectAffinityResolverTests` + navigation suites re-run green after the dedup; `dotnet format --verify-no-changes` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)