### PR TITLE
feat(acp): separate prompt acceptance from session work completion

### DIFF
--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -858,14 +858,9 @@ namespace SalmonEgg.Acp.Client
                     "session/cancel requires 'sessionId'.");
             }
 
-            CancellationToken connectionToken;
-            Task<SessionPromptCompletion>? cancellationCompletion;
-            lock (_lock)
-            {
-                EnsureInitialized();
-                connectionToken = _messageLoopCts!.Token;
-            }
+            var connectionToken = GetConnectionToken();
             using var sendCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectionToken);
+            Task<SessionPromptCompletion>? cancellationCompletion;
             Task<bool> sendTask;
             lock (_lock)
             {
@@ -883,8 +878,8 @@ namespace SalmonEgg.Acp.Client
                 cancellationCompletion = ProtocolVersion == AcpProtocolVersion.V2
                     ? _sessionWork.RequestCancellation(@params.SessionId, connectionToken)
                     : null;
-                // The send claim and its token belong to the same connection. A queued write must
-                // be cancelled before the transport can carry it into a replacement connection.
+                // Claim the send before a disconnect can replace the connection. The linked token
+                // also prevents a queued physical write from reaching that replacement connection.
                 sendTask = _transport.SendMessageAsync(_parser.SerializeMessage(notification), sendCancellation.Token);
             }
             var sent = await sendTask.ConfigureAwait(false);

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -724,26 +724,13 @@ namespace SalmonEgg.Acp.Client
                 prompt = _sessionWork.BeginPrompt(@params.SessionId, _wire, connectionToken);
             }
 
-            try
-            {
-                // Record acceptance synchronously in response dispatch. An asynchronous continuation
-                // could otherwise run after the very next state_update and lose an immediate idle.
-                await SendRequestAsync(request, cancellationToken, prompt.ConnectionToken,
-                    response => _sessionWork.ReceivePromptResponse(prompt, response)).ConfigureAwait(false);
-                var completion = await prompt.Completion.WaitAsync(cancellationToken).ConfigureAwait(false);
-                return completion.GetResponse();
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // Cancelling a local wait cannot invent an idle state. The peer response and any
-                // later state_update remain correlated until they settle or the connection ends.
-                throw;
-            }
-            catch (Exception error)
-            {
-                _sessionWork.FailPrompt(prompt, error);
-                throw;
-            }
+            // Record acceptance synchronously in response dispatch. An asynchronous continuation
+            // could otherwise run after the very next state_update and lose an immediate idle.
+            await SendRequestAsync(request, cancellationToken, prompt.ConnectionToken,
+                response => _sessionWork.ReceivePromptResponse(prompt, response),
+                error => _sessionWork.FailPrompt(prompt, error)).ConfigureAwait(false);
+            var completion = await prompt.Completion.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return completion.GetResponse();
         }
 
         // spec MUST: the client must restrict the content types it sends to the promptCapabilities
@@ -1497,7 +1484,8 @@ namespace SalmonEgg.Acp.Client
             JsonRpcRequest request,
             CancellationToken cancellationToken,
             CancellationToken connectionToken = default,
-            Action<JsonRpcResponse>? responseObserver = null)
+            Action<JsonRpcResponse>? responseObserver = null,
+            Action<Exception>? requestNotSentObserver = null)
         {
             if (!connectionToken.CanBeCanceled)
             {
@@ -1512,6 +1500,7 @@ namespace SalmonEgg.Acp.Client
             using var sendCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectionToken);
             var requestWriteStarted = false;
             var retainPendingRequest = false;
+            Exception? failure = null;
 
             try
             {
@@ -1596,18 +1585,21 @@ namespace SalmonEgg.Acp.Client
                     await SendCancelRequestNotificationAsync(requestId, connectionToken).ConfigureAwait(false);
                 }
 
-                throw new OperationCanceledException(cancellationToken);
+                failure = new OperationCanceledException(cancellationToken);
+                throw failure;
             }
             catch (TaskCanceledException ex)
             {
                 var exception = new OperationCanceledException(
                     "ACP request was canceled because the transport disconnected.",
                     ex);
+                failure = exception;
                 AcpActivitySources.RecordException(activity, exception);
                 throw exception;
             }
             catch (Exception ex)
             {
+                failure = ex;
                 AcpActivitySources.RecordException(activity, ex);
                 _logger.Log(
                     AcpClientLogLevel.Error,
@@ -1619,6 +1611,25 @@ namespace SalmonEgg.Acp.Client
             }
             finally
             {
+                if (failure is not null)
+                {
+                    if (!requestWriteStarted)
+                    {
+                        requestNotSentObserver?.Invoke(failure);
+                    }
+                    else if (responseObserver is not null)
+                    {
+                        // Once transport I/O starts, false or an exception cannot prove that no
+                        // bytes reached the peer. Keep prompt acceptance correlated until its
+                        // response or disconnect; only the send owner can declare it unsent.
+                        retainPendingRequest = true;
+                        _ = tcs.Task.ContinueWith(
+                            static completed => _ = completed.Exception,
+                            CancellationToken.None,
+                            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                            TaskScheduler.Default);
+                    }
+                }
                 if (!retainPendingRequest)
                 {
                     _pendingRequests.TryRemove(requestIdStr, out _);

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -1487,23 +1488,27 @@ namespace SalmonEgg.Acp.Client
             Action<JsonRpcResponse>? responseObserver = null,
             Action<Exception>? requestNotSentObserver = null)
         {
-            if (!connectionToken.CanBeCanceled)
-            {
-                lock (_lock)
-                {
-                    connectionToken = _messageLoopCts?.Token ?? CancellationToken.None;
-                }
-            }
-            using var activity = AcpActivitySources.StartClientRequest(request.Method);
+            Activity? activity = null;
+            CancellationTokenSource? sendCancellation = null;
             var requestIdStr = request.Id?.ToString() ?? string.Empty;
             var tcs = new TaskCompletionSource<JsonRpcResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-            using var sendCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectionToken);
             var requestWriteStarted = false;
             var retainPendingRequest = false;
             Exception? failure = null;
 
             try
             {
+                if (!connectionToken.CanBeCanceled)
+                {
+                    lock (_lock)
+                    {
+                        connectionToken = _messageLoopCts?.Token ?? CancellationToken.None;
+                    }
+                }
+                // Host tracing callbacks can throw before the physical send is claimed. They
+                // belong to the same failure scope as serialization and transport preparation.
+                activity = AcpActivitySources.StartClientRequest(request.Method);
+                sendCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectionToken);
                 var json = _parser.SerializeMessage(request);
                 Task<bool> sendTask;
                 lock (_lock)
@@ -1638,6 +1643,8 @@ namespace SalmonEgg.Acp.Client
                         _ = tcs.Task.Exception;
                     }
                 }
+                sendCancellation?.Dispose();
+                activity?.Dispose();
             }
         }
 

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -31,6 +31,10 @@ namespace SalmonEgg.Acp.Client
         // Shared with behavioral tests so they validate the lifecycle, not a second timeout value.
         internal static readonly TimeSpan CancellationNotificationTimeout = TimeSpan.FromSeconds(2);
 
