### PR TITLE
feat(acp): add consented Windows terminal authentication

### DIFF
--- a/.github/workflows/terminal-auth-windows.yml
+++ b/.github/workflows/terminal-auth-windows.yml
@@ -1,0 +1,44 @@
+name: Terminal Authentication Windows
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terminal-auth-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terminal-authentication:
+    name: Windows Terminal Authentication
+    runs-on: windows-latest
+    timeout-minutes: 12
+    env:
+      DOTNET_PROCESSOR_COUNT: 2
+      DOTNET_CLI_USE_MSBUILD_SERVER: 0
+      MSBUILDDISABLENODEREUSE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Run actual ConPTY process and teardown gate
+        shell: pwsh
+        run: ./scripts/gates/run-terminal-auth-windows-gate.ps1
+      - name: Upload terminal authentication results
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: terminal-auth-windows-results
+          path: artifacts/terminal-auth-windows
+          if-no-files-found: error

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -69,7 +69,7 @@ Windows 原生路径必须用 MSIX 脚本；Linux/macOS 桌面版走 Skia；WASM
 
 ### Windows 终端登录门禁
 
-ACP `auth.terminal` 当前仅在 Windows 桌面进程宿主且具备交互终端界面时启用。用户同意后，应用根据当前 Agent 进程的启动快照创建独立 ConPTY；只有正常退出码 `0` 才重新连接并初始化，再重试原操作。关闭窗口、取消或退出应用会回收登录进程及其子孙进程。
+ACP `auth.terminal` 的 Windows PTY host 已实现，但产品能力暂不广告。须用本次安装包通过同意、终端交互、退出、重连、原操作重试和取消回收的 GUI 门禁后，才能启用。独立 ConPTY 门禁通过显式测试 host 验证进程能力：根据当前 Agent 启动快照创建独立 ConPTY，正常退出码 `0` 才允许重连，关闭或取消会回收登录进程及其子孙进程。
 
 Windows 主机运行：
 

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -67,6 +67,20 @@ dotnet run --project SalmonEgg/SalmonEgg/SalmonEgg.csproj \
 
 Windows 原生路径必须用 MSIX 脚本；Linux/macOS 桌面版走 Skia；WASM 必须使用 BrowserWasm 目标。不要用一个目标的成功替代其他平台验证。
 
+### Windows 终端登录门禁
+
+ACP `auth.terminal` 当前仅在 Windows 桌面进程宿主且具备交互终端界面时启用。用户同意后，应用根据当前 Agent 进程的启动快照创建独立 ConPTY；只有正常退出码 `0` 才重新连接并初始化，再重试原操作。关闭窗口、取消或退出应用会回收登录进程及其子孙进程。
+
+Windows 主机运行：
+
+```powershell
+./scripts/gates/run-terminal-auth-windows-gate.ps1
+```
+
+该门禁使用 `tests/SalmonEgg.TerminalAuth.Windows.Tests`，实际启动 Agent 与 ConPTY，至少执行四项测试，禁止跳过；验证输入输出、参数边界、环境覆盖、退出码和进程树回收。GHA 的 `Windows Terminal Authentication` job 在 hosted Windows 上执行相同命令，日志与提交来源保存在 `artifacts/terminal-auth-windows`。Linux 交叉编译不能替代这项运行验证；原生登录对话框仍需 Windows UI 验收。
+
+Linux/macOS 暂不广告终端登录：当前 Porta.Pty 对 Unix 信号退出不能提供可靠的正常退出结果。普通会话终端不受此能力限制影响。SDK 默认能力与远程 WebSocket/HTTP 连接也不会广告 `auth.terminal`。
+
 ## 快速开始
 
 ### Windows 用户

--- a/SalmonEgg/SalmonEgg/Controls/XtermTerminalView.xaml.cs
+++ b/SalmonEgg/SalmonEgg/Controls/XtermTerminalView.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class XtermTerminalView : UserControl
     public static readonly DependencyProperty SessionProperty =
         DependencyProperty.Register(
             nameof(Session),
-            typeof(ILocalTerminalSession),
+            typeof(IInteractiveTerminalSession),
             typeof(XtermTerminalView),
             new PropertyMetadata(null, OnSessionChanged));
 
@@ -48,7 +48,7 @@ public sealed partial class XtermTerminalView : UserControl
     private int _sessionGeneration;
     private string _currentHostId = CreateHostId();
     private string _pendingContent = string.Empty;
-    private ILocalTerminalSession? _attachedSession;
+    private IInteractiveTerminalSession? _attachedSession;
     private bool _guiLocalTerminalSmokeCommandSent;
     private string? _guiLocalTerminalSmokeCommand;
 
@@ -66,9 +66,9 @@ public sealed partial class XtermTerminalView : UserControl
         set => SetValue(ContentTextProperty, value);
     }
 
-    public ILocalTerminalSession? Session
+    public IInteractiveTerminalSession? Session
     {
-        get => (ILocalTerminalSession?)GetValue(SessionProperty);
+        get => (IInteractiveTerminalSession?)GetValue(SessionProperty);
         set => SetValue(SessionProperty, value);
     }
 
@@ -136,8 +136,8 @@ public sealed partial class XtermTerminalView : UserControl
         }
 
         view._sessionGeneration++;
-        view.DetachSession(e.OldValue as ILocalTerminalSession);
-        view.AttachSession(e.NewValue as ILocalTerminalSession);
+        view.DetachSession(e.OldValue as IInteractiveTerminalSession);
+        view.AttachSession(e.NewValue as IInteractiveTerminalSession);
         view._sessionHasLiveOutput = false;
         view.ClearPendingCommands(static _ => true);
         view._guiLocalTerminalSmokeCommandSent = false;
@@ -193,7 +193,7 @@ public sealed partial class XtermTerminalView : UserControl
         TerminalWebView.NavigationCompleted -= OnNavigationCompleted;
     }
 
-    private void AttachSession(ILocalTerminalSession? session)
+    private void AttachSession(IInteractiveTerminalSession? session)
     {
         if (session is null)
         {
@@ -206,7 +206,7 @@ public sealed partial class XtermTerminalView : UserControl
         session.StateChanged += OnSessionStateChanged;
     }
 
-    private void DetachSession(ILocalTerminalSession? session)
+    private void DetachSession(IInteractiveTerminalSession? session)
     {
         if (session is null)
         {
@@ -336,7 +336,7 @@ public sealed partial class XtermTerminalView : UserControl
 
     private void OnSessionOutputReceived(object? sender, string output)
     {
-        if (sender is not ILocalTerminalSession session || string.IsNullOrEmpty(output))
+        if (sender is not IInteractiveTerminalSession session || string.IsNullOrEmpty(output))
         {
             return;
         }
@@ -346,7 +346,7 @@ public sealed partial class XtermTerminalView : UserControl
 
     private void OnSessionStateChanged(object? sender, EventArgs e)
     {
-        if (sender is not ILocalTerminalSession session)
+        if (sender is not IInteractiveTerminalSession session)
         {
             return;
         }
@@ -359,7 +359,7 @@ public sealed partial class XtermTerminalView : UserControl
         _ = QueueHostResizeAsync();
     }
 
-    private Task AppendSessionOutputAsync(ILocalTerminalSession session, string output)
+    private Task AppendSessionOutputAsync(IInteractiveTerminalSession session, string output)
     {
         if (!ReferenceEquals(session, Session))
         {
@@ -455,7 +455,7 @@ public sealed partial class XtermTerminalView : UserControl
         return SyncSessionStateAsync(Session);
     }
 
-    private async Task SyncSessionStateAsync(ILocalTerminalSession? session)
+    private async Task SyncSessionStateAsync(IInteractiveTerminalSession? session)
     {
         if (session is not null && !ReferenceEquals(session, Session))
         {
@@ -476,7 +476,8 @@ public sealed partial class XtermTerminalView : UserControl
                     Enabled = Session is not null && Session.CanAcceptInput
                 }));
         await QueueHostResizeAsync();
-        await TryInjectGuiSmokeCommandAsync(session);
+        // The existing shell smoke injection belongs only to conversation terminals.
+        if (session is ILocalTerminalSession localSession) await TryInjectGuiSmokeCommandAsync(localSession);
     }
 
     private async Task TryInjectGuiSmokeCommandAsync(ILocalTerminalSession? session)

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -378,6 +378,13 @@ public static class DependencyInjection
         services.AddSingleton<IPlatformRuntimeCapabilityProbe, PlatformRuntimeCapabilityProbe>();
 #endif
         services.AddSingleton<IPlatformCapabilityService, PlatformCapabilityService>();
+#if !__WASM__ && !__ANDROID__ && !__IOS__
+        services.AddSingleton<ITerminalAuthenticationSessionFactory, TerminalAuthenticationSessionFactory>();
+#else
+        services.AddSingleton<ITerminalAuthenticationSessionFactory, UnsupportedTerminalAuthenticationSessionFactory>();
+#endif
+        services.AddSingleton<ITerminalAuthenticationInteraction, TerminalAuthenticationInteraction>();
+        services.AddSingleton<TerminalAuthenticationCoordinator>();
         services.AddSingleton<ITransportSupportPolicy, TransportSupportPolicy>();
 #if __WASM__
         if (OperatingSystem.IsBrowser())
@@ -575,7 +582,8 @@ public static class DependencyInjection
                 sessionManager,
                 acpClientFactory,
                 logger,
-                chatServiceDecorator);
+                chatServiceDecorator,
+                sp.GetRequiredService<ITerminalAuthenticationSessionFactory>());
         });
         services.AddTransient<ConfigurationEditorViewModel>();
         services.AddSingleton<IConversationWorkspacePreferences>(sp =>
@@ -797,10 +805,11 @@ public static class DependencyInjection
                 // 本地 PTY 协调器只在 desktop 注册；其余平台传 null，由 workflow 跳过该段。
                 // 用 GetService 而非 GetRequiredService 表达"可选"，避免为此在各平台注册空实现。
 #if !__WASM__ && !__ANDROID__ && !__IOS__
-                sp.GetService<LocalTerminalPanelCoordinator>()
+                sp.GetService<LocalTerminalPanelCoordinator>(),
 #else
-                null
+                null,
 #endif
+                sp.GetRequiredService<TerminalAuthenticationCoordinator>()
                 ));
 
         // Global search

--- a/SalmonEgg/SalmonEgg/Presentation/Services/TerminalAuthenticationInteraction.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Services/TerminalAuthenticationInteraction.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Utilities;
+using SalmonEgg.Presentation.ViewModels.Chat;
+using SalmonEgg.Presentation.Views.Chat;
+
+namespace SalmonEgg.Presentation.Services;
+
+public sealed class TerminalAuthenticationInteraction : ITerminalAuthenticationInteraction
+{
+    private readonly AppActivationSignalSource _activation;
+    private readonly IUiDispatcher _dispatcher;
+
+    public TerminalAuthenticationInteraction(AppActivationSignalSource activation, IUiDispatcher dispatcher)
+    {
+        _activation = activation ?? throw new ArgumentNullException(nameof(activation));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<bool> ConfirmAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken)
+        => ShowAsync(new ContentDialog
+        {
+            Title = viewModel.Title,
+            Content = new TextBlock { Text = viewModel.ConsentMessage, TextWrapping = TextWrapping.Wrap },
+            PrimaryButtonText = viewModel.ContinueButtonText,
+            CloseButtonText = viewModel.CancelButtonText,
+            DefaultButton = ContentDialogButton.Close
+        }, cancellationToken);
+
+    public async Task ShowSessionAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken)
+        => _ = await ShowAsync(new TerminalAuthenticationDialog(viewModel), cancellationToken).ConfigureAwait(true);
+
+    private async Task<bool> ShowAsync(ContentDialog dialog, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_activation.ActiveWindow?.Content is not FrameworkElement { XamlRoot: { } root }) return false;
+        ContentDialogHost.AttachToXamlRoot(dialog, root);
+        using var registration = cancellationToken.Register(() => _dispatcher.Enqueue(dialog.Hide));
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = await dialog.ShowAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        return result == ContentDialogResult.Primary;
+    }
+}

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Chat/TerminalAuthenticationDialog.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Chat/TerminalAuthenticationDialog.xaml
@@ -1,0 +1,31 @@
+<ContentDialog
+    x:Class="SalmonEgg.Presentation.Views.Chat.TerminalAuthenticationDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:SalmonEgg.Controls"
+    xmlns:views="using:SalmonEgg.Presentation.Views.Chat"
+    Title="{x:Bind ViewModel.Title}"
+    CloseButtonText="{x:Bind ViewModel.CancelButtonText}"
+    DefaultButton="None"
+    AutomationProperties.AutomationId="ChatAuth.TerminalDialog">
+
+    <ContentDialog.Resources>
+        <Style TargetType="views:TerminalAuthenticationDialog"
+               BasedOn="{StaticResource DefaultContentDialogStyle}" />
+        <!-- This is the terminal viewport budget; native dialog chrome still adapts to the window. -->
+        <x:Double x:Key="TerminalAuthenticationViewportHeight">360</x:Double>
+        <x:Double x:Key="TerminalAuthenticationContentSpacing">12</x:Double>
+    </ContentDialog.Resources>
+
+    <Grid RowSpacing="{StaticResource TerminalAuthenticationContentSpacing}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock Text="{x:Bind ViewModel.RunningMessage}" TextWrapping="Wrap" />
+        <controls:XtermTerminalView Grid.Row="1"
+                                    Height="{StaticResource TerminalAuthenticationViewportHeight}"
+                                    Session="{x:Bind ViewModel.Session, Mode=OneWay}"
+                                    AutomationProperties.AutomationId="ChatAuth.Terminal" />
+    </Grid>
+</ContentDialog>

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Chat/TerminalAuthenticationDialog.xaml.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Chat/TerminalAuthenticationDialog.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Views.Chat;
+
+public sealed partial class TerminalAuthenticationDialog : ContentDialog
+{
+    public TerminalAuthenticationDialog(TerminalAuthenticationViewModel viewModel)
+    {
+        ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        InitializeComponent();
+    }
+
+    public TerminalAuthenticationViewModel ViewModel { get; }
+}

--- a/scripts/gates/run-acp-credential-transport-gates.sh
+++ b/scripts/gates/run-acp-credential-transport-gates.sh
@@ -21,7 +21,7 @@ timeout --signal=TERM --kill-after=10s 180s "$dotnet_bin" test \
   --no-ansi \
   -p:UseSharedCompilation=false \
   --filter-class SalmonEgg.Infrastructure.Tests.Transport.CredentialTransportCanaryTests \
