### PR TITLE
fix(gates): repair the WASM smoke gates

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/DiagnosticsSettingsPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/DiagnosticsSettingsPage.xaml
@@ -488,7 +488,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.StatusText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadStatus"
-                                                       AutomationProperties.Name="Diagnostics.GamepadStatus"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.StatusText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -506,7 +506,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.ConnectedGamepadsText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadStandardCount"
-                                                       AutomationProperties.Name="Diagnostics.GamepadStandardCount"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.ConnectedGamepadsText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -524,7 +524,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.ConnectedRawControllersText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadRawCount"
-                                                       AutomationProperties.Name="Diagnostics.GamepadRawCount"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.ConnectedRawControllersText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -542,7 +542,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.InputSourceText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadInputSource"
-                                                       AutomationProperties.Name="Diagnostics.GamepadInputSource"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.InputSourceText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -560,7 +560,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.ActiveInputsText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadActiveInputs"
-                                                       AutomationProperties.Name="Diagnostics.GamepadActiveInputs"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.ActiveInputsText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -578,7 +578,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.ThumbstickText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadThumbstick"
-                                                       AutomationProperties.Name="Diagnostics.GamepadThumbstick"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.ThumbstickText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"/>
                                         </controls:ResponsiveFormRow.Value>
                                     </controls:ResponsiveFormRow>
@@ -596,7 +596,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.StandardGamepadsText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadStandardDetails"
-                                                       AutomationProperties.Name="Diagnostics.GamepadStandardDetails"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.StandardGamepadsText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"
                                                        TextWrapping="WrapWholeWords"/>
                                         </controls:ResponsiveFormRow.Value>
@@ -615,7 +615,7 @@
                                         <controls:ResponsiveFormRow.Value>
                                             <TextBlock Text="{x:Bind ViewModel.GamepadDiagnostics.RawControllersText, Mode=OneWay}"
                                                        AutomationProperties.AutomationId="Diagnostics.GamepadRawDetails"
-                                                       AutomationProperties.Name="Diagnostics.GamepadRawDetails"
+                                                       AutomationProperties.Name="{x:Bind ViewModel.GamepadDiagnostics.RawControllersText, Mode=OneWay}"
                                                        Style="{StaticResource SettingsRowDescriptionTextStyle}"
                                                        TextWrapping="WrapWholeWords"/>
                                         </controls:ResponsiveFormRow.Value>

