### PR TITLE
docs(acp): clarify SDK support boundaries

### DIFF
--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -31,6 +31,30 @@ variants, permission subjects, config-option wire shapes, and JSON-RPC batches a
 and protected by a separate experimental feature flag. The modeled v2 contracts are marked
 `[Experimental("SEACP002")]`; see [ACP v2 draft surface](#acp-v2-draft-surface-seacp002).
 
+## Capability support boundaries
+
+The presence of a wire type does not advertise a capability or supply its host implementation.
+`ClientCapabilityDefaults.Create()` is the authority for the capabilities SalmonEgg advertises;
+hosts must enable optional capabilities only after implementing their interaction and lifecycle.
+
+| Surface | Current behavior | Remaining work |
+| --- | --- | --- |
+| Agent authentication | An eligibility check blocks `terminal` and other non-blank unknown method types before `authenticate`. | Blank and malformed discriminators still need correction in [#147](https://github.com/salmonloop/salmon-egg/issues/147). Interactive terminal authentication also needs a host implementation before advertising `auth.terminal`. |
+| Request cancellation | The SDK implements `$/cancel_request`, `-32800`, and late-response correlation. `session/cancel` remains a separate session operation. | Network adapter cancellation and cancel-send error handling still need correction in [#148](https://github.com/salmonloop/salmon-egg/issues/148). Peer cancellation is best effort. |
+| Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
+| URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
+| ACP v2 | Experimental wire contracts and version-specific serialization tests exist. Live initialization rejects v2. | Wire coverage and the runtime lifecycle remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+
+V2 wire coverage still needs grouped config-option identifiers (`groupId`), required message IDs
+on chunks, resource-link icons, command-input discriminators, and the treatment of v1-only fields
+and MCP variants. Its permission subject types are not connected to live request handling.
+Completing these contracts does not complete message upserts, streaming tool and terminal
+projections, or the acknowledgement-to-`state_update` completion lifecycle.
+
+Keep the v1 runtime and public API compatible while these gaps are addressed. Enabling v2 needs
+both the upstream stabilization/Agent prerequisites and end-to-end verification of the complete
+lifecycle. Passing DTO tests or suppressing `SEACP002` does not satisfy that requirement.
+
 ## ACP v2 draft surface (SEACP002)
 
 Every v2 draft contract on the public surface carries `[Experimental("SEACP002")]`, so naming one is


### PR DESCRIPTION
ACP SDK 的公开 DTO 容易被误认为已经完成产品能力。README 新增能力边界表，说明鉴权、请求取消、form/URL elicitation 与 v2 的实际支持范围，并链接已更新的开发计划。

只修改 `src/SalmonEgg.Acp/README.md`。稳定 V1 默认、现有 SDK 和应用行为保持现状；此 PR 不关闭尚有缺口的 issues。

关联：#144、#146、#147、#148、#149、#154。开发顺序为 #147/#148 的 P1 正确性修复，然后 URL/凭据产品接入；v2 按 wire、状态生命周期、投影/权限、batch 和正式验收分阶段推进。

验证：

- 文档-only 变更；`git diff --check` 通过，文档逐项对照当前源码与官方 schema。未为文字修改另跑本地构建。
- PR 提交 `ac1257a7bcdd59075136f8a9fce601ef215fba74` 的 [SDK CI](https://github.com/salmonloop/salmon-egg/actions/runs/34233982522) 544/544 tests 通过，SDK/测试构建均为 0 warning / 0 error；包 `SalmonEgg.Acp.1.0.1-alpha.0.163.nupkg` 的外部 consumer 和 37 个草案类型的编译保护均通过。[WASM GUI gate](https://github.com/salmonloop/salmon-egg/actions/runs/34233982470)、Core tests 及平台构建也通过。最终检查为 16 成功、1 条件跳过，无待运行/失败项，PR 为 `MERGEABLE / CLEAN`。
- 隔离副本中现有 auth/cancellation 定向用例 13/13 通过；临时移除门控后 4 个相应用例失败，恢复源码并重编后再次通过。
- 新增的临时原始报文探针复现 4 种 auth discriminator 错误放行；另 2 个探针复现网络适配器吞 caller cancellation、cancel-send 错误事件外泄。失败证据已写入 #147/#148，探针及临时源码不进入本 PR。这些是现有问题，本 PR 未修复它们。
- 未执行新的真实第三方 Agent 互操作、五平台 URL 安全打开或 live v2 验收；对应要求保留在 issues。