-  --minimum-expected-tests 8 \
+  --minimum-expected-tests 9 \
   --output Detailed > "$log_file" 2>&1 || {
     cat "$log_file"
     exit 1
@@ -36,7 +36,7 @@ import sys
 text = pathlib.Path(sys.argv[1]).read_text()
 passed = re.findall(r'^\s+succeeded:\s+(\d+)\s*$', text, re.M)
 skipped = re.findall(r'^\s+skipped:\s+(\d+)\s*$', text, re.M)
-if not passed or int(passed[-1]) < 8 or not skipped or int(skipped[-1]) != 0:
+if not passed or int(passed[-1]) < 9 or not skipped or int(skipped[-1]) != 0:
     raise SystemExit('Credential transport gate requires every real process and endpoint case with zero skips.')
 print('[gate] Credential destination, real child environment, HTTP/2 + SSE, WebSocket, and redirect isolation passed.')
 PY

--- a/scripts/gates/run-terminal-auth-windows-gate.ps1
+++ b/scripts/gates/run-terminal-auth-windows-gate.ps1
@@ -1,0 +1,31 @@
+param([string] $Configuration = 'Release')
+
+$ErrorActionPreference = 'Stop'
+if (-not $IsWindows) {
+    throw 'The terminal authentication gate requires Windows and actual ConPTY processes.'
+}
+
+$repositoryRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+Push-Location $repositoryRoot
+try {
+    $outputDirectory = Join-Path $repositoryRoot 'artifacts/terminal-auth-windows'
+    New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+    git rev-parse HEAD | Set-Content (Join-Path $outputDirectory 'source-commit.txt')
+    dotnet test --project tests/SalmonEgg.TerminalAuth.Windows.Tests/SalmonEgg.TerminalAuth.Windows.Tests.csproj `
+        --configuration $Configuration -p:UseSharedCompilation=false `
+        --minimum-expected-tests 4 --timeout 3m --output Normal --no-ansi 2>&1 |
+        Tee-Object -FilePath (Join-Path $outputDirectory 'test.log')
+    if ($LASTEXITCODE -ne 0) {
+        throw "Terminal authentication tests failed with exit code $LASTEXITCODE."
+    }
+
+    $log = Get-Content (Join-Path $outputDirectory 'test.log') -Raw
+    if ($log -notmatch '(?m)^\s+succeeded:\s+([4-9]|[1-9][0-9]+)\s*$' -or
+        $log -notmatch '(?m)^\s+failed:\s+0\s*$' -or
+        $log -match '(?im)\bskipped:\s*[1-9]') {
+        throw 'The gate requires at least four executed tests, zero failures and zero skips.'
+    }
+}
+finally {
+    Pop-Location
+}

--- a/scripts/gates/wasm-smoke-lib/elicitation-form-flow.mjs
+++ b/scripts/gates/wasm-smoke-lib/elicitation-form-flow.mjs
@@ -4,6 +4,7 @@ import {
   typeIntoVisibleTextField,
   waitForControlEnabledState,
   waitForLaidOutControl,
+  waitForNativeControlFocus,
   waitForSemanticText
 } from "./ui-affordances.mjs";
 
@@ -80,8 +81,8 @@ async function verifyMultiSelectForm(page, server, suffix) {
   for (const [index, checked, enabled] of [
     [0, true, false], [1, true, true], [2, true, false], [1, false, true]
   ]) {
-    await activateNativeControl(page, checkboxes[index], "Space", options[index]);
-    await waitForCheckboxState(page, checkboxes[index], checked);
+    await activateNativeControl(page, { labels: [options[index]], role: "input" }, "Space", options[index]);
+    await waitForCheckboxState(page, options[index], checked);
     await waitForControlEnabledState(page, submitButton, enabled, "Multi-select bounds update Submit", formTimeoutMs);
     assert.equal(form.request.responses().length, 0, "Toggling a choice must not submit the form.");
   }
@@ -121,8 +122,8 @@ async function verifyTitledMultiSelectForm(page, server, suffix) {
   assert.equal(form.request.responses().length, 0);
 
   for (const [index, checked, enabled] of [[0, false, false], [1, true, true], [2, true, true]]) {
-    await activateNativeControl(page, checkboxes[index], "Space", labels[index]);
-    await waitForCheckboxState(page, checkboxes[index], checked);
+    await activateNativeControl(page, { labels: [labels[index]], role: "input" }, "Space", labels[index]);
+    await waitForCheckboxState(page, labels[index], checked);
     await waitForControlEnabledState(page, submitButton, enabled, "Titled choices update Submit", formTimeoutMs);
     assert.equal(form.request.responses().length, 0, "Choosing a display label must not submit the form.");
   }
@@ -212,14 +213,18 @@ async function findNamedCheckbox(page, name, expectedChecked) {
   }, { name, expectedChecked }, `enabled checkbox ${name} with its default state`);
 }
 
-async function waitForCheckboxState(page, id, expectedChecked) {
-  await waitForValue(page, ({ id, expectedChecked }) => {
-    const checkbox = document.getElementById(id);
-    if (!checkbox || checkbox.closest("[hidden]")) return false;
+async function waitForCheckboxState(page, name, expectedChecked) {
+  await waitForValue(page, ({ name, expectedChecked }) => {
+    const current = window.__salmoneggSmoke.semantic.describe({ labels: [name], role: "input" });
+    const checkbox = current?.id ? document.getElementById(current.id) : null;
+    const rect = checkbox?.getBoundingClientRect();
+    if (!checkbox || checkbox.type !== "checkbox" || checkbox.closest("[hidden]")
+      || checkbox.disabled || checkbox.getAttribute("aria-disabled") === "true"
+      || rect.width < 12 || rect.height < 12) return false;
     const aria = checkbox.getAttribute("aria-checked");
     const checked = aria === null ? checkbox.checked : aria === "true" ? true : aria === "false" ? false : null;
     return checked === expectedChecked;
-  }, { id, expectedChecked }, `same checkbox ${id} changing to ${expectedChecked}`);
+  }, { name, expectedChecked }, `checkbox ${name} changing to ${expectedChecked}`);
 }
 
 async function activateFormAction(page, form, label) {
@@ -227,7 +232,7 @@ async function activateFormAction(page, form, label) {
   await waitForControlEnabledState(page, options, true, `form ${label} enabled`, formTimeoutMs);
   const state = await waitForLaidOutControl(page, options, `form ${label} laid out`, formTimeoutMs);
   assert.equal(state.id, form.actions[label], "The action must still belong to the recorded form.");
-  await activateNativeControl(page, state.id, "Enter", `form ${label}`);
+  await activateNativeControl(page, options, "Enter", `form ${label}`);
 }
 
 async function waitForFormTabCompletion(page, form) {
@@ -251,17 +256,11 @@ async function waitForFormTabCompletion(page, form) {
   throw new Error("The form's Cancel button did not retain Tab focus across a frame.");
 }
 
-async function activateNativeControl(page, id, key, label) {
-  await page.locator(`#${id}`).focus();
-  const focused = await page.evaluate(async id => {
-    await new Promise(requestAnimationFrame);
-    const element = document.getElementById(id);
-    const rect = element?.getBoundingClientRect();
-    return document.activeElement?.id === id && element && !element.closest("[hidden]")
-      && !element.disabled && element.getAttribute("aria-disabled") !== "true"
-      && rect.width >= 12 && rect.height >= 12;
-  }, id);
-  assert.equal(focused, true, `${label} must retain native focus, layout and enabled state before ${key}.`);
+async function activateNativeControl(page, options, key, label) {
+  await waitForControlEnabledState(page, options, true, `${label} enabled`, formTimeoutMs);
+  const state = await waitForLaidOutControl(page, options, `${label} laid out`, formTimeoutMs);
+  await page.locator(`#${state.id}`).focus();
+  await waitForNativeControlFocus(page, options, label, formTimeoutMs);
   await page.keyboard.press(key);
 }
 

--- a/scripts/gates/wasm-smoke-lib/permission-flow.mjs
+++ b/scripts/gates/wasm-smoke-lib/permission-flow.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   waitForControlEnabledState,
   waitForLaidOutControl,
+  waitForNativeControlFocus,
   waitForSemanticText
 } from "./ui-affordances.mjs";
 
@@ -36,8 +37,7 @@ export async function verifyStandalonePermissionQueue(page, server) {
     assert.equal(state.enabled, true);
     choiceIds.push(state.id);
     await page.locator(`#${state.id}`).focus();
-    assert.equal(await page.evaluate(() => document.activeElement?.id), state.id,
-      "The actual native permission Button must own focus before Enter.");
+    await waitForNativeControlFocus(page, button, "current permission choice");
     await page.keyboard.press("Enter");
     assert.deepEqual(await item.request.waitForResponse(), {
       jsonrpc: "2.0",

--- a/src/SalmonEgg.Acp/Protocol/AuthMethodTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/AuthMethodTypes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SalmonEgg.Acp.Serialization;
@@ -60,7 +61,13 @@ namespace SalmonEgg.Acp.Protocol
         [JsonPropertyName("description")]
         public string? Description { get; init; }
 
-        // Unimplemented variants must survive initialization replay, including terminal args/env.
+        /// <summary>Arguments appended to the configured agent invocation for terminal sign-in.</summary>
+        public IReadOnlyList<string>? Args { get; init; }
+
+        /// <summary>Environment overrides for terminal sign-in, keyed by variable name.</summary>
+        public IReadOnlyDictionary<string, string>? Env { get; init; }
+
+        // Unimplemented variants must survive initialization replay without interpretation.
         // Known properties remain owned by the typed model so edits do not replay stale values.
         internal JsonElement? RawPayload { get; init; }
     }
@@ -72,13 +79,17 @@ namespace SalmonEgg.Acp.Protocol
             using var document = JsonDocument.ParseValue(ref reader);
             var root = document.RootElement;
             var protocolVersion = AcpWireFormat.NegotiatedVersion(options);
+            var discriminator = ReadDiscriminator(root, protocolVersion);
+            var isTerminal = discriminator == AuthMethodDefinition.TerminalType;
 
             return new AuthMethodDefinition
             {
                 Id = ReadString(root, GetIdPropertyName(protocolVersion)) ?? string.Empty,
                 Name = ReadString(root, "name") ?? string.Empty,
-                Type = ReadDiscriminator(root, protocolVersion),
+                Type = discriminator,
                 Description = ReadString(root, "description"),
+                Args = isTerminal ? ReadArguments(root) : null,
+                Env = isTerminal ? ReadEnvironment(root, protocolVersion) : null,
                 Meta = AcpMetaJson.Read(root),
                 RawPayload = root.Clone()
             };
@@ -104,7 +115,12 @@ namespace SalmonEgg.Acp.Protocol
             }
 
             AcpMetaJson.Write(writer, value.Meta);
-            WriteAdditionalProperties(writer, value.RawPayload, protocolVersion);
+            if (value.ResolvedType == AuthMethodDefinition.TerminalType)
+            {
+                WriteTerminalInvocation(writer, value, protocolVersion);
+            }
+
+            WriteAdditionalProperties(writer, value, protocolVersion);
             writer.WriteEndObject();
         }
 
@@ -133,9 +149,9 @@ namespace SalmonEgg.Acp.Protocol
             return property.GetString();
         }
 
-        private static void WriteAdditionalProperties(Utf8JsonWriter writer, JsonElement? rawPayload, int protocolVersion)
+        private static void WriteAdditionalProperties(Utf8JsonWriter writer, AuthMethodDefinition value, int protocolVersion)
         {
-            if (rawPayload is not { ValueKind: JsonValueKind.Object } root)
+            if (value.RawPayload is not { ValueKind: JsonValueKind.Object } root)
             {
                 return;
             }
@@ -143,13 +159,107 @@ namespace SalmonEgg.Acp.Protocol
             foreach (var property in root.EnumerateObject())
             {
                 if (property.Name == GetIdPropertyName(protocolVersion)
-                    || property.Name is "name" or "type" or "description" or "_meta")
+                    || property.Name is "name" or "type" or "description" or "_meta"
+                    || (value.ResolvedType == AuthMethodDefinition.TerminalType && property.Name is "args" or "env"))
                 {
                     continue;
                 }
 
                 writer.WritePropertyName(property.Name);
                 writer.WriteRawValue(property.Value.GetRawText());
+            }
+        }
+
+        private static IReadOnlyList<string>? ReadArguments(JsonElement root)
+        {
+            if (!root.TryGetProperty("args", out var args)) return null;
+            var result = new List<string>();
+            // The schema explicitly defaults malformed args and skips malformed items.
+            if (args.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in args.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String) result.Add(item.GetString()!);
+                }
+            }
+
+            return result;
+        }
+
+        private static IReadOnlyDictionary<string, string>? ReadEnvironment(JsonElement root, int protocolVersion)
+        {
+            if (!root.TryGetProperty("env", out var env)) return null;
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (protocolVersion == AcpProtocolVersion.V1)
+            {
+                if (env.ValueKind != JsonValueKind.Object) return result;
+                foreach (var property in env.EnumerateObject())
+                {
+                    // V1 defaults the whole field on error; it does not permit per-entry recovery.
+                    if (property.Value.ValueKind != JsonValueKind.String) return new Dictionary<string, string>();
+                    result[property.Name] = property.Value.GetString()!;
+                }
+            }
+            else if (env.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in env.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.Object
+                        && ReadString(item, "name") is { } name && ReadString(item, "value") is { } value)
+                    {
+                        result.TryAdd(name, value);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static void WriteTerminalInvocation(Utf8JsonWriter writer, AuthMethodDefinition value, int protocolVersion)
+        {
+            if (value.Args is { } arguments)
+            {
+                writer.WriteStartArray("args");
+                foreach (var argument in arguments) writer.WriteStringValue(argument);
+                writer.WriteEndArray();
+            }
+
+            if (value.Env is not { } environment) return;
+            if (protocolVersion == AcpProtocolVersion.V1)
+            {
+                writer.WriteStartObject("env");
+                foreach (var entry in environment) writer.WriteString(entry.Key, entry.Value);
+                writer.WriteEndObject();
+                return;
+            }
+
+            writer.WriteStartArray("env");
+            foreach (var entry in environment)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("name", entry.Key);
+                writer.WriteString("value", entry.Value);
+                WriteEnvironmentExtensions(writer, value.RawPayload, entry.Key);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static void WriteEnvironmentExtensions(Utf8JsonWriter writer, JsonElement? raw, string name)
+        {
+            if (raw is not { ValueKind: JsonValueKind.Object } root
+                || !root.TryGetProperty("env", out var env) || env.ValueKind != JsonValueKind.Array) return;
+            foreach (var item in env.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object || ReadString(item, "name") != name
+                    || ReadString(item, "value") is null) continue;
+                foreach (var property in item.EnumerateObject())
+                {
+                    if (property.Name is not ("name" or "value")) property.WriteTo(writer);
+                }
+
+                return;
             }
         }
 

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -39,7 +39,7 @@ hosts must enable optional capabilities only after implementing their interactio
 
 | Surface | Current behavior | Remaining work |
 | --- | --- | --- |
-| Agent authentication | Only an absent discriminator or the exact `agent` type can reach `authenticate`. Unsupported strings round-trip without being selected; non-string discriminators are rejected. | Hosts must implement interactive login before opting into `ClientCapabilities.Auth.Terminal`. SalmonEgg provides a consented Windows PTY host; its platform acceptance is tracked in [#147](https://github.com/salmonloop/salmon-egg/issues/147). SalmonEgg credential injection binds a stored value to an explicit transport destination independently of the ACP `authenticate` request. |
+| Agent authentication | Only an absent discriminator or the exact `agent` type can reach `authenticate`. Unsupported strings round-trip without being selected; non-string discriminators are rejected. | Hosts must implement interactive login before opting into `ClientCapabilities.Auth.Terminal`. The Windows PTY host is implemented, but SalmonEgg does not advertise it until packaged-application acceptance completes; see [#147](https://github.com/salmonloop/salmon-egg/issues/147). SalmonEgg credential injection binds a stored value to an explicit transport destination independently of the ACP `authenticate` request. |
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
@@ -66,9 +66,11 @@ interoperability with a public v2 Agent, and it does not enable public live v2 i
 Terminal methods append their arguments to the invocation used by the active stdio connection and
 override its effective environment. SalmonEgg asks for consent before starting a separate PTY,
 reclaims that process tree on cancellation, and reconnects through its existing connection owner
-only after a normal zero exit. Terminal methods never reach `authenticate`. This host is advertised
-only on interactive Windows hosts; other platforms remain disabled until their process exit and
-cleanup semantics have equivalent acceptance coverage. The real Windows process gate and remaining
+only after a normal zero exit. Terminal methods never reach `authenticate`. Product capability
+advertisement remains disabled, including on Windows, until the packaged application's consent,
+terminal interaction, exit, reconnect, retry and cancellation paths pass the GUI gate. The dedicated
+Windows process gate opts in explicitly to validate ConPTY independently of product rollout. Other
+platforms also need trustworthy process exit and cleanup semantics. The process gate and remaining
 GUI prerequisites are described in the repository's `BUILD_GUIDE.md`.
 
 V2 wire coverage includes `configId`/`groupId`, required `messageId` values, text/custom command

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -39,7 +39,7 @@ hosts must enable optional capabilities only after implementing their interactio
 
 | Surface | Current behavior | Remaining work |
 | --- | --- | --- |
-| Agent authentication | Only an absent discriminator or the exact `agent` type can reach `authenticate`. Unsupported strings round-trip without being selected; non-string discriminators are rejected. | Interactive terminal authentication still needs a host implementation before opting into `ClientCapabilities.Auth.Terminal`; see [#147](https://github.com/salmonloop/salmon-egg/issues/147). SalmonEgg credential injection binds a stored value to an explicit transport destination independently of the ACP `authenticate` request. |
+| Agent authentication | Only an absent discriminator or the exact `agent` type can reach `authenticate`. Unsupported strings round-trip without being selected; non-string discriminators are rejected. | Hosts must implement interactive login before opting into `ClientCapabilities.Auth.Terminal`. SalmonEgg provides a consented Windows PTY host; its platform acceptance is tracked in [#147](https://github.com/salmonloop/salmon-egg/issues/147). SalmonEgg credential injection binds a stored value to an explicit transport destination independently of the ACP `authenticate` request. |
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
@@ -62,6 +62,14 @@ its retained responses, without starting an automatic retry loop.
 `tests/SalmonEgg.Acp.Desktop.Tests` and `scripts/gates/run-acp-batch-stdio-gate.sh` exercise real
 Linux pipes through the production transport and adapter. This gate does not establish
 interoperability with a public v2 Agent, and it does not enable public live v2 initialization.
+
+Terminal methods append their arguments to the invocation used by the active stdio connection and
+override its effective environment. SalmonEgg asks for consent before starting a separate PTY,
+reclaims that process tree on cancellation, and reconnects through its existing connection owner
+only after a normal zero exit. Terminal methods never reach `authenticate`. This host is advertised
+only on interactive Windows hosts; other platforms remain disabled until their process exit and
+cleanup semantics have equivalent acceptance coverage. The real Windows process gate and remaining
+GUI prerequisites are described in the repository's `BUILD_GUIDE.md`.
 
 V2 wire coverage includes `configId`/`groupId`, required `messageId` values, text/custom command
 inputs, and v1-only session fields and MCP variants. Unknown extension fields are preserved;

--- a/src/SalmonEgg.Application/Services/Chat/ChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/ChatService.cs
@@ -9,6 +9,7 @@ using SalmonEgg.Acp.Plan;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Application.Observability;
 using SalmonEgg.Domain.Models.Session;
+using SalmonEgg.Domain.Models;
 using SalmonEgg.Acp.Tool;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Domain.Services.Security;
@@ -18,11 +19,13 @@ using SalmonEgg.Acp.Client;
 
 namespace SalmonEgg.Application.Services.Chat
 {
-    public class ChatService : IChatService
+    public class ChatService : IChatService, IStdioInvocationSource
     {
         private readonly IAcpClient _acpClient;
         private readonly IErrorLogger _errorLogger;
         private readonly ISessionManager _sessionManager;
+        private readonly IStdioInvocationSource? _stdioInvocationSource;
+        private readonly ITerminalAuthenticationSessionFactory? _terminalAuthentication;
         // 保护下列四个共享可变态的所有读写:pump 线程(传输读线程续体)与请求-响应续体
         // (线程池)并发触碰它们。锁内只做同步内存读写与 HashSet 操作,绝不跨 await、
         // 绝不在锁内做协议 I/O 或调用可能重入的 _sessionManager 路径。
@@ -54,6 +57,7 @@ namespace SalmonEgg.Application.Services.Chat
         public bool IsConnected => _acpClient.IsConnected;
         public AgentInfo? AgentInfo => _acpClient.AgentInfo;
         public AgentCapabilities? AgentCapabilities => _acpClient.AgentCapabilities;
+        public StdioInvocationSnapshot? StdioInvocation => _stdioInvocationSource?.StdioInvocation;
 
         // 返回快照而非 live List:pump 会并发向同一会话追加历史,直接把内部 List
         // 交给 UI 枚举会触发并发修改异常。Session.SnapshotHistory 在会话自己的锁下拷贝。
@@ -97,11 +101,18 @@ namespace SalmonEgg.Application.Services.Chat
         public event EventHandler<ElicitationCompletedEventArgs>? ElicitationCompleted;
         public event EventHandler<string>? ErrorOccurred;
 
-        public ChatService(IAcpClient acpClient, IErrorLogger errorLogger, ISessionManager sessionManager)
+        public ChatService(
+            IAcpClient acpClient,
+            IErrorLogger errorLogger,
+            ISessionManager sessionManager,
+            IStdioInvocationSource? stdioInvocationSource = null,
+            ITerminalAuthenticationSessionFactory? terminalAuthentication = null)
         {
             _acpClient = acpClient ?? throw new ArgumentNullException(nameof(acpClient));
             _errorLogger = errorLogger ?? throw new ArgumentNullException(nameof(errorLogger));
             _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+            _stdioInvocationSource = stdioInvocationSource;
+            _terminalAuthentication = terminalAuthentication;
 
             _acpClient.SessionUpdateReceived += OnSessionUpdateReceived;
             _acpClient.PermissionRequestReceived += OnPermissionRequestReceived;
@@ -550,6 +561,17 @@ namespace SalmonEgg.Application.Services.Chat
                 ActivityKind.Internal);
             try
             {
+                if (_stdioInvocationSource is not null && _terminalAuthentication?.IsSupported == true)
+                {
+                    @params = @params with
+                    {
+                        ClientCapabilities = @params.ClientCapabilities with
+                        {
+                            Auth = new AuthCapabilities { Terminal = true }
+                        }
+                    };
+                }
+
                 var response = await _acpClient.InitializeAsync(@params);
                 activity?.SetStatus(ActivityStatusCode.Ok);
                 return response;

--- a/src/SalmonEgg.Application/Services/Chat/ChatServiceFactory.cs
+++ b/src/SalmonEgg.Application/Services/Chat/ChatServiceFactory.cs
@@ -24,6 +24,7 @@ public class ChatServiceFactory
     private readonly IAcpClientFactory _acpClientFactory;
     private readonly ILogger _logger;
     private readonly Func<IChatService, IChatService> _decorateChatService;
+    private readonly ITerminalAuthenticationSessionFactory? _terminalAuthentication;
 
     /// <summary>
     /// 创建 <see cref="ChatServiceFactory"/> 的新实例。
@@ -37,7 +38,8 @@ public class ChatServiceFactory
         ISessionManager sessionManager,
         IAcpClientFactory acpClientFactory,
         ILogger logger,
-        Func<IChatService, IChatService>? decorateChatService = null)
+        Func<IChatService, IChatService>? decorateChatService = null,
+        ITerminalAuthenticationSessionFactory? terminalAuthentication = null)
     {
         _transportFactory = transportFactory ?? throw new ArgumentNullException(nameof(transportFactory));
         _errorLogger = errorLogger ?? throw new ArgumentNullException(nameof(errorLogger));
@@ -45,6 +47,7 @@ public class ChatServiceFactory
         _acpClientFactory = acpClientFactory ?? throw new ArgumentNullException(nameof(acpClientFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _decorateChatService = decorateChatService ?? (service => service);
+        _terminalAuthentication = terminalAuthentication;
     }
 
     /// <summary>
@@ -79,7 +82,8 @@ public class ChatServiceFactory
             var acpClient = _acpClientFactory.CreateClient(transport);
 
             // 3. 创建 Chat 服务
-            var chatService = _decorateChatService(new ChatService(acpClient, _errorLogger, _sessionManager));
+            var chatService = _decorateChatService(new ChatService(acpClient, _errorLogger, _sessionManager,
+                transport as IStdioInvocationSource, _terminalAuthentication));
 
             activity?.SetStatus(ActivityStatusCode.Ok);
             activity?.SetTag(ApplicationSemanticConventions.Chat.ServiceType, chatService.GetType().Name);
@@ -126,7 +130,8 @@ public class ChatServiceFactory
 
             var transport = _transportFactory.CreateTransport(configuration);
             var acpClient = _acpClientFactory.CreateClient(transport);
-            var chatService = _decorateChatService(new ChatService(acpClient, _errorLogger, _sessionManager));
+            var chatService = _decorateChatService(new ChatService(acpClient, _errorLogger, _sessionManager,
+                transport as IStdioInvocationSource, _terminalAuthentication));
 
             activity?.SetStatus(ActivityStatusCode.Ok);
 

--- a/src/SalmonEgg.Application/Services/Chat/DelayedLoadChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/DelayedLoadChatService.cs
@@ -15,7 +15,7 @@ namespace SalmonEgg.Application.Services.Chat;
 /// Decorates <see cref="IChatService"/> so GUI smoke tests can deterministically
 /// stretch the session/load round-trip without touching ViewModel logic.
 /// </summary>
-public sealed class DelayedLoadChatService : IChatService
+public sealed class DelayedLoadChatService : IChatService, IStdioInvocationSource
 {
     private readonly IChatService _inner;
     private readonly TimeSpan _loadSessionDelay;
@@ -33,6 +33,9 @@ public sealed class DelayedLoadChatService : IChatService
     public bool IsInitialized => _inner.IsInitialized;
 
     public bool IsConnected => _inner.IsConnected;
+
+    public SalmonEgg.Domain.Models.StdioInvocationSnapshot? StdioInvocation
+        => (_inner as IStdioInvocationSource)?.StdioInvocation;
 
     public AgentInfo? AgentInfo => _inner.AgentInfo;
 

--- a/src/SalmonEgg.Domain/Models/StdioInvocationSnapshot.cs
+++ b/src/SalmonEgg.Domain/Models/StdioInvocationSnapshot.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SalmonEgg.Domain.Models;
+
+/// <summary>A private-to-process copy of the invocation used by the current ACP connection.</summary>
+/// <remarks>
+/// Environment values may contain credentials. This is intentionally a class with no value-rendering
+/// ToString, and must never be persisted, logged or displayed as a command preview.
+/// </remarks>
+public sealed class StdioInvocationSnapshot
+{
+    public StdioInvocationSnapshot(
+        string command,
+        IReadOnlyList<string> arguments,
+        IReadOnlyDictionary<string, string> environment,
+        string workingDirectory,
+        bool environmentNamesIgnoreCase)
+    {
+        Command = command;
+        Arguments = new ReadOnlyCollection<string>(new List<string>(arguments));
+        Environment = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(
+            environment, environmentNamesIgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
+        WorkingDirectory = workingDirectory;
+        EnvironmentNamesIgnoreCase = environmentNamesIgnoreCase;
+    }
+
+    public string Command { get; }
+
+    public IReadOnlyList<string> Arguments { get; }
+
+    public IReadOnlyDictionary<string, string> Environment { get; }
+
+    public string WorkingDirectory { get; }
+
+    public bool EnvironmentNamesIgnoreCase { get; }
+
+    /// <summary>Append the method's arguments and apply its environment overrides as ACP requires.</summary>
+    public StdioInvocationSnapshot WithAuthenticationMethod(
+        IReadOnlyList<string>? arguments,
+        IReadOnlyDictionary<string, string>? environment)
+    {
+        var combinedArguments = new List<string>(Arguments);
+        if (arguments is not null)
+        {
+            combinedArguments.AddRange(arguments);
+        }
+
+        var combinedEnvironment = new Dictionary<string, string>(Environment,
+            EnvironmentNamesIgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        if (environment is not null)
+        {
+            foreach (var entry in environment)
+            {
+                combinedEnvironment[entry.Key] = entry.Value;
+            }
+        }
+
+        return new StdioInvocationSnapshot(Command, combinedArguments, combinedEnvironment,
+            WorkingDirectory, EnvironmentNamesIgnoreCase);
+    }
+}

--- a/src/SalmonEgg.Domain/Services/IInteractiveTerminalSession.cs
+++ b/src/SalmonEgg.Domain/Services/IInteractiveTerminalSession.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Domain.Services;
+
+/// <summary>The native terminal I/O surface shared by local shells and sign-in processes.</summary>
+public interface IInteractiveTerminalSession : IAsyncDisposable
+{
+    LocalTerminalTransportMode TransportMode { get; }
+
+    bool CanAcceptInput { get; }
+
+    event EventHandler<string>? OutputReceived;
+
+    event EventHandler? StateChanged;
+
+    ValueTask WriteInputAsync(string input, CancellationToken cancellationToken = default);
+
+    ValueTask ResizeAsync(int columns, int rows, CancellationToken cancellationToken = default);
+}

--- a/src/SalmonEgg.Domain/Services/ILocalTerminalSession.cs
+++ b/src/SalmonEgg.Domain/Services/ILocalTerminalSession.cs
@@ -1,27 +1,11 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace SalmonEgg.Domain.Services;
 
 /// <summary>
 /// Represents one reusable local interactive terminal session bound to a conversation.
 /// </summary>
-public interface ILocalTerminalSession : IAsyncDisposable
+public interface ILocalTerminalSession : IInteractiveTerminalSession
 {
     string ConversationId { get; }
 
     string CurrentWorkingDirectory { get; }
-
-    LocalTerminalTransportMode TransportMode { get; }
-
-    bool CanAcceptInput { get; }
-
-    event EventHandler<string>? OutputReceived;
-
-    event EventHandler? StateChanged;
-
-    ValueTask WriteInputAsync(string input, CancellationToken cancellationToken = default);
-
-    ValueTask ResizeAsync(int columns, int rows, CancellationToken cancellationToken = default);
 }

--- a/src/SalmonEgg.Domain/Services/IPlatformCapabilityService.cs
+++ b/src/SalmonEgg.Domain/Services/IPlatformCapabilityService.cs
@@ -12,6 +12,7 @@ public interface IPlatformCapabilityService
     bool SupportsWebSocketRequestHeaders => false;
     bool SupportsInteractiveTerminalSurface { get; }
     bool SupportsLocalTerminal { get; }
+    bool SupportsTerminalAuthentication => false;
     bool SupportsGamepadInput { get; }
 
     /// <summary>

--- a/src/SalmonEgg.Domain/Services/IStdioInvocationSource.cs
+++ b/src/SalmonEgg.Domain/Services/IStdioInvocationSource.cs
@@ -1,0 +1,9 @@
+using SalmonEgg.Domain.Models;
+
+namespace SalmonEgg.Domain.Services;
+
+/// <summary>Exposes only the invocation actually used by an existing local ACP process.</summary>
+public interface IStdioInvocationSource
+{
+    StdioInvocationSnapshot? StdioInvocation { get; }
+}

--- a/src/SalmonEgg.Domain/Services/ITerminalAuthenticationSessionFactory.cs
+++ b/src/SalmonEgg.Domain/Services/ITerminalAuthenticationSessionFactory.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models;
+
+namespace SalmonEgg.Domain.Services;
+
+/// <summary>Creates independent interactive sign-in processes with a reliable exit result.</summary>
+public interface ITerminalAuthenticationSessionFactory
+{
+    bool IsSupported { get; }
+
+    ValueTask<ITerminalAuthenticationSession> StartAsync(
+        StdioInvocationSnapshot invocation,
+        CancellationToken cancellationToken = default);
+}
+
+public interface ITerminalAuthenticationSession : IInteractiveTerminalSession
+{
+    /// <summary>Null means no trustworthy normal exit status was available.</summary>
+    Task<int?> Completion { get; }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Services/TerminalAuthenticationSessionFactory.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Services/TerminalAuthenticationSessionFactory.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Porta.Pty;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Infrastructure.Services;
+
+public sealed class TerminalAuthenticationSessionFactory : ITerminalAuthenticationSessionFactory, IAsyncDisposable
+{
+    private readonly IPlatformCapabilityService _platform;
+    private readonly Func<PtyOptions, CancellationToken, Task<IPtyConnection>> _spawn;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly SemaphoreSlim _lifetimeGate = new(1, 1);
+    private readonly object _gate = new();
+    private readonly HashSet<AuthenticationSession> _sessions = new();
+    private Task? _dispose;
+
+    public TerminalAuthenticationSessionFactory(IPlatformCapabilityService platform)
+        : this(platform, PtyProvider.SpawnAsync)
+    {
+    }
+
+    internal TerminalAuthenticationSessionFactory(
+        IPlatformCapabilityService platform,
+        Func<PtyOptions, CancellationToken, Task<IPtyConnection>> spawn)
+    {
+        _platform = platform ?? throw new ArgumentNullException(nameof(platform));
+        _spawn = spawn ?? throw new ArgumentNullException(nameof(spawn));
+    }
+
+    public bool IsSupported => _platform.SupportsTerminalAuthentication;
+
+    public async ValueTask<ITerminalAuthenticationSession> StartAsync(
+        StdioInvocationSnapshot invocation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        if (!IsSupported)
+        {
+            throw new PlatformNotSupportedException("Interactive agent sign-in is not available on this platform.");
+        }
+
+        using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdown.Token);
+        await _lifetimeGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+        try
+        {
+            return await StartCoreAsync(invocation, lifetime.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifetimeGate.Release();
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            _dispose ??= DisposeCoreAsync();
+            return new ValueTask(_dispose);
+        }
+    }
+
+    private async Task<ITerminalAuthenticationSession> StartCoreAsync(
+        StdioInvocationSnapshot invocation, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var connection = await _spawn(new PtyOptions
+        {
+            Name = "SalmonEgg agent sign-in",
+            App = invocation.Command,
+            CommandLine = invocation.Arguments.ToArray(),
+            Cwd = invocation.WorkingDirectory,
+            Environment = new Dictionary<string, string>(invocation.Environment),
+            Cols = 100,
+            Rows = 28
+        }, cancellationToken).ConfigureAwait(false);
+        AuthenticationSession? session = null;
+        try
+        {
+            session = new AuthenticationSession(connection, RemoveSession);
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate) _sessions.Add(session);
+            return session;
+        }
+        catch
+        {
+            if (session is not null) await session.DisposeAsync().ConfigureAwait(false);
+            else await Task.Run(() => CloseNativeConnection(connection)).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private void RemoveSession(AuthenticationSession session)
+    {
+        lock (_gate) _sessions.Remove(session);
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+        await _lifetimeGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            AuthenticationSession[] sessions;
+            lock (_gate) sessions = _sessions.ToArray();
+            await Task.WhenAll(sessions.Select(static session => session.DisposeAsync().AsTask())).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifetimeGate.Release();
+        }
+    }
+
+    private static void CloseNativeConnection(IPtyConnection connection)
+    {
+        try
+        {
+            connection.Kill();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
+        {
+            // The process may already have exited; closing the Windows job still reclaims descendants.
+        }
+        finally
+        {
+            connection.Dispose();
+        }
+    }
+
+    private sealed class AuthenticationSession : ITerminalAuthenticationSession
+    {
+        private const int MaximumBufferedCharacters = 64 * 1024;
+        private readonly IPtyConnection _connection;
+        private readonly Action<AuthenticationSession> _onDisposed;
+        private readonly StreamReader _reader;
+        private readonly StreamWriter _writer;
+        private readonly SemaphoreSlim _inputGate = new(1, 1);
+        private readonly TaskCompletionSource<int?> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly object _gate = new();
+        private readonly object _outputGate = new();
+        private readonly Queue<string> _output = new();
+        private readonly Task _pump;
+        private Task? _dispose;
+        private EventHandler<string>? _outputReceived;
+        private int _outputCharacters;
+        private bool _closed;
+
+        public AuthenticationSession(IPtyConnection connection, Action<AuthenticationSession> onDisposed)
+        {
+            _connection = connection;
+            _onDisposed = onDisposed;
+            _reader = new StreamReader(connection.ReaderStream, new UTF8Encoding(false), false, 1024, leaveOpen: true);
+            _writer = new StreamWriter(connection.WriterStream, new UTF8Encoding(false), 1024, leaveOpen: true) { AutoFlush = true };
+            connection.ProcessExited += OnExited;
+            // Subscribe first: an extremely fast process can exit before SpawnAsync returns.
+            if (connection.WaitForExit(0))
+            {
+                Complete(connection.ExitCode);
+            }
+
+            _pump = PumpAsync();
+        }
+
+        public LocalTerminalTransportMode TransportMode => LocalTerminalTransportMode.PseudoConsole;
+
+        public bool CanAcceptInput
+        {
+            get { lock (_gate) { return !_closed && !_completion.Task.IsCompleted; } }
+        }
+
+        public Task<int?> Completion => _completion.Task;
+
+        public event EventHandler? StateChanged;
+
+        public event EventHandler<string>? OutputReceived
+        {
+            add
+            {
+                if (value is null) return;
+                lock (_outputGate)
+                {
+                    _outputReceived += value;
+                    try
+                    {
+                        foreach (var output in _output.ToArray()) value(this, output);
+                    }
+                    catch (Exception)
+                    {
+                        // A detached/failed view is not a successful login. Keep the native reader
+                        // alive until the owner disposes the session and closes its process tree.
+                        _completion.TrySetResult(null);
+                        _outputReceived -= value;
+                    }
+                }
+            }
+            remove { lock (_outputGate) { _outputReceived -= value; } }
+        }
+
+        public async ValueTask WriteInputAsync(string input, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            await _inputGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!CanAcceptInput) throw new InvalidOperationException("The sign-in terminal has closed.");
+                await _writer.WriteAsync(input.AsMemory(), cancellationToken).ConfigureAwait(false);
+                await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _inputGate.Release();
+            }
+        }
+
+        public ValueTask ResizeAsync(int columns, int rows, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (columns <= 0 || rows <= 0) throw new ArgumentOutOfRangeException(nameof(columns));
+            lock (_gate)
+            {
+                if (!_closed) _connection.Resize(columns, rows);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            lock (_gate)
+            {
+                _closed = true;
+                _dispose ??= DisposeCoreAsync();
+                return new ValueTask(_dispose);
+            }
+        }
+
+        private async Task DisposeCoreAsync()
+        {
+            _connection.ProcessExited -= OnExited;
+            _completion.TrySetResult(null);
+            // On Windows, disposing the native connection closes its JobObject with
+            // KILL_ON_JOB_CLOSE, reclaiming descendants as well as the original process.
+            try
+            {
+                await Task.Run(() => CloseNativeConnection(_connection)).ConfigureAwait(false);
+            }
+            finally
+            {
+                try
+                {
+                    await _pump.ConfigureAwait(false);
+                    await _inputGate.WaitAsync().ConfigureAwait(false);
+                    try
+                    {
+                        _reader.Dispose();
+                        try { _writer.Dispose(); }
+                        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+                        {
+                            // Native teardown already closed the pipe; StreamWriter's final flush
+                            // cannot succeed after that and is not an authentication failure.
+                        }
+                    }
+                    finally { _inputGate.Release(); }
+                }
+                finally
+                {
+                    lock (_outputGate) { _output.Clear(); _outputReceived = null; _outputCharacters = 0; }
+                    _onDisposed(this);
+                }
+            }
+        }
+
+        private async Task PumpAsync()
+        {
+            var buffer = new char[1024];
+            try
+            {
+                while (await _reader.ReadAsync(buffer.AsMemory()).ConfigureAwait(false) is var length && length > 0)
+                {
+                    var output = new string(buffer, 0, length);
+                    lock (_outputGate)
+                    {
+                        // ClosePseudoConsole can wait for its output pipe to drain. During teardown
+                        // keep consuming native output, but stop publishing it to the detached view.
+                        if (Volatile.Read(ref _closed)) continue;
+                        _output.Enqueue(output);
+                        _outputCharacters += output.Length;
+                        while (_outputCharacters > MaximumBufferedCharacters)
+                            _outputCharacters -= _output.Dequeue().Length;
+                        try { _outputReceived?.Invoke(this, output); }
+                        catch (Exception)
+                        {
+                            _completion.TrySetResult(null);
+                            _outputReceived = null;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException
+                || (Volatile.Read(ref _closed) && ex is InvalidOperationException))
+            {
+                // Pipe closure is expected during native teardown. No terminal output is logged.
+            }
+            finally
+            {
+                // EOF is not evidence of authentication success. Only the process exit result is.
+                // WaitForExit catches an exit whose event has not yet reached us; a live process that
+                // closes its terminal stream has no interactive path and must fail closed.
+                if (!Volatile.Read(ref _closed) && !_completion.Task.IsCompleted)
+                {
+                    try
+                    {
+                        if (_connection.WaitForExit(0)) Complete(_connection.ExitCode);
+                        else _completion.TrySetResult(null);
+                    }
+                    catch (InvalidOperationException) when (Volatile.Read(ref _closed))
+                    {
+                        _completion.TrySetResult(null);
+                    }
+                }
+            }
+        }
+
+        private void OnExited(object? sender, PtyExitedEventArgs args) => Complete(args.ExitCode);
+
+        private void Complete(int exitCode)
+        {
+            if (_completion.TrySetResult(exitCode)) StateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Transport/StdioTransport.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using SalmonEgg.Domain.Interfaces.Transport;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
 using SalmonEgg.Acp.JsonRpc;
 
 namespace SalmonEgg.Infrastructure.Transport
@@ -17,7 +19,7 @@ namespace SalmonEgg.Infrastructure.Transport
     /// Stdio 传输层实现。
     /// 通过标准输入/输出与 Agent 进程通信。
     /// </summary>
-    public class StdioTransport : ITransport, IDisposable
+    public class StdioTransport : ITransport, IStdioInvocationSource, IDisposable
     {
         private static readonly ILogger _logger = Log.ForContext<StdioTransport>();
 
@@ -33,6 +35,7 @@ namespace SalmonEgg.Infrastructure.Transport
         private readonly Encoding _encoding;
         private readonly string _workingDirectory;
         private readonly IReadOnlyDictionary<string, string> _environment;
+        private StdioInvocationSnapshot? _runningInvocation;
         private bool _disposed;
         private readonly object _lock = new();
 
@@ -55,6 +58,17 @@ namespace SalmonEgg.Infrastructure.Transport
         /// 判断传输是否已连接。
         /// </summary>
         public bool IsConnected { get; private set; }
+
+        public StdioInvocationSnapshot? StdioInvocation
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return IsConnected ? _runningInvocation : null;
+                }
+            }
+        }
 
         /// <summary>
         /// 创建新的 StdioTransport 实例。
@@ -176,6 +190,13 @@ namespace SalmonEgg.Infrastructure.Transport
                         // "a child exists" by construction, which is what lets both kill sites stay
                         // free of defensive checks.
                         _process = starting;
+                        _runningInvocation = new StdioInvocationSnapshot(
+                            processInfo.FileName,
+                            processInfo.ArgumentList.ToArray(),
+                            processInfo.Environment.Where(static entry => entry.Value is not null)
+                                .ToDictionary(static entry => entry.Key, static entry => entry.Value!),
+                            processInfo.WorkingDirectory,
+                            OperatingSystem.IsWindows());
                         _logger.Information("[StdioTransport.Connect] Process started. PID={Pid}", starting.Id);
                     }
                 }, cancellationToken).ConfigureAwait(false);
@@ -810,6 +831,7 @@ namespace SalmonEgg.Infrastructure.Transport
                 //
                 // _readCts is NOT cleared — IsTearingDown reads IsCancellationRequested off it.
                 _process = null;
+                _runningInvocation = null;
                 _stdin = null;
                 _stdout = null;
                 _stderr = null;

--- a/src/SalmonEgg.Infrastructure/SalmonEgg.Infrastructure.csproj
+++ b/src/SalmonEgg.Infrastructure/SalmonEgg.Infrastructure.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="SalmonEgg.Infrastructure.Tests" />
     <InternalsVisibleTo Include="SalmonEgg.Acp.Desktop.Tests" />
+    <InternalsVisibleTo Include="SalmonEgg.TerminalAuth.Windows.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
+++ b/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
@@ -47,6 +47,11 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
 
     public bool SupportsLocalTerminal => SupportsStdioTransport && SupportsInteractiveTerminalSurface;
 
+    // Porta.Pty 1.0.7 reports Unix signal termination as ExitCode=0 and does not expose the signal.
+    // Keep auth disabled there until upstream exposes a trustworthy normal exit result.
+    // https://github.com/tomlm/Porta.Pty/blob/54684ba55148ed6bcd0c827ad7e8841a3289a466/src/Porta.Pty/Unix/PtyConnection.cs
+    public bool SupportsTerminalAuthentication => IsWindowsDesktopProcessHost && SupportsInteractiveTerminalSurface;
+
     public bool SupportsGamepadInput => IsBrowserRuntime || IsWindowsDesktopProcessHost;
 
     public bool SupportsCliCommandInspection => _runtimeProbe.IsDesktopProcessHost;

--- a/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
+++ b/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
@@ -50,7 +50,9 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
     // Porta.Pty 1.0.7 reports Unix signal termination as ExitCode=0 and does not expose the signal.
     // Keep auth disabled there until upstream exposes a trustworthy normal exit result.
     // https://github.com/tomlm/Porta.Pty/blob/54684ba55148ed6bcd0c827ad7e8841a3289a466/src/Porta.Pty/Unix/PtyConnection.cs
-    public bool SupportsTerminalAuthentication => IsWindowsDesktopProcessHost && SupportsInteractiveTerminalSurface;
+    // #147 also requires the packaged application's consent, terminal, reconnect and retry flow
+    // to pass on Windows. ConPTY-only tests do not establish that product capability.
+    public bool SupportsTerminalAuthentication => false;
 
     public bool SupportsGamepadInput => IsBrowserRuntime || IsWindowsDesktopProcessHost;
 

--- a/src/SalmonEgg.Infrastructure/Services/UnsupportedTerminalAuthenticationSessionFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Services/UnsupportedTerminalAuthenticationSessionFactory.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Infrastructure.Services;
+
+public sealed class UnsupportedTerminalAuthenticationSessionFactory : ITerminalAuthenticationSessionFactory
+{
+    public bool IsSupported => false;
+
+    public ValueTask<ITerminalAuthenticationSession> StartAsync(
+        StdioInvocationSnapshot invocation,
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromException<ITerminalAuthenticationSession>(
+            new PlatformNotSupportedException("Interactive agent sign-in is not available on this platform."));
+}

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1435,4 +1435,19 @@ Create the corresponding Markdown file in:
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>Use one HTTP token for the header scheme, or leave it empty for a raw value.</value>
   </data>
+  <data name="ChatAuth_TerminalTitle" xml:space="preserve">
+    <value>Sign in to agent</value>
+  </data>
+  <data name="ChatAuth_TerminalConsent" xml:space="preserve">
+    <value>Open {0}'s interactive sign-in ({1})? This starts a separate agent process. Its output stays in this sign-in window.</value>
+  </data>
+  <data name="ChatAuth_TerminalRunning" xml:space="preserve">
+    <value>Complete sign-in below. The agent will reconnect when sign-in succeeds.</value>
+  </data>
+  <data name="ChatAuth_TerminalContinue" xml:space="preserve">
+    <value>Open sign-in</value>
+  </data>
+  <data name="ChatAuth_TerminalCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1435,4 +1435,19 @@ Create the corresponding Markdown file in:
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>Use one HTTP token for the header scheme, or leave it empty for a raw value.</value>
   </data>
+  <data name="ChatAuth_TerminalTitle" xml:space="preserve">
+    <value>Sign in to agent</value>
+  </data>
+  <data name="ChatAuth_TerminalConsent" xml:space="preserve">
+    <value>Open {0}'s interactive sign-in ({1})? This starts a separate agent process. Its output stays in this sign-in window.</value>
+  </data>
+  <data name="ChatAuth_TerminalRunning" xml:space="preserve">
+    <value>Complete sign-in below. The agent will reconnect when sign-in succeeds.</value>
+  </data>
+  <data name="ChatAuth_TerminalContinue" xml:space="preserve">
+    <value>Open sign-in</value>
+  </data>
+  <data name="ChatAuth_TerminalCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1441,4 +1441,19 @@
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>请求头方案只能填写一个 HTTP 标记；如需直接发送凭据原值，请留空。</value>
   </data>
+  <data name="ChatAuth_TerminalTitle" xml:space="preserve">
+    <value>登录智能体</value>
+  </data>
+  <data name="ChatAuth_TerminalConsent" xml:space="preserve">
+    <value>是否打开 {0} 的交互式登录（{1}）？这会启动独立的智能体进程，输出只在此登录窗口显示。</value>
+  </data>
+  <data name="ChatAuth_TerminalRunning" xml:space="preserve">
+    <value>请在下方完成登录。成功后将重新连接智能体。</value>
+  </data>
+  <data name="ChatAuth_TerminalContinue" xml:space="preserve">
+    <value>打开登录</value>
+  </data>
+  <data name="ChatAuth_TerminalCancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1441,4 +1441,19 @@
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>请求头方案只能填写一个 HTTP 标记；如需直接发送凭据原值，请留空。</value>
   </data>
+  <data name="ChatAuth_TerminalTitle" xml:space="preserve">
+    <value>登录智能体</value>
+  </data>
+  <data name="ChatAuth_TerminalConsent" xml:space="preserve">
+    <value>是否打开 {0} 的交互式登录（{1}）？这会启动独立的智能体进程，输出只在此登录窗口显示。</value>
+  </data>
+  <data name="ChatAuth_TerminalRunning" xml:space="preserve">
+    <value>请在下方完成登录。成功后将重新连接智能体。</value>
+  </data>
+  <data name="ChatAuth_TerminalContinue" xml:space="preserve">
+    <value>打开登录</value>
+  </data>
+  <data name="ChatAuth_TerminalCancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownWorkflow.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/ApplicationShutdownWorkflow.cs
@@ -16,6 +16,7 @@ public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
     private readonly IDiscoverSessionsConnectionFacade _discoverConnectionFacade;
     private readonly ITerminalSessionManager _terminalSessionManager;
     private readonly IAsyncDisposable? _localTerminalSessions;
+    private readonly IAsyncDisposable? _terminalAuthentication;
     private readonly IApplicationShutdownProgressSink _progressSink;
     private readonly ITelemetryRuntime _telemetryRuntime;
     private readonly ILogger<ApplicationShutdownWorkflow> _logger;
@@ -35,7 +36,8 @@ public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
         IApplicationShutdownProgressSink progressSink,
         ITelemetryRuntime telemetryRuntime,
         ILogger<ApplicationShutdownWorkflow> logger,
-        IAsyncDisposable? localTerminalSessions = null)
+        IAsyncDisposable? localTerminalSessions = null,
+        IAsyncDisposable? terminalAuthentication = null)
     {
         _chatRuntimePersistence = chatRuntimePersistence ?? throw new ArgumentNullException(nameof(chatRuntimePersistence));
         _connectionSessionCleaner = connectionSessionCleaner ?? throw new ArgumentNullException(nameof(connectionSessionCleaner));
@@ -45,6 +47,7 @@ public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
         _telemetryRuntime = telemetryRuntime ?? throw new ArgumentNullException(nameof(telemetryRuntime));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _localTerminalSessions = localTerminalSessions;
+        _terminalAuthentication = terminalAuthentication;
     }
 
     public Task ShutdownAsync(CancellationToken cancellationToken = default)
@@ -118,6 +121,13 @@ public sealed class ApplicationShutdownWorkflow : IApplicationShutdownWorkflow
     /// </remarks>
     private async Task DrainChildProcessesAsync()
     {
+        if (_terminalAuthentication is not null)
+        {
+            await TryRunAsync(
+                _terminalAuthentication.DisposeAsync().AsTask,
+                "Failed to dispose agent sign-in sessions during shutdown").ConfigureAwait(false);
+        }
+
         var drainResult = await TryRunAsync(
             _connectionSessionCleaner.DrainAllAsync,
             "Failed to drain cached ACP connection sessions during shutdown").ConfigureAwait(false);

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
@@ -112,16 +112,17 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         ArgumentNullException.ThrowIfNull(transportConfiguration);
         ArgumentNullException.ThrowIfNull(sink);
 
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, cancellationToken);
         profile = profile.Clone();
         using var applyScope = EnterApplyScope(cancellationToken);
         var applyToken = applyScope.Token;
         applyToken.ThrowIfCancellationRequested();
         EnsureTransportSupported(profile.Transport);
         var mcpServers = await _mcpServerProvider.GetMcpServersAsync(applyToken).ConfigureAwait(false);
-        applyToken.ThrowIfCancellationRequested();
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, applyToken);
         sink.SetCurrentMcpServers(mcpServers);
         await sink.SelectProfileAsync(profile.Clone(), applyToken).ConfigureAwait(false);
-        applyToken.ThrowIfCancellationRequested();
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, applyToken);
         ApplyProfileToTransportConfiguration(profile, transportConfiguration);
 
         return await ApplyTransportConfigurationCoreAsync(
@@ -152,6 +153,8 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         AcpConnectionContext connectionContext,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(sink);
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, cancellationToken);
         using var applyScope = EnterApplyScope(cancellationToken);
         return await ApplyTransportConfigurationCoreAsync(
             transportConfiguration,
@@ -177,6 +180,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         ArgumentNullException.ThrowIfNull(transportConfiguration);
         ArgumentNullException.ThrowIfNull(sink);
         cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, cancellationToken);
 
         var applyToken = applyScope.Token;
         applyToken.ThrowIfCancellationRequested();
@@ -212,6 +216,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
                 cleanupResult.DisposeFailureCount);
         }
 
+        ThrowIfExpectedConnectionChanged(connectionContext, sink, applyToken);
         var currentConnectionReuseKey = BuildConnectionReuseKey(transportConfiguration, profileForServiceCreation);
 
         var previousConnectionState = await CaptureConnectionStateAsync(sink, applyToken).ConfigureAwait(false);
@@ -220,7 +225,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             ? ServiceReplaceIntent.PoolOnly
             : ServiceReplaceIntent.ForegroundOwner;
 
-        if (_connectionPoolManager.TryGetReusableSession(
+        if (!connectionContext.ForceReconnect && _connectionPoolManager.TryGetReusableSession(
                 selectedProfileId,
                 currentConnectionReuseKey,
                 out var cachedSession)
@@ -292,7 +297,11 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
                 connectionContext.ConversationId);
             applyToken.ThrowIfCancellationRequested();
 
-            await sink.ReplaceChatServiceAsync(wrappedService, replaceIntent, applyToken).ConfigureAwait(false);
+            await sink.Dispatcher.EnqueueAsync(async () =>
+            {
+                ThrowIfExpectedConnectionChanged(connectionContext, sink, applyToken);
+                await sink.ReplaceChatServiceAsync(wrappedService, replaceIntent, applyToken).ConfigureAwait(true);
+            }).ConfigureAwait(false);
             _activeChatServiceAdapter = wrappedService;
             committed = true;
             if (!ShouldKeepServiceAlive(previousService, selectedProfileId))
@@ -340,7 +349,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
                 await DisposeServiceAsync(candidateService).ConfigureAwait(false);
                 wrappedService?.SuppressAllBufferedUpdates("ApplySupersededBeforeCommit");
 
-                if (applyScope.IsSuperseded(cancellationToken))
+                if (applyScope.IsSuperseded(cancellationToken) || !connectionContext.MatchesExpectedConnection(sink))
                 {
                     _logger.LogInformation(
                         "ACP candidate superseded before commit. transport={TransportType} conversationId={ConversationId}",
@@ -367,7 +376,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             {
                 await DisposeServiceAsync(candidateService).ConfigureAwait(false);
                 wrappedService?.SuppressAllBufferedUpdates("ApplySupersededBeforeCommitError");
-                if (applyScope.IsSuperseded(cancellationToken))
+                if (applyScope.IsSuperseded(cancellationToken) || !connectionContext.MatchesExpectedConnection(sink))
                 {
                     _logger.LogInformation(
                         ex,
@@ -404,6 +413,16 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             await _connectionCoordinator.SetDisconnectedAsync(ex.Message, cancellationToken).ConfigureAwait(false);
             _logger.LogError(ex, "Failed to apply ACP transport configuration");
             throw;
+        }
+    }
+
+    private static void ThrowIfExpectedConnectionChanged(
+        AcpConnectionContext context, IAcpChatCoordinatorSink sink, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!context.MatchesExpectedConnection(sink))
+        {
+            throw new OperationCanceledException("The connection changed during agent sign-in.", cancellationToken);
         }
     }
 

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatServiceAdapter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatServiceAdapter.cs
@@ -18,7 +18,7 @@ namespace SalmonEgg.Presentation.Core.Services.Chat;
 /// Wraps IChatService so ACP session updates are serialized through AcpEventAdapter
 /// before being published to UI subscribers.
 /// </summary>
-public sealed class AcpChatServiceAdapter : IChatService, IAcpSessionUpdateBufferController, IDisposable
+public sealed class AcpChatServiceAdapter : IChatService, IStdioInvocationSource, IAcpSessionUpdateBufferController, IDisposable
 {
     private readonly IChatService _inner;
     private readonly AcpEventAdapter _eventAdapter;
@@ -77,6 +77,9 @@ public sealed class AcpChatServiceAdapter : IChatService, IAcpSessionUpdateBuffe
     public bool IsInitialized => _inner.IsInitialized;
 
     public bool IsConnected => _inner.IsConnected;
+
+    public SalmonEgg.Domain.Models.StdioInvocationSnapshot? StdioInvocation
+        => (_inner as IStdioInvocationSource)?.StdioInvocation;
 
     public AgentInfo? AgentInfo => _inner.AgentInfo;
 

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionCommandOrchestrator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionCommandOrchestrator.cs
@@ -127,6 +127,8 @@ public sealed class AcpSessionCommandOrchestrator : IAcpSessionCommandOrchestrat
                     ex);
             }
 
+            ThrowIfConversationChanged(sink, conversationId, selectedProfileId, cancellationToken);
+            chatService = RequireReadyChatService(sink);
             sessionParams = new SessionNewParams(
                 activeSessionCwd,
                 McpServerSnapshots.CloneServers(
@@ -257,6 +259,7 @@ public sealed class AcpSessionCommandOrchestrator : IAcpSessionCommandOrchestrat
         ArgumentNullException.ThrowIfNull(ensureRemoteSessionAsync);
 
         var conversationId = sink.CurrentSessionId;
+        var profileId = sink.SelectedProfileId;
         var chatService = RequireReadyChatService(sink);
         var promptParams = new SessionPromptParams(
             remoteSessionId,
@@ -280,9 +283,29 @@ public sealed class AcpSessionCommandOrchestrator : IAcpSessionCommandOrchestrat
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfConversationChanged(sink, conversationId, profileId, cancellationToken);
+            var retryService = RequireReadyChatService(sink);
+            var reconnected = !ReferenceEquals(chatService, retryService);
+            if (reconnected)
+            {
+                // Authentication's reconnect path owns authoritative hydration. Read its binding
+                // after completion instead of sending a stale session id to the old process.
+                var binding = await sink.GetCurrentRemoteBindingAsync(cancellationToken).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(binding?.RemoteSessionId))
+                {
+                    var recovered = await ensureRemoteSessionAsync(
+                        sink, authenticateAsync, static () => { }, cancellationToken).ConfigureAwait(false);
+                    promptParams = new SessionPromptParams(recovered.RemoteSessionId, promptParams.Prompt);
+                }
+                else
+                {
+                    promptParams = new SessionPromptParams(binding.RemoteSessionId!, promptParams.Prompt);
+                }
+            }
+
             await sink.NotifyPromptRequestDispatchedAsync(cancellationToken).ConfigureAwait(false);
-            var response = await chatService.SendPromptAsync(promptParams, cancellationToken).ConfigureAwait(false);
-            return new AcpPromptDispatchResult(promptParams.SessionId, response, RetriedAfterSessionRecovery: false);
+            var response = await retryService.SendPromptAsync(promptParams, cancellationToken).ConfigureAwait(false);
+            return new AcpPromptDispatchResult(promptParams.SessionId, response, RetriedAfterSessionRecovery: reconnected);
         }
         catch (Exception ex) when (AcpErrorClassifier.IsRemoteSessionNotFound(ex))
         {
@@ -307,8 +330,19 @@ public sealed class AcpSessionCommandOrchestrator : IAcpSessionCommandOrchestrat
             var recoveredParams = new SessionPromptParams(recovered.RemoteSessionId, promptParams.Prompt);
             cancellationToken.ThrowIfCancellationRequested();
             await sink.NotifyPromptRequestDispatchedAsync(cancellationToken).ConfigureAwait(false);
-            var recoveredResponse = await chatService.SendPromptAsync(recoveredParams, cancellationToken).ConfigureAwait(false);
+            var recoveredResponse = await RequireReadyChatService(sink).SendPromptAsync(recoveredParams, cancellationToken).ConfigureAwait(false);
             return new AcpPromptDispatchResult(recovered.RemoteSessionId, recoveredResponse, RetriedAfterSessionRecovery: true);
+        }
+    }
+
+    private static void ThrowIfConversationChanged(
+        IAcpChatCoordinatorSink sink, string? conversationId, string? profileId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!string.Equals(conversationId, sink.CurrentSessionId, StringComparison.Ordinal)
+            || !string.Equals(profileId, sink.SelectedProfileId, StringComparison.Ordinal))
+        {
+            throw new OperationCanceledException("The active conversation changed during authentication.", cancellationToken);
         }
     }
 

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/IAcpConnectionCommands.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/IAcpConnectionCommands.cs
@@ -29,6 +29,21 @@ public readonly record struct AcpConnectionContext(
     public static AcpConnectionContext None { get; } = new(null, PreserveConversation: false);
 
     public bool HasConversationTarget => !string.IsNullOrWhiteSpace(ConversationId);
+
+    /// <summary>Interactive sign-in changes the agent's credentials; an existing pooled process cannot observe them.</summary>
+    public bool ForceReconnect { get; init; }
+
+    public IChatService? ExpectedChatService { get; init; }
+
+    public string? ExpectedConnectionInstanceId { get; init; }
+
+    public string? ExpectedProfileId { get; init; }
+
+    public bool MatchesExpectedConnection(IAcpChatCoordinatorSink sink)
+        => !ForceReconnect || (ReferenceEquals(ExpectedChatService, sink.CurrentChatService)
+            && string.Equals(ExpectedConnectionInstanceId, sink.ConnectionInstanceId, System.StringComparison.Ordinal)
+            && string.Equals(ExpectedProfileId, sink.SelectedProfileId, System.StringComparison.Ordinal)
+            && string.Equals(ConversationId, sink.CurrentSessionId, System.StringComparison.Ordinal));
 }
 
 /// <summary>

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/TerminalAuthenticationCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/TerminalAuthenticationCoordinator.cs
@@ -1,0 +1,204 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Services.Chat;
+
+/// <summary>Owns one consent, PTY and reconnect sequence, independent of conversation terminals.</summary>
+public sealed class TerminalAuthenticationCoordinator : IAsyncDisposable
+{
+    private readonly ITerminalAuthenticationSessionFactory _factory;
+    private readonly ITerminalAuthenticationInteraction _interaction;
+    private readonly IUiDispatcher _dispatcher;
+    private readonly ILogger<TerminalAuthenticationCoordinator> _logger;
+    private readonly IStringLocalizer<CoreStrings>? _localizer;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public TerminalAuthenticationCoordinator(
+        ITerminalAuthenticationSessionFactory factory,
+        ITerminalAuthenticationInteraction interaction,
+        IUiDispatcher dispatcher,
+        ILogger<TerminalAuthenticationCoordinator> logger,
+        IStringLocalizer<CoreStrings>? localizer = null)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _localizer = localizer;
+    }
+
+    public bool CanAuthenticate(IChatService? chatService)
+        => _factory.IsSupported && chatService is IStdioInvocationSource { StdioInvocation: not null };
+
+    public async Task<bool> TryAuthenticateAsync(
+        AuthMethodDefinition method,
+        IAcpChatCoordinatorSink sink,
+        Func<AcpConnectionContext, CancellationToken, Task<bool>> reconnectAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(reconnectAsync);
+        if (method.ResolvedType != AuthMethodDefinition.TerminalType || string.IsNullOrWhiteSpace(method.Id)
+            || !CanAuthenticate(sink.CurrentChatService)) return false;
+
+        using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdown.Token);
+        // A second auth_required from the same connection must not launch a second login process.
+        if (!await _gate.WaitAsync(0, lifetime.Token).ConfigureAwait(false)) return false;
+        try
+        {
+            return await AuthenticateCoreAsync(method, sink, reconnectAsync, lifetime.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            // Exceptions from process creation can contain invocation/environment details.
+            _logger.LogWarning("Interactive agent sign-in did not complete.");
+            return false;
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+        await _gate.WaitAsync().ConfigureAwait(false);
+        _gate.Release();
+        if (_factory is IAsyncDisposable disposable) await disposable.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async Task<bool> AuthenticateCoreAsync(
+        AuthMethodDefinition method,
+        IAcpChatCoordinatorSink sink,
+        Func<AcpConnectionContext, CancellationToken, Task<bool>> reconnectAsync,
+        CancellationToken cancellationToken)
+    {
+        using var intent = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        AuthenticationIdentity? identity = null;
+        TerminalAuthenticationViewModel? viewModel = null;
+        PropertyChangedEventHandler changed = (_, _) =>
+        {
+            if (identity is not null && !identity.Matches(sink)) intent.Cancel();
+        };
+        await _dispatcher.EnqueueAsync(() =>
+        {
+            if (sink.CurrentChatService is not IStdioInvocationSource { StdioInvocation: { } invocation }
+                || !sink.IsInitialized || string.IsNullOrWhiteSpace(sink.SelectedProfileId)) return;
+            identity = new AuthenticationIdentity(sink, invocation);
+            viewModel = new TerminalAuthenticationViewModel(sink.AgentName ?? method.Name, method.Name, _localizer);
+            sink.PropertyChanged += changed;
+        }).ConfigureAwait(false);
+        if (identity is null || viewModel is null) return false;
+
+        try
+        {
+            if (!await ConfirmAsync(viewModel, intent.Token).ConfigureAwait(false)
+                || !await IsCurrentAsync(identity, sink).ConfigureAwait(false)) return false;
+            var invocation = identity.Invocation.WithAuthenticationMethod(method.Args, method.Env);
+            if (!await RunSessionAsync(viewModel, invocation, intent.Token).ConfigureAwait(false)) return false;
+            intent.Token.ThrowIfCancellationRequested();
+            if (!await IsCurrentAsync(identity, sink).ConfigureAwait(false)) return false;
+        }
+        finally
+        {
+            await _dispatcher.EnqueueAsync(() => sink.PropertyChanged -= changed).ConfigureAwait(false);
+        }
+
+        // From here the connection coordinator owns latest-intent and candidate commit. The expected
+        // identity prevents a consent completion from reconnecting over a newly selected profile.
+        return await reconnectAsync(identity.ReconnectContext, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ConfirmAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken)
+    {
+        var confirmed = false;
+        await _dispatcher.EnqueueAsync(async () =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            confirmed = await _interaction.ConfirmAsync(viewModel, cancellationToken).ConfigureAwait(true);
+        }).ConfigureAwait(false);
+        return confirmed;
+    }
+
+    private async Task<bool> IsCurrentAsync(AuthenticationIdentity identity, IAcpChatCoordinatorSink sink)
+    {
+        var current = false;
+        await _dispatcher.EnqueueAsync(() => current = identity.Matches(sink)).ConfigureAwait(false);
+        return current;
+    }
+
+    private async Task<bool> RunSessionAsync(
+        TerminalAuthenticationViewModel viewModel,
+        StdioInvocationSnapshot invocation,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await using var session = await _factory.StartAsync(invocation, cancellationToken).ConfigureAwait(false);
+        using var dialogLifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await _dispatcher.EnqueueAsync(() => viewModel.Session = session).ConfigureAwait(false);
+        var dialog = _dispatcher.EnqueueAsync(() => _interaction.ShowSessionAsync(viewModel, dialogLifetime.Token));
+        try
+        {
+            var exited = session.Completion.WaitAsync(cancellationToken);
+            var completed = await Task.WhenAny(exited, dialog).ConfigureAwait(false);
+            if (completed != exited || cancellationToken.IsCancellationRequested) return false;
+            return await exited.ConfigureAwait(false) == 0;
+        }
+        finally
+        {
+            await dialogLifetime.CancelAsync().ConfigureAwait(false);
+            try { await dialog.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            await _dispatcher.EnqueueAsync(() => viewModel.Session = null).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class AuthenticationIdentity
+    {
+        private readonly IChatService? _service;
+        private readonly string? _profileId;
+        private readonly string? _conversationId;
+        private readonly string? _connectionId;
+
+        public AuthenticationIdentity(IAcpChatCoordinatorSink sink, StdioInvocationSnapshot invocation)
+        {
+            _service = sink.CurrentChatService;
+            _profileId = sink.SelectedProfileId;
+            _conversationId = sink.CurrentSessionId;
+            _connectionId = sink.ConnectionInstanceId;
+            Invocation = invocation;
+            ReconnectContext = new AcpConnectionContext(_conversationId, PreserveConversation: true)
+            {
+                ForceReconnect = true,
+                ExpectedChatService = _service,
+                ExpectedConnectionInstanceId = _connectionId,
+                ExpectedProfileId = _profileId
+            };
+        }
+
+        public StdioInvocationSnapshot Invocation { get; }
+
+        public AcpConnectionContext ReconnectContext { get; }
+
+        public bool Matches(IAcpChatCoordinatorSink sink)
+            => ReferenceEquals(_service, sink.CurrentChatService) && _service is { IsConnected: true }
+                && sink.IsInitialized && !sink.IsConnecting && !sink.IsInitializing
+                && string.Equals(_profileId, sink.SelectedProfileId, StringComparison.Ordinal)
+                && string.Equals(_conversationId, sink.CurrentSessionId, StringComparison.Ordinal)
+                && string.Equals(_connectionId, sink.ConnectionInstanceId, StringComparison.Ordinal);
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/Services/ITerminalAuthenticationInteraction.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/ITerminalAuthenticationInteraction.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Services;
+
+/// <summary>Native consent and interactive terminal surfaces. No command or environment is displayed.</summary>
+public interface ITerminalAuthenticationInteraction
+{
+    Task<bool> ConfirmAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken);
+
+    Task ShowSessionAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken);
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatAuthenticationCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatAuthenticationCoordinator.cs
@@ -105,7 +105,8 @@ public sealed class ChatAuthenticationCoordinator
         CancellationToken cancellationToken,
         AuthenticationHintPresentation? requiredFallback = null,
         Func<string, AuthenticationHintPresentation>? formatAuthenticationFailed = null,
-        AuthenticationHintPresentation? unsupportedMethodTypeFallback = null)
+        AuthenticationHintPresentation? unsupportedMethodTypeFallback = null,
+        Func<AuthMethodDefinition, CancellationToken, Task<bool>>? terminalAuthenticateAsync = null)
     {
         ArgumentNullException.ThrowIfNull(coordinator);
         ArgumentNullException.ThrowIfNull(logger);
@@ -117,6 +118,20 @@ public sealed class ChatAuthenticationCoordinator
         }
 
         var method = GetPrimaryAuthMethod();
+        if (method is null && terminalAuthenticateAsync is not null)
+        {
+            var terminalMethod = _advertisedAuthMethods?.FirstOrDefault(static candidate =>
+                candidate.ResolvedType == AuthMethodDefinition.TerminalType && !string.IsNullOrWhiteSpace(candidate.Id));
+            if (terminalMethod is not null)
+            {
+                MarkAuthenticationRequired(coordinator, logger, showTransientNotificationToast,
+                    terminalMethod, requiredFallback: requiredFallback);
+                if (!await terminalAuthenticateAsync(terminalMethod, cancellationToken).ConfigureAwait(false)) return false;
+                await coordinator.ClearAuthenticationRequiredAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+        }
+
         if (method == null)
         {
             // Fail closed: the agent may have advertised methods we are forbidden or unable to use.

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -2345,7 +2345,32 @@ public partial class ChatViewModel
                     "ChatAuth_UnsupportedMethodType",
                     "The agent only offers sign-in methods this app cannot run. Sign in with the agent's own command-line tool, then reconnect."),
                 ResourceKey: "ChatAuth_UnsupportedMethodType",
-                Fallback: "The agent only offers sign-in methods this app cannot run. Sign in with the agent's own command-line tool, then reconnect."));
+                Fallback: "The agent only offers sign-in methods this app cannot run. Sign in with the agent's own command-line tool, then reconnect."),
+            terminalAuthenticateAsync: _terminalAuthenticationCoordinator?.CanAuthenticate(_chatService) == true
+                ? (method, token) => _terminalAuthenticationCoordinator.TryAuthenticateAsync(
+                    method, this, ReconnectAfterTerminalAuthenticationAsync, token)
+                : null);
+
+    private async Task<bool> ReconnectAfterTerminalAuthenticationAsync(
+        AcpConnectionContext connectionContext, CancellationToken cancellationToken)
+    {
+        using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token);
+        if (!connectionContext.MatchesExpectedConnection(this)) return false;
+        var profile = ResolveNewSessionDraftProfile(connectionContext.ExpectedProfileId);
+        if (profile?.Id != connectionContext.ExpectedProfileId) return false;
+        var connected = await ConnectToAcpProfileCoreAsync(
+            profile, connectionContext, lifetime.Token, updateSelectedProfileIntent: false).ConfigureAwait(false);
+        if (!connected) return false;
+        if (connectionContext.ConversationId is not { } conversationId) return true;
+        if (!string.Equals(conversationId, CurrentSessionId, StringComparison.Ordinal)) return false;
+
+        // A restarted agent process cannot inherit a warm remote session. Existing hydration owns
+        // capability gating, transcript replay and the new authoritative connection identity.
+        return await EnsureActiveConversationRemoteHydratedAsync(
+            conversationId, new ConversationFailurePublicationContext(
+                conversationId, ActivationVersion: null, OperationOwner: conversationId, ExpectedShellSnapshotVersion: null), lifetime.Token,
+            allowWarmReuseShortCircuit: false).ConfigureAwait(false);
+    }
 
     private Task AddMessageToHistoryAsync(string? conversationId, ContentBlock content, bool isOutgoing)
     {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.NewSessionDraft.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.NewSessionDraft.cs
@@ -32,6 +32,13 @@ public partial class ChatViewModel
         string? cwd,
         string? requiredProfileId,
         CancellationToken cancellationToken = default)
+        => await EnsureNewSessionDraftCoreAsync(cwd, requiredProfileId, allowAuthentication: true, cancellationToken).ConfigureAwait(false);
+
+    private async Task EnsureNewSessionDraftCoreAsync(
+        string? cwd,
+        string? requiredProfileId,
+        bool allowAuthentication,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (_disposed)
@@ -197,7 +204,8 @@ public partial class ChatViewModel
                     normalizedCwd,
                     requestVersion,
                     chatService,
-                    cancellationToken);
+                    cancellationToken,
+                    allowAuthentication);
                 inFlightRequestTask = StartInFlightNewSessionDraftRequest(request);
             }
         }
@@ -1009,6 +1017,20 @@ public partial class ChatViewModel
         try
         {
             var response = await CreateNewSessionDraftResponseAsync(request).ConfigureAwait(false);
+            if (response is null)
+            {
+                // A terminal login restarted the connection. Let the same draft owner resolve its
+                // new identity, replace the request key and create the session exactly once.
+                if (IsDesiredNewSessionDraftRequest(request.RequestKey)
+                    && string.Equals(request.ProfileId, SelectedProfileId, StringComparison.Ordinal))
+                {
+                    await EnsureNewSessionDraftCoreAsync(
+                        request.Cwd, request.ProfileId, allowAuthentication: false, request.CancellationToken).ConfigureAwait(false);
+                }
+
+                return;
+            }
+
             await CompleteSuccessfulNewSessionDraftRequestAsync(request, response).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (_disposed)
@@ -1030,7 +1052,7 @@ public partial class ChatViewModel
         }
     }
 
-    private async Task<SessionNewResponse> CreateNewSessionDraftResponseAsync(
+    private async Task<SessionNewResponse?> CreateNewSessionDraftResponseAsync(
         PendingNewSessionDraftRequest request)
     {
         var operationCancellationToken = _disposed ? CancellationToken.None : _disposeCts.Token;
@@ -1043,7 +1065,7 @@ public partial class ChatViewModel
                     request.Cwd,
                     McpServerSnapshots.CloneServers(mcpServers))).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ChatAuthenticationCoordinator.IsAuthenticationRequiredError(ex))
+        catch (Exception ex) when (request.AllowAuthentication && ChatAuthenticationCoordinator.IsAuthenticationRequiredError(ex))
         {
             var authenticated = await TryAuthenticateAsync(operationCancellationToken).ConfigureAwait(false);
             if (!authenticated)
@@ -1051,6 +1073,7 @@ public partial class ChatViewModel
                 throw new OperationCanceledException("Authentication was not completed.", operationCancellationToken);
             }
 
+            if (!ReferenceEquals(request.ChatService, _chatService)) return null;
             var mcpServers = await ResolveCurrentMcpServersAsync(operationCancellationToken).ConfigureAwait(false);
             return await request.ChatService.CreateSessionAsync(
                 new SessionNewParams(
@@ -1266,7 +1289,8 @@ public partial class ChatViewModel
         string Cwd,
         long RequestVersion,
         SalmonEgg.Application.Services.Chat.IChatService ChatService,
-        CancellationToken CancellationToken);
+        CancellationToken CancellationToken,
+        bool AllowAuthentication);
 
     private enum RequiredProfileIdentityWaitStatus
     {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.NewSessionDraft.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.NewSessionDraft.cs
@@ -1063,7 +1063,8 @@ public partial class ChatViewModel
             return await request.ChatService.CreateSessionAsync(
                 new SessionNewParams(
                     request.Cwd,
-                    McpServerSnapshots.CloneServers(mcpServers))).ConfigureAwait(false);
+                    McpServerSnapshots.CloneServers(mcpServers))).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("The agent did not return a session/new response.");
         }
         catch (Exception ex) when (request.AllowAuthentication && ChatAuthenticationCoordinator.IsAuthenticationRequiredError(ex))
         {
@@ -1078,7 +1079,8 @@ public partial class ChatViewModel
             return await request.ChatService.CreateSessionAsync(
                 new SessionNewParams(
                     request.Cwd,
-                    McpServerSnapshots.CloneServers(mcpServers))).ConfigureAwait(false);
+                    McpServerSnapshots.CloneServers(mcpServers))).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("The agent did not return a session/new response.");
         }
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -1367,6 +1367,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
     private readonly IUiInteractionService? _uiInteractionService;
     private readonly IAiContentReportLauncher? _aiContentReportLauncher;
     private readonly IRemoteDirectoryRegistrar _remoteDirectoryRegistrar;
+    private readonly TerminalAuthenticationCoordinator? _terminalAuthenticationCoordinator;
 
     public ChatViewModel(
         IChatStore chatStore,
@@ -1409,7 +1410,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         IUiInteractionService? uiInteractionService = null,
         IAiContentReportLauncher? aiContentReportLauncher = null,
         IShellLayoutMetricsSink? shellLayoutMetricsSink = null,
-        IRemoteDirectoryRegistrar? remoteDirectoryRegistrar = null)
+        IRemoteDirectoryRegistrar? remoteDirectoryRegistrar = null,
+        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null)
         : base(logger)
     {
         _chatStore = chatStore ?? throw new ArgumentNullException(nameof(chatStore));
@@ -1417,6 +1419,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         _localizer = localizer;
         _languageService = languageService;
         _uiInteractionService = uiInteractionService;
+        _terminalAuthenticationCoordinator = terminalAuthenticationCoordinator;
         _aiContentReportLauncher = aiContentReportLauncher;
         _shellLayoutMetricsSink = shellLayoutMetricsSink;
         _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
@@ -3167,6 +3170,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!connectionContext.MatchesExpectedConnection(this)) return false;
             if (updateSelectedProfileIntent)
             {
                 await PrepareSelectedProfileConnectionAsync(profile, cancellationToken).ConfigureAwait(false);
@@ -3174,10 +3178,11 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
             else
             {
                 var connectionState = await _chatConnectionStore.GetCurrentStateAsync().ConfigureAwait(false);
-                if (!string.Equals(
-                    connectionState.SelectedProfileIntentId,
-                    profile.Id,
-                    StringComparison.Ordinal))
+                var effectiveIntent = connectionContext.ForceReconnect
+                    && string.IsNullOrWhiteSpace(connectionState.SelectedProfileIntentId)
+                        ? connectionState.ForegroundTransportProfileId
+                        : connectionState.SelectedProfileIntentId;
+                if (!string.Equals(effectiveIntent, profile.Id, StringComparison.Ordinal))
                 {
                     return false;
                 }
@@ -3187,7 +3192,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
             var scopedSink = CreateScopedAcpCoordinatorSink(connectionContext);
             await PostToUiAsync(() =>
             {
-                if (cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested || !connectionContext.MatchesExpectedConnection(this))
                 {
                     return;
                 }
@@ -3235,6 +3240,13 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
             }).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             return true;
+        }
+        catch (OperationCanceledException) when (connectionContext.ForceReconnect
+            && !connectionContext.MatchesExpectedConnection(this))
+        {
+            // A new user intent owns the connection projection; the abandoned login cannot
+            // publish a disconnected state over it.
+            return false;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/TerminalAuthenticationViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/TerminalAuthenticationViewModel.cs
@@ -1,0 +1,47 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Resources;
+
+namespace SalmonEgg.Presentation.ViewModels.Chat;
+
+/// <summary>One native sign-in surface; terminal output belongs only to its interactive session.</summary>
+public sealed class TerminalAuthenticationViewModel : ObservableObject
+{
+    private ITerminalAuthenticationSession? _session;
+
+    public TerminalAuthenticationViewModel(string agentName, string methodName, IStringLocalizer<CoreStrings>? localizer = null)
+    {
+        Title = Text("ChatAuth_TerminalTitle", "Sign in to agent");
+        ConsentMessage = string.Format(
+            System.Globalization.CultureInfo.CurrentCulture,
+            Text("ChatAuth_TerminalConsent", "Open {0}'s interactive sign-in ({1})? This starts a separate agent process. Its output stays in this sign-in window."),
+            agentName, methodName);
+        RunningMessage = Text("ChatAuth_TerminalRunning", "Complete sign-in below. The agent will reconnect when sign-in succeeds.");
+        ContinueButtonText = Text("ChatAuth_TerminalContinue", "Open sign-in");
+        CancelButtonText = Text("ChatAuth_TerminalCancel", "Cancel");
+
+        string Text(string key, string fallback)
+        {
+            var resource = localizer?[key];
+            return resource is { ResourceNotFound: false } ? resource.Value : fallback;
+        }
+    }
+
+    public string Title { get; }
+
+    public string ConsentMessage { get; }
+
+    public string RunningMessage { get; }
+
+    public string ContinueButtonText { get; }
+
+    public string CancelButtonText { get; }
+
+    public ITerminalAuthenticationSession? Session
+    {
+        get => _session;
+        internal set => SetProperty(ref _session, value);
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Protocol/TerminalAuthMethodTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Protocol/TerminalAuthMethodTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+
+namespace SalmonEgg.Acp.Tests.Protocol;
+
+public sealed class TerminalAuthMethodTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TerminalMethod_InvocationFields_RoundTripsAndEditsOwnWire(int version)
+    {
+        // Arrange
+        var id = version == 1 ? "id" : "methodId";
+        var env = version == 1 ? """{"LOGIN":"yes"}""" : """[{"name":"LOGIN","value":"yes","future":1.20e+02,"_meta":{"source":"auth"}}]""";
+        var json = $$$"""{"{{{id}}}":"login","name":"Sign in","type":"terminal","args":["login","--interactive"],"env":{{{env}}},"future":{"keep":true}}""";
+
+        // Act
+        var method = JsonSerializer.Deserialize(json, Wire.Of<AuthMethodDefinition>(version))!;
+        var changed = method with { Args = ["signin"], Env = new Dictionary<string, string> { ["LOGIN"] = "new" } };
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(changed, Wire.Of<AuthMethodDefinition>(version)));
+
+        // Assert
+        Assert.Equal(new[] { "login", "--interactive" }, method.Args);
+        Assert.Equal("yes", method.Env!["LOGIN"]);
+        Assert.False(method.SupportsAuthenticateRequest);
+        Assert.Equal("signin", document.RootElement.GetProperty("args")[0].GetString());
+        Assert.True(document.RootElement.GetProperty("future").GetProperty("keep").GetBoolean());
+        var variables = document.RootElement.GetProperty("env");
+        Assert.Equal("new", version == 1 ? variables.GetProperty("LOGIN").GetString() : variables[0].GetProperty("value").GetString());
+        if (version == 2)
+        {
+            Assert.Equal("1.20e+02", variables[0].GetProperty("future").GetRawText());
+            Assert.Equal("auth", variables[0].GetProperty("_meta").GetProperty("source").GetString());
+        }
+    }
+
+    [Theory]
+    [InlineData(1, "null")]
+    [InlineData(1, "42")]
+    [InlineData(2, "{}")]
+    [InlineData(2, "false")]
+    public void TerminalMethod_MalformedArguments_DefaultsField(int version, string args)
+    {
+        // Arrange / Act
+        var id = version == 1 ? "id" : "methodId";
+        var method = JsonSerializer.Deserialize($$"""{"{{id}}":"login","name":"Login","type":"terminal","args":{{args}}}""", Wire.Of<AuthMethodDefinition>(version))!;
+
+        // Assert
+        Assert.Empty(method.Args!);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TerminalMethod_MalformedArgumentItems_SkipsOnlyInvalid(int version)
+    {
+        // Arrange / Act
+        var id = version == 1 ? "id" : "methodId";
+        var method = JsonSerializer.Deserialize($$"""{"{{id}}":"login","name":"Login","type":"terminal","args":["login",42,null,{},"--device"]}""", Wire.Of<AuthMethodDefinition>(version))!;
+
+        // Assert
+        Assert.Equal(new[] { "login", "--device" }, method.Args);
+    }
+
+    [Fact]
+    public void TerminalMethodV1_MalformedEnvironmentValue_DefaultsWholeField()
+    {
+        // Arrange / Act
+        var method = JsonSerializer.Deserialize("""{"id":"login","name":"Login","type":"terminal","env":{"KEEP":"one","bad":42}}""", Wire.Of<AuthMethodDefinition>(1))!;
+
+        // Assert
+        Assert.Empty(method.Env!);
+    }
+
+    [Fact]
+    public void TerminalMethodV2_MalformedEnvironmentItems_SkipsInvalidAndEmitsUniqueNames()
+    {
+        // Arrange / Act
+        var method = JsonSerializer.Deserialize("""{"methodId":"login","name":"Login","type":"terminal","env":[{"name":"KEEP","value":"one"},42,{}, {"name":"bad","value":42},{"name":"KEEP","value":"two"}]}""", Wire.Of<AuthMethodDefinition>(2))!;
+
+        // Assert
+        Assert.Equal("one", Assert.Single(method.Env!).Value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TerminalMethod_AbsentInvocationFields_StaysAbsent(int version)
+    {
+        // Arrange / Act
+        var id = version == 1 ? "id" : "methodId";
+        var method = JsonSerializer.Deserialize($$"""{"{{id}}":"login","name":"Login","type":"terminal"}""", Wire.Of<AuthMethodDefinition>(version))!;
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(method, Wire.Of<AuthMethodDefinition>(version)));
+
+        // Assert
+        Assert.Null(method.Args);
+        Assert.Null(method.Env);
+        Assert.False(document.RootElement.TryGetProperty("args", out _));
+        Assert.False(document.RootElement.TryGetProperty("env", out _));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void UnknownMethod_InvocationLikeFields_RemainUninterpreted(int version)
+    {
+        // Arrange
+        var id = version == 1 ? "id" : "methodId";
+        const string raw = """{"token":1.20e+02}""";
+        var json = $$"""{"{{id}}":"future","name":"Future","type":"_vendor","args":{{raw}},"env":{{raw}}}""";
+
+        // Act
+        var method = JsonSerializer.Deserialize(json, Wire.Of<AuthMethodDefinition>(version))!;
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(method, Wire.Of<AuthMethodDefinition>(version)));
+
+        // Assert
+        Assert.Null(method.Args);
+        Assert.Null(method.Env);
+        Assert.Equal(raw, document.RootElement.GetProperty("args").GetRawText());
+        Assert.Equal(raw, document.RootElement.GetProperty("env").GetRawText());
+    }
+}

--- a/tests/SalmonEgg.Application.Tests/Services/Chat/ChatServiceTerminalAuthenticationTests.cs
+++ b/tests/SalmonEgg.Application.Tests/Services/Chat/ChatServiceTerminalAuthenticationTests.cs
@@ -1,0 +1,56 @@
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Services;
+
+namespace SalmonEgg.Application.Tests.Services.Chat;
+
+public sealed class ChatServiceTerminalAuthenticationTests
+{
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    public async Task InitializeAsync_OnlyLocalInvocationWithSupportedHost_AdvertisesTerminal(bool local, bool supported, bool expected)
+    {
+        // Arrange
+        var client = new Mock<IAcpClient>();
+        InitializeParams? sent = null;
+        client.Setup(x => x.InitializeAsync(It.IsAny<InitializeParams>(), It.IsAny<CancellationToken>()))
+            .Callback<InitializeParams, CancellationToken>((p, _) => sent = p)
+            .ReturnsAsync(new InitializeResponse(1, new AgentInfo("agent", "1"), new AgentCapabilities()));
+        var factory = new Mock<ITerminalAuthenticationSessionFactory>();
+        factory.SetupGet(x => x.IsSupported).Returns(supported);
+        using var service = new ChatService(client.Object, Mock.Of<IErrorLogger>(), new SessionManager(),
+            local ? Mock.Of<IStdioInvocationSource>() : null, factory.Object);
+        var capabilities = ClientCapabilityDefaults.Create();
+
+        // Act
+        await service.InitializeAsync(new InitializeParams(new ClientInfo("client", "1"), capabilities));
+
+        // Assert
+        Assert.Equal(expected, sent!.ClientCapabilities.Auth?.Terminal == true);
+        Assert.Null(capabilities.Auth);
+        Assert.Same(capabilities.Meta, sent.ClientCapabilities.Meta);
+    }
+
+    [Fact]
+    public void Invocation_DelayedDecorator_TracksLiveSourceWithoutResolvingAgain()
+    {
+        // Arrange
+        var snapshot = new StdioInvocationSnapshot("agent", ["--acp"], new Dictionary<string, string>(), "/work", true);
+        var source = new Mock<IStdioInvocationSource>();
+        source.SetupGet(x => x.StdioInvocation).Returns(snapshot);
+        using var service = new ChatService(Mock.Of<IAcpClient>(), Mock.Of<IErrorLogger>(), new SessionManager(), source.Object);
+        using var delayed = new DelayedLoadChatService(service, TimeSpan.FromMilliseconds(1));
+
+        // Act / Assert
+        Assert.Same(snapshot, ((IStdioInvocationSource)delayed).StdioInvocation);
+        source.SetupGet(x => x.StdioInvocation).Returns((StdioInvocationSnapshot?)null);
+        Assert.Null(((IStdioInvocationSource)delayed).StdioInvocation);
+    }
+}

--- a/tests/SalmonEgg.Domain.Tests/Models/StdioInvocationSnapshotTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Models/StdioInvocationSnapshotTests.cs
@@ -1,0 +1,47 @@
+using SalmonEgg.Domain.Models;
+using Xunit;
+
+namespace SalmonEgg.Domain.Tests.Models;
+
+public sealed class StdioInvocationSnapshotTests
+{
+    [Fact]
+    public void Constructor_MutableSource_IsolatesInvocationAndDoesNotRenderSecrets()
+    {
+        // Arrange
+        var arguments = new List<string> { "--token=secret-argument" };
+        var environment = new Dictionary<string, string> { ["TOKEN"] = "secret-environment" };
+
+        // Act
+        var snapshot = new StdioInvocationSnapshot("agent", arguments, environment, "/work", false);
+        arguments.Clear();
+        environment["TOKEN"] = "changed";
+
+        // Assert
+        Assert.Equal("--token=secret-argument", Assert.Single(snapshot.Arguments));
+        Assert.Equal("secret-environment", snapshot.Environment["TOKEN"]);
+        Assert.DoesNotContain("secret", snapshot.ToString());
+    }
+
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 2)]
+    public void WithAuthenticationMethod_AppendsArgumentsAndUsesPlatformEnvironmentComparer(bool ignoreCase, int count)
+    {
+        // Arrange
+        var snapshot = new StdioInvocationSnapshot("agent", ["--acp"],
+            new Dictionary<string, string> { ["TOKEN"] = "base" }, "/work", ignoreCase);
+
+        // Act
+        var login = snapshot.WithAuthenticationMethod(["login", "--interactive"],
+            new Dictionary<string, string> { ["token"] = "override" });
+
+        // Assert
+        Assert.Equal(new[] { "--acp", "login", "--interactive" }, login.Arguments);
+        Assert.Equal(count, login.Environment.Count);
+        Assert.Equal("override", login.Environment["token"]);
+        Assert.Equal("base", snapshot.Environment["TOKEN"]);
+        Assert.Equal(snapshot.Command, login.Command);
+        Assert.Equal(snapshot.WorkingDirectory, login.WorkingDirectory);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Services/PlatformCapabilityServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Services/PlatformCapabilityServiceTests.cs
@@ -6,6 +6,22 @@ namespace SalmonEgg.Infrastructure.Tests.Services;
 
 public sealed class PlatformCapabilityServiceTests
 {
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(false, true, true, false)]
+    public void SupportsTerminalAuthentication_RequiresWindowsProcessHostAndInteractiveSurface(
+        bool windows, bool desktop, bool terminalSurface, bool expected)
+    {
+        // Arrange
+        var service = new PlatformCapabilityService(new FakeRuntimeCapabilityProbe(desktop, true, terminalSurface),
+            platform => windows && platform == OSPlatform.Windows);
+
+        // Act / Assert
+        Assert.Equal(expected, service.SupportsTerminalAuthentication);
+    }
+
     [Fact]
     public void SupportsLocalTerminal_RequiresTransportAndInteractiveSurface()
     {

--- a/tests/SalmonEgg.Infrastructure.Tests/Services/PlatformCapabilityServiceTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Services/PlatformCapabilityServiceTests.cs
@@ -1,4 +1,10 @@
 using System.Runtime.InteropServices;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
 using SalmonEgg.Infrastructure.Services;
 using Xunit;
 
@@ -7,11 +13,11 @@ namespace SalmonEgg.Infrastructure.Tests.Services;
 public sealed class PlatformCapabilityServiceTests
 {
     [Theory]
-    [InlineData(true, true, true, true)]
+    [InlineData(true, true, true, false)]
     [InlineData(true, true, false, false)]
     [InlineData(true, false, true, false)]
     [InlineData(false, true, true, false)]
-    public void SupportsTerminalAuthentication_RequiresWindowsProcessHostAndInteractiveSurface(
+    public void SupportsTerminalAuthentication_ProductHost_RemainsDisabledUntilApplicationGatePasses(
         bool windows, bool desktop, bool terminalSurface, bool expected)
     {
         // Arrange
@@ -20,6 +26,33 @@ public sealed class PlatformCapabilityServiceTests
 
         // Act / Assert
         Assert.Equal(expected, service.SupportsTerminalAuthentication);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ProductionTerminalFactory_DoesNotAdvertiseUnverifiedAuthentication()
+    {
+        // Arrange
+        var platform = new PlatformCapabilityService(new FakeRuntimeCapabilityProbe(true, true, true),
+            target => target == OSPlatform.Windows);
+        await using var factory = new TerminalAuthenticationSessionFactory(platform);
+        var client = new Mock<IAcpClient>();
+        InitializeParams? sent = null;
+        client.Setup(value => value.InitializeAsync(It.IsAny<InitializeParams>(), It.IsAny<CancellationToken>()))
+            .Callback<InitializeParams, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(new InitializeResponse(1, new AgentInfo("agent", "1"), new AgentCapabilities()));
+        var invocation = new Mock<IStdioInvocationSource>();
+        invocation.SetupGet(value => value.StdioInvocation).Returns(
+            new StdioInvocationSnapshot("agent", [], new Dictionary<string, string>(), "/work", true));
+        using var chat = new ChatService(client.Object, Mock.Of<IErrorLogger>(), new SessionManager(),
+            invocation.Object, factory);
+
+        // Act
+        await chat.InitializeAsync(new InitializeParams(new ClientInfo("client", "1"), ClientCapabilityDefaults.Create()));
+
+        // Assert
+        Assert.NotNull(sent);
+        Assert.False(factory.IsSupported);
+        Assert.False(sent.ClientCapabilities.Auth?.Terminal == true);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Infrastructure.Tests/Services/TerminalAuthenticationSessionFactoryTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Services/TerminalAuthenticationSessionFactoryTests.cs
@@ -1,0 +1,182 @@
+using System.IO.Pipelines;
+using System.Text;
+using Moq;
+using Porta.Pty;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Services;
+
+namespace SalmonEgg.Infrastructure.Tests.Services;
+
+public sealed class TerminalAuthenticationSessionFactoryTests
+{
+    [Fact]
+    public async Task Start_InvocationSnapshot_SpawnsWithoutShellReparsingAndCapturesEarlyExit()
+    {
+        // Arrange
+        using var connection = new FakeConnection { Exited = true, ExitCode = 0 };
+        PtyOptions? options = null;
+        await using var factory = CreateFactory((value, _) => { options = value; return Task.FromResult<IPtyConnection>(connection); });
+        var invocation = new StdioInvocationSnapshot("agent", ["--acp", "literal & $(not-shell)"],
+            new Dictionary<string, string> { ["TOKEN"] = "private" }, "/work", true);
+
+        // Act
+        await using var session = await factory.StartAsync(invocation, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, await session.Completion.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(invocation.Arguments, options!.CommandLine);
+        Assert.Equal("private", options.Environment["TOKEN"]);
+        Assert.Equal(invocation.Command, options.App);
+        Assert.Equal(invocation.WorkingDirectory, options.Cwd);
+    }
+
+    [Fact]
+    public async Task Session_OutputInputAndResize_UsePtyStreams()
+    {
+        // Arrange
+        using var connection = new FakeConnection();
+        await using var factory = CreateFactory((_, _) => Task.FromResult<IPtyConnection>(connection));
+        await using var session = await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+        var output = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        session.OutputReceived += (_, value) => output.TrySetResult(value);
+
+        // Act
+        await connection.Output.Writer.WriteAsync(Encoding.UTF8.GetBytes("sign-in prompt"), TestContext.Current.CancellationToken);
+        await session.WriteInputAsync("response\r", TestContext.Current.CancellationToken);
+        await session.ResizeAsync(80, 24, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("sign-in prompt", await output.Task.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("response\r", Encoding.UTF8.GetString(connection.Input.ToArray()));
+        Assert.Equal((80, 24), connection.Size);
+    }
+
+    [Fact]
+    public async Task Session_OutputClosesWithoutExit_DoesNotReportSuccess()
+    {
+        // Arrange
+        using var connection = new FakeConnection();
+        await using var factory = CreateFactory((_, _) => Task.FromResult<IPtyConnection>(connection));
+        await using var session = await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+
+        // Act
+        await connection.Output.Writer.CompleteAsync();
+
+        // Assert
+        Assert.Null(await session.Completion.WaitAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Session_OutputConsumerFails_FailsClosedAndStillReclaimsNativeConnection()
+    {
+        // Arrange
+        using var connection = new FakeConnection();
+        await using var factory = CreateFactory((_, _) => Task.FromResult<IPtyConnection>(connection));
+        var session = await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+        session.OutputReceived += (_, _) => throw new InvalidOperationException("View detached");
+
+        // Act
+        await connection.Output.Writer.WriteAsync(Encoding.UTF8.GetBytes("sign-in prompt"), TestContext.Current.CancellationToken);
+        Assert.Null(await session.Completion.WaitAsync(TestContext.Current.CancellationToken));
+        await session.DisposeAsync();
+
+        // Assert
+        Assert.Equal(1, connection.KillCount);
+        Assert.Equal(1, connection.DisposeCount);
+        Assert.False(session.CanAcceptInput);
+    }
+
+    [Fact]
+    public async Task Dispose_KillFailsBecauseProcessExited_StillDisposesConnectionAndStopsReader()
+    {
+        // Arrange
+        using var connection = new FakeConnection { ThrowOnKill = true };
+        await using var factory = CreateFactory((_, _) => Task.FromResult<IPtyConnection>(connection));
+        var session = await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+
+        // Act
+        await session.DisposeAsync();
+        await session.DisposeAsync();
+
+        // Assert
+        Assert.Equal(1, connection.KillCount);
+        Assert.Equal(1, connection.DisposeCount);
+        Assert.Null(await session.Completion);
+        Assert.False(session.CanAcceptInput);
+    }
+
+    [Fact]
+    public async Task DisposeFactory_ActiveSessions_DrainsEverySessionAndRejectsLaterStart()
+    {
+        // Arrange
+        var connections = new List<FakeConnection>();
+        await using var factory = CreateFactory((_, _) =>
+        {
+            var connection = new FakeConnection();
+            connections.Add(connection);
+            return Task.FromResult<IPtyConnection>(connection);
+        });
+        await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+        await factory.StartAsync(Invocation(), TestContext.Current.CancellationToken);
+
+        // Act
+        await factory.DisposeAsync();
+
+        // Assert
+        Assert.All(connections, connection => Assert.Equal(1, connection.DisposeCount));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => factory.StartAsync(Invocation(), TestContext.Current.CancellationToken).AsTask());
+    }
+
+    [Fact]
+    public async Task Start_CancelledAfterNativeSpawn_ReclaimsUnpublishedConnection()
+    {
+        // Arrange
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var connection = new FakeConnection();
+        await using var factory = CreateFactory((_, _) => { cancellation.Cancel(); return Task.FromResult<IPtyConnection>(connection); });
+
+        // Act / Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => factory.StartAsync(Invocation(), cancellation.Token).AsTask());
+        Assert.Equal(1, connection.KillCount);
+        Assert.Equal(1, connection.DisposeCount);
+    }
+
+    private static StdioInvocationSnapshot Invocation() => new("agent", [], new Dictionary<string, string>(), "/work", true);
+
+    private static TerminalAuthenticationSessionFactory CreateFactory(Func<PtyOptions, CancellationToken, Task<IPtyConnection>> spawn)
+    {
+        var platform = new Mock<IPlatformCapabilityService>();
+        platform.SetupGet(x => x.SupportsTerminalAuthentication).Returns(true);
+        return new TerminalAuthenticationSessionFactory(platform.Object, spawn);
+    }
+
+    private sealed class FakeConnection : IPtyConnection
+    {
+        public readonly Pipe Output = new();
+        public readonly MemoryStream Input = new();
+        private readonly Stream _reader;
+        public int KillCount;
+        public int DisposeCount;
+        public bool ThrowOnKill;
+        public bool Exited;
+        public (int, int) Size;
+        public FakeConnection() => _reader = Output.Reader.AsStream();
+        public event EventHandler<PtyExitedEventArgs>? ProcessExited { add { } remove { } }
+        public Stream ReaderStream => _reader;
+        public Stream WriterStream => Input;
+        public int Pid => 1;
+        public int ExitCode { get; set; }
+        public bool WaitForExit(int milliseconds) => Exited;
+        public void Kill() { KillCount++; if (ThrowOnKill) throw new InvalidOperationException("Exited"); }
+        public void Resize(int cols, int rows) => Size = (cols, rows);
+        public void Dispose()
+        {
+            if (DisposeCount > 0) return;
+            DisposeCount++;
+            Output.Writer.Complete();
+            _reader.Dispose();
+            Input.Dispose();
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/CredentialTransportCanaryTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/CredentialTransportCanaryTests.cs
@@ -3,19 +3,24 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.IO.Pipelines;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Porta.Pty;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Application.Services.Acp;
 using SalmonEgg.Domain.Models;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Infrastructure.Client;
 using SalmonEgg.Infrastructure.Network;
 using SalmonEgg.Infrastructure.Transport;
+using SalmonEgg.Infrastructure.Services;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -158,6 +163,84 @@ public sealed class CredentialTransportCanaryTests
     }
 
     [Fact]
+    public async Task BoundStdio_ActualEnvironmentSnapshot_ReachesTerminalAuthenticationSpawn()
+    {
+        // Arrange: this gate reads a real child environment, without enabling product terminal auth.
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Requires the real Linux /proc process environment and /bin/sh.");
+        var directory = Path.Combine(Path.GetTempPath(), "acp-terminal-credential-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var script = Path.Combine(directory, "agent.sh");
+        await File.WriteAllTextAsync(script, """
+            printf '{"jsonrpc":"2.0","method":"canary/ready","params":{"pid":%s}}\n' "$$"
+            while IFS= read -r line; do :; done
+            """, TestContext.Current.CancellationToken);
+        var profile = new ServerConfiguration
+        {
+            Transport = TransportType.Stdio,
+            StdioCommand = "/bin/sh",
+            StdioArguments = [script, "literal argument"],
+            Authentication = new AuthenticationConfig { Token = Secret },
+        };
+        profile.CredentialBinding = CredentialBindingPolicy.Create(profile, CredentialSource.Token,
+            CredentialTarget.Environment, "SALMONEGG_CREDENTIAL_CANARY");
+        var sourceFactory = new CapturedStdioFactory();
+        var platform = new Mock<IPlatformCapabilityService>();
+        platform.SetupGet(value => value.SupportsStdioTransport).Returns(true);
+        platform.SetupGet(value => value.SupportsTerminalAuthentication).Returns(true);
+        using var logger = new LoggerConfiguration().CreateLogger();
+        var transportFactory = new TransportFactory(logger, new TransportSupportPolicy(platform.Object), sourceFactory);
+        var chatFactory = new ChatServiceFactory(transportFactory, Mock.Of<IErrorLogger>(),
+            new SessionManager(), new AcpClientFactory(Mock.Of<IErrorLogger>(), new SessionManager(),
+                Mock.Of<ITerminalSessionManager>()), logger,
+            decorateChatService: service => new DelayedLoadChatService(service, TimeSpan.FromMilliseconds(1)));
+
+        try
+        {
+            using var chat = chatFactory.CreateChatService(profile);
+            var transport = Assert.IsType<StdioTransport>(sourceFactory.Created);
+            var ready = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            transport.MessageReceived += (_, message) =>
+            {
+                using var frame = JsonDocument.Parse(message.Message);
+                ready.TrySetResult(frame.RootElement.GetProperty("params").GetProperty("pid").GetInt32());
+            };
+
+            // Act
+            Assert.True(await transport.ConnectAsync(TestContext.Current.CancellationToken));
+            var pid = await ready.Task.WaitAsync(Deadline, TestContext.Current.CancellationToken);
+            var snapshot = Assert.IsType<StdioInvocationSnapshot>(Assert.IsAssignableFrom<IStdioInvocationSource>(chat).StdioInvocation);
+            var environment = await File.ReadAllTextAsync($"/proc/{pid}/environ", TestContext.Current.CancellationToken);
+            Assert.Contains("SALMONEGG_CREDENTIAL_CANARY=" + Secret + '\0', environment);
+            profile.Authentication!.Token = "edited-after-launch";
+            var login = snapshot.WithAuthenticationMethod(["login argument"],
+                new Dictionary<string, string> { ["LOGIN_MODE"] = "interactive" });
+            using var pty = new CapturedPty();
+            PtyOptions? options = null;
+            await using var terminalFactory = new TerminalAuthenticationSessionFactory(platform.Object,
+                (request, _) => { options = request; return Task.FromResult<IPtyConnection>(pty); });
+            await using var terminal = await terminalFactory.StartAsync(login, TestContext.Current.CancellationToken);
+
+            // Assert: the actual running process snapshot, not a re-read edited profile, feeds the PTY.
+            Assert.NotNull(options);
+            Assert.Equal(Secret, options.Environment["SALMONEGG_CREDENTIAL_CANARY"]);
+            Assert.Equal("interactive", options.Environment["LOGIN_MODE"]);
+            Assert.Equal(snapshot.Arguments.Concat(["login argument"]), options.CommandLine);
+            Assert.Equal(snapshot.Command, options.App);
+            Assert.Equal(snapshot.WorkingDirectory, options.Cwd);
+            Assert.DoesNotContain(Secret, snapshot.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain(Secret, string.Join(" ", options.CommandLine), StringComparison.Ordinal);
+            Assert.True(await chat.DisconnectAsync());
+            Assert.False(Directory.Exists($"/proc/{pid}"));
+            Assert.Null(((IStdioInvocationSource)chat).StdioInvocation);
+        }
+        finally
+        {
+            sourceFactory.Created?.Dispose();
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Factory_UnsupportedWebSocketHeaders_FailsBeforeCreatingConnection()
     {
         var profile = CreateProfile(TransportType.WebSocket, "wss://agent.example/acp", Secret);
@@ -186,6 +269,41 @@ public sealed class CredentialTransportCanaryTests
     };
 
     private sealed record CapturedRequest(string Method, string Path, string Credential, string Body);
+
+    private sealed class CapturedStdioFactory : IStdioTransportFactory
+    {
+        public SalmonEgg.Domain.Interfaces.Transport.ITransport? Created { get; private set; }
+
+        public SalmonEgg.Domain.Interfaces.Transport.ITransport Create(string command, string[] args,
+            Encoding encoding, IReadOnlyDictionary<string, string>? environment = null)
+            => Created = new DesktopStdioTransportFactory().Create(command, args, encoding, environment);
+    }
+
+    private sealed class CapturedPty : IPtyConnection
+    {
+        private readonly Pipe _output = new();
+        private readonly Stream _reader;
+        private readonly MemoryStream _input = new();
+        private bool _disposed;
+
+        public CapturedPty() => _reader = _output.Reader.AsStream();
+        public event EventHandler<PtyExitedEventArgs>? ProcessExited { add { } remove { } }
+        public Stream ReaderStream => _reader;
+        public Stream WriterStream => _input;
+        public int Pid => 1;
+        public int ExitCode => 0;
+        public bool WaitForExit(int milliseconds) => true;
+        public void Kill() { }
+        public void Resize(int cols, int rows) { }
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _output.Writer.Complete();
+            _reader.Dispose();
+            _input.Dispose();
+        }
+    }
 
     private sealed class RecordingLogSink : ILogEventSink
     {

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.TerminalCredentials.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.TerminalCredentials.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public sealed partial class AcpChatCoordinatorTests
+{
+    [Fact]
+    public async Task ConnectToProfileAsync_TerminalLoginForcesFreshCredentialSessionAndKeepsInvocationSource()
+    {
+        // Arrange
+        var oldService = CreateChatService();
+        var freshService = CreateChatService();
+        var invocation = new StdioInvocationSnapshot("agent", ["--acp"],
+            new Dictionary<string, string> { ["AGENT_TOKEN"] = "unchanged-secret" }, "/work", true);
+        oldService.As<IStdioInvocationSource>().SetupGet(value => value.StdioInvocation).Returns(invocation);
+        freshService.As<IStdioInvocationSource>().SetupGet(value => value.StdioInvocation).Returns(invocation);
+        var factory = new Mock<IAcpChatServiceFactory>();
+        factory.SetupSequence(value => value.CreateChatService(It.IsAny<ServerConfiguration>()))
+            .Returns(oldService.Object).Returns(freshService.Object);
+        var coordinator = CreateCoordinator(factory.Object, NullLogger<AcpChatCoordinator>.Instance,
+            CreateTransportSupportPolicy(), EmptyMcpServerProvider);
+        var profile = CreateBoundProfile("unchanged-secret");
+        var sink = new FakeSink();
+        var first = await ConnectCredentialProfileAsync(coordinator, profile, sink, pooled: false);
+        Assert.Same(invocation, Assert.IsAssignableFrom<IStdioInvocationSource>(first.ChatService).StdioInvocation);
+        var context = new AcpConnectionContext(sink.CurrentSessionId, PreserveConversation: true)
+        {
+            ForceReconnect = true,
+            ExpectedChatService = first.ChatService,
+            ExpectedConnectionInstanceId = sink.ConnectionInstanceId,
+            ExpectedProfileId = profile.Id
+        };
+
+        // Act: credentials and key are unchanged, but interactive login must bypass the old process.
+        var second = await coordinator.ConnectToProfileAsync(profile, new FakeTransportConfiguration(), sink,
+            context, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotSame(first.ChatService, second.ChatService);
+        Assert.Same(invocation, Assert.IsAssignableFrom<IStdioInvocationSource>(second.ChatService).StdioInvocation);
+        Assert.True(Assert.IsType<AcpChatServiceAdapter>(second.ChatService)
+            .UsesCredentialSnapshot(CredentialBindingResolver.Resolve(profile).Value));
+        factory.Verify(value => value.CreateChatService(It.IsAny<ServerConfiguration>()), Times.Exactly(2));
+        oldService.Verify(value => value.DisconnectAsync(), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConnectToProfileAsync_StaleTerminalCallback_DoesNotCancelNewCredentialConnection(bool directTransportEntry)
+    {
+        // Arrange
+        var firstService = CreateChatService();
+        var newService = CreateChatService();
+        var initializeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var initializeRelease = new TaskCompletionSource<InitializeResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        newService.Setup(value => value.InitializeAsync(It.IsAny<InitializeParams>())).Returns(() =>
+        {
+            initializeStarted.TrySetResult();
+            return initializeRelease.Task;
+        });
+        var factory = new Mock<IAcpChatServiceFactory>();
+        factory.SetupSequence(value => value.CreateChatService(It.IsAny<ServerConfiguration>()))
+            .Returns(firstService.Object).Returns(newService.Object);
+        var registry = new InMemoryAcpConnectionSessionRegistry();
+        var coordinator = CreateCoordinator(factory.Object, NullLogger<AcpChatCoordinator>.Instance,
+            CreateTransportSupportPolicy(), EmptyMcpServerProvider, sessionRegistry: registry);
+        var sink = new FakeSink();
+        var profile = CreateBoundProfile("old-secret");
+        var first = await ConnectCredentialProfileAsync(coordinator, profile, sink, pooled: false);
+        var oldContext = new AcpConnectionContext(sink.CurrentSessionId, PreserveConversation: true)
+        {
+            ForceReconnect = true,
+            ExpectedChatService = first.ChatService,
+            ExpectedConnectionInstanceId = sink.ConnectionInstanceId,
+            ExpectedProfileId = profile.Id
+        };
+        var replacement = profile.Clone();
+        replacement.Authentication!.Token = "new-secret";
+        var connecting = ConnectCredentialProfileAsync(coordinator, replacement, sink, pooled: false);
+        await initializeStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        // This models a newer conversation selection without a third connection request.
+        sink.CurrentSessionId = "new-conversation";
+
+        try
+        {
+            // Act: an old auth completion must be rejected before it supersedes the new apply scope.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => directTransportEntry
+                ? coordinator.ApplyTransportConfigurationAsync(new FakeTransportConfiguration(), sink,
+                    oldContext, TestContext.Current.CancellationToken)
+                : coordinator.ConnectToProfileAsync(profile, new FakeTransportConfiguration(), sink,
+                    oldContext, TestContext.Current.CancellationToken));
+            initializeRelease.TrySetResult(new InitializeResponse(1, new AgentInfo("new", "1"), new AgentCapabilities()));
+            var active = await connecting.WaitAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.NotSame(first.ChatService, active.ChatService);
+            Assert.Same(active.ChatService, sink.CurrentChatService);
+            Assert.True(registry.TryGetByProfile(profile.Id, out var session));
+            Assert.True(session.Service.UsesCredentialSnapshot(CredentialBindingResolver.Resolve(replacement).Value));
+            newService.Verify(value => value.Dispose(), Times.Never);
+            factory.Verify(value => value.CreateChatService(It.IsAny<ServerConfiguration>()), Times.Exactly(2));
+        }
+        finally
+        {
+            initializeRelease.TrySetResult(new InitializeResponse(1, new AgentInfo("new", "1"), new AgentCapabilities()));
+            try { await connecting.WaitAsync(TestContext.Current.CancellationToken); }
+            catch (OperationCanceledException) { }
+            await coordinator.DisconnectAsync(sink, TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.cs
@@ -386,6 +386,103 @@ public sealed partial class AcpChatCoordinatorTests
     }
 
     [Fact]
+    public async Task ConnectToProfileAsync_AfterTerminalAuthentication_BypassesWarmPoolAndReinitializes()
+    {
+        // Arrange
+        var oldService = CreateChatService();
+        var freshService = CreateChatService();
+        var factory = new Mock<IAcpChatServiceFactory>();
+        factory.SetupSequence(x => x.CreateChatService(It.IsAny<ServerConfiguration>()))
+            .Returns(oldService.Object).Returns(freshService.Object);
+        var sink = new FakeSink();
+        var transport = new FakeTransportConfiguration();
+        var profile = new ServerConfiguration { Id = "profile-auth", Name = "Agent", Transport = TransportType.Stdio, StdioCommand = "agent" };
+        var coordinator = CreateCoordinator(factory.Object, NullLogger<AcpChatCoordinator>.Instance,
+            CreateTransportSupportPolicy(), EmptyMcpServerProvider);
+        var first = await coordinator.ConnectToProfileAsync(profile, transport, sink, TestContext.Current.CancellationToken);
+        sink.ConnectionInstanceId = "connection-before-auth";
+
+        // Act
+        var second = await coordinator.ConnectToProfileAsync(profile, transport, sink,
+            new AcpConnectionContext(sink.CurrentSessionId, PreserveConversation: true)
+            {
+                ForceReconnect = true,
+                ExpectedChatService = first.ChatService,
+                ExpectedConnectionInstanceId = sink.ConnectionInstanceId,
+                ExpectedProfileId = profile.Id
+            }, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotSame(first.ChatService, second.ChatService);
+        freshService.Verify(x => x.InitializeAsync(It.IsAny<InitializeParams>()), Times.Once);
+        oldService.Verify(x => x.DisconnectAsync(), Times.Once);
+        Assert.Equal(ServiceReplaceIntent.PoolOnly, sink.ReplaceChatServiceIntents[^1]);
+    }
+
+    [Fact]
+    public async Task ConnectToProfileAsync_AuthenticationSnapshotIsStale_DoesNotChangeSelectionOrCreateProcess()
+    {
+        // Arrange
+        var service = CreateChatService();
+        var factory = new Mock<IAcpChatServiceFactory>();
+        var sink = new FakeSink { CurrentChatService = service.Object, SelectedProfileId = "profile-current", ConnectionInstanceId = "new" };
+        var coordinator = CreateCoordinator(factory.Object, NullLogger<AcpChatCoordinator>.Instance,
+            CreateTransportSupportPolicy(), EmptyMcpServerProvider);
+        var profile = new ServerConfiguration { Id = "profile-old", Transport = TransportType.Stdio, StdioCommand = "agent" };
+
+        // Act / Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => coordinator.ConnectToProfileAsync(
+            profile, new FakeTransportConfiguration(), sink, new AcpConnectionContext(null, true)
+            {
+                ForceReconnect = true,
+                ExpectedChatService = service.Object,
+                ExpectedConnectionInstanceId = "old",
+                ExpectedProfileId = profile.Id
+            }, TestContext.Current.CancellationToken));
+        Assert.Equal("profile-current", sink.SelectedProfileId);
+        factory.Verify(x => x.CreateChatService(It.IsAny<ServerConfiguration>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConnectToProfileAsync_AuthenticationIdentityChangesDuringInitialize_DiscardsWithoutRestoringStaleState()
+    {
+        // Arrange
+        var oldService = CreateChatService();
+        var candidate = CreateChatService();
+        var initialized = new TaskCompletionSource<InitializeResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        candidate.Setup(x => x.InitializeAsync(It.IsAny<InitializeParams>())).Returns(initialized.Task);
+        var factory = new Mock<IAcpChatServiceFactory>();
+        factory.Setup(x => x.CreateChatService(It.IsAny<ServerConfiguration>())).Returns(candidate.Object);
+        var state = new Mock<IAcpConnectionCoordinator>();
+        var sink = new FakeSink { CurrentChatService = oldService.Object, SelectedProfileId = "profile-old", ConnectionInstanceId = "old", IsConnected = true };
+        var coordinator = CreateCoordinator(factory.Object, NullLogger<AcpChatCoordinator>.Instance,
+            CreateTransportSupportPolicy(), EmptyMcpServerProvider, connectionCoordinator: state.Object);
+        var context = new AcpConnectionContext(null, true)
+        {
+            ForceReconnect = true,
+            ExpectedChatService = oldService.Object,
+            ExpectedConnectionInstanceId = "old",
+            ExpectedProfileId = "profile-old"
+        };
+
+        // Act: a newer intent arrives without entering another apply scope.
+        var pending = coordinator.ConnectToProfileAsync(
+            new ServerConfiguration { Id = "profile-old", Transport = TransportType.Stdio, StdioCommand = "agent" },
+            new FakeTransportConfiguration(), sink, context, TestContext.Current.CancellationToken);
+        sink.SelectedProfileId = "profile-new";
+        sink.ConnectionInstanceId = "new";
+        initialized.SetResult(new InitializeResponse());
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        Assert.Empty(sink.ReplaceChatServiceCalls);
+        Assert.Equal("profile-new", sink.SelectedProfileId);
+        state.Verify(x => x.SetConnectedAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        state.Verify(x => x.SetConnectionInstanceIdAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        candidate.Verify(x => x.DisconnectAsync(), Times.Once);
+    }
+
+    [Fact]
     public async Task ConnectToProfileAsync_WhenCanceledDuringInitialize_ReturnsAndDisposesCandidate()
     {
         var transport = new FakeTransportConfiguration();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AuthenticationRetryTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AuthenticationRetryTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Mcp;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public sealed class AuthenticationRetryTests
+{
+    [Fact]
+    public async Task CreateSession_AuthenticationReplacesConnection_RetriesThroughNewService()
+    {
+        // Arrange
+        var oldService = ReadyService();
+        var newService = ReadyService();
+        oldService.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>())).ThrowsAsync(AuthRequired());
+        newService.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>())).ReturnsAsync(new SessionNewResponse("remote-new"));
+        var sink = CreateSink(oldService.Object);
+        var orchestrator = CreateOrchestrator();
+
+        // Act
+        var result = await orchestrator.EnsureRemoteSessionAsync(sink.Object, _ =>
+        {
+            sink.SetupGet(x => x.CurrentChatService).Returns(newService.Object);
+            return Task.FromResult(true);
+        }, () => { }, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("remote-new", result.RemoteSessionId);
+        oldService.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+        newService.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendPrompt_AuthenticationReplacesConnection_UsesHydratedBindingAndNewService()
+    {
+        // Arrange
+        var oldService = ReadyService();
+        var newService = ReadyService();
+        oldService.Setup(x => x.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>())).ThrowsAsync(AuthRequired());
+        newService.Setup(x => x.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>())).ReturnsAsync(new SessionPromptResponse());
+        var sink = CreateSink(oldService.Object);
+        var orchestrator = CreateOrchestrator();
+
+        // Act
+        var result = await orchestrator.DispatchPromptToRemoteSessionAsync("remote-old", "hello", sink.Object, _ =>
+        {
+            sink.SetupGet(x => x.CurrentChatService).Returns(newService.Object);
+            sink.Setup(x => x.GetCurrentRemoteBindingAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ConversationRemoteBindingState("conversation-1", "remote-loaded", "profile-1"));
+            return Task.FromResult(true);
+        }, (_, _, _, _) => throw new InvalidOperationException("Hydrated binding must be reused."), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("remote-loaded", result.RemoteSessionId);
+        Assert.True(result.RetriedAfterSessionRecovery);
+        oldService.Verify(x => x.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()), Times.Once);
+        newService.Verify(x => x.SendPromptAsync(It.Is<SessionPromptParams>(p => p.SessionId == "remote-loaded"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Retry_ConversationChangesWhileAuthenticating_DoesNotSendAgain(bool create)
+    {
+        // Arrange
+        var service = ReadyService();
+        service.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>())).ThrowsAsync(AuthRequired());
+        service.Setup(x => x.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>())).ThrowsAsync(AuthRequired());
+        var sink = CreateSink(service.Object);
+        var orchestrator = CreateOrchestrator();
+        Task<bool> Authenticate(CancellationToken _)
+        {
+            sink.SetupGet(x => x.CurrentSessionId).Returns("conversation-2");
+            return Task.FromResult(true);
+        }
+
+        // Act / Assert
+        if (create)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => orchestrator.EnsureRemoteSessionAsync(
+                sink.Object, Authenticate, () => { }, TestContext.Current.CancellationToken));
+            service.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+        }
+        else
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => orchestrator.DispatchPromptToRemoteSessionAsync(
+                "remote-old", "hello", sink.Object, Authenticate, (_, _, _, _) => throw new InvalidOperationException(), TestContext.Current.CancellationToken));
+            service.Verify(x => x.SendPromptAsync(It.IsAny<SessionPromptParams>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    private static AcpException AuthRequired() => new(JsonRpcErrorCode.AuthenticationRequired, "Sign in");
+
+    private static Mock<IChatService> ReadyService()
+    {
+        var service = new Mock<IChatService>();
+        service.SetupGet(x => x.IsInitialized).Returns(true);
+        service.SetupGet(x => x.IsConnected).Returns(true);
+        return service;
+    }
+
+    private static AcpSessionCommandOrchestrator CreateOrchestrator()
+    {
+        var mcp = new Mock<IAcpMcpServerResolver>();
+        mcp.Setup(x => x.ResolveCurrentMcpServersAsync(It.IsAny<IAcpChatCoordinatorSink>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<McpServer>());
+        return new AcpSessionCommandOrchestrator(NullLogger<AcpSessionCommandOrchestrator>.Instance, mcp.Object);
+    }
+
+    private static Mock<IAcpChatCoordinatorSink> CreateSink(IChatService service)
+    {
+        var sink = new Mock<IAcpChatCoordinatorSink>();
+        sink.SetupGet(x => x.CurrentChatService).Returns(service);
+        sink.SetupGet(x => x.IsInitialized).Returns(true);
+        sink.SetupGet(x => x.IsSessionActive).Returns(true);
+        sink.SetupGet(x => x.CurrentSessionId).Returns("conversation-1");
+        sink.SetupGet(x => x.SelectedProfileId).Returns("profile-1");
+        sink.Setup(x => x.GetActiveSessionCwdOrDefault()).Returns("/work");
+        sink.Setup(x => x.ResolveProfile("profile-1")).Returns(new ServerConfiguration { Id = "profile-1", Transport = TransportType.Stdio });
+        var bindings = new Mock<IConversationBindingCommands>();
+        bindings.Setup(x => x.UpdateBindingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(BindingUpdateResult.Success());
+        sink.SetupGet(x => x.ConversationBindingCommands).Returns(bindings.Object);
+        return sink;
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTerminalAuthenticationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTerminalAuthenticationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.ViewModels.Chat;
+using Xunit;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TerminalAuthentication_DraftCreation_RetriesThroughFreshConnection(bool missingExplicitIntent)
+    {
+        // Arrange: use the real ViewModel draft owner, consent coordinator and public connect path.
+        var original = new Mock<IChatService>();
+        original.As<IStdioInvocationSource>().SetupGet(x => x.StdioInvocation).Returns(
+            new StdioInvocationSnapshot("agent", ["--acp"], new Dictionary<string, string>(), "/work", false));
+        original.SetupGet(x => x.IsConnected).Returns(true);
+        original.SetupGet(x => x.IsInitialized).Returns(true);
+        original.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>())).ThrowsAsync(
+            new AcpException(JsonRpcErrorCode.AuthenticationRequired, "Sign in"));
+        var fresh = CreateConnectedChatService();
+        fresh.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>())).ReturnsAsync(new SessionNewResponse("draft-after-login"));
+        var terminalSession = new Mock<ITerminalAuthenticationSession>();
+        terminalSession.SetupGet(x => x.Completion).Returns(Task.FromResult<int?>(0));
+        var sessionFactory = new Mock<ITerminalAuthenticationSessionFactory>();
+        sessionFactory.SetupGet(x => x.IsSupported).Returns(true);
+        sessionFactory.Setup(x => x.StartAsync(It.IsAny<StdioInvocationSnapshot>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(terminalSession.Object);
+        var interaction = new Mock<ITerminalAuthenticationInteraction>();
+        interaction.Setup(x => x.ConfirmAsync(It.IsAny<TerminalAuthenticationViewModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        interaction.Setup(x => x.ShowSessionAsync(It.IsAny<TerminalAuthenticationViewModel>(), It.IsAny<CancellationToken>()))
+            .Returns<TerminalAuthenticationViewModel, CancellationToken>((_, token) => Task.Delay(Timeout.InfiniteTimeSpan, token));
+        await using var authentication = new TerminalAuthenticationCoordinator(sessionFactory.Object, interaction.Object,
+            new ImmediateUiDispatcher(), NullLogger<TerminalAuthenticationCoordinator>.Instance);
+        var commands = new Mock<IAcpConnectionCommands>();
+        var profile = CreateConnectableStdioProfile("profile-terminal", "Terminal agent");
+        var response = new InitializeResponse
+        {
+            ProtocolVersion = 1,
+            AuthMethods = [new AuthMethodDefinition { Id = "login", Name = "Sign in", Type = "terminal" }]
+        };
+        await using var fixture = CreateViewModel(acpConnectionCommands: commands.Object, terminalAuthenticationCoordinator: authentication);
+        fixture.Profiles.Profiles.Add(profile);
+        commands.Setup(x => x.ConnectToProfileAsync(profile, It.IsAny<IAcpTransportConfiguration>(),
+                It.IsAny<IAcpChatCoordinatorSink>(), It.IsAny<CancellationToken>()))
+            .Returns<ServerConfiguration, IAcpTransportConfiguration, IAcpChatCoordinatorSink, CancellationToken>(
+                async (_, _, sink, token) =>
+                {
+                    await sink.ReplaceChatServiceAsync(original.Object, token);
+                    await fixture.DispatchConnectionAsync(new SetForegroundTransportProfileAction(profile.Id));
+                    await fixture.DispatchConnectionAsync(new SetConnectionInstanceIdAction("before-login"));
+                    await fixture.DispatchConnectionAsync(new SetConnectionPhaseAction(ConnectionPhase.Connected));
+                    return new AcpTransportApplyResult(original.Object, response);
+                });
+        AcpConnectionContext? observedContext = null;
+        commands.Setup(x => x.ConnectToProfileAsync(profile, It.IsAny<IAcpTransportConfiguration>(),
+                It.IsAny<IAcpChatCoordinatorSink>(), It.IsAny<AcpConnectionContext>(), It.IsAny<CancellationToken>()))
+            .Returns<ServerConfiguration, IAcpTransportConfiguration, IAcpChatCoordinatorSink, AcpConnectionContext, CancellationToken>(
+                async (_, _, sink, context, token) =>
+                {
+                    observedContext = context;
+                    await sink.ReplaceChatServiceAsync(fresh.Object, ServiceReplaceIntent.PoolOnly, token);
+                    await fixture.DispatchConnectionAsync(new SetConnectionInstanceIdAction("after-login"));
+                    await fixture.DispatchConnectionAsync(new SetConnectionPhaseAction(ConnectionPhase.Connected));
+                    return new AcpTransportApplyResult(fresh.Object, new InitializeResponse());
+                });
+        await fixture.ViewModel.ConnectToAcpProfileCommand.ExecuteAsync(profile);
+        if (missingExplicitIntent) await fixture.DispatchConnectionAsync(new SetSelectedProfileIntentAction(null));
+        await fixture.ApplyCurrentStoreProjectionAsync();
+
+        // Act: the original session/new fails, signs in, reconnects, and re-enters the same draft owner.
+        await fixture.ViewModel.EnsureNewSessionDraftAsync("/work", TestContext.Current.CancellationToken);
+
+        // Assert: no authenticate request or second call reaches the stale service.
+        var state = await fixture.GetConnectionStateAsync();
+        Assert.True(observedContext?.ForceReconnect);
+        Assert.Same(original.Object, observedContext?.ExpectedChatService);
+        Assert.Equal("draft-after-login", state.NewSessionDraft?.RemoteSessionId);
+        Assert.Equal("after-login", state.NewSessionDraft?.ConnectionInstanceId);
+        Assert.Equal(NewSessionDraftPhase.Ready, state.NewSessionDraft?.Phase);
+        original.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+        original.Verify(x => x.AuthenticateAsync(It.IsAny<AuthenticateParams>(), It.IsAny<CancellationToken>()), Times.Never);
+        fresh.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+        terminalSession.Verify(x => x.DisposeAsync(), Times.Once);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTerminalAuthenticationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTerminalAuthenticationTests.cs
@@ -20,6 +20,30 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat;
 
 public partial class ChatViewModelTests
 {
+    [Fact]
+    public async Task EnsureNewSessionDraftAsync_NullResponseWithoutReconnect_FaultsInsteadOfRetrying()
+    {
+        // A null service response is invalid; only an actual authentication reconnect permits retry.
+        await using var fixture = CreateViewModel();
+        var service = CreateConnectedChatService();
+        service.Setup(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()))
+            .ReturnsAsync((SessionNewResponse)null!);
+        await fixture.ViewModel.ReplaceChatServiceAsync(service.Object, TestContext.Current.CancellationToken);
+        await fixture.DispatchConnectionAsync(new SetForegroundTransportProfileAction("profile-1"));
+        await fixture.DispatchConnectionAsync(new SetConnectionInstanceIdAction("conn-1"));
+        await fixture.DispatchConnectionAsync(new SetConnectionPhaseAction(ConnectionPhase.Connected));
+
+        await fixture.ViewModel.EnsureNewSessionDraftAsync("/work", TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var state = await fixture.GetConnectionStateAsync();
+        Assert.Equal(NewSessionDraftPhase.Faulted, state.NewSessionDraft?.Phase);
+        Assert.False(fixture.ViewModel.IsNewSessionDraftLoading);
+        Assert.False(fixture.ViewModel.IsNewSessionDraftReady);
+        service.Verify(x => x.CreateSessionAsync(It.IsAny<SessionNewParams>()), Times.Once);
+        service.Verify(x => x.AuthenticateAsync(It.IsAny<AuthenticateParams>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -86,7 +86,8 @@ public partial class ChatViewModelTests
         IUiInteractionService? uiInteractionService = null,
         IAiContentReportLauncher? aiContentReportLauncher = null,
         IShellLayoutMetricsSink? shellLayoutMetricsSink = null,
-        bool enableWorkspacePersistence = false)
+        bool enableWorkspacePersistence = false,
+        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null)
     {
         var stateOwner = new object();
         var connectionStateOwner = new object();
@@ -236,7 +237,8 @@ public partial class ChatViewModelTests
                 languageService: languageService,
                 uiInteractionService: uiInteractionService,
                 aiContentReportLauncher: aiContentReportLauncher,
-                shellLayoutMetricsSink: shellLayoutMetricsSink);
+                shellLayoutMetricsSink: shellLayoutMetricsSink,
+                terminalAuthenticationCoordinator: terminalAuthenticationCoordinator);
             conversationCatalogFacade.SetPanelCleanup(viewModel);
             return new ViewModelFixture(
                 viewModel,

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/TerminalAuthenticationCoordinatorTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/TerminalAuthenticationCoordinatorTests.cs
@@ -1,0 +1,295 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public sealed class TerminalAuthenticationCoordinatorTests
+{
+    [Fact]
+    public async Task Authenticate_PendingOrDeclinedConsent_DoesNotSpawn()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var consent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Interaction.Confirm = (_, _) => consent.Task;
+
+        // Act
+        var pending = fixture.AuthenticateAsync();
+        Assert.Equal(0, fixture.SpawnCount);
+        consent.SetResult(false);
+
+        // Assert
+        Assert.False(await pending);
+        Assert.Equal(0, fixture.SpawnCount);
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_ExitZero_DisposesThenReconnectsWithExpectedIdentity()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Session.Exit.TrySetResult(0);
+
+        // Act
+        var result = await fixture.AuthenticateAsync();
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, fixture.SpawnCount);
+        Assert.Equal(1, fixture.Session.DisposeCount);
+        Assert.Equal(1, fixture.ReconnectCount);
+        Assert.True(fixture.ReconnectContext!.Value.ForceReconnect);
+        Assert.Same(fixture.Service.Object, fixture.ReconnectContext.Value.ExpectedChatService);
+        Assert.Equal("connection-1", fixture.ReconnectContext.Value.ExpectedConnectionInstanceId);
+        Assert.Equal(new[] { "--acp", "login" }, fixture.Invocation!.Arguments);
+        Assert.Equal("method", fixture.Invocation.Environment["TOKEN"]);
+        fixture.Service.Verify(x => x.AuthenticateAsync(It.IsAny<AuthenticateParams>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(null)]
+    public async Task Authenticate_UnsuccessfulTermination_DoesNotReconnect(int? exitCode)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Session.Exit.TrySetResult(exitCode);
+
+        // Act / Assert
+        Assert.False(await fixture.AuthenticateAsync());
+        Assert.Equal(1, fixture.Session.DisposeCount);
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_UserClosesDialog_ReclaimsSessionWithoutReconnect()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Interaction.Show = (_, _) => Task.CompletedTask;
+
+        // Act / Assert
+        Assert.False(await fixture.AuthenticateAsync());
+        Assert.Equal(1, fixture.Session.DisposeCount);
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_CallerCancels_ReclaimsSessionWithoutReconnect()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        // Act
+        var pending = fixture.AuthenticateAsync(cancellation.Token);
+        await fixture.Interaction.Shown.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await cancellation.CancelAsync();
+
+        // Assert
+        Assert.False(await pending);
+        Assert.Equal(1, fixture.Session.DisposeCount);
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    [Theory]
+    [InlineData("profile")]
+    [InlineData("conversation")]
+    [InlineData("connection")]
+    [InlineData("service")]
+    public async Task Authenticate_NewIntentDuringLogin_CancelsBeforeSuccessCanReconnect(string changed)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var pending = fixture.AuthenticateAsync();
+        await fixture.Interaction.Shown.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        switch (changed)
+        {
+            case "profile": fixture.Sink.SetupGet(x => x.SelectedProfileId).Returns("profile-2"); break;
+            case "conversation": fixture.Sink.SetupGet(x => x.CurrentSessionId).Returns("conversation-2"); break;
+            case "connection": fixture.Sink.SetupGet(x => x.ConnectionInstanceId).Returns("connection-2"); break;
+            default: fixture.Sink.SetupGet(x => x.CurrentChatService).Returns(Mock.Of<IChatService>()); break;
+        }
+
+        fixture.Sink.Raise(x => x.PropertyChanged += null, new PropertyChangedEventArgs(null));
+        fixture.Session.Exit.TrySetResult(0);
+
+        // Assert
+        Assert.False(await pending);
+        Assert.Equal(1, fixture.Session.DisposeCount);
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_ParallelRequests_OnlyOneInteractiveSession()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var first = fixture.AuthenticateAsync();
+        await fixture.Interaction.Shown.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        Assert.False(await fixture.AuthenticateAsync());
+        fixture.Session.Exit.TrySetResult(0);
+
+        // Assert
+        Assert.True(await first);
+        Assert.Equal(1, fixture.SpawnCount);
+        Assert.Equal(1, fixture.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task Dispose_ActiveLogin_DrainsBeforeReturning()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var pending = fixture.AuthenticateAsync();
+        await fixture.Interaction.Shown.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        await fixture.Coordinator.DisposeAsync();
+
+        // Assert
+        Assert.False(await pending);
+        Assert.Equal(1, fixture.Session.DisposeCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_UnsupportedHost_DoesNotAskOrSpawn()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Factory.SetupGet(x => x.IsSupported).Returns(false);
+
+        // Act / Assert
+        Assert.False(await fixture.AuthenticateAsync());
+        Assert.Equal(0, fixture.Interaction.ConfirmCount);
+        Assert.Equal(0, fixture.SpawnCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_RemoteConnectionWithoutInvocation_DoesNotAskOrSpawn()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Service.As<IStdioInvocationSource>().SetupGet(x => x.StdioInvocation).Returns((StdioInvocationSnapshot?)null);
+
+        // Act / Assert
+        Assert.False(await fixture.AuthenticateAsync());
+        Assert.Equal(0, fixture.Interaction.ConfirmCount);
+        Assert.Equal(0, fixture.SpawnCount);
+    }
+
+    [Fact]
+    public async Task Authenticate_SpawnFailureWithSecrets_DoesNotPublishExceptionText()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        fixture.Factory.Setup(x => x.StartAsync(It.IsAny<StdioInvocationSnapshot>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("secret-command secret-env"));
+
+        // Act / Assert
+        Assert.False(await fixture.AuthenticateAsync());
+        Assert.Equal(0, fixture.ReconnectCount);
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        public readonly Mock<IChatService> Service = new();
+        public readonly Mock<IAcpChatCoordinatorSink> Sink = new();
+        public readonly Mock<ITerminalAuthenticationSessionFactory> Factory = new();
+        public readonly Interaction Interaction = new();
+        public readonly Session Session = new();
+        public readonly TerminalAuthenticationCoordinator Coordinator;
+        public StdioInvocationSnapshot? Invocation;
+        public AcpConnectionContext? ReconnectContext;
+        public int SpawnCount;
+        public int ReconnectCount;
+
+        public Fixture()
+        {
+            Service.As<IStdioInvocationSource>().SetupGet(x => x.StdioInvocation).Returns(
+                new StdioInvocationSnapshot("agent", ["--acp"], new Dictionary<string, string> { ["TOKEN"] = "base" }, "/work", true));
+            Service.SetupGet(x => x.IsConnected).Returns(true);
+            Service.SetupGet(x => x.IsInitialized).Returns(true);
+            Sink.SetupGet(x => x.CurrentChatService).Returns(Service.Object);
+            Sink.SetupGet(x => x.IsInitialized).Returns(true);
+            Sink.SetupGet(x => x.SelectedProfileId).Returns("profile-1");
+            Sink.SetupGet(x => x.CurrentSessionId).Returns("conversation-1");
+            Sink.SetupGet(x => x.ConnectionInstanceId).Returns("connection-1");
+            Sink.SetupGet(x => x.ConnectionGeneration).Returns(1);
+            Factory.SetupGet(x => x.IsSupported).Returns(true);
+            Factory.Setup(x => x.StartAsync(It.IsAny<StdioInvocationSnapshot>(), It.IsAny<CancellationToken>()))
+                .Callback<StdioInvocationSnapshot, CancellationToken>((invocation, _) => { Invocation = invocation; SpawnCount++; })
+                .ReturnsAsync(Session);
+            Coordinator = new TerminalAuthenticationCoordinator(Factory.Object, Interaction,
+                new ImmediateUiDispatcher(), NullLogger<TerminalAuthenticationCoordinator>.Instance);
+        }
+
+        public Task<bool> AuthenticateAsync(CancellationToken? cancellationToken = null)
+            => Coordinator.TryAuthenticateAsync(new AuthMethodDefinition
+            {
+                Id = "login",
+                Name = "Login",
+                Type = "terminal",
+                Args = ["login"],
+                Env = new Dictionary<string, string> { ["TOKEN"] = "method" }
+            }, Sink.Object, (context, _) =>
+            {
+                Assert.Equal(1, Session.DisposeCount);
+                ReconnectContext = context;
+                ReconnectCount++;
+                return Task.FromResult(true);
+            }, cancellationToken ?? TestContext.Current.CancellationToken);
+
+        public ValueTask DisposeAsync() => Coordinator.DisposeAsync();
+    }
+
+    private sealed class Interaction : ITerminalAuthenticationInteraction
+    {
+        public readonly TaskCompletionSource Shown = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int ConfirmCount;
+        public Func<TerminalAuthenticationViewModel, CancellationToken, Task<bool>> Confirm = (_, _) => Task.FromResult(true);
+        public Func<TerminalAuthenticationViewModel, CancellationToken, Task>? Show;
+
+        public Task<bool> ConfirmAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken)
+        {
+            ConfirmCount++;
+            return Confirm(viewModel, cancellationToken);
+        }
+
+        public Task ShowSessionAsync(TerminalAuthenticationViewModel viewModel, CancellationToken cancellationToken)
+        {
+            Assert.NotNull(viewModel.Session);
+            Shown.TrySetResult();
+            return Show?.Invoke(viewModel, cancellationToken) ?? Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+
+    private sealed class Session : ITerminalAuthenticationSession
+    {
+        public readonly TaskCompletionSource<int?> Exit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int DisposeCount;
+        public Task<int?> Completion => Exit.Task;
+        public LocalTerminalTransportMode TransportMode => LocalTerminalTransportMode.PseudoConsole;
+        public bool CanAcceptInput => !Completion.IsCompleted;
+        public event EventHandler<string>? OutputReceived { add { } remove { } }
+        public event EventHandler? StateChanged { add { } remove { } }
+        public ValueTask WriteInputAsync(string input, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask ResizeAsync(int columns, int rows, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() { DisposeCount++; Exit.TrySetResult(null); return ValueTask.CompletedTask; }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Services/ApplicationShutdownWorkflowTests.cs
@@ -41,6 +41,23 @@ public sealed class ApplicationShutdownWorkflowTests
     }
 
     [Fact]
+    public async Task ShutdownAsync_AuthenticationActive_DrainsLoginBeforeAgentConnections()
+    {
+        // Arrange: sign-in could otherwise reconnect while the application drains its agent pool.
+        var authentication = new Mock<IAsyncDisposable>();
+        var harness = new Harness(terminalAuthentication: authentication.Object);
+        authentication.Setup(x => x.DisposeAsync()).Callback(() => harness.Order.Add("sign-in"))
+            .Returns(ValueTask.CompletedTask);
+
+        // Act
+        await harness.Workflow.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        authentication.Verify(x => x.DisposeAsync(), Times.Once);
+        Assert.Equal(new[] { "chat", "sign-in", "acp-drain", "discover", "acp-terminal", "local-terminal", "telemetry" }, harness.Order);
+    }
+
+    [Fact]
     public async Task ShutdownAsync_WhenOneChildProcessOwnerFails_StillReleasesTheRest()
     {
         // 一个 owner 释放失败不得让其余子进程继续泄漏：这正是"关不掉的 agent"最常见的成因。
@@ -167,7 +184,7 @@ public sealed class ApplicationShutdownWorkflowTests
 
     private sealed class Harness
     {
-        public Harness(bool includeLocalTerminals = true)
+        public Harness(bool includeLocalTerminals = true, IAsyncDisposable? terminalAuthentication = null)
         {
             Persistence = new Mock<IChatRuntimePersistence>();
             Persistence
@@ -199,7 +216,8 @@ public sealed class ApplicationShutdownWorkflowTests
                 Progress,
                 Telemetry.Object,
                 NullLogger<ApplicationShutdownWorkflow>.Instance,
-                LocalTerminals);
+                LocalTerminals,
+                terminalAuthentication);
         }
 
         public List<string> Order { get; } = new();

--- a/tests/SalmonEgg.TerminalAuth.Windows.Tests/Fixtures/TerminalAuthAgent.ps1
+++ b/tests/SalmonEgg.TerminalAuth.Windows.Tests/Fixtures/TerminalAuthAgent.ps1
@@ -1,0 +1,82 @@
+param(
+    [string] $BaseValue,
+    [string] $Mode = 'acp',
+    [string] $LoginValue
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+
+if ($Mode -eq 'acp') {
+    while ($null -ne ($line = [Console]::ReadLine())) {
+        $request = $line | ConvertFrom-Json
+        if ($request.method -eq 'initialize') {
+            $response = @{
+                jsonrpc = '2.0'
+                id = $request.id
+                result = @{
+                    protocolVersion = 1
+                    agentInfo = @{ name = 'terminal-auth-fixture'; version = '1.0' }
+                    agentCapabilities = @{}
+                    authMethods = @(@{
+                        id = 'fixture-login'
+                        name = 'Fixture login'
+                        type = 'terminal'
+                        args = @('-Mode', $env:SALMONEGG_AUTH_FIXTURE_MODE, '-LoginValue', 'login argument & literal')
+                        env = @{ SALMONEGG_AUTH_FIXTURE_VALUE = 'method override' }
+                    })
+                }
+            }
+            [Console]::WriteLine(($response | ConvertTo-Json -Depth 10 -Compress))
+        }
+    }
+    exit 0
+}
+
+# This must be a real console. Redirected pipes cannot satisfy terminal authentication.
+if ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected) {
+    exit 91
+}
+
+$descendantId = $null
+if ($Mode -eq 'cancel') {
+    $childStart = [Diagnostics.ProcessStartInfo]::new()
+    $childStart.FileName = (Get-Process -Id $PID).Path
+    $childStart.Arguments = '-NoLogo -NoProfile -Command "while ($true) { Start-Sleep -Seconds 1 }"'
+    $childStart.UseShellExecute = $false
+    $child = [Diagnostics.Process]::Start($childStart)
+    $descendantId = $child.Id
+    $child.Dispose()
+}
+
+$observation = @{
+    processId = $PID
+    descendantId = $descendantId
+    baseValue = $BaseValue
+    loginValue = $LoginValue
+    environmentValue = $env:SALMONEGG_AUTH_FIXTURE_VALUE
+    workingDirectory = [Environment]::CurrentDirectory
+    inputRedirected = [Console]::IsInputRedirected
+    outputRedirected = [Console]::IsOutputRedirected
+}
+[IO.File]::WriteAllText($env:SALMONEGG_AUTH_FIXTURE_OBSERVATION, ($observation | ConvertTo-Json -Compress))
+[Console]::WriteLine('TERMINAL_AUTH_READY')
+
+if ($Mode -eq 'cancel') {
+    # Keep producing output while teardown closes ConPTY. The client must drain it to avoid
+    # ClosePseudoConsole deadlocking, and closing the job must reclaim the descendant above.
+    while ($true) {
+        [Console]::WriteLine(('output while cancellation drains ' * 30))
+        Start-Sleep -Milliseconds 20
+    }
+}
+
+if ([Console]::ReadLine() -ne 'user confirmed') {
+    exit 92
+}
+[Console]::WriteLine('TERMINAL_AUTH_ACCEPTED')
+if ($Mode -eq 'failure') {
+    exit 23
+}
+exit 0

--- a/tests/SalmonEgg.TerminalAuth.Windows.Tests/SalmonEgg.TerminalAuth.Windows.Tests.csproj
+++ b/tests/SalmonEgg.TerminalAuth.Windows.Tests/SalmonEgg.TerminalAuth.Windows.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../src/SalmonEgg.Infrastructure.Desktop/SalmonEgg.Infrastructure.Desktop.csproj" />
+    <None Update="Fixtures/TerminalAuthAgent.ps1" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/SalmonEgg.TerminalAuth.Windows.Tests/TerminalAuthenticationWindowsTests.cs
+++ b/tests/SalmonEgg.TerminalAuth.Windows.Tests/TerminalAuthenticationWindowsTests.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Services;
+using SalmonEgg.Infrastructure.Transport;
+
+namespace SalmonEgg.TerminalAuth.Windows.Tests;
+
+public sealed class TerminalAuthenticationWindowsTests
+{
+    [Theory]
+    [InlineData("success", 0)]
+    [InlineData("failure", 23)]
+    public async Task StartAsync_ActualAgentInvocation_UsesConsoleAndPreservesNormalExitResult(string mode, int exitCode)
+    {
+        // Arrange: obtain the invocation and terminal method from a live ACP process.
+        await using var agent = await AgentFixture.CreateAsync(mode);
+        await using var factory = new TerminalAuthenticationSessionFactory(new PlatformCapabilityService());
+        Assert.True(factory.IsSupported);
+        await using var session = await factory.StartAsync(agent.LoginInvocation, TestContext.Current.CancellationToken);
+        using var output = new TerminalOutput(session);
+
+        // Act: interact over the real ConPTY pipe and observe its actual exit code.
+        await output.WaitForAsync("TERMINAL_AUTH_READY");
+        await session.ResizeAsync(90, 24, TestContext.Current.CancellationToken);
+        await session.WriteInputAsync("user confirmed\r", TestContext.Current.CancellationToken);
+        Assert.Equal(exitCode, await session.Completion.WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken));
+        await output.WaitForAsync("TERMINAL_AUTH_ACCEPTED");
+
+        // Assert: argv boundaries, the effective environment override and cwd reached the process.
+        using var observation = await agent.ReadObservationAsync();
+        var root = observation.RootElement;
+        Assert.False(root.GetProperty("inputRedirected").GetBoolean());
+        Assert.False(root.GetProperty("outputRedirected").GetBoolean());
+        Assert.Equal("base argument", root.GetProperty("baseValue").GetString());
+        Assert.Equal("login argument & literal", root.GetProperty("loginValue").GetString());
+        Assert.Equal("method override", root.GetProperty("environmentValue").GetString());
+        Assert.Equal(agent.LoginInvocation.WorkingDirectory, root.GetProperty("workingDirectory").GetString(), ignoreCase: true);
+        Assert.False(session.CanAcceptInput);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DisposeAsync_ActiveConsole_ReclaimsProcessTreeAndDoesNotReportSuccess(bool disposeFactory)
+    {
+        // Arrange: the login process starts a descendant inside the Windows job.
+        await using var agent = await AgentFixture.CreateAsync("cancel");
+        await using var factory = new TerminalAuthenticationSessionFactory(new PlatformCapabilityService());
+        await using var session = await factory.StartAsync(agent.LoginInvocation, TestContext.Current.CancellationToken);
+        using var output = new TerminalOutput(session);
+        await output.WaitForAsync("TERMINAL_AUTH_READY");
+        using var observation = await agent.ReadObservationAsync();
+        using var process = Process.GetProcessById(observation.RootElement.GetProperty("processId").GetInt32());
+        using var descendant = Process.GetProcessById(observation.RootElement.GetProperty("descendantId").GetInt32());
+
+        // Act: both closing a login dialog and application shutdown must own teardown.
+        var teardown = disposeFactory ? factory.DisposeAsync() : session.DisposeAsync();
+        await teardown.AsTask().WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
+
+        // Assert: a closed console never becomes a successful login, and no descendants survive.
+        Assert.Null(await session.Completion);
+        Assert.False(session.CanAcceptInput);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await descendant.WaitForExitAsync(TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        Assert.True(process.HasExited);
+        Assert.True(descendant.HasExited);
+    }
+
+    private sealed class AgentFixture : IAsyncDisposable
+    {
+        private readonly string _directory;
+        private readonly StdioTransport _transport;
+        private readonly AcpClient _client;
+
+        private AgentFixture(string directory, StdioTransport transport, AcpClient client, StdioInvocationSnapshot invocation)
+        {
+            _directory = directory;
+            _transport = transport;
+            _client = client;
+            LoginInvocation = invocation;
+        }
+
+        public StdioInvocationSnapshot LoginInvocation { get; }
+
+        public static async Task<AgentFixture> CreateAsync(string mode)
+        {
+            // The platform project must fail when run in an unsuitable environment; never skip.
+            Assert.True(OperatingSystem.IsWindows(), "This gate requires a Windows host with ConPTY.");
+            var directory = Path.Combine(Path.GetTempPath(), $"salmon-egg-terminal-auth-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+            var command = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell", "v1.0", "powershell.exe");
+            var script = Path.Combine(AppContext.BaseDirectory, "Fixtures", "TerminalAuthAgent.ps1");
+            var transport = new StdioTransport(command,
+                ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script, "-BaseValue", "base argument"],
+                environment: new Dictionary<string, string>
+                {
+                    ["SALMONEGG_AUTH_FIXTURE_MODE"] = mode,
+                    ["SALMONEGG_AUTH_FIXTURE_VALUE"] = "base value",
+                    ["SALMONEGG_AUTH_FIXTURE_OBSERVATION"] = Path.Combine(directory, "observation.json")
+                });
+            var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            try
+            {
+                Assert.True(await transport.ConnectAsync(TestContext.Current.CancellationToken));
+                var response = await client.InitializeAsync(new InitializeParams(
+                    new ClientInfo("terminal-auth-gate", "1.0"),
+                    new ClientCapabilities { Auth = new AuthCapabilities { Terminal = true } }), TestContext.Current.CancellationToken);
+                var method = Assert.Single(response.AuthMethods!);
+                Assert.Equal("terminal", method.ResolvedType);
+                var invocation = Assert.IsType<StdioInvocationSnapshot>(transport.StdioInvocation);
+                return new AgentFixture(directory, transport, client, invocation.WithAuthenticationMethod(method.Args, method.Env));
+            }
+            catch
+            {
+                client.Dispose();
+                transport.Dispose();
+                Directory.Delete(directory, recursive: true);
+                throw;
+            }
+        }
+
+        public async Task<JsonDocument> ReadObservationAsync() => JsonDocument.Parse(
+            await File.ReadAllTextAsync(Path.Combine(_directory, "observation.json"), TestContext.Current.CancellationToken));
+
+        public async ValueTask DisposeAsync()
+        {
+            _client.Dispose();
+            await _transport.DisconnectAsync();
+            _transport.Dispose();
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private sealed class TerminalOutput : IDisposable
+    {
+        private readonly ITerminalAuthenticationSession _session;
+        private readonly StringBuilder _output = new();
+        private readonly object _gate = new();
+        private TaskCompletionSource _changed = NewSignal();
+
+        public TerminalOutput(ITerminalAuthenticationSession session)
+        {
+            _session = session;
+            session.OutputReceived += OnOutput;
+        }
+
+        public void Dispose() => _session.OutputReceived -= OnOutput;
+
+        public async Task WaitForAsync(string marker)
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(20));
+            while (true)
+            {
+                Task changed;
+                lock (_gate)
+                {
+                    if (_output.ToString().Contains(marker, StringComparison.Ordinal)) return;
+                    changed = _changed.Task;
+                }
+
+                await changed.WaitAsync(timeout.Token);
+            }
+        }
+
+        private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private void OnOutput(object? sender, string text)
+        {
+            lock (_gate)
+            {
+                _output.Append(text);
+                if (_output.Length > 128 * 1024) _output.Remove(0, _output.Length - 64 * 1024);
+                _changed.TrySetResult();
+                _changed = NewSignal();
+            }
+        }
+    }
+}

--- a/tests/SalmonEgg.TerminalAuth.Windows.Tests/TerminalAuthenticationWindowsTests.cs
+++ b/tests/SalmonEgg.TerminalAuth.Windows.Tests/TerminalAuthenticationWindowsTests.cs
@@ -20,7 +20,7 @@ public sealed class TerminalAuthenticationWindowsTests
     {
         // Arrange: obtain the invocation and terminal method from a live ACP process.
         await using var agent = await AgentFixture.CreateAsync(mode);
-        await using var factory = new TerminalAuthenticationSessionFactory(new PlatformCapabilityService());
+        await using var factory = new TerminalAuthenticationSessionFactory(new ConPtyGateCapabilities());
         Assert.True(factory.IsSupported);
         await using var session = await factory.StartAsync(agent.LoginInvocation, TestContext.Current.CancellationToken);
         using var output = new TerminalOutput(session);
@@ -51,7 +51,7 @@ public sealed class TerminalAuthenticationWindowsTests
     {
         // Arrange: the login process starts a descendant inside the Windows job.
         await using var agent = await AgentFixture.CreateAsync("cancel");
-        await using var factory = new TerminalAuthenticationSessionFactory(new PlatformCapabilityService());
+        await using var factory = new TerminalAuthenticationSessionFactory(new ConPtyGateCapabilities());
         await using var session = await factory.StartAsync(agent.LoginInvocation, TestContext.Current.CancellationToken);
         using var output = new TerminalOutput(session);
         await output.WaitForAsync("TERMINAL_AUTH_READY");
@@ -70,6 +70,25 @@ public sealed class TerminalAuthenticationWindowsTests
         await descendant.WaitForExitAsync(TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.True(process.HasExited);
         Assert.True(descendant.HasExited);
+    }
+
+    // This gate exercises the actual PTY host before the application opts into the capability.
+    // Product advertisement remains governed by PlatformCapabilityService and the application GUI gate.
+    private sealed class ConPtyGateCapabilities : IPlatformCapabilityService
+    {
+        public bool SupportsTerminalAuthentication => OperatingSystem.IsWindows();
+        public bool SupportsStdioTransport => OperatingSystem.IsWindows();
+        public bool SupportsInteractiveTerminalSurface => OperatingSystem.IsWindows();
+        public bool SupportsLocalTerminal => OperatingSystem.IsWindows();
+        public bool SupportsLaunchOnStartup => false;
+        public bool SupportsTray => false;
+        public bool SupportsLanguageOverride => false;
+        public bool SupportsMiniWindow => false;
+        public bool SupportsExternalFileOpen => false;
+        public bool SupportsLocalFileExport => false;
+        public bool SupportsGamepadInput => false;
+        public bool SupportsCliCommandInspection => false;
+        public bool SupportsCliCommandLinking => false;
     }
 
     private sealed class AgentFixture : IAsyncDisposable


### PR DESCRIPTION
终端认证方法不能发送给 `authenticate`，它要求按当前 Agent 的启动快照运行独立交互进程。本 PR 实现用户同意、Windows ConPTY 登录、退出码判定、重连与原操作重试；取消或连接身份变化会回收原进程，旧登录结果不能覆盖新的凭据连接。

产品暂不广告 `auth.terminal`，包括 Windows。启用前仍需用本次安装包完成“同意 → 终端交互 → 退出 → 重连 → 重试”和取消回收的 GUI 验收。专用 Windows 测试显式启用真实 ConPTY host，验证参数、环境、工作目录、退出码和子孙进程回收；Unix 仍缺可信的异常退出判据。

已整合 main `027514f2` 的取消、V2 生命周期、投影、权限和批处理修复。凭据快照继续沿原服务转发，登录的连接身份检查发生在可能取消新连接的操作之前。WASM 门禁使用当前语义控件的原生焦点与跨帧就绪状态，保留真实按键和协议结果断言。

验证：本地 SDK 1190/1190、Presentation 3523/3523；全部零失败、零跳过。最终提交 `4389e791` 的 19 项检查通过、1 项仓库条件检查跳过；包含真实 Windows ConPTY、WASM 全链、SDK 包消费和全部平台构建。生产仍默认 ACP V1。Refs #144、#147；真实第三方 Agent 与安装包 GUI 验收未完成，不关闭总单。
