### PR TITLE
fix(tests): RecordingChatStore dispatch contract must not capture ambient context

### DIFF
--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -7564,14 +7564,16 @@ public partial class ChatViewModelTests
 
         public async ValueTask Dispatch(ChatAction action)
         {
+            // 临界区不捕获环境上下文：与真实 ChatStore.Dispatch 的契约一致，
+            // 闸的释放绝不依赖外部泵（fire-and-forget 分发也必须能自完成）。
             _actions.Enqueue(action);
-            await _dispatchGate.WaitAsync();
+            await _dispatchGate.WaitAsync().ConfigureAwait(false);
             try
             {
                 var currentState = LatestState;
                 var updatedState = ChatReducer.Reduce(currentState, action);
                 LatestState = updatedState;
-                await State.Update(_ => updatedState, CancellationToken.None);
+                await State.Update(_ => updatedState, CancellationToken.None).ConfigureAwait(false);
                 if (updatedState.Generation > currentState.Generation)
                 {
                     _workspaceWriter?.Enqueue(updatedState, scheduleSave: true);
@@ -7579,7 +7581,7 @@ public partial class ChatViewModelTests
 
                 if (AfterDispatch is { } afterDispatch)
                 {
-                    await afterDispatch(action);
+                    await afterDispatch(action).ConfigureAwait(false);
                 }
             }
             finally
@@ -7591,7 +7593,7 @@ public partial class ChatViewModelTests
         public async ValueTask SetStateAsync(ChatState state)
         {
             LatestState = state;
-            await State.Update(_ => state, CancellationToken.None);
+            await State.Update(_ => state, CancellationToken.None).ConfigureAwait(false);
         }
 
         public ValueTask<ChatState> GetCurrentStateAsync()


### PR DESCRIPTION
## 问题

CI 上 `ArchiveConversation_WhenMutationCompletesOffUi_UpdatesTerminalPanelStateOnUiContext`（ChatViewModelTests）随机挂死到超时。

## 根因（dotnet-dump 取证闭环）

测试 fake `RecordingChatStore.Dispatch` 的临界区内 4 处裸 `await`。测试泵 `QueueingSynchronizationContext.RunNext` 执行回调前会 `SetSynchronizationContext(this)`，因此泵内发起的 fire-and-forget dispatch（`ChatViewModel.AcpSessionLifecycle.cs` 的 `RemoveBottomPanelState` → `_ = _chatStore.Dispatch(new ClearConversationRuntimeStateAction(...))`）会捕获队列上下文。测试泵排空后，该孤儿续体躺在无人泵的队列里——`_dispatchGate` 永不释放，测试随后自己的 `await archiveTask`（内含一次 Dispatch）永久排队 → 死锁。

真实 `ChatStore.Dispatch` 对所有 await 一律 `.ConfigureAwait(false)`（闸的释放绝不依赖外部泵，fire-and-forget 分发必须能自完成）。fake 偏离了这一契约才是病根。

## 修复

给 fake 的 `Dispatch`（3 处）与 `SetStateAsync`（1 处）补齐 `.ConfigureAwait(false)`，对齐真 store 契约。`AfterDispatch` 回调无任何测试设置，行为面无额外影响。

## 验证

| 验证 | 结果 |
|---|---|
| 原挂死测试 ×5 | 5/5 绿 |
| 整类 ChatViewModelTests ×3 | 348×3 全绿 |
| 全套 Presentation.Core.Tests | 3316/3316 绿（1m32s） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)