+        private sealed record PendingOutboundRequest(
+            TaskCompletionSource<JsonRpcResponse> Completion,
+            Action<JsonRpcResponse>? ResponseObserver);
+
         private sealed class PendingInboundRequest
         {
             public PendingInboundRequest(
@@ -93,9 +97,8 @@ namespace SalmonEgg.Acp.Client
         private readonly IAcpClientSessionStore _sessionStore;
         private readonly IAcpTerminalSessionManager _terminalSessionManager;
         private readonly IAcpClientLogger _logger;
-
-
-        private readonly ConcurrentDictionary<string, TaskCompletionSource<JsonRpcResponse>> _pendingRequests = new();
+        private readonly AcpSessionWorkController _sessionWork = new();
+        private readonly ConcurrentDictionary<string, PendingOutboundRequest> _pendingRequests = new();
         // Inbound tool requests (agent -> client) are correlated by request id so we can format responses correctly.
         private readonly ConcurrentDictionary<string, PendingInboundRequest> _pendingInboundRequests = new();
         // URL completion outlives the JSON-RPC response. Both indexes refer to the same request identity;
@@ -234,14 +237,29 @@ namespace SalmonEgg.Acp.Client
         /// <summary>
         /// Initializes the connection to the agent.
         /// </summary>
-        public async Task<InitializeResponse> InitializeAsync(InitializeParams @params, CancellationToken cancellationToken = default)
+        public Task<InitializeResponse> InitializeAsync(InitializeParams @params, CancellationToken cancellationToken = default)
+            => InitializeCoreAsync(@params, allowDraftRuntime: false, cancellationToken);
+
+        // Assembly-internal staging seam: deterministic protocol peers exercise the actual parser,
+        // dispatch and lifecycle before the full draft can be enabled by a future feature gate.
+        internal Task<InitializeResponse> InitializeDraftAsync(InitializeParams @params, CancellationToken cancellationToken = default)
+            => InitializeCoreAsync(@params, allowDraftRuntime: true, cancellationToken);
+
+        internal SessionWorkSnapshot? GetSessionWorkSnapshot(string sessionId)
+            => _sessionWork.GetSnapshot(sessionId);
+
+        private async Task<InitializeResponse> InitializeCoreAsync(
+            InitializeParams @params,
+            bool allowDraftRuntime,
+            CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(@params);
             // A modeled version is not a served version: the SDK carries draft v2 wire contracts so they
             // can be developed and asserted, while this runtime runs exactly one version end to end.
             // Ask the single authority rather than spelling out which version that is here.
             if (AcpProtocolVersion.IsSupported(@params.ProtocolVersion)
-                && !AcpProtocolVersion.IsRuntimeServed(@params.ProtocolVersion))
+                && !AcpProtocolVersion.IsRuntimeServed(@params.ProtocolVersion)
+                && !allowDraftRuntime)
             {
                 throw new AcpException(
                     JsonRpcErrorCode.ProtocolVersionMismatch,
@@ -287,13 +305,14 @@ namespace SalmonEgg.Acp.Client
                 // through the successful handshake instead of introducing it only afterwards.
                 _messageLoopCts = new CancellationTokenSource();
                 connectionToken = _messageLoopCts.Token;
+                _sessionWork.BeginConnection(connectionToken);
                 AttachConnectionMessageHandler(connectionToken);
             }
 
             InitializeResponse initializeResponse;
             try
             {
-                initializeResponse = await InitializeConnectionAsync(@params, connectionToken, cancellationToken)
+                initializeResponse = await InitializeConnectionAsync(@params, allowDraftRuntime, connectionToken, cancellationToken)
                     .ConfigureAwait(false);
             }
             catch
@@ -315,6 +334,7 @@ namespace SalmonEgg.Acp.Client
 
         private async Task<InitializeResponse> InitializeConnectionAsync(
             InitializeParams @params,
+            bool allowDraftRuntime,
             CancellationToken connectionToken,
             CancellationToken cancellationToken)
         {
@@ -364,7 +384,9 @@ namespace SalmonEgg.Acp.Client
             // runtime actually serves; otherwise the connection would proceed under a version whose
             // lifecycle is unimplemented. serverVersion > clientVersion stays rejected separately: an
             // Agent must never answer above what the Client asked for.
-            if (!AcpProtocolVersion.IsRuntimeServed(serverVersion) || serverVersion > clientVersion)
+            if ((!AcpProtocolVersion.IsRuntimeServed(serverVersion)
+                    && !(allowDraftRuntime && serverVersion == AcpProtocolVersion.V2))
+                || serverVersion > clientVersion)
             {
                 throw new AcpException(
                     JsonRpcErrorCode.ProtocolVersionMismatch,
@@ -398,6 +420,7 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionNewResponse> CreateSessionAsync(SessionNewParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            var connectionToken = GetConnectionToken();
             ValidateRequiredAbsolutePath(@params.Cwd, "cwd", "session/new");
             ValidateAdditionalDirectories(@params.AdditionalDirectories, "session/new");
             EnsureMcpServersSupported(@params.McpServers, "session/new");
@@ -427,6 +450,7 @@ namespace SalmonEgg.Acp.Client
             {
                 await _sessionStore.CreateSessionAsync(sessionNewResponse.SessionId, @params.Cwd).ConfigureAwait(false);
             }
+            RegisterSessionWork(sessionNewResponse.SessionId, connectionToken);
 
             return sessionNewResponse;
         }
@@ -437,6 +461,7 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionLoadResponse> LoadSessionAsync(SessionLoadParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            var connectionToken = GetConnectionToken();
             if (!SupportsSessionLoad)
             {
                 _logger.Log(
@@ -467,7 +492,7 @@ namespace SalmonEgg.Acp.Client
             // A successful session/load means the agent has acknowledged the session, so register it in
             // the local store. Otherwise the existence fast-fail in session/prompt would locally reject
             // the official load -> prompt flow as SessionNotFound.
-            await RegisterSessionAsync(@params.SessionId, @params.Cwd).ConfigureAwait(false);
+            await RegisterSessionAsync(@params.SessionId, @params.Cwd, connectionToken).ConfigureAwait(false);
 
             if (!response.Result.HasValue ||
                 response.Result.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
@@ -487,6 +512,7 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionResumeResponse> ResumeSessionAsync(SessionResumeParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            var connectionToken = GetConnectionToken();
             ArgumentNullException.ThrowIfNull(@params);
             if (ProtocolVersion == AcpProtocolVersion.V1 && @params.ReplayFrom is not null)
             {
@@ -525,7 +551,7 @@ namespace SalmonEgg.Acp.Client
             // The agent has acknowledged the resumed session, so register the local tracking entry. This
             // keeps the existence fast-fail gate in SendPromptAsync from misreporting the official
             // resume -> prompt flow as SessionNotFound.
-            await RegisterSessionAsync(@params.SessionId, @params.Cwd).ConfigureAwait(false);
+            await RegisterSessionAsync(@params.SessionId, @params.Cwd, connectionToken).ConfigureAwait(false);
 
             if (!response.Result.HasValue ||
                 response.Result.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
@@ -544,6 +570,7 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionCloseResponse> CloseSessionAsync(SessionCloseParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            var connectionToken = GetConnectionToken();
 
             if (!SupportsSessionClose)
             {
@@ -553,7 +580,7 @@ namespace SalmonEgg.Acp.Client
                     "Agent does not support session/close capability",
                     nameof(CloseSessionAsync));
 
-                _sessionStore.RemoveSession(@params.SessionId);
+                RemoveSession(@params.SessionId, connectionToken);
                 return SessionCloseResponse.Completed;
             }
 
@@ -572,13 +599,13 @@ namespace SalmonEgg.Acp.Client
             if (!response.Result.HasValue ||
                 response.Result.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
             {
-                _sessionStore.RemoveSession(@params.SessionId);
+                RemoveSession(@params.SessionId, connectionToken);
                 return SessionCloseResponse.Completed;
             }
 
             var sessionCloseResponse = FromElement<SessionCloseResponse>(response.Result.Value);
 
-            _sessionStore.RemoveSession(@params.SessionId);
+            RemoveSession(@params.SessionId, connectionToken);
             return sessionCloseResponse ?? SessionCloseResponse.Completed;
         }
 
@@ -588,6 +615,7 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionDeleteResponse> DeleteSessionAsync(SessionDeleteParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            var connectionToken = GetConnectionToken();
 
             if (!SupportsSessionDelete)
             {
@@ -615,13 +643,13 @@ namespace SalmonEgg.Acp.Client
             if (!response.Result.HasValue ||
                 response.Result.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
             {
-                _sessionStore.RemoveSession(@params.SessionId);
+                RemoveSession(@params.SessionId, connectionToken);
                 return SessionDeleteResponse.Completed;
             }
 
             var sessionDeleteResponse = FromElement<SessionDeleteResponse>(response.Result.Value);
 
-            _sessionStore.RemoveSession(@params.SessionId);
+            RemoveSession(@params.SessionId, connectionToken);
             return sessionDeleteResponse ?? SessionDeleteResponse.Completed;
         }
 
@@ -667,11 +695,13 @@ namespace SalmonEgg.Acp.Client
         }
 
         /// <summary>
-        /// Sends a prompt to a session.
+        /// Sends a prompt and waits for the session's foreground work to finish.
         /// </summary>
         public async Task<SessionPromptResponse> SendPromptAsync(SessionPromptParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            ArgumentNullException.ThrowIfNull(@params);
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Check whether the session exists.
             if (!_sessionStore.ContainsSession(@params.SessionId))
@@ -681,27 +711,39 @@ namespace SalmonEgg.Acp.Client
 
             EnsurePromptContentAllowed(@params);
 
-            var request = new JsonRpcRequest(
-                Interlocked.Increment(ref _nextMessageId),
-                "session/prompt",
-                ToElement<SessionPromptParams>(@params));
-
-            // ACP requires a real session/prompt response with a protocol stopReason.
-            // The client must wait for the protocol response instead of fabricating a terminal result.
-            var response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
-
-            if (response.IsError)
+            SessionPromptOperation prompt;
+            JsonRpcRequest request;
+            lock (_lock)
             {
-                throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
+                EnsureInitialized();
+                var connectionToken = _messageLoopCts!.Token;
+                request = new JsonRpcRequest(
+                    Interlocked.Increment(ref _nextMessageId),
+                    "session/prompt",
+                    ToElement<SessionPromptParams>(@params));
+                prompt = _sessionWork.BeginPrompt(@params.SessionId, _wire, connectionToken);
             }
 
-            var promptResponse = FromElement<SessionPromptResponse>(response.Result!.Value);
-            if (promptResponse == null)
+            try
             {
-                throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse session/prompt response");
+                // Record acceptance synchronously in response dispatch. An asynchronous continuation
+                // could otherwise run after the very next state_update and lose an immediate idle.
+                await SendRequestAsync(request, cancellationToken, prompt.ConnectionToken,
+                    response => _sessionWork.ReceivePromptResponse(prompt, response)).ConfigureAwait(false);
+                var completion = await prompt.Completion.WaitAsync(cancellationToken).ConfigureAwait(false);
+                return completion.GetResponse();
             }
-
-            return promptResponse;
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Cancelling a local wait cannot invent an idle state. The peer response and any
+                // later state_update remain correlated until they settle or the connection ends.
+                throw;
+            }
+            catch (Exception error)
+            {
+                _sessionWork.FailPrompt(prompt, error);
+                throw;
+            }
         }
 
         // spec MUST: the client must restrict the content types it sends to the promptCapabilities
@@ -817,6 +859,7 @@ namespace SalmonEgg.Acp.Client
             }
 
             CancellationToken connectionToken;
+            Task<SessionPromptCompletion>? cancellationCompletion;
             lock (_lock)
             {
                 EnsureInitialized();
@@ -837,6 +880,9 @@ namespace SalmonEgg.Acp.Client
                     "session/cancel",
                     ToElement<SessionCancelParams>(@params));
 
+                cancellationCompletion = ProtocolVersion == AcpProtocolVersion.V2
+                    ? _sessionWork.RequestCancellation(@params.SessionId, connectionToken)
+                    : null;
                 // The send claim and its token belong to the same connection. A queued write must
                 // be cancelled before the transport can carry it into a replacement connection.
                 sendTask = _transport.SendMessageAsync(_parser.SerializeMessage(notification), sendCancellation.Token);
@@ -849,6 +895,11 @@ namespace SalmonEgg.Acp.Client
             }
 
             await CancelPendingInboundRequestsForSessionAsync(@params.SessionId, connectionToken).ConfigureAwait(false);
+            if (cancellationCompletion is not null)
+            {
+                var completion = await cancellationCompletion.WaitAsync(cancellationToken).ConfigureAwait(false);
+                completion.GetResponse();
+            }
             Task<bool> cancelSessionTask;
             lock (_lock)
             {
@@ -1450,7 +1501,8 @@ namespace SalmonEgg.Acp.Client
         private async Task<JsonRpcResponse> SendRequestAsync(
             JsonRpcRequest request,
             CancellationToken cancellationToken,
-            CancellationToken connectionToken = default)
+            CancellationToken connectionToken = default,
+            Action<JsonRpcResponse>? responseObserver = null)
         {
             if (!connectionToken.CanBeCanceled)
             {
@@ -1482,7 +1534,7 @@ namespace SalmonEgg.Acp.Client
                     // Pending registration must precede synchronous peer replies,
                     // under the same connection lock as starting transport I/O. The linked token also
                     // prevents a transport's delayed write from crossing a subsequent reconnect.
-                    _pendingRequests[requestIdStr] = tcs;
+                    _pendingRequests[requestIdStr] = new PendingOutboundRequest(tcs, responseObserver);
                     requestWriteStarted = true;
                     sendTask = _transport.SendMessageAsync(json, sendCancellation.Token);
                 }
@@ -1661,29 +1713,68 @@ namespace SalmonEgg.Acp.Client
         /// The local entry is only an optional fast-fail optimization; the agent remains the source of
         /// truth for session existence, and nothing is tightened when a capability is not advertised.
         /// </summary>
-        private async Task RegisterSessionAsync(string sessionId, string cwd)
+        private async Task RegisterSessionAsync(string sessionId, string cwd, CancellationToken connectionToken)
         {
-            if (string.IsNullOrWhiteSpace(sessionId) || _sessionStore.ContainsSession(sessionId))
+            if (string.IsNullOrWhiteSpace(sessionId))
             {
                 return;
             }
 
-            await _sessionStore.CreateSessionAsync(sessionId, cwd).ConfigureAwait(false);
+            if (!_sessionStore.ContainsSession(sessionId))
+            {
+                await _sessionStore.CreateSessionAsync(sessionId, cwd).ConfigureAwait(false);
+            }
+            RegisterSessionWork(sessionId, connectionToken);
+        }
+
+        private void RegisterSessionWork(string sessionId, CancellationToken connectionToken)
+        {
+            lock (_lock)
+            {
+                if (_messageLoopCts?.Token == connectionToken)
+                {
+                    _sessionWork.RegisterSession(sessionId, connectionToken);
+                }
+            }
+        }
+
+        private void RemoveSession(string sessionId, CancellationToken connectionToken)
+        {
+            lock (_lock)
+            {
+                if (_messageLoopCts?.Token == connectionToken)
+                {
+                    _sessionWork.RemoveSession(sessionId, connectionToken);
+                    _sessionStore.RemoveSession(sessionId);
+                }
+            }
+        }
+
+        private CancellationToken GetConnectionToken()
+        {
+            lock (_lock)
+            {
+                EnsureInitialized();
+                return _messageLoopCts!.Token;
+            }
         }
 
         private void CancelPendingRequests(string? transportErrorMessage = null)
         {
+            _sessionWork.EndConnection(string.IsNullOrWhiteSpace(transportErrorMessage)
+                ? new OperationCanceledException("The ACP client disconnected.")
+                : new InvalidOperationException(CreateTransportDisconnectedMessage(transportErrorMessage)));
             foreach (var pendingRequest in _pendingRequests)
             {
                 if (_pendingRequests.TryRemove(pendingRequest.Key, out var pending))
                 {
                     if (string.IsNullOrWhiteSpace(transportErrorMessage))
                     {
-                        pending.TrySetCanceled();
+                        pending.Completion.TrySetCanceled();
                     }
                     else
                     {
-                        pending.TrySetException(new InvalidOperationException(
+                        pending.Completion.TrySetException(new InvalidOperationException(
                             CreateTransportDisconnectedMessage(transportErrorMessage)));
                     }
                 }
@@ -1770,9 +1861,13 @@ namespace SalmonEgg.Acp.Client
                 {
                     var responseIdStr = response.Id?.ToString() ?? string.Empty;
                     // Match the pending request.
-                    if (_pendingRequests.TryRemove(responseIdStr, out var tcs)
-                        && !tcs.TrySetResult(response))
+                    if (_pendingRequests.TryRemove(responseIdStr, out var pending))
                     {
+                        pending.ResponseObserver?.Invoke(response);
+                        if (pending.Completion.TrySetResult(response))
+                        {
+                            return;
+                        }
                         // The entry was still correlated, so the only thing that can already have
                         // completed it is the caller's own cancellation: this is the terminal
                         // response ACP requires the peer to send for a cancelled request (a partial
@@ -1855,7 +1950,7 @@ namespace SalmonEgg.Acp.Client
                     HandleInboundCancellation(notification, connectionToken);
                     break;
                 case "session/update":
-                    HandleSessionUpdate(notification);
+                    HandleSessionUpdate(notification, connectionToken);
                     break;
                 case ElicitationMethods.Complete:
                     HandleElicitationCompleted(notification);
@@ -2044,7 +2139,7 @@ namespace SalmonEgg.Acp.Client
         /// <summary>
         /// Handles the session/update notification.
         /// </summary>
-        private void HandleSessionUpdate(JsonRpcNotification notification)
+        private void HandleSessionUpdate(JsonRpcNotification notification, CancellationToken connectionToken)
         {
             try
             {
@@ -2053,8 +2148,23 @@ namespace SalmonEgg.Acp.Client
                     return;
                 }
 
-                var updateParams = FromElement<SessionUpdateParams>(notification.Params.Value);
+                AcpWireFormat wire;
+                lock (_lock)
+                {
+                    if (connectionToken.CanBeCanceled
+                        && (connectionToken.IsCancellationRequested || _messageLoopCts?.Token != connectionToken))
+                    {
+                        return;
+                    }
+                    wire = _wire;
+                }
+                var updateParams = notification.Params.Value.Deserialize(wire.TypeInfo<SessionUpdateParams>());
                 if (updateParams == null || updateParams.Update == null)
+                {
+                    return;
+                }
+                if (connectionToken.CanBeCanceled
+                    && !_sessionWork.ReceiveUpdate(updateParams.SessionId, updateParams.Update, connectionToken))
                 {
                     return;
                 }

--- a/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
@@ -134,7 +134,8 @@ internal sealed class AcpSessionWorkController
                 }
 
                 // The acknowledgement's metadata belongs to acceptance, not to the later idle.
-                prompt.Accept(AcpMetaJson.Read(response.Result.Value));
+                // PromptResponse._meta explicitly defaults on error in the schema.
+                prompt.Accept(AcpMetaJson.ReadOrDefault(response.Result.Value));
                 if (prompt.CompletionBeforeAcceptance is { } completion)
                 {
                     prompt.Complete(completion);

--- a/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Client;
+
+// Foreground work belongs to a session, not to a prompt RPC. In v2 several accepted prompts may
+// contribute to the same work, and unsolicited work may start before this client sends any prompt.
+internal sealed class AcpSessionWorkController
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, SessionWork> _sessions = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _closedSessions = new(StringComparer.Ordinal);
+    private CancellationToken _connectionToken;
+
+    internal void BeginConnection(CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            _connectionToken = connectionToken;
+            _sessions.Clear();
+            _closedSessions.Clear();
+        }
+    }
+
+    internal void EndConnection(Exception failure)
+    {
+        lock (_gate)
+        {
+            foreach (var session in _sessions.Values)
+            {
+                foreach (var prompt in session.Prompts)
+                {
+                    prompt.Fail(failure);
+                }
+                session.CancellationCompletion?.TrySetResult(new SessionPromptCompletion(null, failure));
+            }
+
+            _sessions.Clear();
+            _closedSessions.Clear();
+            _connectionToken = default;
+        }
+    }
+
+    internal void RegisterSession(string sessionId, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (IsCurrent(connectionToken))
+            {
+                _closedSessions.Remove(sessionId);
+                GetOrCreateSession(sessionId);
+            }
+        }
+    }
+
+    internal void RemoveSession(string sessionId, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (!IsCurrent(connectionToken))
+            {
+                return;
+            }
+
+            _closedSessions.Add(sessionId);
+            if (_sessions.Remove(sessionId, out var session))
+            {
+                foreach (var prompt in session.Prompts)
+                {
+                    prompt.Fail(new OperationCanceledException("The ACP session was closed."));
+                }
+                session.CancellationCompletion?.TrySetResult(new SessionPromptCompletion(
+                    null, new OperationCanceledException("The ACP session was closed.")));
+            }
+        }
+    }
+
+    internal SessionPromptOperation BeginPrompt(
+        string sessionId,
+        AcpWireFormat wire,
+        CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (!IsCurrent(connectionToken) || _closedSessions.Contains(sessionId))
+            {
+                throw new OperationCanceledException("The ACP connection or session changed before the prompt was sent.");
+            }
+
+            var prompt = new SessionPromptOperation(sessionId, wire, connectionToken);
+            var session = GetOrCreateSession(sessionId);
+            session.Prompts.Add(prompt);
+            return prompt;
+        }
+    }
+
+    internal void ReceivePromptResponse(SessionPromptOperation prompt, JsonRpcResponse response)
+    {
+        lock (_gate)
+        {
+            if (!TryGetCurrentPrompt(prompt, out var session))
+            {
+                return;
+            }
+
+            try
+            {
+                if (response.IsError)
+                {
+                    throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
+                }
+
+                if (prompt.Wire.Version == AcpProtocolVersion.V1)
+                {
+                    var completed = response.Result?.Deserialize(prompt.Wire.TypeInfo<SessionPromptResponse>())
+                        ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse session/prompt response");
+                    prompt.Accept();
+                    prompt.Complete(completed);
+                    session.Prompts.Remove(prompt);
+                    return;
+                }
+
+                if (response.Result?.ValueKind != JsonValueKind.Object)
+                {
+                    throw new AcpException(JsonRpcErrorCode.ParseError, "ACP v2 session/prompt acknowledgement must be an object.");
+                }
+
+                // The acknowledgement's metadata belongs to acceptance, not to the later idle.
+                prompt.Accept(AcpMetaJson.Read(response.Result.Value));
+                if (prompt.CompletionBeforeAcceptance is { } completion)
+                {
+                    prompt.Complete(completion);
+                    session.Prompts.Remove(prompt);
+                }
+            }
+            catch (Exception error)
+            {
+                prompt.Fail(error);
+                session.Prompts.Remove(prompt);
+            }
+        }
+    }
+
+    internal void FailPrompt(SessionPromptOperation prompt, Exception error)
+    {
+        lock (_gate)
+        {
+            if (TryGetCurrentPrompt(prompt, out var session))
+            {
+                session.Prompts.Remove(prompt);
+                prompt.Fail(error);
+            }
+        }
+    }
+
+    internal bool ReceiveUpdate(string sessionId, SessionUpdate update, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (!IsCurrent(connectionToken) || _closedSessions.Contains(sessionId))
+            {
+                return false;
+            }
+
+            if (update is not StateSessionUpdate workUpdate)
+            {
+                return true;
+            }
+
+            var session = GetOrCreateSession(sessionId);
+            session.State = CloneState(workUpdate.State);
+            if (workUpdate.State is IdleSessionWorkState idle)
+            {
+                CompleteIdle(session, idle);
+            }
+            else if (workUpdate.State is RunningSessionWorkState or RequiresActionSessionWorkState)
+            {
+                foreach (var prompt in session.Prompts)
+                {
+                    prompt.WorkObserved = true;
+                    prompt.CompletionBeforeAcceptance = null;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    internal Task<SessionPromptCompletion>? RequestCancellation(string sessionId, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (IsCurrent(connectionToken) && _sessions.TryGetValue(sessionId, out var session)
+                && (session.Prompts.Count > 0 || session.State is RunningSessionWorkState or RequiresActionSessionWorkState))
+            {
+                session.CancellationRequested = true;
+                session.CancellationCompletion ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+                return session.CancellationCompletion.Task;
+            }
+
+            return null;
+        }
+    }
+
+    internal SessionWorkSnapshot? GetSnapshot(string sessionId)
+    {
+        lock (_gate)
+        {
+            return _sessions.TryGetValue(sessionId, out var session)
+                ? new SessionWorkSnapshot(
+                    CloneState(session.State),
+                    session.CancellationRequested,
+                    session.Prompts.Count,
+                    session.Prompts.Count(static prompt => prompt.Accepted is not null))
+                : null;
+        }
+    }
+
+    private static SessionWorkState? CloneState(SessionWorkState? state)
+        => state is null ? null : state with { Meta = AcpMetaJson.Clone(state.Meta) };
+
+    private static void CompleteIdle(SessionWork session, IdleSessionWorkState idle)
+    {
+        session.CancellationRequested = false;
+        // The pinned schema makes stopReason nullable/default-on-error (SHOULD for an ending
+        // transition); the prose lifecycle says MUST. Preserve the schema's unknown reason and
+        // still finish on idle: inventing end_turn or waiting forever would both misreport the peer.
+        var completion = new SessionPromptResponse
+        {
+            StopReason = idle.StopReason ?? default,
+            HasStopReason = idle.StopReason is not null,
+            Meta = AcpMetaJson.Clone(idle.Meta)
+        };
+        session.CancellationCompletion?.TrySetResult(new SessionPromptCompletion(completion, null));
+        session.CancellationCompletion = null;
+
+        foreach (var prompt in session.Prompts.ToArray())
+        {
+            if (prompt.Wire.Version != AcpProtocolVersion.V2)
+            {
+                continue;
+            }
+
+            if (prompt.Accepted is not null)
+            {
+                prompt.Complete(completion);
+                session.Prompts.Remove(prompt);
+            }
+            else if (prompt.WorkObserved)
+            {
+                // A response can be delayed behind already emitted work. An idle from setup
+                // alone cannot finish a prompt; only work observed since this submission can.
+                prompt.CompletionBeforeAcceptance = completion;
+            }
+        }
+    }
+
+    private bool IsCurrent(CancellationToken token)
+        => token.CanBeCanceled && !token.IsCancellationRequested && _connectionToken == token;
+
+    private bool TryGetCurrentPrompt(SessionPromptOperation prompt, out SessionWork session)
+    {
+        session = null!;
+        return IsCurrent(prompt.ConnectionToken)
+            && _sessions.TryGetValue(prompt.SessionId, out session!)
+            && session.Prompts.Contains(prompt);
+    }
+
+    private SessionWork GetOrCreateSession(string sessionId)
+    {
+        if (!_sessions.TryGetValue(sessionId, out var session))
+        {
+            session = new SessionWork();
+            _sessions.Add(sessionId, session);
+        }
+
+        return session;
+    }
+
+    private sealed class SessionWork
+    {
+        internal List<SessionPromptOperation> Prompts { get; } = [];
+        internal SessionWorkState? State { get; set; }
+        internal bool CancellationRequested { get; set; }
+        internal TaskCompletionSource<SessionPromptCompletion>? CancellationCompletion { get; set; }
+    }
+}
+
+internal sealed record SessionWorkSnapshot(
+    SessionWorkState? State,
+    bool CancellationRequested,
+    int PendingPrompts,
+    int AcceptedPrompts);
+
+internal sealed record SessionPromptAcceptance(Dictionary<string, object?>? Meta);
+
+internal sealed record SessionPromptCompletion(SessionPromptResponse? Response, Exception? Error)
+{
+    internal SessionPromptResponse GetResponse()
+    {
+        if (Error is not null)
+        {
+            ExceptionDispatchInfo.Capture(Error).Throw();
+        }
+
+        return Response!;
+    }
+}
+
+internal sealed class SessionPromptOperation
+{
+    private readonly TaskCompletionSource<SessionPromptCompletion> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal SessionPromptOperation(string sessionId, AcpWireFormat wire, CancellationToken connectionToken)
+    {
+        SessionId = sessionId;
+        Wire = wire;
+        ConnectionToken = connectionToken;
+    }
+
+    internal string SessionId { get; }
+    internal AcpWireFormat Wire { get; }
+    internal CancellationToken ConnectionToken { get; }
+    internal SessionPromptAcceptance? Accepted { get; private set; }
+    internal bool WorkObserved { get; set; }
+    internal SessionPromptResponse? CompletionBeforeAcceptance { get; set; }
+    internal Task<SessionPromptCompletion> Completion => _completion.Task;
+
+    internal void Accept(Dictionary<string, object?>? meta = null)
+        => Accepted = new SessionPromptAcceptance(meta);
+
+    internal void Complete(SessionPromptResponse response)
+        => _completion.TrySetResult(new SessionPromptCompletion(response, null));
+
+    // The caller can abandon its await while the RPC/work remains correlated. Carry failures as
+    // outcomes so a later disconnect does not create an unobserved fault on that abandoned task.
+    internal void Fail(Exception error)
+        => _completion.TrySetResult(new SessionPromptCompletion(null, error));
+}

--- a/src/SalmonEgg.Acp/Client/IAcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/IAcpClient.cs
@@ -168,8 +168,9 @@ namespace SalmonEgg.Acp.Client
         Task<SessionListResponse> ListSessionsAsync(SessionListParams @params, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends a prompt to the session.
-        /// Sends a session/prompt request and waits for the Agent's response.
+        /// Sends a prompt to the session and waits for foreground work to finish.
+        /// On stable v1 the terminal session/prompt response supplies the completion.
+        /// A prompt acceptance acknowledgement is never returned as completed work.
         /// </summary>
         /// <param name="params">The send-prompt parameters</param>
         /// <param name="cancellationToken">The cancellation token</param>

--- a/src/SalmonEgg.Acp/Protocol/AcpProtocolObject.cs
+++ b/src/SalmonEgg.Acp/Protocol/AcpProtocolObject.cs
@@ -17,6 +17,15 @@ public abstract record AcpProtocolObject
 
 public static class AcpMetaJson
 {
+    // Opt in only at fields whose schema declares x-deserialize-default-on-error, or when projecting
+    // an unconstrained custom payload that remains authoritative. The general readers stay strict.
+    internal static Dictionary<string, object?>? ReadOrDefault(JsonElement root)
+    {
+        return root.TryGetProperty("_meta", out var metadata) && metadata.ValueKind == JsonValueKind.Object
+            ? Read(root)
+            : null;
+    }
+
     public static Dictionary<string, object?>? Read(JsonElement root)
     {
         if (!root.TryGetProperty("_meta", out var metaElement)

--- a/src/SalmonEgg.Acp/Protocol/SessionPromptTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionPromptTypes.cs
@@ -114,7 +114,8 @@ namespace SalmonEgg.Acp.Protocol
             {
                 StopReason = has ? new StopReason(reason.GetString() ?? string.Empty) : StopReason.EndTurn,
                 HasStopReason = has,
-                Meta = AcpMetaJson.Read(root)
+                // PromptResponse._meta defaults on error in both stable and draft schemas.
+                Meta = AcpMetaJson.ReadOrDefault(root)
             };
         }
 

--- a/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
@@ -374,7 +374,7 @@ namespace SalmonEgg.Acp.Protocol
                     {
                         SessionId = sessionId,
                         Update = StateSessionUpdateWireFormat.Read(updateElement, options),
-                        Meta = AcpMetaJson.Read(root)
+                        Meta = AcpMetaJson.ReadOrDefault(root)
                     };
                 }
 
@@ -506,7 +506,7 @@ namespace SalmonEgg.Acp.Protocol
             return new StateSessionUpdate
             {
                 State = state!,
-                Meta = AcpMetaJson.Read(root)
+                Meta = AcpMetaJson.Clone(state!.Meta)
             };
         }
 
@@ -530,6 +530,11 @@ namespace SalmonEgg.Acp.Protocol
             writer.WriteString("sessionUpdate", Discriminator);
             foreach (var property in element.EnumerateObject())
             {
+                if (property.NameEquals("sessionUpdate")
+                    || (property.NameEquals("_meta") && value.Meta is not null))
+                {
+                    continue;
+                }
                 property.WriteTo(writer);
             }
 

--- a/src/SalmonEgg.Acp/Protocol/SessionWorkStateUpdateTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionWorkStateUpdateTypes.cs
@@ -170,7 +170,9 @@ namespace SalmonEgg.Acp.Protocol
             }
 
             var state = stateElement.GetString() ?? string.Empty;
-            var meta = AcpMetaJson.Read(root);
+            // All three known state payloads mark _meta x-deserialize-default-on-error. Custom
+            // states keep the complete raw payload; only their optional object projection defaults.
+            var meta = AcpMetaJson.ReadOrDefault(root);
 
             return state switch
             {

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -43,7 +43,7 @@ hosts must enable optional capabilities only after implementing their interactio
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
-| ACP v2 | Explicit v2 contexts model grouped configuration IDs, message IDs, resource-link icons, command inputs, and version-specific initialization/session/MCP shapes. Live initialization rejects v2. | Runtime state, projections, permission handling, and batch processing remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+| ACP v2 | Explicit v2 wire contracts and the internal prompt/work-state lifecycle are covered by deterministic protocol peers. Live initialization rejects v2. | Update projections, permission handling, batch processing, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
 
 V2 wire coverage includes `configId`/`groupId`, required `messageId` values, text/custom command
 inputs, and v1-only session fields and MCP variants. Unknown extension fields are preserved;
@@ -51,7 +51,20 @@ default-on-error and skip-invalid-item behavior applies only where the upstream 
 Resource-link icons are available through the experimental `ResourceLinkDraftExtensions` helper,
 so constructing them requires an explicit draft opt-in. Permission subject types are still not
 connected to live request handling. These contracts do not supply message upserts, streaming tool
-and terminal projections, or the acknowledgement-to-`state_update` completion lifecycle.
+and terminal projections.
+
+`SendPromptAsync` always waits for completed foreground work. The internal v2 development path
+records the prompt acknowledgement separately and finishes on an idle `state_update`; cancellation
+keeps accepting trailing updates until that idle arrives. One controller owns session work, including
+unsolicited running/requires-action/idle updates, and uses the connection's existing lifetime token
+to reject stale callbacks. This path is exercised through the actual JSON parser and client handlers,
+not exposed as a public v2 opt-in. V1 still completes from its terminal prompt response.
+
+The pinned [v2 lifecycle](https://github.com/agentclientprotocol/agent-client-protocol/blob/5ebaf0aceb04a4ba6574cd63fa6355352dc6d931/docs/protocol/v2/prompt-lifecycle.mdx)
+says an ending idle must carry a stop reason, while its
+[schema](https://github.com/agentclientprotocol/agent-client-protocol/blob/5ebaf0aceb04a4ba6574cd63fa6355352dc6d931/schema/v2/schema.json)
+allows an omitted/null/default-on-error reason. The client preserves that unknown reason and still
+finishes on idle (`HasStopReason == false`), without fabricating `end_turn` or waiting indefinitely.
 
 Keep the v1 runtime and public API compatible while these gaps are addressed. Enabling v2 needs
 both the upstream stabilization/Agent prerequisites and end-to-end verification of the complete

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientPromptSubmissionTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientPromptSubmissionTests.cs
@@ -1,0 +1,292 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Observability;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpClientPromptSubmissionTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task SendPromptAsync_CancelledBeforeTransportWrite_DoesNotRetainUnsentWork(int version)
+    {
+        // Arrange
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        using var peer = await PromptPeer.CreateAsync(version, () => caller.Cancel());
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => peer.PromptAsync(caller.Token));
+
+        // Assert
+        Assert.Empty(peer.PromptWrites);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")?.PendingPrompts ?? 0);
+        Assert.DoesNotContain(peer.Notifications, static notification => notification.Method == CancelRequestParams.Method);
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken).WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_CancelledAfterWorkRegistration_DoesNotWaitForUnsentAcceptance()
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2);
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        using var trace = new Activity("prompt-submission").Start();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == AcpActivitySources.ClientName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => options.Parent.TraceId == trace.TraceId
+                ? ActivitySamplingResult.AllData : ActivitySamplingResult.None,
+            ActivityStarted = activity =>
+            {
+                if (activity.TraceId == trace.TraceId && activity.OperationName == "acp.request session/prompt") caller.Cancel();
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => peer.PromptAsync(caller.Token));
+
+        // Assert
+        Assert.Empty(peer.PromptWrites);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken).WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_UnsentContributionCancelled_PreservesOtherActiveWork()
+    {
+        // Arrange
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        var cancelSubmission = false;
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2, () =>
+        {
+            if (cancelSubmission) caller.Cancel();
+        });
+        var active = peer.PromptAsync(TestToken);
+        var activeRequest = Assert.Single(peer.PromptWrites);
+        peer.Accept(activeRequest);
+        peer.State("running");
+
+        // Act
+        cancelSubmission = true;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => peer.PromptAsync(caller.Token));
+
+        // Assert
+        Assert.Single(peer.PromptWrites);
+        var work = Assert.IsType<SessionWorkSnapshot>(peer.Client.GetSessionWorkSnapshot("session"));
+        Assert.Equal(1, work.PendingPrompts);
+        Assert.Equal(1, work.AcceptedPrompts);
+        Assert.IsType<RunningSessionWorkState>(work.State);
+        peer.State("idle");
+        await active.WaitAsync(TestToken);
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task SendPromptAsync_CancelledDuringWrite_RetainsCorrelationUntilPeerResponds(int version)
+    {
+        // Arrange
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        using var peer = await PromptPeer.CreateAsync(version);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.CompletePromptWrite = async (_, token) =>
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(TestToken);
+            token.ThrowIfCancellationRequested();
+            return true;
+        };
+        var pending = peer.PromptAsync(caller.Token);
+        await entered.Task.WaitAsync(TestToken);
+
+        // Act
+        try
+        {
+            caller.Cancel();
+            release.TrySetResult();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending.WaitAsync(TestToken));
+
+            // Assert
+            Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+            peer.Accept(Assert.Single(peer.PromptWrites));
+            if (version == AcpProtocolVersion.V2) peer.State("idle");
+            Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1, false)]
+    [InlineData(AcpProtocolVersion.V1, true)]
+    [InlineData(AcpProtocolVersion.V2, false)]
+    [InlineData(AcpProtocolVersion.V2, true)]
+    public async Task SendPromptAsync_WriteReturnsFalse_RetainsPossiblePeerWork(int version, bool acknowledgedDuringWrite)
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(version);
+        peer.CompletePromptWrite = (request, _) =>
+        {
+            if (acknowledgedDuringWrite) peer.Accept(request);
+            return Task.FromResult(false);
+        };
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.PromptAsync(TestToken));
+
+        // Assert
+        var request = Assert.Single(peer.PromptWrites);
+        Assert.Equal(acknowledgedDuringWrite && version == AcpProtocolVersion.V1 ? 0 : 1,
+            peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        if (!acknowledgedDuringWrite) peer.Accept(request);
+        if (version == AcpProtocolVersion.V2)
+        {
+            Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("session")!.AcceptedPrompts);
+            peer.State("idle");
+        }
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        peer.Accept(request);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_WriteThrowsAfterStart_RetainsPeerRejectionCorrelation()
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2);
+        var failure = new IOException("The write outcome is unknown.");
+        peer.CompletePromptWrite = (_, _) => Task.FromException<bool>(failure);
+
+        // Act
+        Assert.Same(failure, await Assert.ThrowsAsync<IOException>(() => peer.PromptAsync(TestToken)));
+
+        // Assert
+        Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        peer.Reject(Assert.Single(peer.PromptWrites));
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_WriteOutcomeUnknown_DisconnectReleasesRetainedWork()
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2);
+        peer.CompletePromptWrite = (_, _) => Task.FromResult(false);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.PromptAsync(TestToken));
+        Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+
+        // Act
+        await peer.Client.DisconnectAsync();
+
+        // Assert
+        Assert.Null(peer.Client.GetSessionWorkSnapshot("session"));
+    }
+
+    private sealed class PromptPeer : IAcpTransport
+    {
+        private readonly MessageParser _parser = new();
+        private readonly int _version;
+
+        private PromptPeer(int version, Action? validateSession)
+        {
+            _version = version;
+            var store = new Mock<IAcpClientSessionStore>();
+            store.Setup(value => value.ContainsSession("session"))
+                .Callback(() => validateSession?.Invoke()).Returns(true);
+            store.Setup(value => value.CancelSessionAsync("session")).ReturnsAsync(true);
+            Client = new AcpClient(this, sessionStore: store.Object);
+        }
+
+        internal AcpClient Client { get; }
+        public bool IsConnected { get; private set; }
+        internal ConcurrentQueue<JsonRpcRequest> PromptWrites { get; } = new();
+        internal ConcurrentQueue<JsonRpcNotification> Notifications { get; } = new();
+        internal Func<JsonRpcRequest, CancellationToken, Task<bool>>? CompletePromptWrite { get; set; }
+
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var parsed = _parser.ParseMessage(message);
+            if (parsed is JsonRpcNotification notification) Notifications.Enqueue(notification);
+            if (parsed is not JsonRpcRequest request) return Task.FromResult(true);
+            if (request.Method == "initialize")
+            {
+                var response = new InitializeResponse(_version, new AgentInfo("submission-peer", "1.0"), new AgentCapabilities());
+                Reply(request, JsonSerializer.Serialize(response, AcpWireFormat.For(_version).TypeInfo<InitializeResponse>()));
+            }
+            else if (request.Method == "session/prompt")
+            {
+                PromptWrites.Enqueue(request);
+                return CompletePromptWrite?.Invoke(request, cancellationToken) ?? Task.FromResult(true);
+            }
+            return Task.FromResult(true);
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            IsConnected = false;
+        }
+
+        internal static async Task<PromptPeer> CreateAsync(int version, Action? validateSession = null)
+        {
+            var peer = new PromptPeer(version, validateSession);
+            var request = new InitializeParams(new ClientInfo("submission-test", "1.0"), new ClientCapabilities())
+            {
+                ProtocolVersion = version
+            };
+            if (version == AcpProtocolVersion.V2) await peer.Client.InitializeDraftAsync(request, TestToken);
+            else await peer.Client.InitializeAsync(request, TestToken);
+            return peer;
+        }
+
+        internal Task<SessionPromptResponse> PromptAsync(CancellationToken token)
+            => Client.SendPromptAsync(new SessionPromptParams("session", []), token);
+
+        internal void Accept(JsonRpcRequest request)
+            => Reply(request, _version == AcpProtocolVersion.V2 ? "{}" : "{\"stopReason\":\"end_turn\"}");
+
+        internal void Reject(JsonRpcRequest request)
+            => Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id
+                + ",\"error\":{\"code\":-32602,\"message\":\"prompt rejected\"}}");
+
+        internal void State(string state)
+            => Deliver("{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"session\","
+                + "\"update\":{\"sessionUpdate\":\"state_update\",\"state\":\"" + state + "\",\"stopReason\":\"end_turn\"}}}");
+
+        private void Reply(JsonRpcRequest request, string result)
+            => Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":" + result + "}");
+
+        private void Deliver(string message)
+            => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(message));
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientPromptSubmissionTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientPromptSubmissionTests.cs
@@ -61,6 +61,75 @@ public sealed class AcpClientPromptSubmissionTests
         await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken).WaitAsync(TestToken);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SendPromptAsync_TracePreparationThrows_DoesNotRetainUnsentWork(bool throwWhenStarted)
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2);
+        using var trace = new Activity("prompt-submission-throws").Start();
+        var failure = new InvalidOperationException("Host tracing failed.");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == AcpActivitySources.ClientName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+            {
+                if (options.Parent.TraceId != trace.TraceId || options.Name != "acp.request session/prompt")
+                    return ActivitySamplingResult.None;
+                if (!throwWhenStarted) throw failure;
+                return ActivitySamplingResult.AllData;
+            },
+            ActivityStarted = activity =>
+            {
+                if (activity.TraceId == trace.TraceId && activity.OperationName == "acp.request session/prompt") throw failure;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Act
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => peer.PromptAsync(TestToken)));
+
+        // Assert
+        Assert.Empty(peer.PromptWrites);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken).WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_TraceDisposalThrows_PreservesAcceptedWorkUntilIdle()
+    {
+        // Arrange
+        using var peer = await PromptPeer.CreateAsync(AcpProtocolVersion.V2);
+        using var trace = new Activity("prompt-disposal-throws").Start();
+        var failure = new InvalidOperationException("Host trace completion failed.");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == AcpActivitySources.ClientName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => options.Parent.TraceId == trace.TraceId
+                ? ActivitySamplingResult.AllData : ActivitySamplingResult.None,
+            ActivityStopped = activity =>
+            {
+                if (activity.TraceId == trace.TraceId && activity.OperationName == "acp.request session/prompt") throw failure;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+        peer.CompletePromptWrite = (request, _) =>
+        {
+            peer.Accept(request);
+            return Task.FromResult(true);
+        };
+
+        // Act
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => peer.PromptAsync(TestToken)));
+
+        // Assert
+        Assert.Single(peer.PromptWrites);
+        Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("session")!.AcceptedPrompts);
+        peer.State("idle");
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("session")!.PendingPrompts);
+    }
+
     [Fact]
     public async Task SendPromptAsync_UnsentContributionCancelled_PreservesOtherActiveWork()
     {

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
@@ -12,6 +12,22 @@ public sealed class AcpClientSessionWorkTests
 {
     private static CancellationToken TestToken => TestContext.Current.CancellationToken;
 
+    public static TheoryData<string, string?> StateMetadataCases
+    {
+        get
+        {
+            var cases = new TheoryData<string, string?>();
+            foreach (var state in new[] { "running", "requires_action", "idle" })
+            {
+                foreach (var metadata in new string?[] { null, "null", "42", "[]", "\"invalid\"", "{\"owned\":true}" })
+                {
+                    cases.Add(state, metadata);
+                }
+            }
+            return cases;
+        }
+    }
+
     [Fact]
     public async Task SendPromptAsync_V2Acknowledgement_DoesNotFinishForegroundWork()
     {
@@ -57,6 +73,101 @@ public sealed class AcpClientSessionWorkTests
         var response = await peer.PromptAsync("one").WaitAsync(TestToken);
 
         // Assert
+        Assert.Equal(StopReason.EndTurn, response.StopReason);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("\"invalid\"")]
+    [InlineData("{\"accepted\":true}")]
+    public async Task SendPromptAsync_V2AcknowledgementMetadata_WaitsForAuthoritativeIdle(string? metadata)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+
+        // Act
+        peer.ReplyPrompt("one", metadata is null ? "{}" : "{\"_meta\":" + metadata + "}");
+
+        // Assert
+        Assert.Equal(1, peer.Client.GetSessionWorkSnapshot("one")!.AcceptedPrompts);
+        Assert.False(pending.IsCompleted);
+        peer.State("one", "idle", "end_turn");
+        var response = await pending.WaitAsync(TestToken);
+        Assert.Equal(StopReason.EndTurn, response.StopReason);
+        Assert.Null(response.Meta);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("\"invalid\"")]
+    [InlineData("{\"completed\":true}")]
+    public async Task SendPromptAsync_V1Metadata_KeepsTheTerminalResponseContract(string? metadata)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync(AcpProtocolVersion.V1);
+        var pending = peer.PromptAsync("one");
+
+        // Act
+        peer.ReplyPrompt("one", "{\"stopReason\":\"max_tokens\""
+            + (metadata is null ? "" : ",\"_meta\":" + metadata) + "}");
+        var response = await pending.WaitAsync(TestToken);
+
+        // Assert
+        Assert.Equal(StopReason.MaxTokens, response.StopReason);
+        Assert.True(response.HasStopReason);
+        if (metadata == "{\"completed\":true}")
+        {
+            Assert.True(Assert.IsType<JsonElement>(response.Meta!["completed"]).GetBoolean());
+        }
+        else
+        {
+            Assert.Null(response.Meta);
+        }
+        Assert.Empty(peer.Errors);
+    }
+
+    [Theory]
+    [MemberData(nameof(StateMetadataCases))]
+    public async Task SendPromptAsync_V2StateMetadata_PreservesLifecycleAndSchemaDefaults(string state, string? metadata)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        peer.Update("one", "{\"sessionUpdate\":\"state_update\",\"state\":\"" + state + "\""
+            + (state == "idle" ? ",\"stopReason\":\"end_turn\"" : "")
+            + (metadata is null ? "" : ",\"_meta\":" + metadata) + "}");
+
+        // Assert
+        Assert.Empty(peer.Errors);
+        var snapshot = Assert.IsType<SessionWorkSnapshot>(peer.Client.GetSessionWorkSnapshot("one"));
+        Assert.Equal(state, snapshot.State!.State);
+        if (metadata == "{\"owned\":true}")
+        {
+            Assert.True(Assert.IsType<JsonElement>(snapshot.State.Meta!["owned"]).GetBoolean());
+        }
+        else
+        {
+            Assert.Null(snapshot.State.Meta);
+        }
+        if (state != "idle")
+        {
+            Assert.False(pending.IsCompleted);
+            peer.State("one", "idle", "end_turn");
+        }
+        var response = await pending.WaitAsync(TestToken);
         Assert.Equal(StopReason.EndTurn, response.StopReason);
         Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
     }

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
@@ -589,6 +589,83 @@ public sealed class AcpClientSessionWorkTests
         await replacement.WaitAsync(TestToken);
     }
 
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task CancelSessionAsync_PhysicalWriteDelayedAcrossReconnect_NeverSendsOldNotification(int version)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync(version);
+        var writeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.BeforeCancelWrite = () =>
+        {
+            writeStarted.TrySetResult();
+            return releaseWrite.Task;
+        };
+        var cancellation = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+        await writeStarted.Task.WaitAsync(TestToken);
+
+        try
+        {
+            await peer.Client.DisconnectAsync();
+            await peer.InitializeAsync();
+
+            // Act
+            releaseWrite.TrySetResult();
+
+            // Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancellation.WaitAsync(TestToken));
+            Assert.DoesNotContain(peer.Sent, static message => message is JsonRpcNotification { Method: "session/cancel" });
+            Assert.Empty(peer.Errors);
+            peer.BeforeCancelWrite = null;
+            await peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+            Assert.Single(peer.Sent, static message => message is JsonRpcNotification { Method: "session/cancel" });
+        }
+        finally
+        {
+            releaseWrite.TrySetResult();
+        }
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1, false)]
+    [InlineData(AcpProtocolVersion.V2, false)]
+    [InlineData(AcpProtocolVersion.V1, true)]
+    [InlineData(AcpProtocolVersion.V2, true)]
+    public async Task CancelSessionAsync_PhysicalWriteDelayedUntilCancelledOrDisposed_DoesNotSend(int version, bool dispose)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync(version);
+        using var caller = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        var writeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.BeforeCancelWrite = () =>
+        {
+            writeStarted.TrySetResult();
+            return releaseWrite.Task;
+        };
+        var cancellation = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), caller.Token);
+        await writeStarted.Task.WaitAsync(TestToken);
+
+        try
+        {
+            // Act
+            if (dispose) peer.Client.Dispose();
+            else caller.Cancel();
+            releaseWrite.TrySetResult();
+
+            // Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancellation.WaitAsync(TestToken));
+            Assert.DoesNotContain(peer.Sent, static message => message is JsonRpcNotification { Method: "session/cancel" });
+            Assert.Empty(peer.Errors);
+        }
+        finally
+        {
+            releaseWrite.TrySetResult();
+        }
+    }
+
     [Fact]
     public async Task InitializeDraftAsync_HandshakeQueuedCallback_CannotFinishReconnectedWork()
     {
@@ -637,6 +714,7 @@ public sealed class AcpClientSessionWorkTests
         internal Action<JsonRpcRequest>? BeforeSessionResponse { get; set; }
         internal Action<JsonRpcRequest>? BeforeInitializeResponse { get; set; }
         internal Func<Task<bool>>? OnCancel { get; set; }
+        internal Func<Task>? BeforeCancelWrite { get; set; }
 
         public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
         public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred;
@@ -680,6 +758,10 @@ public sealed class AcpClientSessionWorkTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             var parsed = _parser.ParseMessage(message);
+            if (parsed is JsonRpcNotification { Method: "session/cancel" } && BeforeCancelWrite is { } beforeWrite)
+            {
+                return SendCancellationAfterGateAsync(parsed, beforeWrite(), cancellationToken);
+            }
             Sent.Enqueue(parsed);
             if (parsed is JsonRpcNotification { Method: "session/cancel" } && OnCancel is not null) return OnCancel();
             if (parsed is not JsonRpcRequest request) return Task.FromResult(true);
@@ -714,6 +796,16 @@ public sealed class AcpClientSessionWorkTests
                     break;
             }
             return Task.FromResult(true);