--- a/scripts/gates/wasm-focus-boundary-smoke.mjs
+++ b/scripts/gates/wasm-focus-boundary-smoke.mjs
@@ -7,6 +7,7 @@ import {
 } from "./wasm-smoke-lib/browser-app.mjs";
 import {
   focusVisibleControl,
+  revealCollapsedSection,
   readControlState,
   scrollToVisibleControl,
   waitForBodyText,
@@ -71,86 +72,13 @@ try {
 
 async function revealGamepadDiagnosticsSection(page) {
   await waitForBodyText(page, diagnosticsPagePattern, "diagnostics settings page before gamepad reveal");
-
-  const headerTargets = {
-    labels: ["Gamepad input", "手柄输入", "Compatibility monitor", "兼容性监测"],
-    automationIds: ["Diagnostics.GamepadMonitorHeader"]
-  };
-
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    const state = await readControlState(page, gamepadStart);
-    if (state.found) {
-      return;
-    }
-
-    // Uno Expander does not reliably expand from synthetic element.click() in
-    // BrowserWasm. Use a real Playwright mouse click on the Gamepad expander
-    // toggle (or the nearest ExpanderToggleButton whose text mentions gamepad).
-    const togglePoint = await page.evaluate(() => {
-      const normalize = value => (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-      // Fallback rectangle scanner: match the id contract, not the name. These buttons carry no
-      // AutomationProperties.Name, so their aria-label only *coincidentally* equals the automation
-      // id (the nameless fallback); xamlautomationid keeps working whether or not a name is added.
-      const start = document.querySelector('[xamlautomationid="Diagnostics.GamepadStart"]');
-      const expander =
-        start?.closest(".uno-expander")
-        ?? start?.closest("[class*='Expander']")
-        ?? start?.closest("details")
-        ?? null;
-      const ownedToggle =
-        expander?.querySelector('[xamlautomationid="ExpanderToggleButton"], button, [role="button"], .uno-expanderheader, summary')
-        ?? null;
-      if (ownedToggle) {
-        const rect = ownedToggle.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-          return {
-            x: rect.left + rect.width / 2,
-            y: rect.top + rect.height / 2,
-            source: "owned-toggle"
-          };
-        }
-      }
-
-      const toggles = Array.from(
-        document.querySelectorAll('[xamlautomationid="ExpanderToggleButton"], button, [role="button"], summary'));
-      for (const toggle of toggles) {
-        const text = normalize(toggle.textContent);
-        if (text.includes("gamepad") || text.includes("手柄") || text.includes("compatibility monitor") || text.includes("兼容性监测")) {
-          const rect = toggle.getBoundingClientRect();
-          if (rect.width > 0 && rect.height > 0
-            && rect.left >= -1
-            && rect.top >= -1
-            && rect.left <= innerWidth
-            && rect.top <= innerHeight) {
-            return {
-              x: rect.left + rect.width / 2,
-              y: rect.top + rect.height / 2,
-              source: "text-toggle"
-            };
-          }
-        }
-      }
-
-      return null;
-    });
-
-    if (togglePoint) {
-      await page.mouse.click(togglePoint.x, togglePoint.y);
-      await page.waitForTimeout(500);
-      const afterToggle = await readControlState(page, gamepadStart);
-      if (afterToggle.found) {
-        return;
-      }
-    }
-
-    await scrollToVisibleControl(page, headerTargets);
-    await scrollToVisibleControl(page, gamepadStart);
-    await page.mouse.wheel(0, 700);
-    await page.waitForTimeout(300);
-  }
-
-  const state = await readControlState(page, gamepadStart);
-  throw new Error(`Diagnostics gamepad section was not reachable in BrowserWasm. State=${JSON.stringify(state)}`);
+  await revealCollapsedSection(
+    page,
+    // The Expander header button, matched by the name a screen reader announces. Its automation id
+    // belongs to the header content inside it, which is a 0x0 group that cannot be toggled.
+    { labels: ["Gamepad input", "手柄输入"], automationIds: [] },
+    gamepadStart,
+    "gamepad diagnostics section");
 }
 
 

--- a/scripts/gates/wasm-gamepad-boundary-smoke.mjs
+++ b/scripts/gates/wasm-gamepad-boundary-smoke.mjs
@@ -7,6 +7,7 @@ import {
 } from "./wasm-smoke-lib/browser-app.mjs";
 import {
   clickVisibleControl,
+  revealCollapsedSection,
   readControlState,
   scrollToVisibleControl,
   waitForBodyText,
@@ -587,93 +588,47 @@ async function expectControlText(page, options, pattern, label) {
   return state;
 }
 
+// Read the value off the field's own node. Skia's semantic tree is flat - the value is not a child of
+// the node carrying the automation id - so the value has to be on that node itself, which is what the
+// accessible name is for: these fields now bind their name to the text they render, so a screen reader
+// and this check read the same thing. The old version hunted for a laid-out leaf node containing the
+// text, which could not work, because value nodes are not laid out.
 async function waitForControlText(page, options, pattern, label, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
   let lastState = null;
 
   while (Date.now() < deadline) {
-    await scrollToVisibleControl(page, options, 2_000).catch(() => false);
     lastState = await readControlState(page, options);
-    const text = (lastState?.text || lastState?.aria || "").trim();
+    const text = (lastState?.aria || lastState?.text || "").trim();
     if (lastState?.found && pattern.test(text)) {
       return lastState;
     }
 
-    // BrowserWasm TextBlocks often keep AutomationId off the DOM (no aria-label).
-    // Fall back to leaf text in the expanded Gamepad section for diagnostics projection.
-    // Do not require the leaf to already be in the viewport; scroll it into view first.
-    const fallback = await page.evaluate(({ patternSource, flags }) => {
-      const re = new RegExp(patternSource, flags);
-      const isLaidOut = element => {
-        const rect = element.getBoundingClientRect();
-        const style = getComputedStyle(element);
-        return rect.width > 0
-          && rect.height > 0
-          && style.display !== "none"
-          && style.visibility !== "hidden"
-          && Number(style.opacity || "1") > 0;
-      };
-
-      const start = document.querySelector('[xamlautomationid="Diagnostics.GamepadStart"]');
-      const scope =
-        start?.closest(".uno-expander")
-        ?? start?.closest("[class*='Expander']")
-        ?? document.body;
-      const leaves = Array.from(scope.querySelectorAll("*"))
-        .filter(element => element.children.length === 0)
-        .filter(isLaidOut);
-
-      for (const element of leaves) {
-        const text = (element.textContent || "").replace(/\s+/g, " ").trim();
-        if (!text || !re.test(text)) {
-          continue;
-        }
-
-        element.scrollIntoView({ block: "center", inline: "nearest" });
-        const rect = element.getBoundingClientRect();
-        return {
-          found: true,
-          enabled: true,
-          text,
-          aria: element.getAttribute("aria-label") || "",
-          x: rect.left + rect.width / 2,
-          y: rect.top + rect.height / 2,
-          via: "leaf-text-fallback"
-        };
-      }
-
-      return { found: false, enabled: false };
-    }, { patternSource: pattern.source, flags: pattern.flags });
-
-    if (fallback?.found) {
-      return fallback;
-    }
-
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(200);
   }
 
   throw new Error(`Timed out waiting for ${label}. State=${JSON.stringify(lastState)}`);
 }
 
 async function refreshGamepadDiagnostics(page, label) {
-  // Real Playwright click by id contract (xamlautomationid), not by name: this button carries no
-  // AutomationProperties.Name, so its aria-label only coincidentally equals the automation id.
-  const refresh = page.locator('[xamlautomationid="Diagnostics.GamepadRefresh"]:visible').first();
-  await refresh.scrollIntoViewIfNeeded({ timeout: 15_000 });
-  await refresh.click({ timeout: 15_000 });
-  await waitForRefreshCompletion(refresh, label, 15_000);
+  // Semantic activation, measured against the effect: with a gamepad injected, activating this way
+  // moves the reported count from 0 to 1, while a trusted pointer at the button's own centre leaves it
+  // at 0 - the click never reaches the command even though the rect is real. A locator click cannot
+  // work either (the node has pointer-events: none, so actionability never resolves). Which route
+  // reaches a given control is not something to assume from the others; it has to be observed.
+  await clickVisibleControl(page, gamepadRefresh);
+  await waitForRefreshCompletion(page, label, 15_000);
 }
 
-async function waitForRefreshCompletion(refresh, label, timeoutMs) {
+async function waitForRefreshCompletion(page, label, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   let lastState = null;
   let sawDisabled = false;
   let consecutiveEnabledReadings = 0;
 
   while (Date.now() < deadline) {
-    const found = await refresh.count() > 0;
-    const enabled = found && await refresh.isEnabled();
-    lastState = { found, enabled };
+    const state = await readControlState(page, gamepadRefresh);
+    lastState = { found: state.found, enabled: state.enabled };
     if (lastState?.found && !lastState.enabled) {
       sawDisabled = true;
       consecutiveEnabledReadings = 0;
@@ -707,86 +662,11 @@ async function setInjectedGamepadButtons(page, pressedButtons) {
 
 async function revealGamepadDiagnosticsSection(page) {
   await waitForBodyText(page, diagnosticsPagePattern, "diagnostics settings page before gamepad reveal");
-
-  const headerTargets = {
-    labels: ["Gamepad input", "手柄输入", "Compatibility monitor", "兼容性监测"],
-    automationIds: ["Diagnostics.GamepadMonitorHeader"]
-  };
-
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    const state = await readControlState(page, gamepadStart);
-    if (state.found) {
-      return;
-    }
-
-    // The section hides behind an Expander, whose header is a ToggleButton; in the semantic DOM that
-    // maps to a node whose click the peer programs as Toggle, so semantic activation is the primary
-    // route. An earlier DOM-patching harness measured unreliable expansion from synthetic clicks and
-    // fell back to a real Playwright mouse click; that measurement predates the semantic activation
-    // contract, so the mouse click stays only as the fallback until CI confirms the primary route.
-    try {
-      await clickVisibleControl(page, headerTargets);
-    } catch {
-      const togglePoint = await page.evaluate(() => {
-        const normalize = value => (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-        const start = document.querySelector('[xamlautomationid="Diagnostics.GamepadStart"]');
-        const expander =
-          start?.closest(".uno-expander")
-          ?? start?.closest("[class*='Expander']")
-          ?? start?.closest("details")
-          ?? null;
-        const ownedToggle =
-          expander?.querySelector('[xamlautomationid="ExpanderToggleButton"], button, [role="button"], .uno-expanderheader, summary')
-          ?? null;
-        if (ownedToggle) {
-          const rect = ownedToggle.getBoundingClientRect();
-          if (rect.width > 0 && rect.height > 0) {
-            return {
-              x: rect.left + rect.width / 2,
-              y: rect.top + rect.height / 2,
-              source: "owned-toggle"
-            };
-          }
-        }
-
-        const toggles = Array.from(
-          document.querySelectorAll('[xamlautomationid="ExpanderToggleButton"], button, [role="button"], summary'));
-        for (const toggle of toggles) {
-          const text = normalize(toggle.textContent);
-          if (text.includes("gamepad") || text.includes("手柄") || text.includes("compatibility monitor") || text.includes("兼容性监测")) {
-            const rect = toggle.getBoundingClientRect();
-            if (rect.width > 0 && rect.height > 0
-              && rect.left >= -1
-              && rect.top >= -1
-              && rect.left <= innerWidth
-              && rect.top <= innerHeight) {
-              return {
-                x: rect.left + rect.width / 2,
-                y: rect.top + rect.height / 2,
-                source: "text-toggle"
-              };
-            }
-          }
-        }
-
-        return null;
-      });
-
-      if (togglePoint) {
-        await page.mouse.click(togglePoint.x, togglePoint.y);
-      }
-    }
-
-    await page.waitForTimeout(500);
-    if ((await readControlState(page, gamepadStart)).found) {
-      return;
-    }
-
-    await scrollToVisibleControl(page, gamepadStart);
-    await page.mouse.wheel(0, 700);
-    await page.waitForTimeout(300);
-  }
-
-  const state = await readControlState(page, gamepadStart);
-  throw new Error(`Diagnostics gamepad section was not reachable in BrowserWasm. State=${JSON.stringify(state)}`);
+  await revealCollapsedSection(
+    page,
+    // The Expander header button, matched by the name a screen reader announces. Its automation id
+    // belongs to the header content inside it, which is a 0x0 group that cannot be toggled.
+    { labels: ["Gamepad input", "手柄输入"], automationIds: [] },
+    gamepadStart,
+    "gamepad diagnostics section");
 }

--- a/scripts/gates/wasm-settings-persistence-smoke.mjs
+++ b/scripts/gates/wasm-settings-persistence-smoke.mjs
@@ -18,6 +18,7 @@ import {
   selectComboBoxItem,
   expectComboBoxSelectionText,
   clickVisibleControl,
+  countVisibleControls,
   waitForControlState,
   scrollToVisibleControl,
   typeIntoVisibleTextField,
@@ -60,7 +61,10 @@ const sections = {
   },
   mcp: {
     target: { labels: ["MCP"], automationIds: ["SettingsNav.Mcp"] },
-    bodyPattern: /Service configuration|服务配置|Local services use stdio|本地服务使用 stdio|New|新建/,
+    // "New" used to be in this alternation, and it matches the navigation shell itself, so the
+    // arrival check passed while the page had not changed at all - every later step then ran against
+    // whichever section was still showing. Pinned to copy only this page renders.
+    bodyPattern: /Enable MCP services as needed|按需启用 MCP 服务|Service configuration|服务配置/,
     label: "MCP settings page"
   }
 };
@@ -78,6 +82,11 @@ const controls = {
   mcpServerEnabled: { labels: ["启用", "Enabled"], automationIds: ["Mcp.Server.Enabled"] }
 };
 
+const mcpEditorPanel = { labels: [], automationIds: ["Mcp.Editor.Panel"] };
+const mcpAddServerControl = {
+  labels: ["新建", "New"],
+  automationIds: ["Mcp.AddServer"]
+};
 const dataStorageCacheRetentionControl = {
   labels: ["缓存保留天数", "Cache retention (days)"],
   automationIds: ["DataStorage.CacheRetention"]
@@ -343,12 +352,19 @@ async function changeMcpSettings(page) {
     sections.mcp.target,
     sections.mcp.bodyPattern,
     sections.mcp.label);
-  // Locator actionability waits for AddServerCommand to re-enable after the page's async load.
-  const addServer = page.locator('[aria-label="Mcp.AddServer"]:visible').first();
-  await addServer.click({ timeout: 30_000 });
-  const editorClose = page.locator('[aria-label="Mcp.Editor.Close"]:visible').first();
-  await editorClose.waitFor({ state: "visible", timeout: 10_000 });
-  await waitForBodyText(page, /Launch command|启动命令/, "MCP server editor");
+  // The page's own affordance is the arrival proof that cannot be satisfied by the shell's text.
+  await waitForControlState(page, mcpAddServerControl, "MCP page");
+  // Matched through the semantic tree by automation id: the accessible name is the localized button
+  // text ("New"), so a locator keyed on the id as an aria-label matches nothing.
+  //
+  // Retried against the editor appearing rather than against the click's own return value. The
+  // page's semantic nodes show up before its layout and ViewModel are ready - the button is briefly
+  // reported at 16x6 in the top-left corner - and a command that is not ready yet drops the
+  // activation without the node ever reporting itself disabled, so the click "succeeds" and nothing
+  // opens. Pressing again is what a user does, and the editor becoming visible is the only honest
+  // proof it worked: its field labels reach the DOM solely as the inputs' accessible names, never as
+  // text, so no body-text wait can stand in for it on Skia.
+  await openMcpServerEditor(page);
   await verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, "MCP server editor");
   await typeIntoVisibleTextField(
     page,
@@ -358,15 +374,29 @@ async function changeMcpSettings(page) {
   // Uno WASM does not activate this bound command through locator.click(), so use the proven control helper.
   await scrollToVisibleControl(page, { labels: ["保存", "Save"], automationIds: ["Mcp.SaveServer"] });
   await clickVisibleControl(page, { labels: ["保存", "Save"], automationIds: ["Mcp.SaveServer"] });
-  const savedServerToggles = page.locator('[aria-label="Mcp.Server.Enabled"]:visible');
-  await savedServerToggles.first().waitFor({ state: "visible", timeout: 30_000 });
-  const savedServerToggleCount = await savedServerToggles.count();
-  if (savedServerToggleCount !== 1) {
-    throw new Error(`Expected one saved MCP server row, found ${savedServerToggleCount}.`);
+  // Saving must add exactly one row - a duplicate would mean the editor saved twice, which the row
+  // count is the only way to notice. Counted in the semantic tree for the same reason as above.
+  await waitForControlState(page, controls.mcpServerEnabled, "saved MCP server row");
+  const savedServerRows = await countVisibleControls(page, controls.mcpServerEnabled);
+  if (savedServerRows !== 1) {
+    throw new Error(`Expected one saved MCP server row, found ${savedServerRows}.`);
   }
   await waitForBodyText(page, /new-mcp-server/, "saved MCP server");
   await setToggleSwitchValue(page, controls.mcpServerEnabled, false, "MCP server enabled");
   await verifyMcpSettings(page, "after edit");
+}
+
+async function openMcpServerEditor(page) {
+  const mcpEditorAttempts = 3;
+  for (let attempt = 1; attempt <= mcpEditorAttempts; attempt += 1) {
+    await clickVisibleControl(page, mcpAddServerControl);
+    if (await scrollToVisibleControl(page, mcpEditorPanel, 8_000)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    `The MCP server editor did not open after ${mcpEditorAttempts} activations of the New affordance.`);
 }
 
 async function verifyMcpSettings(page, suffix = "") {
@@ -379,9 +409,20 @@ async function verifyMcpSettings(page, suffix = "") {
   // while the page's async load is still in flight. That load clears the row collection before refilling
   // it, so the server name is briefly absent from the body text. Wait for the row control itself, the way
   // the save path above does, before asserting on text.
+  await waitForControlState(page, mcpAddServerControl, `MCP page ${suffix}`.trim());
   await waitForControlState(page, controls.mcpServerEnabled, `MCP server row control ${suffix}`.trim());
   await waitForBodyText(page, /new-mcp-server/, `MCP server row ${suffix}`.trim());
-  await expectToggleSwitchValue(page, controls.mcpServerEnabled, false, `MCP server enabled ${suffix}`.trim());
+  try {
+    await expectToggleSwitchValue(page, controls.mcpServerEnabled, false, `MCP server enabled ${suffix}`.trim());
+  } catch (error) {
+    // A wrong toggle state is ambiguous on its own: it can mean the change was never persisted, or
+    // that more than one row is present and the first one is a different server. Name which.
+    const rows = await countVisibleControls(page, controls.mcpServerEnabled);
+    const file = await readLocalTextFile(page, mcpSettingsPath);
+    throw new Error(
+      `${error.message} Rows=${rows} McpYaml=${JSON.stringify(file)}`,
+      { cause: error });
+  }
 }
 
 async function verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, label, options = {}) {

--- a/scripts/gates/wasm-settings-persistence-smoke.mjs
+++ b/scripts/gates/wasm-settings-persistence-smoke.mjs
@@ -16,11 +16,9 @@ import {
   expectControlEnabledState,
   selectComboBoxItem,
   expectComboBoxSelectionText,
-  clickVisibleNavigationTargetUntilBodyText,
   clickVisibleControl,
   waitForControlState,
   scrollToVisibleControl,
-  typeIntoAutomationTextBox,
   typeIntoVisibleTextField,
   waitForBodyText,
   readLocalTextFile
@@ -82,10 +80,6 @@ const controls = {
 const dataStorageCacheRetentionControl = {
   labels: ["缓存保留天数", "Cache retention (days)"],
   automationIds: ["DataStorage.CacheRetention"]
-};
-const startNavigationTarget = {
-  labels: ["开始", "Start"],
-  automationIds: ["MainNav.Start"]
 };
 const browser = await chromium.launch({ headless: true });
 
@@ -206,7 +200,10 @@ async function verifyLanguageSelection(page, suffix = "") {
 }
 
 async function changeAppearanceSettings(page) {
-  await verifyStartComposerTextColorTracksAppearanceTheme(page);
+  // Composer text color on Skia is painted into a canvas: the semantic tree mirrors
+  // structure, not styling, so no DOM-observable color assertion can exist here.
+  // Theme behavior is covered by the persisted selection below (combo text plus the
+  // "theme: Dark" yaml snapshot checked later in this smoke).
   await navigateToSettingsSection(
     page,
     sections.appearance.target,
@@ -216,105 +213,6 @@ async function changeAppearanceSettings(page) {
   await setToggleSwitchValue(page, controls.appearanceAnimation, false, "animations");
   await selectComboBoxItem(page, "Appearance.Backdrop", ["Acrylic"], { keyboardSelectVisibleItem: true });
   await verifyAppearanceSettings(page, "after edit");
-}
-
-async function verifyStartComposerTextColorTracksAppearanceTheme(page) {
-  await selectAppearanceTheme(page, ["浅色", "Light"], "light");
-  const lightProjection = await readStartPromptTextProjection(page, "light");
-
-  await selectAppearanceTheme(page, ["深色", "Dark"], "dark");
-  const darkProjection = await waitForStartPromptTextColorChange(page, lightProjection.color, "dark");
-
-  const lightColor = parseCssColor(lightProjection.color);
-  const darkColor = parseCssColor(darkProjection.color);
-  const lightLuminance = relativeLuminance(lightColor);
-  const darkLuminance = relativeLuminance(darkColor);
-  const distance = colorDistance(lightColor, darkColor);
-
-  if (distance < 30 || darkLuminance <= lightLuminance + 40) {
-    throw new Error(
-      `Start prompt text color did not track the appearance theme. `
-      + `Light=${JSON.stringify(lightProjection)} Dark=${JSON.stringify(darkProjection)} `
-      + `Distance=${distance.toFixed(2)} LightLuminance=${lightLuminance.toFixed(2)} DarkLuminance=${darkLuminance.toFixed(2)}`);
-  }
-}
-
-async function selectAppearanceTheme(page, visibleNames, label) {
-  await navigateToSettingsSection(
-    page,
-    sections.appearance.target,
-    sections.appearance.bodyPattern,
-    `appearance settings page for ${label} theme`);
-  await selectComboBoxItem(page, "Appearance.Theme", visibleNames, { keyboardSelectVisibleItem: true });
-}
-
-async function waitForStartPromptTextColorChange(page, previousColor, label) {
-  const deadline = Date.now() + 10_000;
-  let projection = null;
-
-  while (Date.now() < deadline) {
-    projection = await readStartPromptTextProjection(page, label);
-    if (projection.color !== previousColor) {
-      return projection;
-    }
-
-    await page.waitForTimeout(150);
-  }
-
-  throw new Error(
-    `Start prompt text color did not change after selecting ${label} theme. `
-    + `Previous=${previousColor} Projection=${JSON.stringify(projection)}`);
-}
-
-async function readStartPromptTextProjection(page, label) {
-  await clickVisibleNavigationTargetUntilBodyText(
-    page,
-    startNavigationTarget,
-    /Salmon Egg|推荐开发任务|Recommend tasks/,
-    `start page for ${label} composer theme`);
-  await typeIntoAutomationTextBox(page, "StartView.PromptBox", `wasm ${label} theme text`);
-  await page.waitForTimeout(250);
-
-  const projection = await page.evaluate(automationId => {
-    const control = window.__salmoneggSmoke.findVisibleControl({ automationIds: [automationId] }, [], [automationId]);
-    const textInput = control?.matches("input,textarea,[contenteditable='true']")
-      ? control
-      : control?.querySelector("input,textarea,[contenteditable='true']");
-    if (!control || !textInput) {
-      return {
-        found: false,
-        controlText: control?.textContent ?? "",
-        controlAria: control?.getAttribute("aria-label") ?? ""
-      };
-    }
-
-    const style = getComputedStyle(textInput);
-    const rect = textInput.getBoundingClientRect();
-    return {
-      found: true,
-      color: style.color,
-      backgroundColor: style.backgroundColor,
-      opacity: Number(style.opacity || "1"),
-      value: textInput.value ?? textInput.textContent ?? "",
-      rect: {
-        left: rect.left,
-        top: rect.top,
-        width: rect.width,
-        height: rect.height
-      }
-    };
-  }, "StartView.PromptBox");
-
-  if (!projection.found || projection.rect.width <= 0 || projection.rect.height <= 0) {
-    throw new Error(`Start prompt input was not visible for ${label}. Projection=${JSON.stringify(projection)}`);
-  }
-
-  const color = parseCssColor(projection.color);
-  if (color.a <= 0.1 || projection.opacity <= 0.1) {
-    throw new Error(`Start prompt input text resolved transparent for ${label}. Projection=${JSON.stringify(projection)}`);
-  }
-
-  return projection;
 }
 
 function parseCssColor(value) {
@@ -330,14 +228,6 @@ function parseCssColor(value) {
     b: parts[2] ?? 0,
     a: parts.length >= 4 ? parts[3] : 1
   };
-}
-
-function relativeLuminance(color) {
-  return (0.2126 * color.r) + (0.7152 * color.g) + (0.0722 * color.b);
-}
-
-function colorDistance(left, right) {
-  return Math.hypot(left.r - right.r, left.g - right.g, left.b - right.b);
 }
 
 async function verifyAppearanceSettings(page, suffix = "") {

--- a/scripts/gates/wasm-settings-persistence-smoke.mjs
+++ b/scripts/gates/wasm-settings-persistence-smoke.mjs
@@ -9,6 +9,7 @@ import {
 import {
   readNumericControlValue,
   setNumericControlValue,
+  focusNumericControl,
   readAppSettingsPersistenceDebug,
   selectAlternateCacheRetentionValue,
   setToggleSwitchValue,
@@ -258,6 +259,8 @@ async function changeDataStorageSettings(page) {
     dataStorageCacheRetentionControl,
     "cache retention before edit");
   const updatedValue = selectAlternateCacheRetentionValue(initialValue);
+  // Focus first: the editor input only exists in the accessibility view with the page mounted,
+  // and the focused-state contrast check below must observe the editor while it holds focus.
   await focusNumericControl(
     page,
     dataStorageCacheRetentionControl,
@@ -265,10 +268,7 @@ async function changeDataStorageSettings(page) {
   await verifyVisibleSettingsTextInputsResolveDarkThemeForeground(
     page,
     "focused data storage cache retention",
-    {
-      requireFocused: true,
-      focusedControl: dataStorageCacheRetentionControl
-    });
+    { requireFocused: true });
   await setNumericControlValue(
     page,
     dataStorageCacheRetentionControl,
@@ -384,45 +384,8 @@ async function verifyMcpSettings(page, suffix = "") {
   await expectToggleSwitchValue(page, controls.mcpServerEnabled, false, `MCP server enabled ${suffix}`.trim());
 }
 
-async function focusNumericControl(page, controlOptions, label) {
-  // The cache retention row can straddle the fold once the page grows, and clicking a control whose
-  // center is off screen leaves focus behind. Scroll it fully into view before clicking.
-  if (!await scrollToVisibleControl(page, controlOptions)) {
-    throw new Error(`Could not scroll numeric control into view for ${label}. Options=${JSON.stringify(controlOptions)}`);
-  }
-
-  await clickVisibleControl(page, controlOptions);
-  await page.waitForFunction(options => {
-    const labels = options.labels ?? [];
-    const automationIds = options.automationIds ?? [];
-    const control = window.__salmoneggSmoke.findVisibleControl(options, labels, automationIds);
-    const textInput = control?.matches("input,textarea,[contenteditable='true']")
-      ? control
-      : control?.querySelector("input,textarea,[contenteditable='true']");
-    return Boolean(textInput && document.activeElement === textInput);
-  }, controlOptions, { timeout: 5_000 });
-
-  const focused = await page.evaluate(options => {
-    const labels = options.labels ?? [];
-    const automationIds = options.automationIds ?? [];
-    const control = window.__salmoneggSmoke.findVisibleControl(options, labels, automationIds);
-    const textInput = control?.matches("input,textarea,[contenteditable='true']")
-      ? control
-      : control?.querySelector("input,textarea,[contenteditable='true']");
-    return {
-      found: Boolean(textInput),
-      focused: Boolean(textInput && document.activeElement === textInput),
-      activeClassName: document.activeElement?.className?.toString?.() ?? ""
-    };
-  }, controlOptions);
-
-  if (!focused.found || !focused.focused) {
-    throw new Error(`Expected focused numeric control for ${label}. State=${JSON.stringify(focused)}`);
-  }
-}
-
 async function verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, label, options = {}) {
-  const projections = await page.evaluate(focusedControl => {
+  const projections = await page.evaluate(() => {
     const parseColor = value => {
       const match = String(value ?? "").match(/rgba?\(([^)]+)\)/i);
       if (!match) {
@@ -485,16 +448,6 @@ async function verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, l
           }
         : null;
     };
-    const focusedHost = focusedControl
-      ? window.__salmoneggSmoke.findVisibleControl(
-          focusedControl,
-          focusedControl.labels ?? [],
-          focusedControl.automationIds ?? [])
-      : null;
-    const focusedInput = focusedHost?.matches("input,textarea,[contenteditable='true']")
-      ? focusedHost
-      : focusedHost?.querySelector("input,textarea,[contenteditable='true']");
-
     return Array.from(document.querySelectorAll("input,textarea,[contenteditable='true']"))
       .map(element => {
       const rect = element.getBoundingClientRect();
@@ -508,7 +461,6 @@ async function verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, l
         backgroundSources: background?.sources ?? [],
         opacity: Number(style.opacity || "1"),
         focused: document.activeElement === element,
-        focusedTarget: element === focusedInput,
         value: element.value ?? element.textContent ?? "",
         placeholder: element.getAttribute("placeholder") ?? "",
         aria: element.getAttribute("aria-label") ?? "",
@@ -537,16 +489,16 @@ async function verifyVisibleSettingsTextInputsResolveDarkThemeForeground(page, l
       };
       })
       .filter(projection => projection.visible);
-  }, options.focusedControl ?? null);
+  });
 
   if (projections.length === 0) {
     throw new Error(`No visible settings text inputs found for ${label}.`);
   }
 
   if (options.requireFocused === true
-      && !projections.some(projection => projection.focused && projection.focusedTarget)) {
+      && !projections.some(projection => projection.focused)) {
     throw new Error(
-      `The target settings text input did not retain focus for ${label}. Projections=${JSON.stringify(projections)}`);
+      `No visible settings text input held focus for ${label}. Projections=${JSON.stringify(projections)}`);
   }
 
   const failures = projections

--- a/scripts/gates/wasm-smoke-lib/acp-ui-fixture.mjs
+++ b/scripts/gates/wasm-smoke-lib/acp-ui-fixture.mjs
@@ -1,32 +1,53 @@
 import { navigateToSettingsSection } from "./settings-shell.mjs";
+import { openApp } from "./browser-app.mjs";
 import {
   clickStartComposerSendButton,
   clickVisibleNavigationTarget,
-  clickVisibleNavigationTargetUntilBodyText,
   collectVisibleComboBoxDebug,
   collectVisibleInteractiveDebug,
   collectVisibleNavigationTargetDebug,
   escapeRegExp,
+  expectComboBoxSelectionText,
   readControlState,
   scrollToVisibleNavigationTarget,
   selectComboBoxItem,
-  typeIntoAutomationTextBox,
   typeIntoVisibleTextField,
-  waitForBodyText
+  waitForBodyText,
+  waitForControlState,
+  waitForSemanticText
 } from "./ui-affordances.mjs";
 
+const profilesAddAffordance = { labels: ["新建配置", "New profile"], automationIds: ["Acp.Profiles.Add"] };
+const profileEditorNameField = { labels: [], automationIds: ["Acp.ProfileEditor.Name"] };
+const profileEditorAttempts = 3;
+
+// The editor's arrival is the Name field turning up in the semantic tree, not its labels turning up
+// in body text: those labels reach the DOM only as the inputs' accessible names, so a body-text wait
+// for them can never pass on Skia. The activation is retried against that same proof - the page's
+// nodes are published before its ViewModel is ready, and an activation that arrives too early is
+// dropped by the command without the node ever reporting itself disabled, so the click reports
+// success and nothing opens.
 export async function createWebSocketProfile(page, profileName, serverUrl) {
-  await clickVisibleNavigationTargetUntilBodyText(
-    page,
-    { labels: ["新建配置", "New profile"], automationIds: ["Acp.Profiles.Add"] },
-    /名称|Name|服务器地址|Server URL/,
-    "agent profile editor");
+  let opened = false;
+  for (let attempt = 1; attempt <= profileEditorAttempts && !opened; attempt += 1) {
+    await clickVisibleNavigationTarget(page, profilesAddAffordance);
+    opened = Boolean(await scrollToVisibleNavigationTarget(page, profileEditorNameField, 8_000));
+  }
+
+  if (!opened) {
+    throw new Error(
+      `The ACP profile editor did not open after ${profileEditorAttempts} activations of its New affordance.`);
+  }
 
   await fillProfileEditorTextBoxes(page, profileName, serverUrl);
   await clickVisibleNavigationTarget(page, { labels: ["保存", "Save"], automationIds: [] });
   try {
-    await waitForBodyText(page, /ACP Agent|ACP 连接配置|ACP connection profiles/, "ACP Agent settings page after profile save");
-    await waitForBodyText(page, new RegExp(escapeRegExp(profileName)), "saved ACP profile");
+    // Saving must return the list with the new profile on it. Both halves are read from the semantic
+    // tree: the page's own affordance for "we are back on the list", and the profile's name wherever
+    // the tree carries it - a list item's title reaches the DOM as an accessible name, so waiting for
+    // it in body text would time out on a profile the user can plainly see.
+    await waitForControlState(page, profilesAddAffordance, "ACP Agent settings page after profile save");
+    await waitForSemanticText(page, new RegExp(escapeRegExp(profileName)), "saved ACP profile");
     return;
   } catch (error) {
     const debug = await page.evaluate(() => ({
@@ -64,25 +85,31 @@ export async function createWebSocketProfile(page, profileName, serverUrl) {
         .filter(candidate => candidate.visible),
       body: (document.body?.innerText ?? "").slice(0, 2_000)
     }));
-    await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
-    await page.waitForSelector(
-      [
-        '[aria-label="StartView.Title"]',
-        '[aria-label="StartView.PromptBox"]',
-        '[aria-label="StartView.Suggestion.ReportGuidance"]',
-        '[aria-label="StartView.AgentSelector"]',
-        '[aria-label="MainNavView"]'
-      ].join(", "),
-      { timeout: 60_000 });
-    await navigateToSettingsSection(
-      page,
-      { labels: ["ACP Agent", "ACP / Agent"], automationIds: ["SettingsNav.AgentAcp"] },
-      /ACP Agent|ACP 连接配置|ACP connection profiles/,
-      "ACP Agent settings page after forced reload");
-
-    const persistedAfterReload = await page.evaluate(
-      name => (document.body?.innerText ?? "").includes(name),
-      profileName);
+    // This whole block only exists to say *why* the save was not observable, so it must never become
+    // the reported failure itself: a reload that does not come back would otherwise replace the real
+    // error with a bare selector timeout, which is exactly what it used to do.
+    let persistedAfterReload = null;
+    try {
+      await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
+      await openApp(page, page.url());
+      await navigateToSettingsSection(
+        page,
+        { labels: ["ACP Agent", "ACP / Agent"], automationIds: ["SettingsNav.AgentAcp"] },
+        /ACP Agent|ACP 连接配置|ACP connection profiles/,
+        "ACP Agent settings page after forced reload");
+      persistedAfterReload = await page.evaluate(
+        name => Array.from(document.querySelectorAll("#uno-semantics-root [id^='uno-semantics-']"))
+          .some(node => !node.hidden
+            && (`${node.getAttribute("aria-label") ?? ""}|${node.textContent ?? ""}`).includes(name)),
+        profileName);
+    } catch (diagnosticError) {
+      throw new Error(
+        `Saving the ACP profile was not observable: ${error?.message ?? error} `
+        + `The reload used to tell persistence apart from a UI hang also failed `
+        + `(${diagnosticError?.message ?? diagnosticError}), so which one it is stays unknown. `
+        + `Debug=${JSON.stringify(debug)}`,
+        { cause: error });
+    }
 
     if (persistedAfterReload) {
       throw new Error(
@@ -98,13 +125,30 @@ export async function createWebSocketProfile(page, profileName, serverUrl) {
 }
 
 export async function expectProfilePresence(page, profileName, label) {
-  await waitForBodyText(page, new RegExp(escapeRegExp(profileName)), label);
+  await waitForSemanticText(page, new RegExp(escapeRegExp(profileName)), label);
 }
 
+// Same shape as the profile editor above: the editor's own field is the arrival proof (its label
+// exists only as that input's accessible name), and the activation is retried against it because an
+// activation delivered before the row's ViewModel is ready is dropped without a trace.
+const remoteDirectoryAddAffordance = {
+  labels: ["新增远程项目", "Add remote project"],
+  automationIds: ["Acp.RemoteDirectories.Add"]
+};
+const remoteDirectoryNameField = { labels: [], automationIds: ["Acp.RemoteDirectories.DisplayName"] };
+
 export async function createRemoteDirectory(page, displayName, remotePath) {
-  await scrollToVisibleNavigationTarget(page, { labels: ["新增远程项目", "Add remote project"], automationIds: ["Acp.RemoteDirectories.Add"] });
-  await clickVisibleNavigationTarget(page, { labels: ["新增远程项目", "Add remote project"], automationIds: ["Acp.RemoteDirectories.Add"] });
-  await waitForBodyText(page, /显示名称|Project name|ACP 工作路径|ACP working path/, "remote directory editor");
+  await scrollToVisibleNavigationTarget(page, remoteDirectoryAddAffordance);
+  let opened = false;
+  for (let attempt = 1; attempt <= profileEditorAttempts && !opened; attempt += 1) {
+    await clickVisibleNavigationTarget(page, remoteDirectoryAddAffordance);
+    opened = Boolean(await scrollToVisibleNavigationTarget(page, remoteDirectoryNameField, 8_000));
+  }
+
+  if (!opened) {
+    throw new Error(
+      `The remote directory editor did not open after ${profileEditorAttempts} activations of its Add affordance.`);
+  }
 
   await typeIntoVisibleTextField(
     page,
@@ -121,8 +165,10 @@ export async function createRemoteDirectory(page, displayName, remotePath) {
 }
 
 export async function expectRemoteDirectoryPresence(page, displayName, remotePath, label) {
-  await waitForBodyText(page, new RegExp(escapeRegExp(displayName)), `${label} name`);
-  await waitForBodyText(page, new RegExp(escapeRegExp(remotePath)), `${label} path`);
+  // Read from the semantic tree for the same reason as the profile list above: a row's title and
+  // subtitle can exist only as accessible names.
+  await waitForSemanticText(page, new RegExp(escapeRegExp(displayName)), `${label} name`);
+  await waitForSemanticText(page, new RegExp(escapeRegExp(remotePath)), `${label} path`);
 }
 
 export async function expectPersistedProfileAfterReload(page, baseUrl, profileName) {
@@ -131,19 +177,13 @@ export async function expectPersistedProfileAfterReload(page, baseUrl, profileNa
   for (let attempt = 1; attempt <= 2; attempt += 1) {
     try {
       await page.setViewportSize({ width: 1280, height: 900 });
-      await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
       await page.goto(baseUrl, { waitUntil: "domcontentloaded", timeout: 60_000 });
       await page.setViewportSize({ width: 1280, height: 900 });
-      await page.waitForTimeout(500);
-      await page.waitForSelector(
-      [
-        '[aria-label="StartView.Title"]',
-        '[aria-label="StartView.PromptBox"]',
-        '[aria-label="StartView.Suggestion.ReportGuidance"]',
-        '[aria-label="StartView.AgentSelector"]',
-        '[aria-label="MainNavView"]'
-      ].join(", "),
-      { timeout: 60_000 });
+      // openApp owns what "the app is up" means - the shell's own landmarks, the splash being gone,
+      // and a readable failure when it is not. The hand-rolled selector wait here reported a bare
+      // 60s timeout on a blank page, which said nothing about whether the reload had even started
+      // rendering, and it did not wait out the splash that swallows the first pointer gestures.
+      await openApp(page, baseUrl);
       await navigateToSettingsSection(
         page,
         { labels: ["ACP Agent", "ACP / Agent"], automationIds: ["SettingsNav.AgentAcp"] },
@@ -205,19 +245,29 @@ export async function expectPersistedProfileAfterReload(page, baseUrl, profileNa
     + `Cause=${lastError?.message ?? lastError}`);
 }
 
+// The row's ToggleSwitch carries no automation id of its own, so it is found by walking up from the
+// profile's name to the row and taking the switch inside it. Activation goes through the semantic
+// node's own click, which is what Uno programs the Toggle pattern onto; a real pointer at the
+// reported centre does not reach it, because the node has pointer-events: none and the canvas hit
+// test does not pick the switch up (measured: aria-checked stayed false and no connection started).
+//
+// One activation is all this does. The switch reflects IsConnected, not the request, so it stays off
+// until the connection is actually up - waiting for it to flip here would be waiting for the very
+// thing the caller is about to assert.
 export async function clickProfileConnectionToggle(page, profileName) {
-  await page.waitForFunction(
-    name => (document.body?.innerText ?? "").includes(name),
-    profileName,
-    { timeout: 30_000 });
+  await waitForSemanticText(page, new RegExp(escapeRegExp(profileName)), `profile row for '${profileName}'`);
 
-  const point = await page.evaluate(findProfileConnectionTogglePoint, profileName);
-  if (!point) {
+  const activated = await page.evaluate(activateProfileConnectionToggle, profileName);
+  if (!activated?.found) {
     const debug = await page.evaluate(collectVisibleInteractiveDebug);
     throw new Error(`No connection toggle found for profile '${profileName}'. Candidates: ${JSON.stringify(debug)}`);
   }
 
-  await page.mouse.click(point.x, point.y);
+  if (activated.disabled) {
+    throw new Error(
+      `The connection toggle for profile '${profileName}' is disabled, so the connection cannot be started.`);
+  }
+
   await page.waitForTimeout(500);
 }
 
@@ -260,17 +310,25 @@ export async function createSessionAndSendPromptFromStart(
   directoryPath,
   promptText,
   expectedAgentReply) {
-  const promptBoxSelector = '[aria-label="StartView.PromptBox"]';
+  // The composer is located by shape, not by id: StartView sets its automation id through an x:Bind
+  // on AutomationProperties.AutomationId, which never reaches the exported accessibility node on
+  // Skia - the node has no id and its accessible name is the localized placeholder. The Start shell
+  // has exactly one multi-line text box, which is stable in a way the placeholder wording is not.
+  const promptBoxSelector = "#uno-semantics-root textarea";
   await ensureStartPromptVisible(page, promptBoxSelector);
 
+  // Matched on the ComboBox's own x:Name, which Uno exports as the automation id when none is set
+  // explicitly. The ids the hosts pass in (StartView.AgentSelector and friends) are applied through an
+  // x:Bind on AutomationProperties.AutomationId and never reach the exported node, so nothing in the
+  // accessibility view carries them.
   await selectComboBoxItem(
     page,
-    "StartView.AgentSelector",
+    "AgentSelectorHost",
     profileName,
     { keyboardSelectVisibleItem: true });
   await selectComboBoxItem(
     page,
-    "StartView.ProjectSelector",
+    "ProjectSelectorHost",
     directoryName,
     { verifySelectionText: false, keyboardSelectVisibleItem: true });
   const sessionNewRequest = await waitForSessionNewWithDiagnostics(acpServer, page);
@@ -279,8 +337,15 @@ export async function createSessionAndSendPromptFromStart(
     throw new Error(`session/new used unexpected cwd. Expected=${directoryPath} Request=${JSON.stringify(sessionNewRequest)}`);
   }
 
-  await waitForBodyText(page, /Agent 01|Planner 01/, "ready ACP modes after remote directory selection", 30_000);
-  await typeIntoAutomationTextBox(page, "StartView.PromptBox", promptText);
+  // The mode selector is what shows the session's modes arrived, and a collapsed ComboBox on Skia
+  // mirrors no selection text at all - its value is only readable by opening the dropdown, which is
+  // what this helper does. Waiting for the mode names in body text could never pass here.
+  await expectComboBoxSelectionText(
+    page,
+    "ModeSelectorHost",
+    ["Agent 01", "Planner 01"],
+    "ready ACP modes after remote directory selection");
+  await typeIntoVisibleTextField(page, { selector: promptBoxSelector }, promptText, "start composer prompt");
   await clickStartComposerSendButton(page);
 
   const promptRequest = await waitForSessionPromptWithDiagnostics(acpServer, page);
@@ -289,8 +354,10 @@ export async function createSessionAndSendPromptFromStart(
     throw new Error(`session/prompt used unexpected text. Expected=${promptText} Request=${JSON.stringify(promptRequest)}`);
   }
 
-  await waitForBodyText(page, /ChatView\.MessagesList|Salmon Egg|WASM full chain agent reply/, "chat view after prompt", 30_000);
-  await waitForBodyText(page, new RegExp(escapeRegExp(expectedAgentReply)), "agent reply projected into chat UI", 30_000);
+  // Read from the semantic tree: chat turns reach the DOM as accessible names on their message nodes,
+  // never as body text, so the reply a user can read is invisible to a body-text wait on Skia.
+  await waitForSemanticText(page, /ChatView\.MessagesList|Salmon Egg|WASM full chain agent reply/, "chat view after prompt", 30_000);
+  await waitForSemanticText(page, new RegExp(escapeRegExp(expectedAgentReply)), "agent reply projected into chat UI", 30_000);
 }
 
 async function ensureStartPromptVisible(page, promptBoxSelector) {
@@ -396,54 +463,51 @@ function readAcpProfilesAnchorState() {
   return control ? { found: true } : null;
 }
 
-function findProfileConnectionTogglePoint(profileName) {
+// Runs inside the page, so the row walk is inlined: page.evaluate ships only this function's body,
+// and a helper referenced from module scope does not exist in the browser.
+function activateProfileConnectionToggle(profileName) {
+  const isOnScreen = rect => rect.width > 0
+    && rect.height > 0
+    && rect.left >= 0
+    && rect.top >= 0
+    && rect.left <= innerWidth
+    && rect.top <= innerHeight;
+
   const nameNode = Array.from(document.querySelectorAll("body *"))
-    .find(element => {
-      const rect = element.getBoundingClientRect();
-      return rect.width > 0
-        && rect.height > 0
-        && rect.left >= 0
-        && rect.top >= 0
-        && rect.left <= innerWidth
-        && rect.top <= innerHeight
-        && (element.textContent ?? "").trim() === profileName;
-    });
+    .find(element => isOnScreen(element.getBoundingClientRect())
+      && (element.textContent ?? "").trim() === profileName);
 
   let container = nameNode;
   while (container && container !== document.body) {
-    const toggle = Array.from(container.querySelectorAll("input,[role='switch'],[aria-checked],.uno-toggleswitch,*"))
+    const toggle = Array.from(container.querySelectorAll("*"))
       .map(element => {
-        const rect = element.getBoundingClientRect();
         const className = element.className?.toString?.() ?? "";
         return {
           element,
-          rect,
-          className,
-          isToggle:
-            element.matches("input[type='checkbox']")
+          rect: element.getBoundingClientRect(),
+          isToggle: element.matches("input[type='checkbox']")
             || element.getAttribute("role") === "switch"
             || element.getAttribute("aria-checked") != null
             || className.toLowerCase().includes("toggle")
         };
       })
-      .filter(candidate =>
-        candidate.isToggle
-        && candidate.rect.width > 0
-        && candidate.rect.height > 0
-        && candidate.rect.left >= 0
-        && candidate.rect.top >= 0
-        && candidate.rect.left <= innerWidth
-        && candidate.rect.top <= innerHeight)
+      .filter(candidate => candidate.isToggle && isOnScreen(candidate.rect))
       .sort((left, right) => right.rect.right - left.rect.right)[0];
 
     if (toggle) {
-      return window.__salmoneggSmoke.resolveToggleClickPoint(toggle.element);
+      const element = toggle.element;
+      if (element.getAttribute("aria-disabled") === "true" || element.disabled === true) {
+        return { found: true, disabled: true };
+      }
+
+      element.click();
+      return { found: true, disabled: false, checked: element.getAttribute("aria-checked") };
     }
 
     container = container.parentElement;
   }
 
-  return null;
+  return { found: false };
 }
 
 function readProfileConnectionRowState(profileName) {

--- a/scripts/gates/wasm-smoke-lib/browser-app.mjs
+++ b/scripts/gates/wasm-smoke-lib/browser-app.mjs
@@ -36,6 +36,19 @@ const semanticRuntimeScript = `
 
   const normalize = value => (value ?? "").trim().toLowerCase();
 
+  // Prefer a laid-out candidate. Templated rows (a ListView's item template, an editor that is only
+  // realized for the row being edited) put several nodes carrying the SAME automation id into the
+  // tree; the ones belonging to unrealized rows report a placeholder rect a few pixels wide at the
+  // origin. They are indistinguishable by id, they are not hidden, and driving one does nothing a
+  // user could see - typing into it lands in a control that is not on screen and never reaches the
+  // ViewModel. Taking the first match is therefore a coin flip; taking the laid-out one is the
+  // control the user is actually looking at.
+  const laidOutMinimum = 12;
+  const looksLaidOut = element => {
+    const rect = element.getBoundingClientRect();
+    return rect.width >= laidOutMinimum && rect.height >= laidOutMinimum;
+  };
+
   const matchNode = input => {
     const automationIds = (input.automationIds ?? []).map(normalize).filter(Boolean);
     const labels = (input.labels ?? []).map(normalize).filter(Boolean);
@@ -46,7 +59,8 @@ const semanticRuntimeScript = `
       return null;
     }
 
-    let labelMatch = null;
+    const idMatches = [];
+    const labelMatches = [];
     for (const element of nodes) {
       if (element.hidden) {
         continue;
@@ -68,17 +82,21 @@ const semanticRuntimeScript = `
       if (automationIds.length > 0
         && ((automationId !== "" && automationIds.includes(automationId))
           || (aria !== "" && automationIds.includes(aria)))) {
-        return element;
+        idMatches.push(element);
+        continue;
       }
 
-      if (labelMatch === null
-        && labels.length > 0
+      if (labels.length > 0
         && (labels.includes(aria) || labels.includes(normalize(element.textContent)))) {
-        labelMatch = element;
+        labelMatches.push(element);
       }
     }
 
-    return labelMatch;
+    return idMatches.find(looksLaidOut)
+      ?? idMatches[0]
+      ?? labelMatches.find(looksLaidOut)
+      ?? labelMatches[0]
+      ?? null;
   };
 
   const activate = input => {
@@ -191,8 +209,57 @@ const semanticRuntimeScript = `
     };
   };
 
+  // Counting matches, not just finding one: a saved row appearing twice is only observable as a
+  // count, and matchNode deliberately returns the first hit.
+  const countMatches = input => {
+    const automationIds = (input.automationIds ?? []).map(normalize).filter(Boolean);
+    const labels = (input.labels ?? []).map(normalize).filter(Boolean);
+    const nodes = semanticRoot()?.querySelectorAll("[id^='uno-semantics-']") ?? [];
+    let count = 0;
+    for (const element of nodes) {
+      if (element.hidden) {
+        continue;
+      }
+
+      const automationId = normalize(element.getAttribute("xamlautomationid"));
+      const aria = normalize(element.getAttribute("aria-label"));
+      const matchesId = automationIds.length > 0
+        && ((automationId !== "" && automationIds.includes(automationId))
+          || (aria !== "" && automationIds.includes(aria)));
+      const matchesLabel = automationIds.length === 0
+        && labels.length > 0
+        && ((aria !== "" && labels.includes(aria))
+          || labels.includes(normalize(element.textContent)));
+      if (matchesId || matchesLabel) {
+        count += 1;
+      }
+    }
+
+    return count;
+  };
+
   const comboBoxLabeledIds = () => Array.from(semanticRoot().querySelectorAll("[aria-label]"))
     .map(node => node.id);
+
+  // Resolve the real <input> a control writes through, so the driver can put a keyboard on it.
+  // Returning the element id rather than the element itself is forced by page.evaluate: DOM nodes do
+  // not survive the round trip.
+  const resolveEditableField = input => {
+    // A CSS selector is accepted as an escape hatch for controls whose automation id never reaches
+    // the accessibility view. The composer is the standing case: its id is applied through an x:Bind
+    // on AutomationProperties.AutomationId, and the exported node carries no id at all, so there is
+    // nothing to match on - while the box itself is unmistakable in the DOM.
+    const element = input.selector
+      ? document.querySelector(input.selector)
+      : matchNode(input);
+    if (!element) {
+      return { matched: false, id: null, disabled: false, state: null };
+    }
+
+    const state = describeNode(element);
+    const editable = findEditable(element);
+    return { matched: true, id: editable?.id ?? null, disabled: state.disabled, state };
+  };
 
   const focusedSnapshot = () => {
     const element = document.activeElement;
@@ -289,8 +356,10 @@ const semanticRuntimeScript = `
     },
     activate,
     setInput,
+    resolveEditableField,
     comboBoxOpenState,
     comboBoxLabeledIds,
+    countMatches,
     focusControl,
     focusedSnapshot,
     readLocalTextFile,

--- a/scripts/gates/wasm-smoke-lib/browser-app.mjs
+++ b/scripts/gates/wasm-smoke-lib/browser-app.mjs
@@ -547,6 +547,45 @@ export async function openApp(page, baseUrl) {
   } catch (error) {
     throw new Error(`${error.message}\n${await describeUnrenderedPage(page)}`, { cause: error });
   }
+  await waitForSplashLoaderGone(page);
+}
+
+// The bootstrap keeps the `.uno-loader` splash mounted as `#loading` and unmounts it only from a
+// MutationObserver on #uno-body's child list (uno-bootstrap.js `initProgress`). The canvas, the
+// aria-live regions and the semantics root all land in #uno-body during boot, so the observer fires
+// within about a second of first paint - but openApp resolves the moment the semantic shell labels
+// appear, which can still be inside that window (measured: the splash was up for ~750ms after the
+// start cards were already queryable). While it is up it covers the whole viewport with
+// `pointer-events: auto` at z-index 5000, so a real pointer click aimed at the canvas lands on the
+// splash and is silently swallowed - the click reports success, nothing behind it reacts, and the
+// step times out on a body-text wait with no signal of what ate the click. Wait for the splash to
+// detach so pointer-driven steps start from a page a user could actually reach.
+//
+// If it is still mounted this deep into boot the observer never fired, which is itself a defect a
+// real user would see as a splash that never leaves; surface that instead of tearing it out here.
+async function waitForSplashLoaderGone(page) {
+  try {
+    await page.waitForFunction(
+      () => !document.getElementById("loading"),
+      undefined,
+      { timeout: 15_000, polling: 250 });
+  } catch (error) {
+    const splash = await page.evaluate(() => {
+      const element = document.getElementById("loading");
+      if (!element) {
+        return null;
+      }
+      const rect = element.getBoundingClientRect();
+      return {
+        rect: `${rect.width}x${rect.height}@${rect.left},${rect.top}`,
+        pointerEvents: getComputedStyle(element).pointerEvents,
+        zIndex: getComputedStyle(element).zIndex
+      };
+    });
+    throw new Error(
+      `The bootstrap splash loader (#loading) never unmounted, so every real pointer click `
+      + `lands on it instead of the app. Splash state=${JSON.stringify(splash)}`, { cause: error });
+  }
 }
 
 // Skia paints into a <canvas>, so the accessibility tree is the only DOM Uno mirrors - and it builds

--- a/scripts/gates/wasm-smoke-lib/browser-app.mjs
+++ b/scripts/gates/wasm-smoke-lib/browser-app.mjs
@@ -133,54 +133,66 @@ const semanticRuntimeScript = `
     return { matched: true, editable: true, disabled: false, state };
   };
 
-  const matchComboBoxItem = expectedNames => {
-    // An open ComboBox popup contributes option nodes to the semantic DOM. Options carry no
-    // automation id of their own, so match on the accessible name, falling back to contained
-    // text so item templates with secondary copy still resolve.
-    const names = (expectedNames ?? []).map(normalize).filter(Boolean);
-    const nodes = semanticRoot()?.querySelectorAll("[id^='uno-semantics-'][role='option']");
-    if (!nodes) {
+  // Skia collapsed combo boxes mirror no selection text at all: the value only exists as the
+  // popup's highlighted option while the dropdown is open. The readable item names surface as
+  // fresh clean-label nodes outside the popup subtree, in document order matching the popup's
+  // option nodes - but only on the FIRST open of a dropdown: on reopen Uno reuses the same
+  // option nodes and never rebuilds the clean-label mirror. So the first aligned open seeds a
+  // posinset-to-label cache per automation id, and every later open reads labels back through
+  // the option nodes' aria-posinset. The count alignment is the ordering proof; a mismatch
+  // means the mirror has not caught up (or the popup is a half-open ghost) and the caller must
+  // retry. The cache lives in the page, so a shell reload (language switch) clears it.
+  const comboBoxLabelCache = new Map();
+  const comboBoxOpenState = (automationId, beforeIds) => {
+    const combo = matchNode({ automationIds: [automationId], labels: [] });
+    if (!combo) {
       return null;
     }
 
-    for (const element of nodes) {
-      if (element.hidden) {
-        continue;
-      }
+    const expanded = combo.getAttribute("aria-expanded") === "true";
+    const popupId = combo.getAttribute("aria-controls");
+    const popup = (popupId && document.getElementById(popupId))
+      ?? semanticRoot().querySelector("[role='listbox']")
+      ?? null;
+    const optionNodes = popup ? Array.from(popup.children) : [];
+    const activeId = combo.getAttribute("aria-activedescendant");
+    const activeIndex = activeId ? optionNodes.findIndex(node => node.id === activeId) : -1;
 
-      const aria = normalize(element.getAttribute("aria-label"));
-      const text = normalize(element.textContent);
-      if (names.includes(aria) || names.includes(text)) {
-        return element;
-      }
+    const freshLabels = Array.from(semanticRoot().querySelectorAll("[aria-label]"))
+      .filter(node => !beforeIds.includes(node.id)
+        && !node.hidden
+        && node.getAttribute("aria-label") !== "Popup"
+        && !(popup && (popup === node || popup.contains(node))))
+      .map(node => node.getAttribute("aria-label"));
+
+    if (optionNodes.length > 0 && freshLabels.length === optionNodes.length) {
+      const byPos = new Map();
+      optionNodes.forEach((node, index) => {
+        byPos.set(node.getAttribute("aria-posinset") ?? String(index + 1), freshLabels[index]);
+      });
+      comboBoxLabelCache.set(automationId, byPos);
     }
 
-    for (const element of nodes) {
-      if (element.hidden) {
-        continue;
-      }
+    const cached = comboBoxLabelCache.get(automationId);
+    const cacheUsable = cached !== undefined && cached.size === optionNodes.length;
+    const itemLabels = freshLabels.length === optionNodes.length
+      ? freshLabels
+      : optionNodes.map(node => cached?.get(node.getAttribute("aria-posinset")) ?? null);
 
-      const text = normalize(element.textContent);
-      if (names.some(name => text.includes(name))) {
-        return element;
-      }
-    }
-
-    return null;
+    return {
+      expanded,
+      optionCount: optionNodes.length,
+      activeIndex,
+      itemLabels,
+      aligned: expanded
+        && optionNodes.length > 0
+        && (freshLabels.length === optionNodes.length || cacheUsable)
+        && itemLabels.every(label => typeof label === "string")
+    };
   };
 
-  const comboBoxSelectionText = automationId => {
-    const element = matchNode({ automationIds: [automationId], labels: [] });
-    if (!element) {
-      return null;
-    }
-
-    // Prefer an explicit value mirror (inputs and sliders carry one) over template text, which
-    // can include the caret.
-    return element.value
-      ?? element.getAttribute("aria-label")
-      ?? ((element.textContent ?? "").trim() || null);
-  };
+  const comboBoxLabeledIds = () => Array.from(semanticRoot().querySelectorAll("[aria-label]"))
+    .map(node => node.id);
 
   const focusedSnapshot = () => {
     const element = document.activeElement;
@@ -245,6 +257,18 @@ const semanticRuntimeScript = `
     };
   };
 
+  // Real DOM focus on the semantic node. Uno forwards focus into the managed visual tree, which
+  // is the precondition for keyboard choreography (F4, arrows, Enter) on combos and lists.
+  const focusControl = input => {
+    const element = matchNode(input);
+    if (!element) {
+      return false;
+    }
+
+    element.focus();
+    return document.activeElement === element;
+  };
+
   const stateWithLegacyPointers = element => {
     const state = describeNode(element);
     return {
@@ -265,11 +289,9 @@ const semanticRuntimeScript = `
     },
     activate,
     setInput,
-    comboBoxItem: expectedNames => {
-      const element = matchComboBoxItem(expectedNames);
-      return element ? { activate: () => element.click(), state: describeNode(element) } : null;
-    },
-    comboBoxSelectionText,
+    comboBoxOpenState,
+    comboBoxLabeledIds,
+    focusControl,
     focusedSnapshot,
     readLocalTextFile,
     persistenceDebug,

--- a/scripts/gates/wasm-smoke-lib/settings-shell.mjs
+++ b/scripts/gates/wasm-smoke-lib/settings-shell.mjs
@@ -29,22 +29,55 @@ export async function navigateToSettingsSection(page, sectionTarget, bodyPattern
     automationIds: ["SettingsItem"]
   };
 
-  await ensureVisibleNavigationTarget(page, settingsNavigationTarget, {
-    labels: ["Toggle sidebar"],
-    automationIds: ["TitleBar.ToggleSidebar"]
-  });
-  await clickVisibleNavigationTargetUntilBodyText(
-    page,
-    settingsNavigationTarget,
-    /常规|General|外观|Appearance|ACP Agent|ACP \/ Agent/,
-    "settings shell");
+  // Only enter the shell when we are not already in it. The section entries exist in the semantic
+  // tree only while the settings shell is showing, so seeing the wanted one is proof enough - and
+  // activating the Settings entry when it is already open costs more than a wasted click: it starts
+  // a fresh navigation to the shell's default section, which lands asynchronously and can replace
+  // the section page a caller has already navigated to and started using.
+  if (!await scrollToVisibleControl(page, sectionTarget, 1_500)) {
+    await ensureVisibleNavigationTarget(page, settingsNavigationTarget, {
+      labels: ["Toggle sidebar"],
+      automationIds: ["TitleBar.ToggleSidebar"]
+    });
+    await clickVisibleNavigationTargetUntilBodyText(
+      page,
+      settingsNavigationTarget,
+      /常规|General|外观|Appearance|ACP Agent|ACP \/ Agent/,
+      "settings shell");
 
-  if (!await scrollToVisibleControl(page, sectionTarget, 3_000)) {
-    await clickTopNavigationOverflow(page);
-    await waitForControlState(page, sectionTarget, describeTarget(sectionTarget), 10_000);
+    if (!await scrollToVisibleControl(page, sectionTarget, 3_000)) {
+      await clickTopNavigationOverflow(page);
+      await waitForControlState(page, sectionTarget, describeTarget(sectionTarget), 10_000);
+    }
   }
 
-  await clickVisibleNavigationTargetUntilBodyText(page, sectionTarget, bodyPattern, label);
+  await clickSectionUntilItSticks(page, sectionTarget, bodyPattern, label);
+}
+
+// The shell hop above lands asynchronously: activating the Settings entry navigates the shell to its
+// default section, and that navigation can complete AFTER this section click, replacing the page we
+// just asked for. The symptom is brutal to read - the section's own controls appear, the step that
+// follows activates one of them, and only its effect goes missing, because by then the shell has
+// swapped the page back. So arrival is confirmed, given a beat, and confirmed again; if the shell
+// pulled the page out from under us, the section is simply activated again, which a navigation item
+// tolerates because activating it twice is idempotent.
+const sectionArrivalAttempts = 3;
+const sectionSettleMs = 800;
+
+async function clickSectionUntilItSticks(page, sectionTarget, bodyPattern, label) {
+  let lastBodyText = "";
+  for (let attempt = 1; attempt <= sectionArrivalAttempts; attempt += 1) {
+    await clickVisibleNavigationTargetUntilBodyText(page, sectionTarget, bodyPattern, label);
+    await page.waitForTimeout(sectionSettleMs);
+    lastBodyText = await page.locator("body").innerText();
+    if (bodyPattern.test(lastBodyText)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    `Navigated to ${label} but the shell replaced the page again each time `
+    + `(${sectionArrivalAttempts} attempts). Last body text=${JSON.stringify(lastBodyText.slice(0, 400))}`);
 }
 
 function describeTarget(options) {

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -310,72 +310,166 @@ export async function expectToggleSwitchValue(page, options, expectedValue, labe
 
 // ---- combo boxes -----------------------------------------------------------------------------
 
-// Expand-collapse and selection are both semantic clicks; the selector's accessible name tracks
-// the selected value, which is the verification. No keyboard choreography: the semantic layer
-// already programs Enter/Space/Escape onto the nodes.
+// Skia renders the app into a canvas and collapsed combo boxes mirror no selection text, so the
+// selection is only observable by opening the dropdown and reading which option is highlighted
+// (aria-activedescendant), mapped onto the clean item labels. Both helpers below share the
+// keyboard path because it is the only one that actually commits a selection: a semantic click
+// on an item merely collapses the dropdown.
+//
+// F4 is also racy on Skia: focus needs a settle beat before the key opens the popup, and the
+// popup has a half-open ghost state (expanded=true, no option nodes yet). So opening loops:
+// focus -> settle -> F4 -> poll for an aligned open state (option count matching the fresh
+// labeled nodes) -> Escape and retry while budget remains.
+
+const COMBO_SETTLE_MS = 300;
+const COMBO_OPEN_TIMEOUT_MS = 20_000;
+
+const findComboBox = (page, selectorAutomationId) => page.evaluate(
+  automationId => window.__salmoneggSmoke.semantic.describe({
+    automationIds: [automationId], labels: []
+  }),
+  selectorAutomationId);
+
+async function openComboBoxAligned(page, selectorAutomationId, label) {
+  const deadline = Date.now() + COMBO_OPEN_TIMEOUT_MS;
+  let beforeIds = null;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    beforeIds = await page.evaluate(() => window.__salmoneggSmoke.semantic.comboBoxLabeledIds());
+    attempt += 1;
+
+    await waitForControlState(
+      page,
+      { automationIds: [selectorAutomationId], labels: [] },
+      label,
+      5_000);
+    await page.evaluate(
+      automationId => window.__salmoneggSmoke.semantic.focusControl({
+        automationIds: [automationId], labels: []
+      }),
+      selectorAutomationId);
+    await page.waitForTimeout(COMBO_SETTLE_MS);
+    await page.keyboard.press("F4");
+
+    const openDeadline = Date.now() + 2_000;
+    while (Date.now() < openDeadline && Date.now() < deadline) {
+      const state = await page.evaluate(
+        input => window.__salmoneggSmoke.semantic.comboBoxOpenState(input.automationId, input.beforeIds),
+        { automationId: selectorAutomationId, beforeIds });
+      if (state?.aligned) {
+        return state;
+      }
+
+      await page.waitForTimeout(200);
+    }
+
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(
+    `${label} never produced an aligned open state after ${attempt} attempts. `
+    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+}
+
+async function closeComboBox(page) {
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(200);
+}
+
+// Opens the dropdown (retrying through the F4 race), reads the highlighted option's label, then
+// closes it. The dropdown must end closed: a lingering popup would swallow the next gate's keys.
+async function readComboBoxSelectionLabel(page, selectorAutomationId) {
+  const combo = await findComboBox(page, selectorAutomationId);
+  if (!combo?.found) {
+    throw new Error(`combo box '${selectorAutomationId}' was not found in the semantic DOM.`);
+  }
+
+  const state = await openComboBoxAligned(page, selectorAutomationId, `combo box '${selectorAutomationId}'`);
+  const activeIndex = state.activeIndex;
+  if (activeIndex < 0 || activeIndex >= state.itemLabels.length) {
+    await closeComboBox(page);
+    throw new Error(
+      `combo box '${selectorAutomationId}' open state has no highlighted option. `
+      + `State=${JSON.stringify(state)}`);
+  }
+
+  const selected = state.itemLabels[activeIndex];
+  await closeComboBox(page);
+  return selected;
+}
+
+// Keyboard-only selection: open (aligned), Home to reset to the first option, ArrowDown to the
+// target, Enter to commit. Skia's item click only collapses the popup, so keys are the only
+// commit path. The target name must match an item label exactly (case-insensitive) - a miss is
+// an error, never a silent no-op.
 export async function selectComboBoxItem(page, selectorAutomationId, expectedVisibleName, options = {}) {
   const expectedNames = Array.isArray(expectedVisibleName)
     ? expectedVisibleName
     : [expectedVisibleName];
   const label = `combo box '${selectorAutomationId}'`;
 
-  await activateWhenReady(page, { automationIds: [selectorAutomationId], labels: [] }, label, defaultTimeoutMs);
-
-  const deadline = Date.now() + 10_000;
-  let itemState = null;
-  while (Date.now() < deadline) {
-    itemState = await page.evaluate(
-      input => window.__salmoneggSmoke.semantic.comboBoxItem(input.expectedNames),
-      { expectedNames });
-    if (itemState) {
-      break;
-    }
-
-    await page.waitForTimeout(200);
-  }
-
-  if (!itemState) {
+  const state = await openComboBoxAligned(page, selectorAutomationId, label);
+  const targetIndex = state.itemLabels.findIndex(
+    item => expectedNames.some(name => name.toLowerCase() === item.toLowerCase()));
+  if (targetIndex < 0) {
+    await closeComboBox(page);
     throw new Error(
-      `${label} did not expose any item from ${JSON.stringify(expectedNames)} after expanding. `
-      + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+      `${label} open state exposed ${JSON.stringify(state.itemLabels)}; `
+      + `none matched ${JSON.stringify(expectedNames)}.`);
   }
 
-  await page.evaluate(
-    input => window.__salmoneggSmoke.semantic.comboBoxItem(input.expectedNames)?.activate(),
-    { expectedNames });
+  await page.keyboard.press("Home");
+  await page.waitForTimeout(COMBO_SETTLE_MS);
+  for (let i = 0; i < targetIndex; i += 1) {
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(100);
+  }
+  await page.keyboard.press("Enter");
+  await closeComboBox(page);
 
   if (options.verifySelectionText !== false) {
-    await expectComboBoxSelectionText(page, selectorAutomationId, expectedNames, label);
+    const observed = await readComboBoxSelectionLabel(page, selectorAutomationId);
+    if (!expectedNames.some(name => name.toLowerCase() === observed.toLowerCase())) {
+      throw new Error(
+        `${label} selection read back as ${JSON.stringify(observed)}, expected ${JSON.stringify(expectedNames)}.`);
+    }
   }
 }
 
+// Reads the selection by reopening the dropdown and checking the highlighted option's label.
+// Despite the legacy name, no collapsed-state text is read - Skia mirrors none.
 export async function expectComboBoxSelectionText(page, selectorAutomationId, expectedVisibleNames, label) {
   const expectedNames = Array.isArray(expectedVisibleNames)
     ? expectedVisibleNames
     : [expectedVisibleNames];
-  const deadline = Date.now() + 10_000;
-  let observedText = null;
+  const deadline = Date.now() + defaultTimeoutMs;
+  let observed = null;
+  let lastError = null;
 
   while (Date.now() < deadline) {
-    observedText = await readComboBoxSelectionText(page, selectorAutomationId);
-    if (observedText !== null
-      && expectedNames.some(name => observedText.toLowerCase().includes(name.toLowerCase()))) {
-      return;
+    try {
+      observed = await readComboBoxSelectionLabel(page, selectorAutomationId);
+      if (expectedNames.some(name => name.toLowerCase() === observed.toLowerCase())) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
     }
 
     await page.waitForTimeout(200);
   }
 
   throw new Error(
-    `${label ?? `combo box '${selectorAutomationId}'`} did not show one of ${JSON.stringify(expectedNames)}. `
-    + `Observed=${JSON.stringify(observedText)} `
+    `${label ?? `combo box '${selectorAutomationId}'`} selection never read back as `
+    + `${JSON.stringify(expectedNames)}. Last observed=${JSON.stringify(observed)} `
+    + `Last error=${String(lastError)} `
     + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
 }
 
 export async function readComboBoxSelectionText(page, selectorAutomationId) {
-  return await page.evaluate(
-    automationId => window.__salmoneggSmoke.semantic.comboBoxSelectionText(automationId),
-    selectorAutomationId);
+  return await readComboBoxSelectionLabel(page, selectorAutomationId);
 }
 
 // ---- focus -----------------------------------------------------------------------------------

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -290,11 +290,55 @@ function describeTarget(options) {
   return ids.length > 0 ? `automation id '${ids.join("', '")}'` : `label '${labels.join("', '")}'`;
 }
 
+// ---- collapsed sections ----------------------------------------------------------------------
+
+// Open a collapsed Expander and wait until what it holds is genuinely on screen.
+//
+// Two things make this its own helper. The section's contents are in the semantic tree even while the
+// Expander is shut - unhidden, but reporting a placeholder rect at the viewport origin - so "the
+// control exists" is not a usable signal for "the section is open"; the exit condition has to be that
+// the control is laid out. And the thing to click is the Expander's own header button (a real button
+// carrying aria-expanded and a real rect), not the header content inside it: that inner node comes
+// through as a role=group with a 0x0 rect, which cannot be activated and cannot be pointed at.
+//
+// A trusted pointer does the toggling, since BrowserWasm does not reliably expand an Expander from
+// synthetic activation. Clicking is skipped whenever the header already reports itself expanded, so a
+// slow layout can never be "fixed" by a second click that closes the section again.
+export async function revealCollapsedSection(page, toggleTargets, revealedControl, label, attempts = 4) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (isLaidOut(await readControlState(page, revealedControl))) {
+      return;
+    }
+
+    const toggleState = await readControlState(page, toggleTargets);
+    if (toggleState.expanded !== true) {
+      await clickVisibleControlWithTrustedPointer(page, toggleTargets, `${label} expander header`);
+    }
+
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (isLaidOut(await readControlState(page, revealedControl))) {
+        return;
+      }
+
+      await page.waitForTimeout(200);
+    }
+  }
+
+  throw new Error(
+    `Could not open the collapsed section for ${label} in ${attempts} attempts. `
+    + `Header=${JSON.stringify(await readControlState(page, toggleTargets))} `
+    + `Contents=${JSON.stringify(await readControlState(page, revealedControl))}`);
+}
+
 // ---- text entry ------------------------------------------------------------------------------
 
-// The semantic `<input>` forwards `input` events to the managed text box (OnTextInput), and Uno's
-// key handling suppresses native insertion for canvas input - assigning the value and dispatching
-// the event is the supported path, not a workaround.
+// Text goes in as real keystrokes. Uno mirrors a TextBox as a real <input>, so assigning `.value`
+// and dispatching an `input` event looks like it works - and for most fields it does - but the
+// managed side does not always pick it up: the ACP profile editor's Server URL sits inside a
+// conditionally visible container and keeps the ViewModel's old (empty) value while the DOM shows
+// the new one. The app then saves an empty field, the validation message blames the field, and the
+// smoke blames the save. Typing is the user's own path and lands in both cases.
 export async function typeIntoAutomationTextBox(page, automationId, value) {
   const options = { automationIds: [automationId], labels: [] };
   return await setSemanticInputValue(page, options, value, `text box '${automationId}'`, defaultTimeoutMs);
@@ -584,6 +628,7 @@ const findComboBox = (page, selectorAutomationId) => page.evaluate(
   selectorAutomationId);
 
 async function openComboBoxAligned(page, selectorAutomationId, label) {
+  await waitForControlState(page, { automationIds: [selectorAutomationId], labels: [] }, label);
   const deadline = Date.now() + COMBO_OPEN_TIMEOUT_MS;
   let beforeIds = null;
   let attempt = 0;
@@ -634,10 +679,14 @@ async function closeComboBox(page) {
 // Opens the dropdown (retrying through the F4 race), reads the highlighted option's label, then
 // closes it. The dropdown must end closed: a lingering popup would swallow the next gate's keys.
 async function readComboBoxSelectionLabel(page, selectorAutomationId) {
-  const combo = await findComboBox(page, selectorAutomationId);
-  if (!combo?.found) {
-    throw new Error(`combo box '${selectorAutomationId}' was not found in the semantic DOM.`);
-  }
+  // Wait for the combo rather than demanding it be there already: a settings page publishes its
+  // controls as it lays out, so a check made the instant navigation reports success can run before
+  // this one exists. It used to be a bare read, which turned a page still coming up into "the combo
+  // box does not exist".
+  await waitForControlState(
+    page,
+    { automationIds: [selectorAutomationId], labels: [] },
+    `combo box '${selectorAutomationId}'`);
 
   const state = await openComboBoxAligned(page, selectorAutomationId, `combo box '${selectorAutomationId}'`);
   const activeIndex = state.activeIndex;

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -306,28 +306,53 @@ export async function typeIntoVisibleTextField(page, options, value, label, time
 
 async function setSemanticInputValue(page, options, value, label, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
-  let lastResult = null;
-
+  let resolved = null;
   while (Date.now() < deadline) {
-    lastResult = await page.evaluate(
-      input => window.__salmoneggSmoke.semantic.setInput(input.options, input.value),
-      { options, value });
-    if (lastResult?.editable && !lastResult?.disabled) {
-      return lastResult.state;
+    resolved = await page.evaluate(
+      input => window.__salmoneggSmoke.semantic.resolveEditableField(input),
+      options);
+    if (resolved?.id && !resolved.disabled) {
+      break;
     }
 
     await page.waitForTimeout(200);
   }
 
-  if (lastResult?.disabled) {
+  if (resolved?.disabled) {
     throw new Error(
-      `${label} is disabled. State=${JSON.stringify(lastResult.state)} `
+      `${label} is disabled. State=${JSON.stringify(resolved.state)} `
       + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
   }
 
-  throw new Error(
-    `No editable field found for ${label}. Options=${JSON.stringify(options)} `
-    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  if (!resolved?.id) {
+    throw new Error(
+      `No editable field found for ${label}. Options=${JSON.stringify(options)} `
+      + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  }
+
+  const field = page.locator(`#${resolved.id}`);
+  await field.focus();
+  const focusedId = await page.evaluate(() => document.activeElement?.id ?? null);
+  if (focusedId !== resolved.id) {
+    throw new Error(
+      `${label} did not take focus before typing (focus went to ${JSON.stringify(focusedId)}).`);
+  }
+
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type(String(value), { delay: 25 });
+  // Commit with Tab. Some fields update their binding per keystroke, but not all: the ACP profile
+  // editor's Server URL only pushes its value to the ViewModel when the field is left, so without
+  // this the app saves an empty URL while the DOM shows the typed one. It has to be the key, not a
+  // DOM blur() - measured, blur() alone does not commit, because the managed side is driven by Uno's
+  // keyboard pipeline rather than by DOM focus events.
+  await page.keyboard.press("Tab");
+
+  const observed = await field.inputValue().catch(() => null);
+  if (observed !== String(value)) {
+    throw new Error(`Typing into ${label} did not land. Expected ${JSON.stringify(String(value))}, observed ${JSON.stringify(observed)}.`);
+  }
+
+  return resolved.state;
 }
 
 // ---- numeric fields --------------------------------------------------------------------------
@@ -338,8 +363,22 @@ async function setSemanticInputValue(page, options, value, label, timeoutMs) {
 // the application root. That input is the control's actual text field - `.value` is live, focus
 // lands on it, and real keyboard events drive the TwoWay binding (synthetic input events do not
 // commit). The selector is only unambiguous while exactly one NumberBox is mounted, so every
-// helper requires the spinbutton anchor first and fails loudly if more than one editor exists.
+// helper anchors on the spinbutton first and fails loudly if more than one editor exists.
 const numericEditorSelector = '#uno-semantics-root input[xamlautomationid="InputBox"]';
+
+const readNumericEditor = page => page.evaluate(selector => {
+  const editors = Array.from(document.querySelectorAll(selector));
+  const editor = editors[0] ?? null;
+  const active = document.activeElement;
+  return {
+    count: editors.length,
+    id: editor?.id ?? null,
+    value: editor?.value ?? null,
+    focused: Boolean(editor) && active === editor,
+    activeId: active?.id ?? null,
+    activeAutomationId: active?.getAttribute?.("xamlautomationid") ?? null
+  };
+}, numericEditorSelector);
 
 async function waitForNumericEditor(page, controlOptions, label) {
   // The anchor proves the right page is mounted, so a stale editor from a previously visited page
@@ -347,23 +386,47 @@ async function waitForNumericEditor(page, controlOptions, label) {
   await waitForControlState(page, controlOptions, `number box anchor for ${label}`);
 
   const deadline = Date.now() + defaultTimeoutMs;
-  let editorCount = 0;
+  let editor = null;
   while (Date.now() < deadline) {
-    editorCount = await page.locator(numericEditorSelector).count();
-    if (editorCount === 1) {
-      return page.locator(numericEditorSelector).first();
+    editor = await readNumericEditor(page);
+    if (editor.count === 1) {
+      return editor;
     }
 
-    if (editorCount > 1) {
+    if (editor.count > 1) {
       throw new Error(
-        `Found ${editorCount} number box editors while resolving ${label}; `
+        `Found ${editor.count} number box editors while resolving ${label}; `
         + `the editor selector requires a single mounted NumberBox.`);
     }
 
     await page.waitForTimeout(200);
   }
 
-  throw new Error(`No number box editor input found for ${label}.`);
+  throw new Error(`No number box editor input found for ${label}. Last read=${JSON.stringify(editor)}`);
+}
+
+// Focus, then confirm the editor still holds focus. Navigating to a settings section hands focus to
+// the NavigationView's selected item asynchronously, a beat after the navigation itself is
+// observable (measured ~800ms later), so an editor focused before that hand-off loses focus to it
+// and every keystroke afterwards is dropped in silence - the input keeps its old value and nothing
+// reports a problem. Rather than guess how long that beat lasts, focus and check the editor kept
+// it; if something took it, focus again, since the hand-off happens once per navigation.
+async function focusNumericEditor(page, controlOptions, label) {
+  const attempts = [];
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const editor = await waitForNumericEditor(page, controlOptions, label);
+    await page.locator(numericEditorSelector).first().focus();
+    await page.waitForTimeout(300);
+    const held = await readNumericEditor(page);
+    if (held.focused && held.id === editor.id) {
+      return held;
+    }
+
+    attempts.push(held);
+  }
+
+  throw new Error(
+    `The number box editor for ${label} kept losing focus. Attempts=${JSON.stringify(attempts)}`);
 }
 
 function tryParseInteger(value) {

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -479,13 +479,11 @@ function tryParseInteger(value) {
 }
 
 export async function readNumericControlValue(page, controlOptions, label) {
-  const editor = await waitForNumericEditor(page, controlOptions, label);
   const deadline = Date.now() + defaultTimeoutMs;
-  let lastValue = null;
-
+  let editor = null;
   while (Date.now() < deadline) {
-    lastValue = await editor.inputValue().catch(() => null);
-    const parsedValue = tryParseInteger(lastValue);
+    editor = await waitForNumericEditor(page, controlOptions, label);
+    const parsedValue = tryParseInteger(editor.value);
     if (parsedValue != null) {
       return parsedValue;
     }
@@ -493,46 +491,62 @@ export async function readNumericControlValue(page, controlOptions, label) {
     await page.waitForTimeout(200);
   }
 
-  throw new Error(
-    `Timed out reading a numeric value from ${label}. Last editor value=${JSON.stringify(lastValue)}`);
+  throw new Error(`Timed out reading a numeric value from ${label}. Last read=${JSON.stringify(editor)}`);
 }
 
 export async function focusNumericControl(page, controlOptions, label) {
-  const editor = await waitForNumericEditor(page, controlOptions, label);
-  // Bring the real editor row into view first: the focused-state contrast check below only sees
-  // visible inputs, and the spinbutton node's rect is a virtual layout coordinate that cannot be
-  // used for that.
-  await editor.scrollIntoViewIfNeeded();
-  await editor.focus();
-  const focused = await page.evaluate(
-    () => document.activeElement?.getAttribute?.("xamlautomationid") === "InputBox");
-  if (!focused) {
-    throw new Error(`The number box editor did not take focus for ${label}.`);
-  }
+  return await focusNumericEditor(page, controlOptions, label);
 }
 
 export async function setNumericControlValue(page, controlOptions, value, label) {
-  const editor = await waitForNumericEditor(page, controlOptions, label);
-  // A user path, not a synthetic one: focus, select all, type, blur. The TwoWay binding commits
-  // on blur - Enter steals focus without committing, and synthetic input events are ignored.
-  await editor.focus();
-  await page.keyboard.press("Control+a");
-  await page.keyboard.type(String(value), { delay: 40 });
-  await page.keyboard.press("Tab");
+  // The user's path, not a synthetic one: focus, select all, type on the real keyboard, then blur
+  // with Tab, because the TwoWay binding commits on blur and assigning `.value` with a synthetic
+  // input event never commits at all.
+  //
+  // What is verified here is delivery, not acceptance: the editor's value changed, it still holds
+  // focus, it is still the same node, and the blur actually happened. Whether the app accepted the
+  // value is the caller's assertion - re-reading it after leaving and re-entering the page is what
+  // shows the ViewModel's own state.
+  const attempts = [];
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const focused = await focusNumericEditor(page, controlOptions, label);
+    await page.keyboard.press("Control+a");
+    await page.keyboard.type(String(value), { delay: 40 });
+    const typed = await readNumericEditor(page);
+    if (typed.value !== String(value) || !typed.focused || typed.id !== focused.id) {
+      attempts.push(typed);
+      continue;
+    }
 
-  const deadline = Date.now() + 5_000;
-  let observedValue = null;
-  while (Date.now() < deadline) {
-    observedValue = await readNumericControlValue(page, controlOptions, `${label} after edit`);
-    if (observedValue === value) {
+    await page.keyboard.press("Tab");
+    const committed = await waitForNumericEditorBlur(page, label);
+    if (committed.value === String(value)) {
       return;
+    }
+
+    attempts.push(committed);
+  }
+
+  throw new Error(`Typing ${value} into ${label} did not land. Attempts=${JSON.stringify(attempts)}`);
+}
+
+// Tab is the commit gesture, so the blur it causes is the observable proof the key was delivered
+// rather than swallowed by the canvas.
+async function waitForNumericEditorBlur(page, label) {
+  const deadline = Date.now() + 5_000;
+  let editor = null;
+  while (Date.now() < deadline) {
+    editor = await readNumericEditor(page);
+    if (!editor.focused) {
+      return editor;
     }
 
     await page.waitForTimeout(100);
   }
 
   throw new Error(
-    `Failed to set ${label}. Expected ${value}, observed ${observedValue}.`);
+    `The number box editor for ${label} never lost focus after Tab, so the edit was not committed. `
+    + `Last read=${JSON.stringify(editor)}`);
 }
 
 export function selectAlternateCacheRetentionValue(currentValue) {

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -284,18 +284,53 @@ async function setSemanticInputValue(page, options, value, label, timeoutMs) {
 
 // ---- numeric fields --------------------------------------------------------------------------
 
+// NumberBox is the one control whose Skia semantics export splits in two: the spinbutton node
+// carries the automation id but only the two spin buttons as children, while the editable value
+// lives in a separate real `<input>` carrying Uno's template part id ("InputBox") directly under
+// the application root. That input is the control's actual text field - `.value` is live, focus
+// lands on it, and real keyboard events drive the TwoWay binding (synthetic input events do not
+// commit). The selector is only unambiguous while exactly one NumberBox is mounted, so every
+// helper requires the spinbutton anchor first and fails loudly if more than one editor exists.
+const numericEditorSelector = '#uno-semantics-root input[xamlautomationid="InputBox"]';
+
+async function waitForNumericEditor(page, controlOptions, label) {
+  // The anchor proves the right page is mounted, so a stale editor from a previously visited page
+  // can never be edited by mistake.
+  await waitForControlState(page, controlOptions, `number box anchor for ${label}`);
+
+  const deadline = Date.now() + defaultTimeoutMs;
+  let editorCount = 0;
+  while (Date.now() < deadline) {
+    editorCount = await page.locator(numericEditorSelector).count();
+    if (editorCount === 1) {
+      return page.locator(numericEditorSelector).first();
+    }
+
+    if (editorCount > 1) {
+      throw new Error(
+        `Found ${editorCount} number box editors while resolving ${label}; `
+        + `the editor selector requires a single mounted NumberBox.`);
+    }
+
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(`No number box editor input found for ${label}.`);
+}
+
 function tryParseInteger(value) {
   const match = String(value ?? "").match(/-?\d+/);
   return match ? Number.parseInt(match[0], 10) : null;
 }
 
-export async function readNumericControlValue(page, options, label) {
+export async function readNumericControlValue(page, controlOptions, label) {
+  const editor = await waitForNumericEditor(page, controlOptions, label);
   const deadline = Date.now() + defaultTimeoutMs;
-  let lastState = notFoundState;
+  let lastValue = null;
 
   while (Date.now() < deadline) {
-    lastState = await readControlState(page, options);
-    const parsedValue = tryParseInteger(lastState.value ?? lastState.text);
+    lastValue = await editor.inputValue().catch(() => null);
+    const parsedValue = tryParseInteger(lastValue);
     if (parsedValue != null) {
       return parsedValue;
     }
@@ -304,19 +339,36 @@ export async function readNumericControlValue(page, options, label) {
   }
 
   throw new Error(
-    `Timed out reading a numeric value from ${label}. Last state=${JSON.stringify(lastState)} `
-    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+    `Timed out reading a numeric value from ${label}. Last editor value=${JSON.stringify(lastValue)}`);
 }
 
-export async function setNumericControlValue(page, options, value, label) {
-  // The field's value path is the same input event as a text box; blur commits the edit, which the
-  // old keyboard path did by pressing Tab.
-  await setSemanticInputValue(page, options, String(value), label, 10_000);
+export async function focusNumericControl(page, controlOptions, label) {
+  const editor = await waitForNumericEditor(page, controlOptions, label);
+  // Bring the real editor row into view first: the focused-state contrast check below only sees
+  // visible inputs, and the spinbutton node's rect is a virtual layout coordinate that cannot be
+  // used for that.
+  await editor.scrollIntoViewIfNeeded();
+  await editor.focus();
+  const focused = await page.evaluate(
+    () => document.activeElement?.getAttribute?.("xamlautomationid") === "InputBox");
+  if (!focused) {
+    throw new Error(`The number box editor did not take focus for ${label}.`);
+  }
+}
+
+export async function setNumericControlValue(page, controlOptions, value, label) {
+  const editor = await waitForNumericEditor(page, controlOptions, label);
+  // A user path, not a synthetic one: focus, select all, type, blur. The TwoWay binding commits
+  // on blur - Enter steals focus without committing, and synthetic input events are ignored.
+  await editor.focus();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type(String(value), { delay: 40 });
+  await page.keyboard.press("Tab");
 
   const deadline = Date.now() + 5_000;
   let observedValue = null;
   while (Date.now() < deadline) {
-    observedValue = await readNumericControlValue(page, options, `${label} after edit`);
+    observedValue = await readNumericControlValue(page, controlOptions, `${label} after edit`);
     if (observedValue === value) {
       return;
     }
@@ -325,8 +377,7 @@ export async function setNumericControlValue(page, options, value, label) {
   }
 
   throw new Error(
-    `Failed to set ${label}. Expected ${value}, observed ${observedValue}. `
-    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+    `Failed to set ${label}. Expected ${value}, observed ${observedValue}.`);
 }
 
 export function selectAlternateCacheRetentionValue(currentValue) {

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -598,10 +598,24 @@ export async function setToggleSwitchValue(page, options, expectedValue, label) 
     + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
 }
 
-export async function expectToggleSwitchValue(page, options, expectedValue, label) {
-  const actualValue = await readToggleSwitchValue(page, options, label);
+// Polls for the expected state rather than reading once. Settings pages refill their rows
+// asynchronously after navigation, so a row can surface carrying its default state a beat before the
+// persisted one lands - reading immediately after the row appears catches that default and fails on
+// a value the user never sees. A state that never arrives still fails when the budget runs out.
+export async function expectToggleSwitchValue(page, options, expectedValue, label, timeoutMs = defaultTimeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let actualValue = null;
+  while (Date.now() < deadline) {
+    actualValue = await readToggleSwitchValue(page, options, label, Math.max(1_000, deadline - Date.now()));
+    if (actualValue === expectedValue) {
+      return;
+    }
+
+    await page.waitForTimeout(200);
+  }
+
   if (actualValue !== expectedValue) {
-    throw new Error(`Expected toggle ${label} to be ${expectedValue}, got ${actualValue}.`);
+    throw new Error(`Expected toggle ${label} to be ${expectedValue}, last read ${actualValue}.`);
   }
 }
 

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -65,6 +65,29 @@ export async function expectControlEnabledState(page, options, expectedEnabled, 
   }
 }
 
+// Polls until the control's enabled state flips to the expected value. Skia renders the app into a
+// canvas, so "a dialog opened" is not observable as text or DOM - but modality is observable as
+// state: the semantic tree marks the page's controls disabled while the dialog is up and re-enables
+// them once it is dismissed. Waiting on that flip is how a smoke asserts dialog round-trips without
+// depending on how (or whether) the dialog itself is rendered.
+export async function waitForControlEnabledState(page, options, expectedEnabled, label, timeoutMs = defaultTimeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastState = notFoundState;
+
+  while (Date.now() < deadline) {
+    lastState = await readControlState(page, options);
+    if (lastState.found && lastState.enabled === expectedEnabled) {
+      return lastState;
+    }
+
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${label} to become enabled=${expectedEnabled}. Last state=${JSON.stringify(lastState)} `
+    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+}
+
 // Naming note: this used to scroll - activation needed a hit-testable point, so out-of-viewport
 // controls had to be dragged into one first, and callers distinguished "found" from "scrolled" by
 // return value. Semantic activation has no such requirement, so what remains is waiting for the
@@ -126,6 +149,74 @@ export async function clickVisibleControl(page, options) {
 
 export async function clickVisibleNavigationTarget(page, options) {
   return await activateWhenReady(page, options, describeTarget(options), defaultTimeoutMs);
+}
+
+// A real Playwright mouse click at the semantic node's center. The two synthetic routes both fail
+// here and need different medicine:
+// - A raw locator click can never pass Playwright's actionability check: Uno bakes no `role`
+//   attribute into semantic elements (the `<button>`/`<input>` tag carries the semantics
+//   implicitly, and CSS attribute selectors match the attribute, not the ARIA role), and their
+//   `pointer-events` is `none` so the browser's hit test hands the pointer to the canvas below.
+// - `element.click()` on the node fires the peer's Invoke callback but does not always reach the
+//   XAML command (the hero cards, the Gamepad expander, and the gamepad refresh button all
+//   documented that gap).
+// Clicking the node's reported center is the user's actual gesture path: a trusted pointer goes
+// through Uno's canvas hit testing and raises the same pointer events a human click would.
+export async function clickVisibleControlWithTrustedPointer(page, options, label) {
+  const state = await waitForControlState(page, options, label);
+  if (!state.enabled) {
+    throw new Error(
+      `Control ${label} is disabled and cannot receive a pointer click. State=${JSON.stringify(state)} `
+      + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  }
+
+  // `getBoundingClientRect` and `page.mouse.click` share the viewport coordinate space, but a
+  // control Uno keeps laid out off-screen reports a center outside it; clicking there would miss
+  // the canvas. Surface that instead of silently no-oping.
+  const viewport = page.viewportSize();
+  if (state.x == null || state.y == null
+    || state.x < 0 || state.y < 0
+    || state.x > viewport.width || state.y > viewport.height) {
+    throw new Error(
+      `Control ${label} center (${state.x}, ${state.y}) is outside the `
+      + `${viewport.width}x${viewport.height} viewport, so a pointer click would miss it. `
+      + `State=${JSON.stringify(state)} Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  }
+
+  // A control that has just appeared can still be mid-entrance-animation, so the center read
+  // above describes where it was, not where the click lands. Wait for the reported center to
+  // stop moving, then give Uno's canvas hit test one more beat to catch up with the layout it
+  // just reported - both stillness and a settled hit test are part of what "clickable" means
+  // for a real pointer.
+  const deadline = Date.now() + defaultTimeoutMs;
+  let settledState = state;
+  let stableReads = 0;
+  while (stableReads < 3 && Date.now() < deadline) {
+    await page.waitForTimeout(200);
+    const nextState = await readControlState(page, options);
+    if (!nextState.found || !nextState.enabled) {
+      throw new Error(
+        `Control ${label} disappeared or became disabled while waiting for its layout to settle. `
+        + `Last state=${JSON.stringify(nextState)} `
+        + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+    }
+
+    stableReads = (nextState.x === settledState.x && nextState.y === settledState.y)
+      ? stableReads + 1
+      : 0;
+    settledState = nextState;
+  }
+
+  if (stableReads < 3) {
+    throw new Error(
+      `Control ${label} center never settled (first seen (${state.x}, ${state.y}), `
+      + `last seen (${settledState.x}, ${settledState.y})), so a pointer click could not be `
+      + `aimed reliably. Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  }
+
+  await page.waitForTimeout(500);
+  await page.mouse.click(settledState.x, settledState.y);
+  return settledState;
 }
 
 export async function clickVisibleNavigationTargetUntilBodyText(page, options, pattern, label) {
@@ -525,7 +616,9 @@ export async function expectControlDoesNotEscapePage(page, options, stayOnPagePa
 
 async function dismissDialogIfPresent(page) {
   // The app's confirmation dialogs ship 确定/OK as their only button; activating a control that is
-  // not there is a no-op after the timeout, so no presence probe is needed first.
+  // not there is a no-op after the timeout, so no presence probe is needed first. The activate path
+  // (semantic invoke) needs no coordinates, which matters because Skia-rendered dialogs report
+  // garbage rects for their buttons - only their presence in the semantic tree is trustworthy.
   try {
     await activateWhenReady(
       page,
@@ -558,10 +651,19 @@ export async function waitForBodyText(page, pattern, label, timeoutMs = 30_000) 
   const deadline = Date.now() + timeoutMs;
   let lastBodyText = "";
   while (Date.now() < deadline) {
-    await page.waitForFunction(
-      source => new RegExp(source).test(document.body?.innerText ?? ""),
-      pattern.source,
-      { timeout: Math.min(5_000, Math.max(250, deadline - Date.now())) });
+    try {
+      await page.waitForFunction(
+        source => new RegExp(source).test(document.body?.innerText ?? ""),
+        pattern.source,
+        { timeout: Math.min(5_000, Math.max(250, deadline - Date.now())) });
+    } catch (error) {
+      // The poll timing out is not fatal - the outer deadline owns that verdict. Without this
+      // catch a 5s poll timeout escapes the loop entirely and reports a raw Playwright
+      // TimeoutError before the caller's 30s ever elapsed, hiding the collected body text.
+      if (Date.now() >= deadline) {
+        break;
+      }
+    }
 
     lastBodyText = await page.locator("body").innerText();
     if (pattern.test(lastBodyText)) {

--- a/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
+++ b/scripts/gates/wasm-smoke-lib/ui-affordances.mjs
@@ -58,6 +58,42 @@ export async function waitForControlState(page, options, label, timeoutMs = defa
     + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
 }
 
+export async function countVisibleControls(page, options) {
+  return await page.evaluate(input => window.__salmoneggSmoke.semantic.countMatches(input), options);
+}
+
+// A control inside a collapsed container is present and not hidden - Uno simply has not laid it out,
+// so it reports a placeholder rect a few pixels wide at the viewport origin. "Present in the
+// semantic tree" is therefore not the same as "on screen": anything a user has to see, point at, or
+// focus has to be checked for a real rect, or the smoke will happily drive a control that is not
+// there yet (and a pointer aimed at the placeholder lands on whatever occupies the top-left corner).
+const laidOutMinimumSize = 12;
+
+export function isLaidOut(state) {
+  return Boolean(state?.found)
+    && Boolean(state?.rect)
+    && state.rect.width >= laidOutMinimumSize
+    && state.rect.height >= laidOutMinimumSize;
+}
+
+export async function waitForLaidOutControl(page, options, label, timeoutMs = defaultTimeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastState = notFoundState;
+
+  while (Date.now() < deadline) {
+    lastState = await readControlState(page, options);
+    if (isLaidOut(lastState)) {
+      return lastState;
+    }
+
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${label} to be laid out on screen. Last state=${JSON.stringify(lastState)} `
+    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+}
+
 export async function expectControlEnabledState(page, options, expectedEnabled, label) {
   const state = await waitForControlState(page, options, label);
   if (state.enabled !== expectedEnabled) {
@@ -168,6 +204,18 @@ export async function clickVisibleControlWithTrustedPointer(page, options, label
     throw new Error(
       `Control ${label} is disabled and cannot receive a pointer click. State=${JSON.stringify(state)} `
       + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
+  }
+
+  // A control Uno has not laid out yet reports a placeholder rect - a few pixels at the viewport's
+  // top-left - which is what a control inside a collapsed container looks like. Its centre is a
+  // perfectly clickable point belonging to whatever really sits there (the title bar's back button,
+  // in the case that surfaced this), so clicking it navigates away and the failure appears wherever
+  // the caller next looks. Refuse it and name it.
+  if (!isLaidOut(state)) {
+    throw new Error(
+      `Control ${label} reports an unlaid-out rect (${state.rect.width}x${state.rect.height} at `
+      + `${state.rect.left},${state.rect.top}), so it is not on screen for a pointer - it is most `
+      + `likely inside a collapsed container that has to be opened first. State=${JSON.stringify(state)}`);
   }
 
   // `getBoundingClientRect` and `page.mouse.click` share the viewport coordinate space, but a
@@ -691,6 +739,34 @@ export async function clickStartComposerSendButton(page) {
     { automationIds: ["ChatInputArea.Send"], labels: [] },
     "start composer send button",
     defaultTimeoutMs);
+}
+
+// The semantic tree's equivalent of a body-text wait. Skia mirrors much of what a user reads only as
+// an accessible name - list item titles, field labels, button captions on templated controls - so
+// text that is plainly on screen can be absent from every node's textContent. Matching against both
+// is what makes "the user can see this text" checkable on this renderer.
+export async function waitForSemanticText(page, pattern, label, timeoutMs = defaultTimeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSample = [];
+  while (Date.now() < deadline) {
+    lastSample = await page.evaluate(source => {
+      const regex = new RegExp(source);
+      return Array.from(document.querySelectorAll("#uno-semantics-root [id^='uno-semantics-']"))
+        .filter(node => !node.hidden)
+        .map(node => `${node.getAttribute("aria-label") ?? ""}|${(node.textContent ?? "").trim()}`)
+        .filter(text => regex.test(text))
+        .slice(0, 5);
+    }, pattern.source);
+    if (lastSample.length > 0) {
+      return;
+    }
+
+    await page.waitForTimeout(200);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${label} in the semantic tree. Pattern=${pattern} `
+    + `Semantic DOM=${JSON.stringify(await collectSemanticDebug(page))}`);
 }
 
 export async function waitForBodyText(page, pattern, label, timeoutMs = 30_000) {

--- a/scripts/gates/wasm-start-visibility-smoke.mjs
+++ b/scripts/gates/wasm-start-visibility-smoke.mjs
@@ -64,9 +64,7 @@ try {
     // raw locator can never pass Playwright's actionability check against a semantic node (no
     // baked `role` attribute, pointer-events: none). A trusted pointer at the center Uno reports
     // is the user's actual gesture path through the canvas hit test.
-    await clickVisibleControlWithTrustedPointer(page, reportCard, "report suggestion card");
-
-    await waitForControlState(page, noticeAcknowledgement, "report notice acknowledgement button");
+    await activateReportCardUntilNoticeOpens(page, "report suggestion card");
     await waitForControlEnabledState(page, reportCard, false, "report suggestion card behind the notice");
 
     // The OK button's automation peer finishes wiring shortly after the node first surfaces, so an
@@ -92,8 +90,7 @@ try {
 
     // The affordance must survive its own use: a second activation reopens the notice instead of
     // leaving the card dead after one acknowledgement.
-    await clickVisibleControlWithTrustedPointer(page, reportCard, "report suggestion card again");
-    await waitForControlState(page, noticeAcknowledgement, "report notice acknowledgement button again");
+    await activateReportCardUntilNoticeOpens(page, "report suggestion card again");
 
     assertNoFatalConsoleMessages(fatalConsoleMessages);
     console.log("WASM start visibility smoke passed");
@@ -102,4 +99,32 @@ try {
   }
 } finally {
   await browser.close();
+}
+
+// Retried against the notice appearing, not against the click reporting success. A trusted pointer
+// goes through the canvas hit test, and that can miss: the card's reported centre is right, the click
+// is delivered, and the command still does not run - measured on CI, where one run in several opened
+// no notice at all while the same commit passed locally twice and on the previous CI run. Pressing
+// again is what a user does. The card's own enabled state decides whether to press: once the notice
+// is up the page reports its controls disabled, so a card that has gone disabled means the notice is
+// on its way and the only thing left to do is wait for it.
+async function activateReportCardUntilNoticeOpens(page, label) {
+  const attempts = 3;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (await scrollToVisibleControl(page, noticeAcknowledgement, 1_000)) {
+      return;
+    }
+
+    if ((await readControlState(page, reportCard)).enabled) {
+      await clickVisibleControlWithTrustedPointer(page, reportCard, label);
+    }
+
+    if (await scrollToVisibleControl(page, noticeAcknowledgement, 8_000)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    `Activating ${label} did not open its notice in ${attempts} attempts. `
+    + `Card=${JSON.stringify(await readControlState(page, reportCard))}`);
 }

--- a/scripts/gates/wasm-start-visibility-smoke.mjs
+++ b/scripts/gates/wasm-start-visibility-smoke.mjs
@@ -6,7 +6,10 @@ import {
   assertNoFatalConsoleMessages
 } from "./wasm-smoke-lib/browser-app.mjs";
 import {
-  waitForBodyText,
+  clickVisibleControl,
+  clickVisibleControlWithTrustedPointer,
+  readControlState,
+  waitForControlEnabledState,
   waitForControlState
 } from "./wasm-smoke-lib/ui-affordances.mjs";
 
@@ -18,6 +21,9 @@ const expectedSuggestions = [
   { title: ["推荐开发任务", "Recommend tasks"] },
   { title: ["解决最近报错", "Resolve recent errors"] }
 ];
+
+const reportCard = { labels: ["举报 AI 内容", "Report AI content"], automationIds: [], role: "button" };
+const noticeAcknowledgement = { labels: ["确定", "OK"], automationIds: [], role: "button" };
 
 try {
   const { context, page, fatalConsoleMessages } = await createInstrumentedContext(browser);
@@ -44,18 +50,42 @@ try {
         suggestion.title.join(" / "));
     }
 
-    // Activating the report card explains itself instead of sending anything: the tip copy is
-    // the behaviour, and it only exists after the card is activated. The activation is a real
-    // trusted click on the semantic node, not a synthetic element.click(): CI (the role-pin
-    // commit) showed the hero card's command never fires from the semantic activate path - the
-    // same BrowserWasm gap the expander and the gamepad refresh button already documented -
-    // while a trusted click through the same node the screen reader exposes is the closest
-    // thing to the user's gesture.
-    await page.locator('[role="button"][aria-label="Report AI content"]').click({ timeout: 15_000 });
-    await waitForBodyText(
-      page,
-      /这张提示卡本身只是说明，不会发送举报|This tip card only explains the path and cannot send a report/,
-      "report guidance tip");
+    // Activating the report card must answer the user with a modal notice they then acknowledge -
+    // that round-trip is the behaviour, and it is asserted the way a user experiences it, not by
+    // reading the notice's copy: Skia paints the ContentDialog into the canvas without mirroring
+    // it into the DOM/semantic tree, so its text is structurally unobservable here and any
+    // text-based assertion would be pinning a renderer detail. What *is* observable - on this
+    // renderer and on a DOM one - is modality: while the notice is up the semantic tree reports
+    // the page's controls disabled, the notice's own OK button appears in it, and acknowledging
+    // that button hands control back. The activation itself goes through the node's real center:
+    // the semantic activate path (element.click()) does not reach the XAML command - the same
+    // BrowserWasm gap the expander and the gamepad refresh button already documented - while a
+    // raw locator can never pass Playwright's actionability check against a semantic node (no
+    // baked `role` attribute, pointer-events: none). A trusted pointer at the center Uno reports
+    // is the user's actual gesture path through the canvas hit test.
+    await clickVisibleControlWithTrustedPointer(page, reportCard, "report suggestion card");
+
+    await waitForControlState(page, noticeAcknowledgement, "report notice acknowledgement button");
+    await waitForControlEnabledState(page, reportCard, false, "report suggestion card behind the notice");
+
+    // The OK button's automation peer finishes wiring shortly after the node first surfaces, so an
+    // invoke fired at first sight can be swallowed. Acknowledging is retried against the visible
+    // effect (the page coming back) rather than against the invoke's own return value, which is
+    // always true even when the dialog stays up.
+    const acknowledgeDeadline = Date.now() + 30_000;
+    const isCardEnabled = async () => (await readControlState(page, reportCard)).enabled;
+    while (!(await isCardEnabled())) {
+      if (Date.now() > acknowledgeDeadline) {
+        throw new Error("The notice acknowledgement did not return the page within 30s.");
+      }
+      await clickVisibleControl(page, noticeAcknowledgement);
+      await page.waitForTimeout(500);
+    }
+
+    // The affordance must survive its own use: a second activation reopens the notice instead of
+    // leaving the card dead after one acknowledgement.
+    await clickVisibleControlWithTrustedPointer(page, reportCard, "report suggestion card again");
+    await waitForControlState(page, noticeAcknowledgement, "report notice acknowledgement button again");
 
     assertNoFatalConsoleMessages(fatalConsoleMessages);
     console.log("WASM start visibility smoke passed");

--- a/scripts/gates/wasm-start-visibility-smoke.mjs
+++ b/scripts/gates/wasm-start-visibility-smoke.mjs
@@ -9,6 +9,7 @@ import {
   clickVisibleControl,
   clickVisibleControlWithTrustedPointer,
   readControlState,
+  scrollToVisibleControl,
   waitForControlEnabledState,
   waitForControlState
 } from "./wasm-smoke-lib/ui-affordances.mjs";
@@ -78,7 +79,14 @@ try {
       if (Date.now() > acknowledgeDeadline) {
         throw new Error("The notice acknowledgement did not return the page within 30s.");
       }
-      await clickVisibleControl(page, noticeAcknowledgement);
+
+      // Only press while the button is still there. The notice can be gone a beat before the page
+      // reports itself enabled again, and pressing into that gap fails on a control that has already
+      // done its job - which reads as "OK never appeared" and hides what actually happened.
+      if (await scrollToVisibleControl(page, noticeAcknowledgement, 1_000)) {
+        await clickVisibleControl(page, noticeAcknowledgement);
+      }
+
       await page.waitForTimeout(500);
     }
 

--- a/tests/SalmonEgg.Presentation.Core.Tests/WasmStartupAssetsTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/WasmStartupAssetsTests.cs
@@ -646,16 +646,16 @@ public sealed class WasmStartupAssetsTests
         Assert.True(File.Exists(RepoPath(@"scripts\gates\wasm-smoke-lib\acp-test-server.mjs")));
         Assert.False(File.Exists(RepoPath(@"scripts\gates\wasm-file-system-availability-smoke.mjs")));
         Assert.False(File.Exists(RepoPath(@"scripts\gates\wasm-smoke-lib\settings-ui.mjs")));
+        // What this test owns is the split itself - which smoke covers which behaviour - plus the
+        // couple of observable outcomes that identify the persistence smoke. It used to also pin
+        // expressions out of that script's source (which DOM predicate the focus check used, the
+        // name of a parameter, which fields a projection compared, the helper names inside the
+        // contrast check). Those are implementation, not behaviour: rewriting the check to observe
+        // the same thing a different way broke this test while the gate itself stayed green, which
+        // is the wrong way round.
         var settingsPersistenceSmoke = LoadFile(@"scripts\gates\wasm-settings-persistence-smoke.mjs");
         Assert.Contains("language: en-US", settingsPersistenceSmoke, StringComparison.Ordinal);
         Assert.Contains("focused data storage cache retention", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("requireFocused: true,", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("document.activeElement === textInput", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("document.activeElement === element", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("focusedControl: dataStorageCacheRetentionControl", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("projection.focused && projection.focusedTarget", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("findEffectiveBackground", settingsPersistenceSmoke, StringComparison.Ordinal);
-        Assert.Contains("compositeCssColor", settingsPersistenceSmoke, StringComparison.Ordinal);
         // The shell keeps the active Settings section across a language reload, so the English
         // assertion is anchored on the General page summary resource instead of Start copy.
         Assert.Contains("Manage startup, window behavior, and UI language", settingsPersistenceSmoke, StringComparison.Ordinal);


### PR DESCRIPTION
Fixes the WASM smoke gates, which were red on `main`.

## What was actually wrong

The chain was broken at the first gate, so gates two through seven had never been
reached — their assertions had not run in a long time, and most of them could not
pass on Skia at all. Each fix exposed the next one; that is why this is twelve
commits rather than one.

The recurring mistake: the checks read signals that exist in the DOM but do not
describe what a user experiences.

- **Text that only exists as an accessible name.** Skia paints into a canvas and
  mirrors an accessibility view, not a DOM. Chat turns, list row titles, editor
  field labels, combo box items — all of them reach the tree as accessible names,
  never as text content. Every `body.innerText` assertion over them was structurally
  unable to pass. They read the semantic tree now.
- **"Present" mistaken for "on screen".** A control inside a collapsed Expander is in
  the tree, unhidden, reporting a placeholder rect a few pixels wide at the origin.
  Checks treated that as ready, then drove a section the user cannot see — and a
  pointer aimed at that placeholder hit the title bar's back button and navigated
  away. Layout is now part of the readiness question.
- **Duplicate automation ids.** Templated rows publish several nodes with the same id,
  including for rows that are not realized. Typing into one of those lands nowhere.
  Matching prefers the laid-out node.
- **Synthetic input that the ViewModel never sees.** Assigning a mirrored input's
  value works for most fields but not all: the ACP profile editor's Server URL kept
  an empty value in the ViewModel while the DOM showed the typed URL, so saving
  failed validation on a field that was visibly filled. Text entry is real keystrokes
  now, committed with Tab (a DOM `blur()` does not commit — Uno is driven by its own
  keyboard pipeline).
- **A redundant navigation that undid the previous one.** Reaching a settings section
  always activated the Settings entry first, even when the shell was already open,
  which starts an async navigation to the default section that can land *after* the
  section click and replace the page mid-use. The MCP editor "not opening" was this.
- **Assertions that could only ever be true.** The MCP page's arrival was pinned to
  body text containing "New" — a word the navigation shell itself renders.

## Product fixes included

- **Gamepad diagnostics were unreadable by assistive technology.** All eight value
  fields hardcoded `AutomationProperties.Name` to their own automation id, so a screen
  reader announced `Diagnostics.GamepadStandardCount` where the user reads `0`. Each
  name is bound to the text its field renders. This is also what made the values
  readable by the gate.

## Two facts worth keeping

- **Which activation route reaches a control has to be measured per control.** The
  report card needs a trusted pointer; the gamepad refresh button needs semantic
  activation and does nothing from a pointer; a locator click can never satisfy
  actionability against a semantic node at all (`pointer-events: none` hands the
  pointer to the canvas). Assuming from a neighbour is how these went wrong.
- **Some things are structurally unobservable here and should not be asserted.** The
  composer's text colour is painted into the canvas, and a ContentDialog is not
  mirrored at all. Those assertions were removed rather than reworded: theme
  behaviour is covered by the persisted selection and the yaml snapshot, and the
  dialog by its modality (the page reports its controls disabled while it is up).

## Verification

`scripts/gates/run-wasm-smoke-gates.sh Debug` — two consecutive green runs, all seven
smokes, ending on `[gate] WASM smoke gates passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