+        }
+
+        private async Task<bool> SendCancellationAfterGateAsync(JsonRpcMessage message, Task gate, CancellationToken cancellationToken)
+        {
+            // Model a pipe/socket write queued behind another write. Recording before this await
+            // would exercise only a delayed return and would miss a stale physical notification.
+            await gate.ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            Sent.Enqueue(message);
+            return OnCancel is null || await OnCancel().ConfigureAwait(false);
         }
 
         internal void ReplyPrompt(string sessionId, string result)

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientSessionWorkTests.cs
@@ -1,0 +1,764 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpClientSessionWorkTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task SendPromptAsync_V2Acknowledgement_DoesNotFinishForegroundWork()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var observed = new List<SessionUpdate>();
+        peer.Client.SessionUpdateReceived += (_, update) => observed.Add(Assert.IsAssignableFrom<SessionUpdate>(update.Update));
+
+        // Act
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        peer.State("one", "requires_action");
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        var snapshot = Assert.IsType<SessionWorkSnapshot>(peer.Client.GetSessionWorkSnapshot("one"));
+        Assert.IsType<RequiresActionSessionWorkState>(snapshot.State);
+        Assert.Equal(1, snapshot.AcceptedPrompts);
+
+        peer.State("one", "running");
+        peer.State("one", "idle", "max_tokens");
+        var completed = await pending.WaitAsync(TestToken);
+        Assert.Equal(StopReason.MaxTokens, completed.StopReason);
+        Assert.True(completed.HasStopReason);
+        Assert.Equal(4, observed.Count);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_V2BackToBackAcknowledgementAndIdle_ObservesCompletion()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        peer.OnPrompt = request =>
+        {
+            peer.Reply(request, "{}");
+            peer.State("one", "running");
+            peer.State("one", "idle", "end_turn");
+        };
+
+        // Act
+        var response = await peer.PromptAsync("one").WaitAsync(TestToken);
+
+        // Assert
+        Assert.Equal(StopReason.EndTurn, response.StopReason);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_CompletionBeforeDelayedAcknowledgement_WaitsForAcceptance()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+
+        // Act
+        peer.State("one", "running");
+        peer.State("one", "idle", "refusal");
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        peer.ReplyPrompt("one", "{}");
+        Assert.Equal(StopReason.Refusal, (await pending.WaitAsync(TestToken)).StopReason);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_SetupIdleBeforeAcceptance_DoesNotFinishNewWork()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        peer.State("one", "idle");
+        var pending = peer.PromptAsync("one");
+
+        // Act
+        peer.State("one", "idle");
+        peer.ReplyPrompt("one", "{}");
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        peer.State("one", "running");
+        peer.State("one", "idle", "end_turn");
+        Assert.Equal(StopReason.EndTurn, (await pending.WaitAsync(TestToken)).StopReason);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("null")]
+    [InlineData("123")]
+    public async Task SendPromptAsync_IdleWithoutUsableReason_CompletesWithoutInventingReason(string? rawReason)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        peer.Update("one", "{\"sessionUpdate\":\"state_update\",\"state\":\"idle\""
+            + (rawReason is null ? "" : ",\"stopReason\":" + rawReason) + "}");
+
+        // Assert
+        var response = await pending.WaitAsync(TestToken);
+        Assert.False(response.HasStopReason);
+        Assert.NotEqual(StopReason.EndTurn, response.StopReason);
+        Assert.Null(Assert.IsType<IdleSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State).StopReason);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_UnknownStateAndStopReason_PreservesPeerValues()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+
+        // Act
+        peer.State("one", "_paused");
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        Assert.Equal("_paused", Assert.IsType<CustomSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State).State);
+        peer.State("one", "idle", "future_stop");
+        Assert.Equal("future_stop", (await pending.WaitAsync(TestToken)).StopReason.Value);
+    }
+
+    [Fact]
+    public async Task SessionUpdates_UnsolicitedStateBeforePrompt_PreservesStateAndBackgroundUpdates()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var observed = new List<SessionUpdate>();
+        peer.Client.SessionUpdateReceived += (_, update) => observed.Add(Assert.IsAssignableFrom<SessionUpdate>(update.Update));
+
+        // Act
+        peer.State("one", "running");
+        peer.State("two", "requires_action");
+        peer.State("one", "idle");
+        peer.Update("one", "{\"sessionUpdate\":\"agent_message_chunk\",\"messageId\":\"background\",\"content\":{\"type\":\"text\",\"text\":\"background result\"}}");
+
+        // Assert
+        Assert.IsType<IdleSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State);
+        Assert.IsType<RequiresActionSessionWorkState>(peer.Client.GetSessionWorkSnapshot("two")!.State);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+        Assert.IsType<AgentMessageUpdate>(observed[^1]);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_TwoSessionsAndTwoAcceptedPrompts_CompletesOnlyMatchingWork()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var first = peer.PromptAsync("one");
+        var second = peer.PromptAsync("two");
+        peer.ReplyPrompt("one", "{}");
+        peer.ReplyPrompt("two", "{}");
+        peer.State("one", "running");
+        peer.State("two", "running");
+        var contribution = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+
+        // Act
+        peer.State("one", "idle", "end_turn");
+
+        // Assert
+        Assert.Equal(StopReason.EndTurn, (await first.WaitAsync(TestToken)).StopReason);
+        Assert.Equal(StopReason.EndTurn, (await contribution.WaitAsync(TestToken)).StopReason);
+        Assert.False(second.IsCompleted);
+        peer.State("two", "idle", "refusal");
+        Assert.Equal(StopReason.Refusal, (await second.WaitAsync(TestToken)).StopReason);
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_ActiveV2Work_AcceptsTrailingUpdatesAndWaitsForCancelledIdle()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        var observed = new List<SessionUpdate>();
+        peer.Client.SessionUpdateReceived += (_, update) => observed.Add(Assert.IsAssignableFrom<SessionUpdate>(update.Update));
+
+        // Act
+        var cancel = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+        peer.Update("one", "{\"sessionUpdate\":\"agent_message_chunk\",\"messageId\":\"trailing\",\"content\":{\"type\":\"text\",\"text\":\"last bytes\"}}");
+
+        // Assert
+        Assert.False(cancel.IsCompleted);
+        Assert.False(pending.IsCompleted);
+        Assert.True(peer.Client.GetSessionWorkSnapshot("one")!.CancellationRequested);
+        Assert.IsType<AgentMessageUpdate>(Assert.Single(observed));
+        peer.State("one", "idle", "cancelled");
+        await cancel.WaitAsync(TestToken);
+        Assert.Equal(StopReason.Cancelled, (await pending.WaitAsync(TestToken)).StopReason);
+        Assert.False(peer.Client.GetSessionWorkSnapshot("one")!.CancellationRequested);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CancelSessionAsync_NoActiveWork_DoesNotWaitForAnUnpromisedIdle(bool observedIdle)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        if (observedIdle) peer.State("one", "idle");
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken).WaitAsync(TestToken);
+
+        // Assert
+        Assert.Contains(peer.Sent, message => message is JsonRpcNotification { Method: "session/cancel" });
+        Assert.False(peer.Client.GetSessionWorkSnapshot("one")!.CancellationRequested);
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_UnsolicitedWork_WaitsForMatchingIdle()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        peer.State("one", "requires_action");
+
+        // Act
+        var cancel = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+        peer.State("two", "idle", "cancelled");
+
+        // Assert
+        Assert.False(cancel.IsCompleted);
+        peer.State("one", "idle", "cancelled");
+        await cancel.WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_CallerCancelsAfterAcceptance_DoesNotPretendAgentStopped()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        using var caller = new CancellationTokenSource();
+        var pending = peer.PromptAsync("one", caller.Token);
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        caller.Cancel();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        Assert.IsType<RunningSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State);
+        peer.State("one", "idle", "cancelled");
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_CallerCancelsBeforeAcceptance_LateResponseStillSettlesWork()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        using var caller = new CancellationTokenSource();
+        var pending = peer.PromptAsync("one", caller.Token);
+
+        // Act
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        peer.State("one", "idle", "cancelled");
+
+        // Assert
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DisconnectAsync_AcceptedWorkOrPendingCancellation_ReleasesAllWaiters(bool cancelFirst)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        var cancel = cancelFirst ? peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken) : null;
+
+        // Act
+        await peer.Client.DisconnectAsync();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        if (cancel is not null) await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancel);
+        Assert.Null(peer.Client.GetSessionWorkSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task TransportError_AcceptedWork_FaultsWithConnectionFailure()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+
+        // Act
+        peer.DropConnection();
+
+        // Assert
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() => pending);
+        Assert.Contains("disconnected", failure.Message, StringComparison.Ordinal);
+        Assert.Null(peer.Client.GetSessionWorkSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_QueuedOldConnectionHandler_CannotCompleteReconnectedSession()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var oldDelivery = peer.CaptureDelivery();
+        var oldPrompt = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        await peer.Client.DisconnectAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => oldPrompt);
+        await peer.InitializeAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        oldDelivery(peer.StateMessage("one", "idle", "cancelled"));
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        Assert.IsType<RunningSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State);
+        peer.State("one", "idle", "end_turn");
+        Assert.Equal(StopReason.EndTurn, (await pending.WaitAsync(TestToken)).StopReason);
+    }
+
+    [Fact]
+    public async Task CloseSessionAsync_ActiveWork_ReleasesWaiterAndRejectsStaleSessionUpdates()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+
+        // Act
+        await peer.Client.CloseSessionAsync(new SessionCloseParams("one"), TestToken);
+        peer.State("one", "running");
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        Assert.Null(peer.Client.GetSessionWorkSnapshot("one"));
+    }
+
+    [Theory]
+    [InlineData("end_turn")]
+    [InlineData("cancelled")]
+    public async Task SendPromptAsync_V1Response_KeepsCompletionAndMetadataContract(string stopReason)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync(AcpProtocolVersion.V1);
+        var pending = peer.PromptAsync("one");
+        peer.State("one", "idle", "refusal");
+        Assert.False(pending.IsCompleted);
+
+        // Act
+        peer.ReplyPrompt("one", "{\"stopReason\":\"" + stopReason + "\",\"_meta\":{\"original\":true}}");
+
+        // Assert
+        var response = await pending.WaitAsync(TestToken);
+        Assert.Equal(stopReason, response.StopReason.Value);
+        Assert.True(response.HasStopReason);
+        Assert.True(Assert.IsType<JsonElement>(response.Meta!["original"]).GetBoolean());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_PublicV2Entry_StillRejectsBeforeTransportActivity()
+    {
+        // Arrange
+        using var peer = new ProtocolPeer(AcpProtocolVersion.V2);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<AcpException>(() => peer.Client.InitializeAsync(peer.InitializeParams(), TestToken));
+
+        // Assert
+        Assert.Equal(JsonRpcErrorCode.ProtocolVersionMismatch, failure.ErrorCode);
+        Assert.Equal(0, peer.ConnectCalls);
+        Assert.Empty(peer.Sent);
+    }
+
+    [Theory]
+    [InlineData("running")]
+    [InlineData("requires_action")]
+    [InlineData("idle")]
+    public async Task ResumeSessionAsync_StateBeforeResponse_RemainsAuthoritativeWithoutPrompt(string state)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        peer.BeforeSessionResponse = request =>
+        {
+            if (request.Method == "session/resume") peer.State("resumed", state);
+        };
+
+        // Act
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("resumed", "/workspace", []), TestToken);
+
+        // Assert
+        var snapshot = Assert.IsType<SessionWorkSnapshot>(peer.Client.GetSessionWorkSnapshot("resumed"));
+        Assert.Equal(state, snapshot.State!.State);
+        Assert.Equal(0, snapshot.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_RejectedAfterStateUpdates_DoesNotReportSuccessfulCompletion()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.State("one", "running");
+        peer.State("one", "idle", "end_turn");
+
+        // Act
+        peer.RejectPrompt("one", JsonRpcErrorCode.MethodNotAllowed);
+
+        // Assert
+        var error = await Assert.ThrowsAsync<AcpException>(() => pending);
+        Assert.Equal(JsonRpcErrorCode.MethodNotAllowed, error.ErrorCode);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("42")]
+    public async Task SendPromptAsync_MalformedAcknowledgement_FailsWithoutLeakingPendingWork(string result)
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+
+        // Act
+        peer.ReplyPrompt("one", result);
+
+        // Assert
+        await Assert.ThrowsAsync<AcpException>(() => pending);
+        Assert.Equal(0, peer.Client.GetSessionWorkSnapshot("one")!.PendingPrompts);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_UnacceptedContribution_DoesNotInheritPreviousIdle()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var first = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        var contribution = peer.PromptAsync("one");
+
+        // Act
+        peer.State("one", "idle", "end_turn");
+        await first.WaitAsync(TestToken);
+        peer.State("one", "running");
+        peer.ReplyPrompt("one", "{}");
+
+        // Assert
+        Assert.False(contribution.IsCompleted);
+        peer.State("one", "idle", "max_tokens");
+        Assert.Equal(StopReason.MaxTokens, (await contribution.WaitAsync(TestToken)).StopReason);
+    }
+
+    [Fact]
+    public async Task SendPromptAsync_DisposedAfterAcceptance_ReleasesWaiter()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+
+        // Act
+        peer.Client.Dispose();
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => pending);
+        Assert.Null(peer.Client.GetSessionWorkSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_CallerAbandonsWait_LaterIdleStillCompletesWork()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        using var caller = new CancellationTokenSource();
+        var cancel = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), caller.Token);
+
+        // Act
+        caller.Cancel();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancel);
+        Assert.False(pending.IsCompleted);
+        peer.State("one", "idle", "cancelled");
+        Assert.Equal(StopReason.Cancelled, (await pending.WaitAsync(TestToken)).StopReason);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_MutatedSubscriberMetadata_DoesNotChangeOwnedSnapshot()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        peer.Client.SessionUpdateReceived += (_, args) =>
+        {
+            if (args.Update is StateSessionUpdate state) state.State.Meta!["owned"] = false;
+        };
+
+        // Act
+        peer.Update("one", "{\"sessionUpdate\":\"state_update\",\"state\":\"idle\",\"_meta\":{\"owned\":true}}");
+
+        // Assert
+        var snapshot = peer.Client.GetSessionWorkSnapshot("one")!;
+        Assert.True(Assert.IsType<JsonElement>(snapshot.State!.Meta!["owned"]).GetBoolean());
+        snapshot.State.Meta["owned"] = false;
+        Assert.True(Assert.IsType<JsonElement>(peer.Client.GetSessionWorkSnapshot("one")!.State!.Meta!["owned"]).GetBoolean());
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_SendReturnsFalse_FailsWithoutInventingCompletion()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        peer.OnCancel = () => Task.FromResult(false);
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken));
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        Assert.IsType<RunningSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State);
+        peer.State("one", "idle", "end_turn");
+        await pending.WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_WriteFinishesAfterReconnect_DoesNotCancelReplacementState()
+    {
+        // Arrange
+        using var peer = await ProtocolPeer.CreateAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+        var send = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.OnCancel = () => send.Task;
+        var cancel = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+        await peer.Client.DisconnectAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        await peer.InitializeAsync();
+        var replacement = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        send.TrySetResult(true);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancel);
+        Assert.False(peer.Client.GetSessionWorkSnapshot("one")!.CancellationRequested);
+        Assert.False(replacement.IsCompleted);
+        peer.State("one", "idle", "end_turn");
+        await replacement.WaitAsync(TestToken);
+    }
+
+    [Fact]
+    public async Task InitializeDraftAsync_HandshakeQueuedCallback_CannotFinishReconnectedWork()
+    {
+        // Arrange
+        using var peer = new ProtocolPeer(AcpProtocolVersion.V2);
+        Action<string>? oldHandshake = null;
+        peer.BeforeInitializeResponse = _ => oldHandshake ??= peer.CaptureDelivery();
+        await peer.InitializeAsync();
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        await peer.Client.DisconnectAsync();
+        await peer.InitializeAsync();
+        var pending = peer.PromptAsync("one");
+        peer.ReplyPrompt("one", "{}");
+        peer.State("one", "running");
+
+        // Act
+        oldHandshake!(peer.StateMessage("one", "idle", "cancelled"));
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        Assert.IsType<RunningSessionWorkState>(peer.Client.GetSessionWorkSnapshot("one")!.State);
+        peer.State("one", "idle", "end_turn");
+        await pending.WaitAsync(TestToken);
+    }
+
+    private sealed class ProtocolPeer : IAcpTransport
+    {
+        private readonly MessageParser _parser = new();
+        private readonly int _version;
+        private readonly Dictionary<string, Queue<JsonRpcRequest>> _prompts = new(StringComparer.Ordinal);
+        private int _sessionNumber;
+
+        internal ProtocolPeer(int version)
+        {
+            _version = version;
+            Client = new AcpClient(this);
+            Client.ErrorOccurred += (_, error) => Errors.Enqueue(error);
+        }
+
+        public bool IsConnected { get; private set; }
+        internal int ConnectCalls { get; private set; }
+        internal AcpClient Client { get; }
+        internal ConcurrentQueue<JsonRpcMessage> Sent { get; } = new();
+        internal ConcurrentQueue<string> Errors { get; } = new();
+        internal Action<JsonRpcRequest>? OnPrompt { get; set; }
+        internal Action<JsonRpcRequest>? BeforeSessionResponse { get; set; }
+        internal Action<JsonRpcRequest>? BeforeInitializeResponse { get; set; }
+        internal Func<Task<bool>>? OnCancel { get; set; }
+
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred;
+
+        internal static async Task<ProtocolPeer> CreateAsync(int version = AcpProtocolVersion.V2)
+        {
+            var peer = new ProtocolPeer(version);
+            await peer.InitializeAsync();
+            await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+            await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+            return peer;
+        }
+
+        internal InitializeParams InitializeParams() => new(new ClientInfo("test-client", "1.0"), new ClientCapabilities())
+        {
+            ProtocolVersion = _version
+        };
+
+        internal Task<InitializeResponse> InitializeAsync()
+            => _version == AcpProtocolVersion.V2
+                ? Client.InitializeDraftAsync(InitializeParams(), TestToken)
+                : Client.InitializeAsync(InitializeParams(), TestToken);
+
+        internal Task<SessionPromptResponse> PromptAsync(string sessionId, CancellationToken? callerToken = null)
+            => Client.SendPromptAsync(new SessionPromptParams(sessionId, [new TextContentBlock("hello")]), callerToken ?? TestToken);
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            ConnectCalls++;
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var parsed = _parser.ParseMessage(message);
+            Sent.Enqueue(parsed);
+            if (parsed is JsonRpcNotification { Method: "session/cancel" } && OnCancel is not null) return OnCancel();
+            if (parsed is not JsonRpcRequest request) return Task.FromResult(true);
+            switch (request.Method)
+            {
+                case "initialize":
+                    BeforeInitializeResponse?.Invoke(request);
+                    var response = new InitializeResponse(_version, new AgentInfo("deterministic-peer", "1.0"), new AgentCapabilities
+                    {
+                        SessionCapabilities = new SessionCapabilities
+                        {
+                            Close = new SessionCloseCapabilities(),
+                            Resume = new SessionResumeCapabilities()
+                        }
+                    });
+                    Reply(request, JsonSerializer.Serialize(response, AcpWireFormat.For(_version).TypeInfo<InitializeResponse>()));
+                    break;
+                case "session/new":
+                    BeforeSessionResponse?.Invoke(request);
+                    Reply(request, "{\"sessionId\":\"" + (++_sessionNumber == 1 ? "one" : "two") + "\"}");
+                    break;
+                case "session/close":
+                case "session/resume":
+                    BeforeSessionResponse?.Invoke(request);
+                    Reply(request, "{}");
+                    break;
+                case "session/prompt":
+                    var sessionId = request.Params!.Value.GetProperty("sessionId").GetString()!;
+                    if (!_prompts.TryGetValue(sessionId, out var queue)) _prompts[sessionId] = queue = new();
+                    queue.Enqueue(request);
+                    OnPrompt?.Invoke(request);
+                    break;
+            }
+            return Task.FromResult(true);
+        }
+
+        internal void ReplyPrompt(string sessionId, string result)
+            => Reply(_prompts[sessionId].Dequeue(), result);
+
+        internal void RejectPrompt(string sessionId, int code)
+        {
+            var request = _prompts[sessionId].Dequeue();
+            Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id
+                + ",\"error\":{\"code\":" + code + ",\"message\":\"prompt rejected\"}}");
+        }
+
+        internal void Reply(JsonRpcRequest request, string result)
+            => Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":" + result + "}");
+
+        internal void State(string sessionId, string state, string? reason = null)
+            => Deliver(StateMessage(sessionId, state, reason));
+
+        internal string StateMessage(string sessionId, string state, string? reason = null)
+            => UpdateMessage(sessionId, "{\"sessionUpdate\":\"state_update\",\"state\":\"" + state + "\""
+                + (reason is null ? "" : ",\"stopReason\":\"" + reason + "\"") + "}");
+
+        internal void Update(string sessionId, string update) => Deliver(UpdateMessage(sessionId, update));
+
+        private static string UpdateMessage(string sessionId, string update)
+            => "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"" + sessionId + "\",\"update\":" + update + "}}";
+
+        private void Deliver(string json) => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+
+        internal Action<string> CaptureDelivery()
+        {
+            var handlers = MessageReceived;
+            return json => handlers?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+        }
+
+        internal void DropConnection()
+        {
+            IsConnected = false;
+            ErrorOccurred?.Invoke(this, new AcpTransportErrorEventArgs("connection lost"));
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            IsConnected = false;
+        }
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Protocol/SessionWorkStateUpdateTypesTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Protocol/SessionWorkStateUpdateTypesTests.cs
@@ -151,6 +151,144 @@ public sealed class SessionWorkStateUpdateTypesTests
         Assert.Contains("\"state\":\"_vendor_paused\"", json, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("running")]
+    [InlineData("requires_action")]
+    [InlineData("idle")]
+    [InlineData("_vendor_paused")]
+    public void StateSessionUpdate_MetadataRoundTrip_EmitsEachFlattenedFieldOnce(string state)
+    {
+        // Arrange
+        var json = "{\"sessionId\":\"session-1\",\"update\":{\"sessionUpdate\":\"state_update\","
+            + "\"state\":\"" + state + "\",\"_meta\":{\"nested\":{\"owned\":[true,42,null]}}}}";
+        using var original = JsonDocument.Parse(json);
+
+        // Act
+        var restored = Assert.IsType<SessionUpdateParams>(JsonSerializer.Deserialize(json, Wire.V2<SessionUpdateParams>()));
+        using var replay = JsonDocument.Parse(SerializeV2(restored));
+
+        // Assert
+        var update = replay.RootElement.GetProperty("update");
+        Assert.Single(update.EnumerateObject(), property => property.NameEquals("sessionUpdate"));
+        Assert.Single(update.EnumerateObject(), property => property.NameEquals("_meta"));
+        Assert.True(JsonElement.DeepEquals(original.RootElement, replay.RootElement));
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("\"unknown\"")]
+    [InlineData("{\"nested\":[true,42,null]}")]
+    public void StateSessionUpdate_CustomMetadata_RoundTripsTheUnknownPayload(string metadata)
+    {
+        // Arrange
+        var json = "{\"sessionId\":\"session-1\",\"update\":{\"sessionUpdate\":\"state_update\","
+            + "\"state\":\"_vendor_paused\",\"_meta\":" + metadata + "}}";
+        using var original = JsonDocument.Parse(json);
+
+        // Act
+        var restored = Assert.IsType<SessionUpdateParams>(JsonSerializer.Deserialize(json, Wire.V2<SessionUpdateParams>()));
+        using var replay = JsonDocument.Parse(SerializeV2(restored));
+
+        // Assert
+        Assert.IsType<CustomSessionWorkState>(Assert.IsType<StateSessionUpdate>(restored.Update).State);
+        Assert.True(JsonElement.DeepEquals(original.RootElement, replay.RootElement));
+    }
+
+    [Fact]
+    public void StateSessionUpdate_ArbitraryMetadataValue_SurvivesTheParentRoundTrip()
+        => FsCheckPropertyRunner.Run(this, nameof(StateMetadataRoundTripProperty));
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("\"invalid\"")]
+    [InlineData("{\"outer\":true}")]
+    public void StateSessionUpdate_ParentMetadata_DefaultsWithoutDiscardingTheState(string metadata)
+    {
+        // Arrange
+        var json = "{\"sessionId\":\"session-1\",\"update\":{\"sessionUpdate\":\"state_update\","
+            + "\"state\":\"idle\",\"stopReason\":\"cancelled\"},\"_meta\":" + metadata + "}";
+
+        // Act
+        var restored = Assert.IsType<SessionUpdateParams>(JsonSerializer.Deserialize(json, Wire.V2<SessionUpdateParams>()));
+
+        // Assert
+        var update = Assert.IsType<StateSessionUpdate>(restored.Update);
+        Assert.Equal(StopReason.Cancelled, Assert.IsType<IdleSessionWorkState>(update.State).StopReason);
+        Assert.Null(update.Meta);
+        if (metadata == "{\"outer\":true}")
+        {
+            Assert.True(Assert.IsType<JsonElement>(restored.Meta!["outer"]).GetBoolean());
+        }
+        else
+        {
+            Assert.Null(restored.Meta);
+        }
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    public void StateSessionUpdate_InvalidStateDiscriminator_RemainsRejected(string state)
+    {
+        // Arrange
+        var json = "{\"sessionId\":\"session-1\",\"update\":{\"sessionUpdate\":\"state_update\","
+            + "\"state\":" + state + ",\"_meta\":42}}";
+
+        // Act / Assert
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, Wire.V2<SessionUpdateParams>()));
+        Assert.Equal(SessionWorkStateJsonConverter.MissingStateMessage, error.Message);
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("[]")]
+    [InlineData("\"invalid\"")]
+    public void MetadataWithoutSchemaDefaultOptIn_RemainsStrict(string metadata)
+    {
+        // Arrange
+        using var document = JsonDocument.Parse("{\"_meta\":" + metadata + "}");
+
+        // Act / Assert
+        Assert.Throws<JsonException>(() => AcpMetaJson.Read(document.RootElement));
+        Assert.Throws<JsonException>(() => ReadMetadataValue(metadata));
+    }
+
+    private static void ReadMetadataValue(string metadata)
+    {
+        var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(metadata));
+        Assert.True(reader.Read());
+        AcpMetaJson.ReadValue(ref reader);
+    }
+
+    private void StateMetadataRoundTripProperty(string? content, long number, bool flag)
+    {
+        // Arrange
+        var original = new SessionUpdateParams("session-1", new StateSessionUpdate(new IdleSessionWorkState
+        {
+            StopReason = StopReason.EndTurn,
+            Meta = new Dictionary<string, object?>
+            {
+                ["_vendor"] = new object?[] { content, number, flag, null }
+            }
+        }));
+        using var first = JsonDocument.Parse(SerializeV2(original));
+
+        // Act
+        var restored = Assert.IsType<SessionUpdateParams>(
+            JsonSerializer.Deserialize(first.RootElement, Wire.V2<SessionUpdateParams>()));
+        using var replay = JsonDocument.Parse(SerializeV2(restored));
+
+        // Assert
+        Assert.True(JsonElement.DeepEquals(first.RootElement, replay.RootElement));
+        Assert.Single(replay.RootElement.GetProperty("update").EnumerateObject(), property => property.NameEquals("_meta"));
+    }
+
     [Fact]
     public void StateSessionUpdate_MissingState_IsRejected()
     {


### PR DESCRIPTION
ACP V2的prompt回复仅确认接收。本变更用同一个会话work owner区分接收与完成，在权威state_update idle时收敛；独立会话、取消和断连仍各归原连接。

此次复审修正：发送owner尚未开始transport IO的失败会撤销未发送的work（包括诊断listener在准备阶段抛错）；可能已经发出的请求保留原response关联，late ack/idle或拒绝仍能收敛。普通非prompt请求保留原异常行为。15项新的边界测试、失败后晚回复/断连、Sample/Started/Stopped回调异常均覆盖，修复前红灯记录保留。

已按净增量重放到actualmain3e1d32e，当前head978df1e4，源码树与已验证a564c188完全相同；11文件差异，公共auth/MCP/permission/draft/baseconsumer完整保留，八个B独有文件与已审源字节一致。独立Standards/Spec复审通过。

当前整合验证：定向92/92、SDK990/990、零跳过，SDK/test构建零warning/error、format通过；1.0.0包基线与实际nupkgconsumer（旧transport二进制+38草案标记）通过。实际main上的新CI运行中，以最终SHA为门槛。

公开生产初始化继续在connect前拒绝V2，内部staging入口仅供测试；完整产品消息/工具/terminal/configuration/batch与第三方Agent接线仍由#149后续阶段验收。本PR不关闭总单。

最新整合head `7d7e4a3e` 已继承凭据main `c93a7533`。以该提交的新CI为准，前一个基线的通过结果不代替当前门禁。

最终经过实际main重放、全部CI通过后已rebase合并：`5cade2f1fb363dfbb8798db89482f6f0191e8451`。
