### PR TITLE
feat(acp): add consent-driven URL elicitation

### DIFF
--- a/.github/workflows/gui-smoke-gates.yml
+++ b/.github/workflows/gui-smoke-gates.yml
@@ -71,6 +71,23 @@ jobs:
       - name: Run Skia Desktop GUI smoke
         run: ./scripts/gates/run-skia-desktop-gui-smoke-gates.sh Debug
 
+      # This checks the native launcher only. Native URL capability stays disabled until the
+      # product's GUI consent-to-browser path has its own platform gate as well.
+      - name: Run Linux external browser isolation probe
+        timeout-minutes: 3
+        env:
+          DOTNET_PROCESSOR_COUNT: "2"
+          DOTNET_CLI_USE_MSBUILD_SERVER: "0"
+          MSBUILDDISABLENODEREUSE: "1"
+        run: |
+          test -x /usr/bin/google-chrome
+          test -x /usr/bin/xdg-open
+          dotnet build scripts/gates/linux-elicitation-probe/linux-elicitation-probe.csproj \
+            --configuration Release -p:UseSharedCompilation=false
+          timeout --signal=TERM --kill-after=10s 70s python3 scripts/gates/linux-elicitation-browser-smoke.py \
+            scripts/gates/linux-elicitation-probe/bin/Release/net10.0/SalmonEgg.Gates.LinuxElicitationProbe.dll \
+            --dotnet "$(command -v dotnet)" --chromium /usr/bin/google-chrome
+
   deterministic-gui-smokes:
     name: Deterministic GUI Smoke Gates
     # This repository currently has no self-hosted Windows runner registered, so a dispatched run of

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -385,6 +385,15 @@ public static class DependencyInjection
 #endif
         services.AddSingleton<ITerminalAuthenticationInteraction, TerminalAuthenticationInteraction>();
         services.AddSingleton<TerminalAuthenticationCoordinator>();
+#if __WASM__
+#pragma warning disable CA1416 // This registration exists only in the browser target.
+        services.AddSingleton<IExternalUriLauncher, WasmElicitationUriLauncher>();
+#pragma warning restore CA1416
+#else
+        // Native URL elicitation stays off until the real GUI consent-to-browser chain is gated.
+        // The Linux launcher has its own browser isolation probe; that does not prove the GUI path.
+        services.AddSingleton<IExternalUriLauncher>(UnsupportedExternalUriLauncher.Instance);
+#endif
         services.AddSingleton<ITransportSupportPolicy, TransportSupportPolicy>();
 #if __WASM__
         if (OperatingSystem.IsBrowser())
@@ -634,7 +643,8 @@ public static class DependencyInjection
                 sp.GetRequiredService<IAcpConnectionSessionRegistry>(),
                 sp.GetRequiredService<IAcpConnectionSessionCleaner>(),
                 sp.GetRequiredService<IAcpConnectionPoolManager>(),
-                sp.GetRequiredService<IAcpConnectionDependencySnapshotProvider>());
+                sp.GetRequiredService<IAcpConnectionDependencySnapshotProvider>(),
+                platformCapabilities: sp.GetRequiredService<IPlatformCapabilityService>());
         });
         services.AddSingleton(sp =>
         {

--- a/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Program.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/WebAssembly/Program.cs
@@ -1,12 +1,15 @@
+using System.Runtime.Versioning;
 using Uno.UI.Hosting;
 
 namespace SalmonEgg;
 
+[SupportedOSPlatform("browser")]
 public class Program
 {
     public static async Task Main(string[] args)
     {
         App.InitializeLogging();
+        await Platforms.WebAssembly.WasmElicitationUriLauncher.InitializeAsync();
 
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())

--- a/SalmonEgg/SalmonEgg/Platforms/WebAssembly/WasmElicitationUriLauncher.cs
+++ b/SalmonEgg/SalmonEgg/Platforms/WebAssembly/WasmElicitationUriLauncher.cs
@@ -1,0 +1,63 @@
+#if __WASM__
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Platforms.WebAssembly;
+
+[SupportedOSPlatform("browser")]
+public sealed partial class WasmElicitationUriLauncher : IExternalUriLauncher
+{
+    private const string ModuleName = "salmon-egg-wasm-shell.js";
+    private static bool _isReady;
+
+    public bool IsSupported => _isReady && IsSupportedInterop();
+
+    public static async Task InitializeAsync()
+    {
+        try
+        {
+            await JSHost.ImportAsync(ModuleName, WasmModuleUrlResolver.Resolve(ModuleName)).ConfigureAwait(false);
+            _isReady = true;
+        }
+        catch
+        {
+            // Missing modules keep the capability off; never defer the import until consent.
+        }
+    }
+
+    public Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromResult(ExternalUriOpenResult.Cancelled);
+        }
+
+        if (!IsSupported)
+        {
+            return Task.FromResult(ExternalUriOpenResult.Unavailable);
+        }
+
+        try
+        {
+            return Task.FromResult(OpenInterop(target.FullUrl)
+                ? ExternalUriOpenResult.Dispatched : ExternalUriOpenResult.Blocked);
+        }
+        catch
+        {
+            // Platform exceptions may embed the URL; expose a bounded result without retaining them.
+            return Task.FromResult(ExternalUriOpenResult.Failed);
+        }
+    }
+
+    [JSImport("supportsExternalElicitation", ModuleName)]
+    private static partial bool IsSupportedInterop();
+
+    [JSImport("openExternalElicitation", ModuleName)]
+    private static partial bool OpenInterop(string url);
+}
+#endif

--- a/SalmonEgg/SalmonEgg/Platforms/WebAssembly/WasmScripts/salmon-egg-wasm-shell.js
+++ b/SalmonEgg/SalmonEgg/Platforms/WebAssembly/WasmScripts/salmon-egg-wasm-shell.js
@@ -1,3 +1,26 @@
+export function supportsExternalElicitation() {
+    return typeof window.open === "function" && typeof navigator.userActivation?.isActive === "boolean";
+}
+
+export function openExternalElicitation(value) {
+    if (!supportsExternalElicitation() || !navigator.userActivation.isActive) {
+        return false;
+    }
+
+    const target = new URL(value);
+    const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(target.hostname);
+    if (target.origin === window.location.origin || target.username || target.password ||
+        (target.protocol !== "https:" && !(target.protocol === "http:" && loopback))) {
+        return false;
+    }
+
+    // Native noopener creates an unrelated browsing context; assigning opener=null after opening
+    // would still allow named-window access after a redirect back to our origin. With noopener,
+    // browsers return null for both success and a blocked popup. True means dispatched, not opened.
+    window.open(target.href, "_blank", "noopener,noreferrer");
+    return true;
+}
+
 export async function copyToClipboard(text) {
     const value = text ?? "";
     if (navigator?.clipboard?.writeText) {

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
@@ -475,87 +475,122 @@
                                                 MaxContentWidth="{x:Bind models:UiLayout.ContentMaxWidth, Mode=OneTime}"
                                                 Visibility="{x:Bind ViewModel.HasPendingElicitationRequest, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                     <controls:ResponsiveContentHost.Child>
-                        <Border x:Name="ElicitationHost"
-                                Margin="{StaticResource ChatElicitationMargin}"
-                                Padding="{StaticResource ChatElicitationPadding}"
-                                CornerRadius="{StaticResource ChatElicitationCornerRadius}"
-                                Background="{ThemeResource LayerFillColorDefaultBrush}"
-                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                                BorderThickness="{StaticResource ChatElicitationBorderThickness}">
-                            <StackPanel Spacing="{StaticResource ChatElicitationSectionSpacing}">
-                                <StackPanel Spacing="{StaticResource ChatElicitationHeadingSpacing}">
-                                    <TextBlock x:Uid="ChatViewElicitationTitle"
-                                               FontSize="14"
-                                               FontWeight="SemiBold"
-                                               Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
-                                    <TextBlock Text="{x:Bind ViewModel.ElicitationPrompt, Mode=OneWay}"
-                                               TextWrapping="WrapWholeWords"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                </StackPanel>
-
-                                <ItemsControl ItemsSource="{x:Bind ViewModel.ElicitationFields, Mode=OneWay}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="elicitationVm:ElicitationFieldViewModel">
-                                            <StackPanel Spacing="{StaticResource ChatElicitationFieldSpacing}"
-                                                        Margin="{StaticResource ChatElicitationFieldMargin}">
-                                                <TextBlock Text="{x:Bind Title}" FontWeight="SemiBold"/>
-                                                <TextBlock Text="{x:Bind Description}"
+                        <ContentControl Content="{x:Bind ViewModel.PendingElicitationRequest, Mode=OneWay}"
+                                        HorizontalContentAlignment="Stretch"
+                                        IsTabStop="False">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate x:DataType="elicitationVm:ElicitationRequestViewModel">
+                                    <Border AutomationProperties.AutomationId="ElicitationHost"
+                                            Margin="{StaticResource ChatElicitationMargin}"
+                                            Padding="{StaticResource ChatElicitationPadding}"
+                                            CornerRadius="{StaticResource ChatElicitationCornerRadius}"
+                                            Background="{ThemeResource LayerFillColorDefaultBrush}"
+                                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                            BorderThickness="{StaticResource ChatElicitationBorderThickness}">
+                                        <StackPanel Spacing="{StaticResource ChatElicitationSectionSpacing}">
+                                            <StackPanel Spacing="{StaticResource ChatElicitationHeadingSpacing}">
+                                                <TextBlock x:Uid="ChatViewElicitationTitle"
+                                                           FontSize="14"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
+                                                <TextBlock Text="{x:Bind Prompt, Mode=OneWay}"
                                                            TextWrapping="WrapWholeWords"
                                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                                <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         Visibility="{x:Bind IsStringField, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                                <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         InputScope="Number"
-                                                         Visibility="{x:Bind IsIntegerField, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                                <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         InputScope="Number"
-                                                         Visibility="{x:Bind IsNumberField, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                                <CheckBox IsChecked="{x:Bind BooleanValue, Mode=TwoWay}"
-                                                          Visibility="{x:Bind IsBooleanField, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                                <ItemsControl ItemsSource="{x:Bind MultiSelectOptions, Mode=OneWay}"
-                                                              Visibility="{x:Bind IsMultiSelectField, Converter={StaticResource BoolToVisibilityConverter}}">
-                                                    <ItemsControl.ItemTemplate>
-                                                        <DataTemplate x:DataType="elicitationVm:ElicitationMultiSelectOptionViewModel">
-                                                            <CheckBox AutomationProperties.Name="{x:Bind DisplayName}"
-                                                                      IsChecked="{x:Bind IsSelected, Mode=TwoWay}">
-                                                                <StackPanel Spacing="{StaticResource ChatElicitationHeadingSpacing}">
-                                                                    <TextBlock Text="{x:Bind DisplayName}"
-                                                                               TextWrapping="WrapWholeWords" />
-                                                                    <TextBlock Text="{x:Bind Description}"
-                                                                               Style="{StaticResource CaptionTextBlockStyle}"
-                                                                               TextWrapping="WrapWholeWords"
-                                                                               Visibility="{x:Bind HasDescription, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                                </StackPanel>
-                                                            </CheckBox>
-                                                        </DataTemplate>
-                                                    </ItemsControl.ItemTemplate>
-                                                </ItemsControl>
-                                                <TextBlock Text="{x:Bind ErrorMessage, Mode=OneWay}"
-                                                           Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                                           TextWrapping="WrapWholeWords"/>
                                             </StackPanel>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
 
-                                <TextBlock Text="{x:Bind ViewModel.ElicitationErrorMessage, Mode=OneWay}"
-                                           Visibility="{x:Bind ViewModel.ElicitationHasError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                           TextWrapping="WrapWholeWords"/>
+                                            <TextBlock Text="{x:Bind AgentName, Mode=OneWay}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       TextWrapping="Wrap"/>
+                                            <StackPanel Spacing="{StaticResource ChatElicitationFieldSpacing}"
+                                                        Visibility="{x:Bind IsUrl, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                <TextBlock x:Uid="ChatViewElicitationUrlConsent" TextWrapping="Wrap"/>
+                                                <TextBlock Text="{x:Bind UrlHost, Mode=OneWay}"
+                                                           AutomationProperties.AutomationId="Elicitation.UrlHost"
+                                                           FontWeight="SemiBold" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+                                                <TextBlock Text="{x:Bind FullUrl, Mode=OneWay}"
+                                                           AutomationProperties.AutomationId="Elicitation.FullUrl"
+                                                           TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+                                                <TextBlock x:Uid="ChatViewElicitationUrlWarning"
+                                                           Visibility="{x:Bind HasUrlWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                           Foreground="{ThemeResource SystemFillColorCautionBrush}" TextWrapping="Wrap"/>
+                                                <TextBlock Text="{x:Bind UrlStatus, Mode=OneWay}"
+                                                           Visibility="{x:Bind IsAwaitingCompletion, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                           AutomationProperties.LiveSetting="Polite" TextWrapping="Wrap"/>
+                                            </StackPanel>
 
-                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
-                                            Spacing="{StaticResource ChatElicitationActionSpacing}">
-                                    <Button x:Uid="ChatViewElicitationCancelButton"
-                                            Command="{x:Bind ViewModel.ElicitationCancelCommand, Mode=OneWay}"/>
-                                    <Button x:Uid="ChatViewElicitationDeclineButton"
-                                            Command="{x:Bind ViewModel.ElicitationDeclineCommand, Mode=OneWay}"/>
-                                    <Button x:Uid="ChatViewElicitationSubmitButton"
-                                            Command="{x:Bind ViewModel.ElicitationSubmitCommand, Mode=OneWay}"
-                                            Style="{StaticResource AccentButtonStyle}"/>
-                                </StackPanel>
-                            </StackPanel>
-                        </Border>
+                                            <ItemsControl ItemsSource="{x:Bind Fields, Mode=OneWay}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="elicitationVm:ElicitationFieldViewModel">
+                                                        <StackPanel Spacing="{StaticResource ChatElicitationFieldSpacing}"
+                                                                    Margin="{StaticResource ChatElicitationFieldMargin}">
+                                                            <TextBlock Text="{x:Bind Title}" FontWeight="SemiBold"/>
+                                                            <TextBlock Text="{x:Bind Description}"
+                                                                       TextWrapping="WrapWholeWords"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                                            <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                     Visibility="{x:Bind IsStringField, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                            <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                     InputScope="Number"
+                                                                     Visibility="{x:Bind IsIntegerField, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                            <TextBox Text="{x:Bind FieldInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                     InputScope="Number"
+                                                                     Visibility="{x:Bind IsNumberField, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                            <CheckBox IsChecked="{x:Bind BooleanValue, Mode=TwoWay}"
+                                                                      Visibility="{x:Bind IsBooleanField, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                            <ItemsControl ItemsSource="{x:Bind MultiSelectOptions, Mode=OneWay}"
+                                                                          Visibility="{x:Bind IsMultiSelectField, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate x:DataType="elicitationVm:ElicitationMultiSelectOptionViewModel">
+                                                                        <CheckBox AutomationProperties.Name="{x:Bind DisplayName}"
+                                                                                  IsChecked="{x:Bind IsSelected, Mode=TwoWay}">
+                                                                            <StackPanel Spacing="{StaticResource ChatElicitationHeadingSpacing}">
+                                                                                <TextBlock Text="{x:Bind DisplayName}"
+                                                                                           TextWrapping="WrapWholeWords" />
+                                                                                <TextBlock Text="{x:Bind Description}"
+                                                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                                                           TextWrapping="WrapWholeWords"
+                                                                                           Visibility="{x:Bind HasDescription, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                                            </StackPanel>
+                                                                        </CheckBox>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                            <TextBlock Text="{x:Bind ErrorMessage, Mode=OneWay}"
+                                                                       Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                                       TextWrapping="WrapWholeWords"/>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+
+                                            <TextBlock Text="{x:Bind ErrorMessage, Mode=OneWay}"
+                                                       Visibility="{x:Bind HasError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       TextWrapping="WrapWholeWords"/>
+
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                                                        Spacing="{StaticResource ChatElicitationActionSpacing}">
+                                                <Button x:Uid="ChatViewElicitationCancelButton"
+                                                        Command="{x:Bind CancelCommand, Mode=OneWay}"/>
+                                                <Button x:Uid="ChatViewElicitationDeclineButton"
+                                                        Command="{x:Bind DeclineCommand, Mode=OneWay}"/>
+                                                <Button Content="{x:Bind SubmitText, Mode=OneWay}"
+                                                        AutomationProperties.Name="{x:Bind SubmitText, Mode=OneWay}"
+                                                        Command="{x:Bind SubmitCommand, Mode=OneWay}"
+                                                        Style="{StaticResource AccentButtonStyle}"/>
+                                                <Button x:Uid="ChatViewElicitationReopenButton"
+                                                        Visibility="{x:Bind ShowReopen, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                        Command="{x:Bind ReopenCommand, Mode=OneWay}"/>
+                                                <Button x:Uid="ChatViewElicitationDismissButton"
+                                                        Visibility="{x:Bind IsAwaitingCompletion, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                        Command="{x:Bind DismissCommand, Mode=OneWay}"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ContentControl.ContentTemplate>
+                        </ContentControl>
                     </controls:ResponsiveContentHost.Child>
                 </controls:ResponsiveContentHost>
 

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -1801,4 +1801,16 @@
   <data name="CommandLine_UsageHintTitle.Text" xml:space="preserve">
     <value>Try it</value>
   </data>
+  <data name="ChatViewElicitationUrlConsent.Text" xml:space="preserve">
+    <value>Review the complete address. Choosing Open in browser gives consent to visit it; it does not confirm the external step is complete.</value>
+  </data>
+  <data name="ChatViewElicitationUrlWarning.Text" xml:space="preserve">
+    <value>Check the domain carefully: it uses international characters, a numeric address, or an unusual port and may differ from a familiar website.</value>
+  </data>
+  <data name="ChatViewElicitationDismissButton.Content" xml:space="preserve">
+    <value>Close notice</value>
+  </data>
+  <data name="ChatViewElicitationReopenButton.Content" xml:space="preserve">
+    <value>Open again</value>
+  </data>
 </root>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1906,4 +1906,16 @@
   <data name="CommandLine_UsageHintTitle.Text" xml:space="preserve">
     <value>Try it</value>
   </data>
+  <data name="ChatViewElicitationUrlConsent.Text" xml:space="preserve">
+    <value>Review the complete address. Choosing Open in browser gives consent to visit it; it does not confirm the external step is complete.</value>
+  </data>
+  <data name="ChatViewElicitationUrlWarning.Text" xml:space="preserve">
+    <value>Check the domain carefully: it uses international characters, a numeric address, or an unusual port and may differ from a familiar website.</value>
+  </data>
+  <data name="ChatViewElicitationDismissButton.Content" xml:space="preserve">
+    <value>Close notice</value>
+  </data>
+  <data name="ChatViewElicitationReopenButton.Content" xml:space="preserve">
+    <value>Open again</value>
+  </data>
 </root>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -1801,4 +1801,16 @@
   <data name="CommandLine_UsageHintTitle.Text" xml:space="preserve">
     <value>试一下</value>
   </data>
+  <data name="ChatViewElicitationUrlConsent.Text" xml:space="preserve">
+    <value>请核对完整地址。只有点击“在浏览器中打开”才会访问此网页；这不代表外部操作已经完成。</value>
+  </data>
+  <data name="ChatViewElicitationUrlWarning.Text" xml:space="preserve">
+    <value>请仔细核对域名：它包含国际化字符、数字地址或非常规端口，可能与熟悉的网站不同。</value>
+  </data>
+  <data name="ChatViewElicitationDismissButton.Content" xml:space="preserve">
+    <value>关闭提示</value>
+  </data>
+  <data name="ChatViewElicitationReopenButton.Content" xml:space="preserve">
+    <value>再次打开</value>
+  </data>
 </root>

--- a/scripts/gates/linux-elicitation-browser-smoke.py
+++ b/scripts/gates/linux-elicitation-browser-smoke.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Exercise a freshly built launcher through real xdg-open and a separate Chromium process."""
+
+import argparse
+import ctypes
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("probe", type=Path, help="Freshly built LinuxElicitationProbe DLL")
+    parser.add_argument("--dotnet", required=True)
+    parser.add_argument("--chromium", required=True)
+    options = parser.parse_args()
+    assert options.probe.is_file()
+    assert Path(options.chromium).is_file()
+    # Reap the opener's browser descendants after the short-lived probe has exited.
+    assert ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) == 0
+    received = threading.Event()
+    reports = []
+    visits = []
+    nonce = os.urandom(12).hex()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_GET(self):
+            if not self.path.startswith("/authorize?"):
+                self.send_error(404)
+                return
+            visits.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"""<!doctype html><input id='private' value='page-private-canary'>
+                <script>fetch('/report', {method:'POST', body: JSON.stringify({
+                opener: window.opener === null, referrer: document.referrer,
+                privateValue: document.querySelector('#private').value
+                })}).finally(() => document.title='External step complete');</script>""")
+
+        def do_POST(self):
+            reports.append(json.loads(self.rfile.read(int(self.headers["Content-Length"]))))
+            self.send_response(204)
+            self.end_headers()
+            received.set()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    process = None
+    browser_pid = None
+    try:
+        with tempfile.TemporaryDirectory(prefix="salmon-egg-url-browser-") as directory:
+            root = Path(directory)
+            pid_file = root / "browser.pid"
+            browser_profile = root / "profile"
+            browser_log = root / "browser.log"
+            browser_log.touch(mode=0o600)
+            launcher = root / "browser-handler"
+            launcher.write_text("#!/bin/sh\n"
+                "printf 'launcher-private-canary\\n'\n"
+                "printf 'launcher-private-canary\\n' >&2\n"
+                f"{shlex.quote(options.chromium)} --headless=new --disable-gpu --no-first-run "
+                f"--no-default-browser-check --user-data-dir={shlex.quote(str(browser_profile))} "
+                f'"$1" >{shlex.quote(str(browser_log))} 2>&1 &\n'
+                f'printf "%s\\n" "$!" > {shlex.quote(str(pid_file))}\n'
+                "exit 0\n")
+            launcher.chmod(0o700)
+            env = os.environ.copy()
+            env.update(PATH="/usr/bin:/bin", BROWSER=str(launcher), XDG_CURRENT_DESKTOP="X-Generic")
+            env.pop("DISPLAY", None)
+            env.pop("WAYLAND_DISPLAY", None)
+            url = f"http://127.0.0.1:{server.server_port}/authorize?url-private-canary={nonce}"
+            private_values = (url, nonce, "page-private-canary", "launcher-private-canary")
+            process = subprocess.Popen([options.dotnet, str(options.probe)], env=env,
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True, start_new_session=True)
+            try:
+                output, errors = process.communicate(url + "\n", timeout=25)
+                if pid_file.exists():
+                    browser_pid = int(pid_file.read_text())
+                assert process.returncode == 0, "Launcher failed: " + redact_diagnostic(output + errors, private_values)
+                assert output.strip() == "Opened", redact_diagnostic(output, private_values)
+                assert errors == "", redact_diagnostic(errors, private_values)
+                assert received.wait(15), describe_browser_failure(browser_log, browser_pid, private_values)
+                assert len(visits) == 1, f"Expected one browser visit; observed {len(visits)}."
+                assert reports == [{"opener": True, "referrer": "", "privateValue": "page-private-canary"}]
+                assert browser_pid is not None
+                args = Path(f"/proc/{browser_pid}/cmdline").read_bytes().replace(b"\0", b" ")
+                assert b"--remote-debugging" not in args, "The product must not receive a browser debugging bridge."
+                assert b"--no-sandbox" not in args, "The browser must retain its native sandbox."
+                for canary in private_values:
+                    assert canary not in output + errors
+                print(f"Linux URL launcher passed: artifact={options.probe}; real xdg-open; "
+                    "separate sandboxed browser; one visit; no opener/referrer/debug bridge; private output discarded.")
+            finally:
+                # The probe, opener and browser all belong to this isolated gate's process group.
+                # The production launcher itself deliberately never owns or kills the user's browser.
+                if process is not None:
+                    stop_owned_processes(process)
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join(timeout=5)
+
+
+def redact_diagnostic(text, private_values):
+    for value in private_values:
+        text = text.replace(value, "<redacted>")
+    return re.sub(r"\b(?:https?|wss?|file)://\S+", "<redacted-url>", text)
+
+
+def describe_browser_failure(log_path, browser_pid, private_values):
+    # Chrome startup errors must remain observable without publishing the controlled URL or
+    # private page/handler output. The raw file lives only in this gate's private temp directory.
+    details = log_path.read_text(errors="replace") if log_path.exists() else ""
+    diagnostic = redact_diagnostic(details, private_values)[-8000:]
+    if browser_pid is None:
+        state = "handler-not-invoked"
+    else:
+        try:
+            state = Path(f"/proc/{browser_pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+        except FileNotFoundError:
+            state = "exited"
+    return "The real browser never visited the controlled external page. " \
+        + f"Browser process state={state}; stderr={diagnostic or '<empty>'}"
+
+
+def stop_owned_processes(process):
+    for termination in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(process.pid, termination)
+        except ProcessLookupError:
+            pass
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                child, _status = os.waitpid(-1, os.WNOHANG)
+                if child:
+                    continue
+            except ChildProcessError:
+                return
+            time.sleep(0.05)
+    raise RuntimeError("The gate could not reap its browser descendants.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/linux-elicitation-browser-smoke.py
+++ b/scripts/gates/linux-elicitation-browser-smoke.py
@@ -15,6 +15,8 @@ import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+BrowserVisitTimeout = 45.0
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -27,6 +29,8 @@ def main():
     # Reap the opener's browser descendants after the short-lived probe has exited.
     assert ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) == 0
     received = threading.Event()
+    visited = threading.Event()
+    first_visit_at = None
     reports = []
     visits = []
     nonce = os.urandom(12).hex()
@@ -36,10 +40,14 @@ def main():
             pass
 
         def do_GET(self):
+            nonlocal first_visit_at
             if not self.path.startswith("/authorize?"):
                 self.send_error(404)
                 return
             visits.append(self.path)
+            if first_visit_at is None:
+                first_visit_at = time.monotonic()
+            visited.set()
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
@@ -87,13 +95,19 @@ def main():
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, start_new_session=True)
             try:
+                browser_wait_started = time.monotonic()
                 output, errors = process.communicate(url + "\n", timeout=25)
                 if pid_file.exists():
                     browser_pid = int(pid_file.read_text())
                 assert process.returncode == 0, "Launcher failed: " + redact_diagnostic(output + errors, private_values)
                 assert output.strip() == "Opened", redact_diagnostic(output, private_values)
                 assert errors == "", redact_diagnostic(errors, private_values)
-                assert received.wait(15), describe_browser_failure(browser_log, browser_pid, private_values)
+                # This is a browser cold-start gate, not an application's interaction timeout.
+                # Hosted Chrome was still in kernel I/O wait (D, empty stderr) at the former
+                # 15-second assertion. Use one bounded phase-aware budget including opener time;
+                # observe real page/report events, and fail early when the browser has exited.
+                wait_for_browser_report(received, visited, browser_log, browser_pid, private_values,
+                    browser_wait_started + BrowserVisitTimeout)
                 assert len(visits) == 1, f"Expected one browser visit; observed {len(visits)}."
                 assert reports == [{"opener": True, "referrer": "", "privateValue": "page-private-canary"}]
                 assert browser_pid is not None
@@ -104,6 +118,8 @@ def main():
                     assert canary not in output + errors
                 print(f"Linux URL launcher passed: artifact={options.probe}; real xdg-open; "
                     "separate sandboxed browser; one visit; no opener/referrer/debug bridge; private output discarded.")
+                print(f"Browser timing: first visit={first_visit_at - browser_wait_started:.2f}s; "
+                    f"report={time.monotonic() - browser_wait_started:.2f}s; budget={BrowserVisitTimeout:.0f}s.")
             finally:
                 # The probe, opener and browser all belong to this isolated gate's process group.
                 # The production launcher itself deliberately never owns or kills the user's browser.
@@ -121,20 +137,39 @@ def redact_diagnostic(text, private_values):
     return re.sub(r"\b(?:https?|wss?|file)://\S+", "<redacted-url>", text)
 
 
-def describe_browser_failure(log_path, browser_pid, private_values):
+def read_browser_state(browser_pid):
+    if browser_pid is None:
+        return "handler-not-invoked", None
+    try:
+        process = Path(f"/proc/{browser_pid}")
+        state = process.joinpath("stat").read_text().rsplit(")", 1)[1].split()[0]
+        return state, process.joinpath("wchan").read_text().strip()
+    except FileNotFoundError:
+        return "exited", None
+
+
+def wait_for_browser_report(received, visited, log_path, browser_pid, private_values, deadline):
+    while not received.is_set():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(describe_browser_failure(log_path, browser_pid, private_values, visited.is_set()))
+        state, _wait_channel = read_browser_state(browser_pid)
+        if state in ("handler-not-invoked", "exited", "Z", "X"):
+            raise AssertionError(describe_browser_failure(log_path, browser_pid, private_values, visited.is_set()))
+        # Event.wait returns immediately when the actual page reports; there is no startup sleep.
+        received.wait(min(0.1, remaining))
+
+
+def describe_browser_failure(log_path, browser_pid, private_values, page_visited=False):
     # Chrome startup errors must remain observable without publishing the controlled URL or
     # private page/handler output. The raw file lives only in this gate's private temp directory.
     details = log_path.read_text(errors="replace") if log_path.exists() else ""
     diagnostic = redact_diagnostic(details, private_values)[-8000:]
-    if browser_pid is None:
-        state = "handler-not-invoked"
-    else:
-        try:
-            state = Path(f"/proc/{browser_pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
-        except FileNotFoundError:
-            state = "exited"
-    return "The real browser never visited the controlled external page. " \
-        + f"Browser process state={state}; stderr={diagnostic or '<empty>'}"
+    state, wait_channel = read_browser_state(browser_pid)
+    phase = "page-script-report" if page_visited else "browser-start-and-navigation"
+    return "The real browser did not complete the controlled external page check. " \
+        + f"Phase={phase}; process state={state}; wait channel={wait_channel or '<none>'}; " \
+        + f"stderr={diagnostic or '<empty>'}"
 
 
 def stop_owned_processes(process):

--- a/scripts/gates/linux-elicitation-probe/Program.cs
+++ b/scripts/gates/linux-elicitation-probe/Program.cs
@@ -1,0 +1,27 @@
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Services;
+
+// A separate process drives the product launcher, without acquiring a browser automation bridge.
+if (!OperatingSystem.IsLinux() || args.Length != 0)
+{
+    return 2;
+}
+
+var probe = new PlatformRuntimeCapabilityProbe();
+if (!string.Equals(probe.ResolveExternalFileOpener(), "/usr/bin/xdg-open", StringComparison.Ordinal))
+{
+    Console.Error.WriteLine("The gate requires the real /usr/bin/xdg-open.");
+    return 3;
+}
+
+var launcher = new DesktopElicitationUriLauncher(probe);
+if (!launcher.IsSupported
+    || !ExternalUriTarget.TryCreate(await Console.In.ReadLineAsync(), out var target))
+{
+    return 4;
+}
+
+using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+var result = await launcher.OpenAsync(target!, timeout.Token);
+Console.WriteLine(result);
+return result == ExternalUriOpenResult.Opened ? 0 : 5;

--- a/scripts/gates/linux-elicitation-probe/linux-elicitation-probe.csproj
+++ b/scripts/gates/linux-elicitation-probe/linux-elicitation-probe.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>SalmonEgg.Gates.LinuxElicitationProbe</AssemblyName>
+    <RootNamespace>SalmonEgg.Gates.LinuxElicitationProbe</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/SalmonEgg.Infrastructure.Desktop/SalmonEgg.Infrastructure.Desktop.csproj" />
+  </ItemGroup>
+</Project>

--- a/scripts/gates/run-wasm-smoke-gates.sh
+++ b/scripts/gates/run-wasm-smoke-gates.sh
@@ -241,6 +241,7 @@ cp "${REPO_ROOT}/scripts/gates/wasm-capability-boundary-smoke.mjs" "${PLAYWRIGHT
 cp "${REPO_ROOT}/scripts/gates/wasm-gamepad-boundary-smoke.mjs" "${PLAYWRIGHT_WORKDIR}/"
 cp "${REPO_ROOT}/scripts/gates/wasm-acp-full-chain-smoke.mjs" "${PLAYWRIGHT_WORKDIR}/"
 cp "${REPO_ROOT}/scripts/gates/wasm-credential-editor-smoke.mjs" "${PLAYWRIGHT_WORKDIR}/"
+cp "${REPO_ROOT}/scripts/gates/wasm-elicitation-module-smoke.mjs" "${PLAYWRIGHT_WORKDIR}/"
 cp -R "${REPO_ROOT}/scripts/gates/wasm-smoke-lib" "${PLAYWRIGHT_WORKDIR}/"
 
 echo "[gate] Install Playwright package"
@@ -288,5 +289,20 @@ echo "[gate] Run WASM credential editor smoke"
 run_playwright_smoke \
   "${PLAYWRIGHT_WORKDIR}/wasm-credential-editor-smoke.mjs" \
   "${BASE_URL}"
+echo "[gate] Run WASM external URL module smoke"
+ELICITATION_MODULE="$("${PYTHON_BIN}" - "${WWWROOT}" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+modules = list(root.glob("**/_framework/salmon-egg-wasm-shell.js"))
+if len(modules) != 1:
+    raise SystemExit(f"Expected exactly one built URL module under {root}; found {len(modules)}.")
+print(modules[0])
+PY
+)"
+run_playwright_smoke \
+  "${PLAYWRIGHT_WORKDIR}/wasm-elicitation-module-smoke.mjs" \
+  "${ELICITATION_MODULE}"
 
 echo "[gate] WASM smoke gates passed"

--- a/scripts/gates/wasm-acp-full-chain-smoke.mjs
+++ b/scripts/gates/wasm-acp-full-chain-smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdir, writeFile } from "node:fs/promises";
+import http from "node:http";
 import { chromium } from "playwright";
 import {
   normalizeBaseUrl,
@@ -27,6 +28,7 @@ import {
 } from "./wasm-smoke-lib/acp-ui-fixture.mjs";
 import {
   clickVisibleControl,
+  clickVisibleControlWithTrustedPointer,
   collectVisibleInteractiveDebug,
   typeIntoVisibleTextField,
   waitForControlEnabledState,
@@ -43,6 +45,7 @@ const fullChainPromptText = `WASM full chain prompt ${Date.now()}`;
 const fullChainAgentReplyText = `WASM full chain agent reply ${Date.now()}`;
 const browser = await chromium.launch({
   headless: true,
+  ignoreDefaultArgs: ["--disable-popup-blocking"],
   executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined
 });
 let acpServer;
@@ -110,13 +113,17 @@ try {
     elicitationRequests.push(await verifyKnownFormSubmission(page, acpServer));
     elicitationRequests.push(...await verifyRemainingFormInputs(page, acpServer));
     elicitationRequests.push(await verifyUnknownRequiredFieldCancellation(page, acpServer));
+    assert.ok(initialize.params.clientCapabilities?.elicitation?.url,
+      "The tested WASM launcher must advertise URL elicitation.");
+    elicitationRequests.push(...await verifyUrlConsent(page, context, acpServer));
     elicitationRequests.push(...await verifyStandalonePermissionQueue(page, acpServer));
   } catch (error) {
     const artifacts = process.env.WASM_SMOKE_ARTIFACTS_DIR;
     if (artifacts) {
       await mkdir(artifacts, { recursive: true });
-      await page.screenshot({ path: `${artifacts}/interaction-failure.png` });
-      await writeFile(`${artifacts}/interaction-failure.json`, JSON.stringify({
+      await page.screenshot({ path: `${artifacts}/elicitation-failure.png` });
+      await writeFile(`${artifacts}/elicitation-failure.html`, await page.content());
+      await writeFile(`${artifacts}/elicitation-failure.json`, JSON.stringify({
         error: String(error),
         semantic: await page.evaluate(collectVisibleInteractiveDebug),
         fatalConsoleMessages
@@ -140,6 +147,169 @@ try {
   } finally {
     await acpServer?.close();
   }
+}
+
+async function verifyUrlConsent(page, context, server) {
+  let visits = 0;
+  let referrer;
+  const privateConsole = [];
+  const collectConsole = message => privateConsole.push(message.text());
+  page.on("console", collectConsole);
+  const target = http.createServer((request, response) => {
+    if (request.url.startsWith("/authorize")) {
+      visits++;
+      referrer = request.headers.referer;
+    }
+    response.writeHead(200, { "Content-Type": "text/html" });
+    response.end("<!doctype html><title>External authorization</title><input id='private' value='page-canary'>");
+  });
+  await new Promise(resolve => target.listen(0, "127.0.0.1", resolve));
+  const requestSuffix = Date.now();
+  const cancelledUrl = `http://127.0.0.1:${target.address().port}/authorize?canary=url-cancel-${requestSuffix}`;
+  const url = `http://127.0.0.1:${target.address().port}/authorize?canary=url-accept-${requestSuffix}`;
+  const cancelledPrompt = `WASM URL cancellation ${requestSuffix}`;
+  const acceptedPrompt = `WASM URL consent ${requestSuffix}`;
+  const openButton = { labels: ["Open in browser"], role: "button" };
+  const requests = [];
+  try {
+    const cancelled = server.requestClient("elicitation/create", {
+      sessionId: server.sessionId, mode: "url", elicitationId: "url-cancel", url: cancelledUrl,
+      message: cancelledPrompt
+    });
+    requests.push(cancelled);
+    await waitForSemanticText(page, new RegExp(cancelledPrompt), "current URL cancellation request");
+    await waitForSemanticText(page, /Review the complete address/, "URL consent explanation");
+    await waitForSemanticText(page, /127\.0\.0\.1/, "URL target host");
+    await waitForSemanticText(page, /Check the domain carefully/, "numeric host warning");
+    await assertCompleteUrlVisible(page, cancelledUrl);
+    assert.equal(visits, 0, "Receiving a URL must not prefetch it.");
+    await waitForControlEnabledState(page, cancelButton, true, "URL request remains cancellable");
+    await clickVisibleControl(page, cancelButton);
+    assert.deepEqual(await cancelled.waitForResponse(), {
+      jsonrpc: "2.0", id: cancelled.id, result: { action: "cancel" }
+    });
+    assert.equal(visits, 0, "Cancelled URL must never open.");
+
+    const accepted = server.requestClient("elicitation/create", {
+      sessionId: server.sessionId, mode: "url", elicitationId: "url-accept", url,
+      message: acceptedPrompt
+    });
+    requests.push(accepted);
+    server.notifyClient("elicitation/complete", { elicitationId: "unknown-id" });
+    await waitForSemanticText(page, new RegExp(acceptedPrompt), "current URL consent request");
+    await waitForControlEnabledState(page, openButton, true, "URL consent button enabled");
+    await assertCompleteUrlVisible(page, url);
+    assert.equal(visits, 0);
+    assert.equal(accepted.responses().length, 0);
+    const [popup] = await Promise.all([
+      context.waitForEvent("page"),
+      activateUrlButtonWithPointer(page, openButton, "URL browser consent")
+    ]);
+    await popup.waitForURL(url);
+    assert.deepEqual(await accepted.waitForResponse(), {
+      jsonrpc: "2.0", id: accepted.id, result: { action: "accept" }
+    }, "URL acceptance must omit content and only mean consent.");
+    assert.equal(await popup.evaluate(() => window.opener), null);
+    assert.equal(await popup.evaluate(() => document.referrer), "");
+    assert.equal(referrer, undefined);
+    assert.equal(visits, 1);
+    await popup.close();
+    await waitForSemanticText(page, /Waiting for the agent to confirm completion/, "accepted URL still awaits completion");
+    const reopenButton = { labels: ["Open again"], role: "button" };
+    await waitForControlEnabledState(page, reopenButton, true, "explicit reopen available while waiting");
+    const [reopened] = await Promise.all([
+      context.waitForEvent("page"),
+      activateUrlButtonWithKeyboard(page, reopenButton, "explicit URL reopen")
+    ]);
+    await reopened.waitForURL(url);
+    assert.equal(await reopened.evaluate(() => window.opener), null);
+    assert.equal(await reopened.evaluate(() => document.referrer), "");
+    assert.equal(visits, 2);
+    assert.equal(accepted.responses().length, 1, "Opening again must never send a second accept response.");
+    await reopened.close();
+    server.notifyClient("elicitation/complete", { elicitationId: "url-accept" });
+    server.notifyClient("elicitation/complete", { elicitationId: "url-accept" });
+    await waitForSemanticText(page, /The agent reports that the external step is complete/, "authoritative URL completion");
+    await clickVisibleControl(page, { labels: ["Close notice"], role: "button" });
+    await page.waitForFunction(() => {
+      const element = document.querySelector("#uno-semantics-root [xamlautomationid='Elicitation.FullUrl']");
+      return !element || element.hidden || element.getBoundingClientRect().height === 0;
+    });
+    assert.equal(visits, 2);
+    const canaries = [new URL(cancelledUrl).searchParams.get("canary"), new URL(url).searchParams.get("canary"), "page-canary"];
+    assert.ok(!privateConsole.some(text => canaries.some(value => text.includes(value))),
+      "Private external interaction data must not enter the application console.");
+    await assertPrivateDataNotStored(page, canaries);
+    console.log("WASM URL elicitation: two distinct requests and complete URLs, trusted pointer consent and keyboard reopen with native popup policy, cancel, one accept without content, explicit reopen, completion, no opener/referrer or private-data persistence");
+    return requests;
+  } finally {
+    page.off("console", collectConsole);
+    await new Promise(resolve => target.close(resolve));
+  }
+}
+
+async function activateUrlButtonWithPointer(page, options, label) {
+  await waitForControlEnabledState(page, options, true, label);
+  await waitForLaidOutControl(page, options, label);
+  // Initial consent must travel through native canvas hit testing and browser user activation.
+  // Reopening below exercises the native keyboard Button path after the action row reflows.
+  await clickVisibleControlWithTrustedPointer(page, options, label);
+}
+
+async function activateUrlButtonWithKeyboard(page, options, label) {
+  await waitForControlEnabledState(page, options, true, label);
+  const state = await waitForLaidOutControl(page, options, label);
+  assert.equal(state.enabled, true, `${label} must remain enabled before taking focus.`);
+  await page.locator(`#${state.id}`).focus();
+  assert.equal(await page.evaluate(() => document.activeElement?.id), state.id,
+    `${label} must own native keyboard focus before Enter.`);
+  // A real key grants transient browser activation through Uno's native Button path.
+  // Calling the semantic peer's Invoke action would not test user consent.
+  await page.keyboard.press("Enter");
+}
+
+async function assertCompleteUrlVisible(page, url) {
+  await page.waitForFunction(expected => {
+    const element = document.querySelector("#uno-semantics-root [xamlautomationid='Elicitation.FullUrl']");
+    if (!element || element.hidden) return false;
+    const rect = element.getBoundingClientRect();
+    const text = element.getAttribute("aria-label") || element.textContent || "";
+    return rect.width > 0 && rect.height > 0 && text === expected;
+  }, url);
+}
+
+async function assertPrivateDataNotStored(page, canaries) {
+  const result = await page.evaluate(values => {
+    const fs = globalThis.FS;
+    if (!fs) return { error: "The running product filesystem is unavailable." };
+    let files = 0;
+    const inspect = path => {
+      for (const name of fs.readdir(path)) {
+        if (name === "." || name === "..") continue;
+        const child = `${path}/${name}`;
+        const mode = fs.stat(child).mode;
+        if (fs.isDir(mode)) {
+          const found = inspect(child);
+          if (found) return found;
+        } else if (fs.isFile(mode)) {
+          files++;
+          const text = new TextDecoder().decode(fs.readFile(child));
+          if (values.some(value => text.includes(value))) return child;
+        }
+      }
+      return null;
+    };
+    const leakedFile = inspect("/local/SalmonEgg");
+    const leakedStorage = [localStorage, sessionStorage].some(storage =>
+      Object.values(storage).some(text => values.some(value => text.includes(value))));
+    const transcript = document.querySelector("#uno-semantics-root")?.textContent || "";
+    return { files, leakedFile, leakedStorage, leakedTranscript: values.some(value => transcript.includes(value)) };
+  }, canaries);
+  assert.equal(result.error, undefined);
+  assert.ok(result.files > 0, "The gate must inspect the product's existing persistence files.");
+  assert.equal(result.leakedFile, null, "External URL/input leaked into a product file or diagnostic log.");
+  assert.equal(result.leakedStorage, false);
+  assert.equal(result.leakedTranscript, false);
 }
 
 async function verifyKnownFormSubmission(page, server) {
@@ -240,7 +410,7 @@ async function findSingleVisibleFormInput(page, existingControlIds) {
     return inputs.length === 1 ? `#${inputs[0].id}` : null;
   }, existingControlIds, { timeout: 15_000 }).catch(async error => {
     throw new Error(`Expected one editable elicitation input. Semantic DOM=${JSON.stringify(
-      await collectVisibleInteractiveDebug(page))}`, { cause: error });
+      await page.evaluate(collectVisibleInteractiveDebug))}`, { cause: error });
   });
   try {
     return await handle.jsonValue();
@@ -271,7 +441,14 @@ async function waitForVisibleForm(page) {
       ids.push(matches[0].id);
     }
     return ids;
-  }, null, { timeout: 15_000 });
+  }, null, { timeout: 15_000 }).catch(async error => {
+    throw new Error(`Expected one laid-out elicitation host and its actions. Semantic DOM=${JSON.stringify(
+      await page.evaluate(() => Array.from(document.querySelectorAll("#uno-semantics-root *"))
+        .filter(element => !element.closest("[hidden]"))
+        .map(element => ({ id: element.id, tag: element.tagName,
+          name: element.getAttribute("aria-label"), automationId: element.getAttribute("xamlautomationid"),
+          rect: element.getBoundingClientRect().toJSON() }))))}`, { cause: error });
+  });
   try {
     return await handle.jsonValue();
   } finally {
@@ -290,7 +467,7 @@ async function waitForFormDismissal(page, formNodeIds) {
         "#uno-semantics-root [xamlautomationid='ElicitationHost']")).every(isDismissed);
   }, formNodeIds, { timeout: 15_000 }).catch(async error => {
     throw new Error(`Elicitation host and actions did not dismiss. Semantic DOM=${JSON.stringify(
-      await collectVisibleInteractiveDebug(page))}`, { cause: error });
+      await page.evaluate(collectVisibleInteractiveDebug))}`, { cause: error });
   });
   await handle.dispose();
 }
@@ -317,7 +494,7 @@ async function toggleSingleVisibleFormCheckbox(page, existingControlIds) {
     return checked && enabled ? checkbox.id : null;
   }, existingControlIds, { timeout: 15_000 }).catch(async error => {
     throw new Error(`Expected one enabled elicitation checkbox with its true default. Semantic DOM=${JSON.stringify(
-      await collectVisibleInteractiveDebug(page))}`, { cause: error });
+      await page.evaluate(collectVisibleInteractiveDebug))}`, { cause: error });
   });
   let checkboxId;
   try {

--- a/scripts/gates/wasm-elicitation-module-smoke.mjs
+++ b/scripts/gates/wasm-elicitation-module-smoke.mjs
@@ -1,0 +1,124 @@
+// Exercise the bundled external-navigation module with real user activation and popup isolation.
+// Supply the module from this build's WASM output, never the source tree.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import { chromium } from "playwright";
+
+const modulePath = process.argv[2];
+assert.ok(modulePath, "Expected path to built salmon-egg-wasm-shell.js");
+const source = readFileSync(modulePath, "utf8");
+let visits = 0;
+let receivedReferrer;
+const targetServer = http.createServer((request, response) => {
+  if (request.url === "/redirect-to-app") {
+    response.writeHead(302, { Location: `${appOrigin}/private-return` });
+    response.end();
+    return;
+  }
+  if (request.url.startsWith("/authorize")) {
+    visits++;
+    receivedReferrer = request.headers.referer;
+  }
+  response.writeHead(200, { "Content-Type": "text/html" });
+  response.end("<!doctype html><title>Private external step</title><input id='secret' value='private-page-canary'>");
+});
+const appServer = http.createServer((request, response) => {
+  if (request.url === "/module.js") {
+    response.writeHead(200, { "Content-Type": "text/javascript", "Access-Control-Allow-Origin": "*" });
+    response.end(source);
+    return;
+  }
+  if (request.url === "/private-return") {
+    response.writeHead(200, { "Content-Type": "text/html" });
+    response.end("<!doctype html><script>window.name='private-return-context'</script><input id='secret' value='redirect-private-canary'>");
+    return;
+  }
+  if (request.url === "/sandbox-container") {
+    response.writeHead(200, { "Content-Type": "text/html" });
+    response.end("<!doctype html><iframe id='blocker' sandbox='allow-scripts' src='/blocked-wrapper'></iframe>");
+    return;
+  }
+  response.writeHead(200, { "Content-Type": "text/html" });
+  response.end(`<!doctype html><button id='consent'>Open in browser</button><script type='module'>
+    import * as launcher from '/module.js';
+    window.launcher = launcher;
+    window.targetUrl = ${JSON.stringify(`${targetOrigin}/authorize?canary=private-url`)};
+    window.automaticOpenResult = launcher.openExternalElicitation(window.targetUrl);
+    document.querySelector('#consent').onclick = () => window.openResult = launcher.openExternalElicitation(window.targetUrl);
+    </script>`);
+});
+await new Promise(resolve => targetServer.listen(0, "127.0.0.1", resolve));
+await new Promise(resolve => appServer.listen(0, "127.0.0.1", resolve));
+const targetOrigin = `http://127.0.0.1:${targetServer.address().port}`;
+const appOrigin = `http://127.0.0.1:${appServer.address().port}`;
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    ignoreDefaultArgs: ["--disable-popup-blocking"],
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined
+  });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  // CDP Runtime.evaluate can grant user activation, so exercise the automatic call from page load.
+  await page.goto(appOrigin, { waitUntil: "networkidle" });
+  assert.equal(visits, 0, "Loading and rendering must not prefetch a URL.");
+  assert.equal(await page.evaluate(() => window.automaticOpenResult), false,
+    "A script without a real click must not navigate.");
+  assert.equal(visits, 0);
+  const popupPromise = context.waitForEvent("page");
+  await page.locator("#consent").click();
+  const popup = await popupPromise;
+  await popup.waitForURL(`${targetOrigin}/authorize?canary=private-url`);
+  assert.equal(await page.evaluate(() => window.openResult), true);
+  assert.equal(await popup.evaluate(() => window.opener), null, "External page must not retain an opener.");
+  assert.equal(await popup.evaluate(() => document.referrer), "", "External page must receive no referrer.");
+  assert.equal(receivedReferrer, undefined);
+  assert.equal(await page.evaluate(() => document.querySelector("#secret")), null);
+  assert.equal(visits, 1);
+  await popup.close();
+
+  // A redirect back to the application origin must not restore access by a named window.
+  await page.evaluate(url => { window.targetUrl = url; }, `${targetOrigin}/redirect-to-app`);
+  const redirectedPromise = context.waitForEvent("page");
+  await page.locator("#consent").click();
+  const redirected = await redirectedPromise;
+  await redirected.waitForURL(`${appOrigin}/private-return`);
+  assert.equal(await redirected.evaluate(() => window.opener), null);
+  assert.equal(await page.evaluate(() => {
+    const candidate = window.open("", "private-return-context");
+    try {
+      return candidate?.document.querySelector("#secret")?.value ?? null;
+    } finally {
+      candidate?.close();
+    }
+  }), null, "Returning to the app origin must not expose the user's external page input.");
+  await redirected.close();
+
+  // Same-origin pages must not become model-accessible application contexts.
+  await page.evaluate(url => { window.targetUrl = url; }, `${appOrigin}/authorize`);
+  await page.locator("#consent").click();
+  assert.equal(await page.evaluate(() => window.openResult), false);
+  assert.equal(context.pages().length, 1);
+
+  // Native sandbox policy blocks popups even with trusted user activation. noopener deliberately
+  // hides the resulting WindowProxy in both cases, so the contract can only promise dispatch.
+  await page.goto(`${appOrigin}/sandbox-container`, { waitUntil: "networkidle" });
+  const sandbox = page.frameLocator("#blocker");
+  await sandbox.locator("#consent").click();
+  const blockedFrame = page.frames().find(frame => frame.url().endsWith("/blocked-wrapper"));
+  assert.ok(blockedFrame);
+  assert.equal(await blockedFrame.evaluate(() => window.openResult), true,
+    "A successful dispatch must not pretend to report whether a popup opened.");
+  assert.equal(context.pages().length, 1, "The native sandbox must actually block the popup.");
+  assert.equal(visits, 1);
+  await context.close();
+  console.log("WASM external URL module passed: trusted consent, no automatic open, no opener/referrer, same-origin rejection and redirect isolation, native blocked popup reports dispatch only.");
+} finally {
+  await browser?.close();
+  await Promise.all([
+    new Promise(resolve => appServer.close(resolve)),
+    new Promise(resolve => targetServer.close(resolve))
+  ]);
+}

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -50,7 +50,8 @@ namespace SalmonEgg.Acp.Client
                 CancellationToken connectionToken,
                 string? sessionId = null,
                 AskUserRequest? askUserRequest = null,
-                CreateElicitationRequest? elicitationRequest = null)
+                CreateElicitationRequest? elicitationRequest = null,
+                ElicitationRequestState? elicitationState = null)
             {
                 Method = method;
                 MessageId = messageId;
@@ -58,6 +59,7 @@ namespace SalmonEgg.Acp.Client
                 SessionId = sessionId;
                 AskUserRequest = askUserRequest;
                 ElicitationRequest = elicitationRequest;
+                ElicitationState = elicitationState;
             }
 
             public string Method { get; }
@@ -72,9 +74,7 @@ namespace SalmonEgg.Acp.Client
 
             public CreateElicitationRequest? ElicitationRequest { get; }
 
-            public bool IsElicitationResponseInFlight { get; set; }
-
-            public bool IsElicitationCancellationRequested { get; set; }
+            public ElicitationRequestState? ElicitationState { get; }
 
             public HashSet<string>? PermissionOptionIds { get; set; }
 
@@ -99,7 +99,7 @@ namespace SalmonEgg.Acp.Client
             public JsonRpcResponse? PreparedCancellationResponse { get; set; }
 
             public PendingInboundRequest WithSessionId(string sessionId)
-                => new(Method, MessageId, ConnectionToken, sessionId, AskUserRequest, ElicitationRequest);
+                => new(Method, MessageId, ConnectionToken, sessionId, AskUserRequest, ElicitationRequest, ElicitationState);
 
             public PendingInboundRequest WithAskUserRequest(AskUserRequest request)
                 => new(
@@ -108,7 +108,8 @@ namespace SalmonEgg.Acp.Client
                     ConnectionToken,
                     request.SessionId,
                     request,
-                    ElicitationRequest);
+                    ElicitationRequest,
+                    ElicitationState);
         }
         private readonly IAcpTransport _transport;
         private readonly MessageParser _parser;
@@ -132,6 +133,9 @@ namespace SalmonEgg.Acp.Client
         private readonly object _lock = new();
         private bool _disposed;
         private CancellationTokenSource? _messageLoopCts;
+        // A notification projection of the connection lifetime, never an I/O cancellation source.
+        // Host callbacks may block; transport cancellation must still finish before reconnect.
+        private CancellationTokenSource? _connectionClosedObservers;
         private EventHandler<AcpTransportMessageReceivedEventArgs>? _connectionMessageHandler;
         private Task<bool>? _disconnectTask;
         private string? _lastTransportErrorMessage;
@@ -287,6 +291,7 @@ namespace SalmonEgg.Acp.Client
             bool allowDraftRuntime,
             CancellationToken cancellationToken)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             ArgumentNullException.ThrowIfNull(@params);
             // A modeled version is not a served version: the SDK carries draft v2 wire contracts so they
             // can be developed and asserted, while this runtime runs exactly one version end to end.
@@ -338,6 +343,7 @@ namespace SalmonEgg.Acp.Client
                 // The initialize request belongs to this connection too. Keep this same owner
                 // through the successful handshake instead of introducing it only afterwards.
                 _messageLoopCts = new CancellationTokenSource();
+                _connectionClosedObservers = new CancellationTokenSource();
                 connectionToken = _messageLoopCts.Token;
                 _sessionWork.BeginConnection(connectionToken);
                 AttachConnectionMessageHandler(connectionToken);
@@ -351,14 +357,7 @@ namespace SalmonEgg.Acp.Client
             }
             catch
             {
-                lock (_lock)
-                {
-                    if (_messageLoopCts?.Token == connectionToken)
-                    {
-                        ResetConnectionState();
-                        CancelPendingRequests();
-                    }
-                }
+                ResetConnectionState(connectionToken);
                 throw;
             }
 
@@ -429,6 +428,7 @@ namespace SalmonEgg.Acp.Client
 
             lock (_lock)
             {
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 connectionToken.ThrowIfCancellationRequested();
                 // An old handshake may finish after a disconnect and a newer initialize. Its
                 // result cannot replace the newer connection's capabilities or cancellation owner.
@@ -442,8 +442,9 @@ namespace SalmonEgg.Acp.Client
                 _authMethods = initializeResponse.AuthMethods;
                 _clientCapabilities = @params.ClientCapabilities;
                 _isInitialized = true;
-                _ = MonitorTransportConnectionAsync(connectionToken);
             }
+
+            _ = MonitorTransportConnectionAsync(connectionToken);
 
             return initializeResponse;
         }
@@ -1144,6 +1145,14 @@ namespace SalmonEgg.Acp.Client
         {
             var idStr = RequestKey(pending.MessageId);
             CancellationToken connectionCancellation;
+            JsonRpcResponse responseMessage;
+            var isPeerCancellation = false;
+            if (cancelForSession)
+            {
+                pending.ElicitationState!.RequestCancellation();
+                pending.ElicitationState.NotifyChanged();
+            }
+
             lock (_lock)
             {
                 if (_disposed || !_transport.IsConnected || pending.ElicitationRequest is null
@@ -1154,13 +1163,8 @@ namespace SalmonEgg.Acp.Client
                     return false;
                 }
 
-                if (cancelForSession)
-                {
-                    pending.IsElicitationCancellationRequested = true;
-                }
-
-                if (pending.IsElicitationResponseInFlight
-                    || (pending.IsElicitationCancellationRequested && response is not ElicitationCancelResponse))
+                if (pending.ElicitationState!.IsResponseInFlight
+                    || (pending.ElicitationState.IsCancellationRequested && response is not ElicitationCancelResponse))
                 {
                     return false;
                 }
@@ -1168,30 +1172,35 @@ namespace SalmonEgg.Acp.Client
                 // Claim without removing: a failed send must remain retryable, while a second action
                 // cannot race the first one onto the wire. The callback owns this exact request object,
                 // so reusing its JSON-RPC id never lets an old form answer a later request.
-                pending.IsElicitationResponseInFlight = true;
+                pending.ElicitationState!.IsResponseInFlight = true;
                 pending.PreparedElicitationResponse = response;
                 pending.HasPreparedElicitationFailure = false;
                 connectionCancellation = _messageLoopCts?.Token ?? CancellationToken.None;
+                isPeerCancellation = response is ElicitationCancelResponse && pending.PreparedCancellationResponse?.IsError == true;
+                responseMessage = isPeerCancellation ? pending.PreparedCancellationResponse!
+                    : new JsonRpcResponse(pending.MessageId, ToElement<CreateElicitationResponse>(response));
             }
 
             var sent = false;
             try
             {
-                sent = await SendResponseAsync(new JsonRpcResponse(
-                    pending.MessageId,
-                    ToElement<CreateElicitationResponse>(response)), connectionCancellation).ConfigureAwait(false);
+                sent = await SendResponseAsync(responseMessage, connectionCancellation).ConfigureAwait(false);
                 return sent;
             }
             finally
             {
-                if (CompleteElicitationResponse(pending, response, sent))
+                var sendCancellation = CompleteElicitationResponse(pending,
+                    isPeerCancellation ? null : response, sent, isCancellationResponse: response is ElicitationCancelResponse);
+                pending.ElicitationState!.NotifyChanged();
+                if (sendCancellation)
                 {
                     await SendPendingElicitationCancellationAsync(pending, connectionCancellation).ConfigureAwait(false);
                 }
             }
         }
 
-        private bool CompleteElicitationResponse(PendingInboundRequest pending, CreateElicitationResponse? response, bool sent)
+        private bool CompleteElicitationResponse(
+            PendingInboundRequest pending, CreateElicitationResponse? response, bool sent, bool isCancellationResponse = false)
         {
             var idStr = RequestKey(pending.MessageId);
             lock (_lock)
@@ -1199,12 +1208,21 @@ namespace SalmonEgg.Acp.Client
                 if (sent)
                 {
                     _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(idStr, pending));
+                    if (response is null)
+                    {
+                        pending.ElicitationState!.Invalidate();
+                    }
+                    else
+                    {
+                        pending.ElicitationState!.MarkResponseSent(response.Action);
+                    }
                     if (response is not ElicitationAcceptResponse)
                     {
                         RemovePendingUrlElicitation(pending);
                     }
                 }
-                else if (pending.IsElicitationCancellationRequested && response is not ElicitationCancelResponse
+                else if (!IsBatchedResponse(pending) && !isCancellationResponse
+                    && pending.ElicitationState!.IsCancellationRequested && response is not ElicitationCancelResponse
                     && !_disposed && _transport.IsConnected
                     && TryGetPendingInboundRequest(idStr, out var current) && ReferenceEquals(current, pending))
                 {
@@ -1213,7 +1231,7 @@ namespace SalmonEgg.Acp.Client
                     return true;
                 }
 
-                pending.IsElicitationResponseInFlight = false;
+                pending.ElicitationState!.IsResponseInFlight = false;
                 return false;
             }
         }
@@ -1221,17 +1239,24 @@ namespace SalmonEgg.Acp.Client
         private async Task SendPendingElicitationCancellationAsync(PendingInboundRequest pending, CancellationToken cancellationToken)
         {
             var response = new ElicitationCancelResponse();
+            JsonRpcResponse responseMessage;
+            bool isPeerCancellation;
+            lock (_lock)
+            {
+                isPeerCancellation = pending.PreparedCancellationResponse?.IsError == true;
+                responseMessage = isPeerCancellation ? pending.PreparedCancellationResponse!
+                    : new JsonRpcResponse(pending.MessageId, ToElement<CreateElicitationResponse>(response));
+            }
             var sent = false;
             try
             {
-                sent = await SendResponseAsync(new JsonRpcResponse(
-                    pending.MessageId,
-                    ToElement<CreateElicitationResponse>(response)), cancellationToken).ConfigureAwait(false);
+                sent = await SendResponseAsync(responseMessage, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
                 // A failed cancellation remains explicitly retryable; it never schedules another send.
-                CompleteElicitationResponse(pending, response, sent);
+                CompleteElicitationResponse(pending, isPeerCancellation ? null : response, sent, isCancellationResponse: true);
+                pending.ElicitationState!.NotifyChanged();
             }
         }
 
@@ -1242,7 +1267,7 @@ namespace SalmonEgg.Acp.Client
             {
                 if (!TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
                     || !ReferenceEquals(current, pending) || !IsInboundRequestCurrent(pending)
-                    || pending.IsElicitationResponseInFlight || pending.IsElicitationCancellationRequested
+                    || pending.ElicitationState!.IsResponseInFlight || pending.ElicitationState.IsCancellationRequested
                     || pending.PreparedCancellationResponse is not null)
                 {
                     return;
@@ -1250,7 +1275,7 @@ namespace SalmonEgg.Acp.Client
 
                 // Host failures share the original response claim. They cannot overwrite a reply
                 // already sent, consume a replacement id, or escape onto a later connection.
-                pending.IsElicitationResponseInFlight = true;
+                pending.ElicitationState!.IsResponseInFlight = true;
                 pending.HasPreparedElicitationFailure = true;
                 responseTask = SendResponseAsync(new JsonRpcResponse(pending.MessageId,
                     JsonRpcError.CreateInternalError("Failed to process elicitation/create request.")),
@@ -1264,7 +1289,9 @@ namespace SalmonEgg.Acp.Client
             }
             finally
             {
-                if (CompleteElicitationResponse(pending, response: null, sent))
+                var sendCancellation = CompleteElicitationResponse(pending, response: null, sent);
+                pending.ElicitationState!.NotifyChanged();
+                if (sendCancellation)
                 {
                     await SendPendingElicitationCancellationAsync(pending, pending.ConnectionToken).ConfigureAwait(false);
                 }
@@ -1615,6 +1642,7 @@ namespace SalmonEgg.Acp.Client
         public Task<bool> DisconnectAsync()
         {
             TaskCompletionSource<bool> completion;
+            CancellationToken? connectionToken;
             lock (_lock)
             {
                 if (_disconnectTask is { IsCompleted: false } pending)
@@ -1628,21 +1656,23 @@ namespace SalmonEgg.Acp.Client
                 }
 
                 completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                // Publish before cancelling the old connection. A reentrant initializer must not
-                // share a transport whose physical teardown is still in flight.
+                // Publish the lifecycle owner before Reset invalidates the old token and schedules
+                // host callbacks. Reentrant initialize must wait until physical teardown is done.
                 _disconnectTask = completion.Task;
+                connectionToken = _messageLoopCts?.Token;
             }
 
-            _ = CompleteDisconnectAsync(completion);
+            _ = CompleteDisconnectAsync(completion, connectionToken);
             return completion.Task;
         }
 
-        private async Task CompleteDisconnectAsync(TaskCompletionSource<bool> completion)
+        private async Task CompleteDisconnectAsync(
+            TaskCompletionSource<bool> completion,
+            CancellationToken? connectionToken)
         {
             try
             {
-                ResetConnectionState();
-                CancelPendingRequests();
+                ResetConnectionState(connectionToken);
                 var disconnected = await _transport.DisconnectAsync().ConfigureAwait(false);
                 completion.TrySetResult(disconnected);
             }
@@ -2020,9 +2050,11 @@ namespace SalmonEgg.Acp.Client
             {
                 return false;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                OnErrorOccurred($"Failed to send response: {ex.Message}");
+                // Responses may contain private form answers or handler errors. A transport exception
+                // is not a safe source for the user-facing diagnostic or the host logger.
+                OnErrorOccurred("Failed to send the ACP response.");
                 return false;
             }
         }
@@ -2193,6 +2225,7 @@ namespace SalmonEgg.Acp.Client
 
         private void CompleteResponseBatch(InboundResponseBatch batch, IReadOnlyList<JsonRpcResponse> responses)
         {
+            var completedElicitations = new List<ElicitationRequestState>();
             lock (_lock)
             {
                 _responseBatches.Remove(batch);
@@ -2222,6 +2255,7 @@ namespace SalmonEgg.Acp.Client
                         var elicitation = response.Result is { } result
                             ? FromElement<CreateElicitationResponse>(result) : null;
                         CompleteElicitationResponse(pending, elicitation, sent: true);
+                        completedElicitations.Add(pending.ElicitationState!);
                     }
                     if (pending.PreparedAskUserResponse is not null && pending.MessageId is not null
                         && _responseRoutes.TryGetValue(pending.MessageId, out var askRoute) && askRoute.Batch == batch)
@@ -2235,6 +2269,9 @@ namespace SalmonEgg.Acp.Client
                     }
                 }
             }
+            // A different sibling may own the successful retry. Its completion must publish every
+            // committed URL state, including requests whose earlier responder already returned false.
+            foreach (var state in completedElicitations) state.NotifyChanged();
         }
 
         private void NotifyResponseBatchChanged(InboundResponseBatch batch)
@@ -2347,8 +2384,14 @@ namespace SalmonEgg.Acp.Client
                     return;
                 }
                 if (ProtocolVersion != AcpProtocolVersion.V2) return;
-                RemovePendingUrlElicitation(pending);
                 if (TrySubmitBatchCancellation(pending, response)) return;
+                if (pending.ElicitationRequest is not null)
+                {
+                    pending.PreparedCancellationResponse = response;
+                    _ = TrySendElicitationResponseAsync(pending, new ElicitationCancelResponse(), cancelForSession: true);
+                    return;
+                }
+                RemovePendingUrlElicitation(pending);
                 _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(key, pending));
                 _ = SendResponseAsync(response, connectionToken);
             }
@@ -2895,7 +2938,7 @@ namespace SalmonEgg.Acp.Client
                 {
                     FailPendingInboundRequest(request,
                         JsonRpcError.CreateInvalidParams(
-                            $"Elicitation mode '{elicitationRequest.Mode}' was not advertised by the client."));
+                            "The requested elicitation mode was not advertised by the client."));
                     return;
                 }
 
@@ -2919,7 +2962,8 @@ namespace SalmonEgg.Acp.Client
                     elicitationRequest,
                     content => TrySendElicitationResponseAsync(pending, new ElicitationAcceptResponse { Content = content?.ToWireContent() }),
                     () => TrySendElicitationResponseAsync(pending, new ElicitationDeclineResponse()),
-                    () => TrySendElicitationResponseAsync(pending, new ElicitationCancelResponse()));
+                    () => TrySendElicitationResponseAsync(pending, new ElicitationCancelResponse()),
+                    pending.ElicitationState!);
             }
             catch (JsonException)
             {
@@ -2963,28 +3007,48 @@ namespace SalmonEgg.Acp.Client
                 completion = FromElement<CompleteElicitationNotification>(
                     notification.Params.Value);
             }
-            catch (JsonException ex)
+            catch (JsonException)
             {
                 // A notification has no reply, and the specification tells clients to ignore ids they do
                 // not recognize, so a malformed payload is a diagnostic rather than a user-visible fault.
                 _logger.Log(
                     AcpClientLogLevel.Warning,
                     "ELICITATION_COMPLETE_INVALID",
-                    ex.Message);
+                    "Invalid elicitation/complete parameters were ignored.");
                 return;
             }
 
+            PendingInboundRequest pending;
             lock (_lock)
             {
                 // IDs are opaque, and only outstanding URL interactions on this connection qualify.
                 // Removing before publication makes duplicate notifications harmless even on re-entry.
                 if (_disposed || !_transport.IsConnected || completion?.ElicitationId is not { } id
-                    || !_pendingUrlElicitations.Remove(id))
+                    || !_pendingUrlElicitations.Remove(id, out pending!))
                 {
                     return;
                 }
 
-                ElicitationCompleted?.Invoke(this, new ElicitationCompletedEventArgs(id));
+                pending.ElicitationState!.MarkCompleted();
+            }
+
+            pending.ElicitationState!.NotifyChanged();
+            var subscribers = ElicitationCompleted;
+            if (subscribers is not null)
+            {
+                var args = new ElicitationCompletedEventArgs(completion!.ElicitationId);
+                foreach (EventHandler<ElicitationCompletedEventArgs> subscriber in subscribers.GetInvocationList())
+                {
+                    try
+                    {
+                        subscriber(this, args);
+                    }
+                    catch (Exception)
+                    {
+                        _logger.Log(AcpClientLogLevel.Warning, "ELICITATION_OBSERVER_FAILED",
+                            "An elicitation completion observer failed after the request state was updated.");
+                    }
+                }
             }
         }
 
@@ -3320,8 +3384,10 @@ namespace SalmonEgg.Acp.Client
                 return false;
             }
             pending.PreparedCancellationResponse = response;
+            pending.ElicitationState?.RequestCancellation();
             route.Batch.SubmitCancellation(route.Index, response);
             pending.PermissionEvent?.NotifyChanged();
+            pending.ElicitationState?.NotifyChanged();
             return true;
         }
 
@@ -3332,14 +3398,19 @@ namespace SalmonEgg.Acp.Client
         private void RemovePendingInboundTracking(AcpRequestId idStr)
         {
 
+            PendingInboundRequest? removed = null;
             lock (_lock)
             {
                 if (_pendingInboundRequests.TryRemove(idStr, out var pending))
                 {
                     RemovePendingUrlElicitation(pending);
+                    pending.ElicitationState?.Invalidate();
+                    removed = pending;
                     pending.PermissionEvent?.NotifyChanged();
                 }
             }
+
+            removed?.ElicitationState?.NotifyChanged();
         }
 
         private void FailPendingInboundRequest(JsonRpcRequest request, JsonRpcError error)
@@ -3363,13 +3434,21 @@ namespace SalmonEgg.Acp.Client
         private void TrackPendingInboundRequest(AcpRequestId idStr, string method, object? messageId)
         {
 
+            PendingInboundRequest? replaced = null;
             lock (_lock)
             {
-                _pendingInboundRequests.TryGetValue(idStr, out var previous);
+                if (_pendingInboundRequests.TryGetValue(idStr, out replaced))
+                {
+                    RemovePendingUrlElicitation(replaced);
+                    replaced.ElicitationState?.Invalidate();
+                }
+
                 _pendingInboundRequests[idStr] = new PendingInboundRequest(method, messageId,
                     _messageLoopCts?.Token ?? CancellationToken.None);
-                previous?.PermissionEvent?.NotifyChanged();
+                replaced?.PermissionEvent?.NotifyChanged();
             }
+
+            replaced?.ElicitationState?.NotifyChanged();
         }
 
         private bool TryGetPendingInboundRequest(AcpRequestId idStr, out PendingInboundRequest pending)
@@ -3401,6 +3480,8 @@ namespace SalmonEgg.Acp.Client
 
         private PendingInboundRequest? TrackInboundElicitationRequest(object messageId, CreateElicitationRequest request)
         {
+            PendingInboundRequest? previous;
+            PendingInboundRequest pending;
             lock (_lock)
             {
                 if (_disposed || !_transport.IsConnected)
@@ -3408,13 +3489,14 @@ namespace SalmonEgg.Acp.Client
                     return null;
                 }
 
-                var pending = new PendingInboundRequest(
+                pending = new PendingInboundRequest(
                     ElicitationMethods.Create,
                     messageId,
                     _messageLoopCts?.Token ?? CancellationToken.None,
                     request.Scope.SessionId,
                     null,
-                    request);
+                    request,
+                    new ElicitationRequestState(_connectionClosedObservers?.Token ?? CancellationToken.None));
                 if (request is UrlElicitationRequest url && !_pendingUrlElicitations.TryAdd(url.ElicitationId, pending))
                 {
                     _ = SendResponseAsync(new JsonRpcResponse(messageId,
@@ -3422,9 +3504,19 @@ namespace SalmonEgg.Acp.Client
                     return null;
                 }
 
-                _pendingInboundRequests[RequestKey(messageId)] = pending;
-                return pending;
+                var key = RequestKey(messageId);
+                if (_pendingInboundRequests.TryGetValue(key, out previous))
+                {
+                    RemovePendingUrlElicitation(previous);
+                    previous.ElicitationState?.Invalidate();
+                }
+
+                _pendingInboundRequests[key] = pending;
+                previous?.PermissionEvent?.NotifyChanged();
             }
+
+            previous?.ElicitationState?.NotifyChanged();
+            return pending;
         }
 
         private void SetPendingInboundAskUserRequest(AcpRequestId idStr, AskUserRequest request)
@@ -3473,8 +3565,7 @@ namespace SalmonEgg.Acp.Client
             OnErrorOccurred(e.ErrorMessage);
             if (!_transport.IsConnected)
             {
-                ResetConnectionState();
-                CancelPendingRequests(e.ErrorMessage);
+                ResetConnectionState(transportErrorMessage: e.ErrorMessage);
             }
         }
 
@@ -3535,24 +3626,21 @@ namespace SalmonEgg.Acp.Client
                 return;
             }
 
+            ResetConnectionState(cancellationToken, _lastTransportErrorMessage ?? "The transport is no longer connected.");
+        }
+
+        private void ResetConnectionState(CancellationToken? expectedConnection = null, string? transportErrorMessage = null)
+        {
+            CancellationTokenSource? previousObservers;
+            Task? notifications;
             lock (_lock)
             {
-                // A previous watchdog can finish after explicit disconnect and reinitialization.
-                // Only the token still owned by this connection may clear its request state.
-                if (cancellationToken.IsCancellationRequested || _messageLoopCts?.Token != cancellationToken)
+                if (expectedConnection is { } expected
+                    && (expected.IsCancellationRequested || _messageLoopCts?.Token != expected))
                 {
                     return;
                 }
 
-                ResetConnectionState();
-                CancelPendingRequests(_lastTransportErrorMessage ?? "The transport is no longer connected.");
-            }
-        }
-
-        private void ResetConnectionState()
-        {
-            lock (_lock)
-            {
                 if (_connectionMessageHandler is not null)
                 {
                     _transport.MessageReceived -= _connectionMessageHandler;
@@ -3562,9 +3650,10 @@ namespace SalmonEgg.Acp.Client
                         _transport.MessageReceived += OnMessageReceived;
                     }
                 }
-                _messageLoopCts?.Cancel();
-                _messageLoopCts?.Dispose();
+                var previousConnection = _messageLoopCts;
+                previousObservers = _connectionClosedObservers;
                 _messageLoopCts = null;
+                _connectionClosedObservers = null;
                 foreach (var batch in _responseBatches)
                 {
                     batch.Abandon();
@@ -3580,6 +3669,61 @@ namespace SalmonEgg.Acp.Client
                 _authMethods = null;
                 _wire = AcpWireFormat.For(AcpProtocolVersion.Default);
                 _isInitialized = false;
+                CancelPendingRequests(transportErrorMessage);
+                // Linked write tokens are cancelled by callbacks on the I/O source. CancelAsync
+                // on that source leaves a window in which old writes can cross a reconnect. Finish
+                // this internal propagation now; arbitrary host observers use the projection below.
+                try
+                {
+                    previousConnection?.Cancel();
+                }
+                catch (AggregateException)
+                {
+                    try
+                    {
+                        _logger.Log(AcpClientLogLevel.Warning, "TRANSPORT_CANCELLATION_CALLBACK_FAILED",
+                            "A transport cancellation callback failed after connection state was cleared.");
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+                finally
+                {
+                    previousConnection?.Dispose();
+                    // Marks the public token now, then invokes host observers outside this lock.
+                    notifications = previousObservers?.CancelAsync();
+                }
+            }
+
+            if (previousObservers is not null)
+            {
+                _ = ObserveConnectionClosedAsync(previousObservers, notifications!);
+            }
+        }
+
+        private async Task ObserveConnectionClosedAsync(CancellationTokenSource previousConnection, Task notifications)
+        {
+            try
+            {
+                await notifications.ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    // Callback exceptions can contain private interaction data. Neither their text
+                    // nor a failed logger may escape this owned background cleanup task.
+                    _logger.Log(AcpClientLogLevel.Warning, "CONNECTION_OBSERVER_FAILED",
+                        "A connection-closed observer failed after connection state was cleared.");
+                }
+                catch (Exception)
+                {
+                }
+            }
+            finally
+            {
+                previousConnection.Dispose();
             }
         }
 
@@ -3701,15 +3845,13 @@ namespace SalmonEgg.Acp.Client
 
                 _disposed = true;
             }
-            ResetConnectionState();
 
-            // Detach the transport events first so callbacks during teardown cannot re-enter disposed
-            // handlers, then fault every pending request. Otherwise callers awaiting tcs.Task would hang
-            // forever on the Dispose path, because the watchdog's cancellation only covers an explicit
-            // DisconnectAsync and nothing covers Dispose.
+            ResetConnectionState(transportErrorMessage: _lastTransportErrorMessage ?? "The ACP client was disposed.");
+
+            // Reset has synchronously faulted pending requests and invalidated their tokens. Detach
+            // events before disposing the transport so teardown cannot re-enter disposed handlers.
             _transport.MessageReceived -= OnMessageReceived;
             _transport.ErrorOccurred -= OnTransportError;
-            CancelPendingRequests(_lastTransportErrorMessage ?? "The ACP client was disposed.");
 
             // The transport is owned exclusively by this client (process / socket / HttpClient / Rx
             // subject), and Dispose is its authoritative release path; a graceful protocol-level
@@ -3734,8 +3876,6 @@ namespace SalmonEgg.Acp.Client
                     exception: ex);
             }
 
-            _messageLoopCts?.Dispose();
-            _messageLoopCts = null;
             GC.SuppressFinalize(this);
         }
     }

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -1207,18 +1207,22 @@ namespace SalmonEgg.Acp.Client
             {
                 if (sent)
                 {
-                    _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(idStr, pending));
-                    if (response is null)
+                    // A shared batch commits the response actually written before waking its
+                    // original callers. Their continuations cannot overwrite that terminal fact.
+                    if (_pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(idStr, pending)))
                     {
-                        pending.ElicitationState!.Invalidate();
-                    }
-                    else
-                    {
-                        pending.ElicitationState!.MarkResponseSent(response.Action);
-                    }
-                    if (response is not ElicitationAcceptResponse)
-                    {
-                        RemovePendingUrlElicitation(pending);
+                        if (response is null)
+                        {
+                            pending.ElicitationState!.Invalidate();
+                        }
+                        else
+                        {
+                            pending.ElicitationState!.MarkResponseSent(response.Action);
+                        }
+                        if (response is not ElicitationAcceptResponse)
+                        {
+                            RemovePendingUrlElicitation(pending);
+                        }
                     }
                 }
                 else if (!IsBatchedResponse(pending) && !isCancellationResponse

--- a/src/SalmonEgg.Acp/Client/ElicitationEvents.cs
+++ b/src/SalmonEgg.Acp/Client/ElicitationEvents.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SalmonEgg.Acp.Protocol;
 
@@ -14,6 +15,8 @@ namespace SalmonEgg.Acp.Client
     /// </remarks>
     public sealed class ElicitationRequestEventArgs : EventArgs
     {
+        private int _standaloneResponseInFlight;
+
         /// <summary>
         /// Creates the event payload for an inbound elicitation request.
         /// </summary>
@@ -28,13 +31,34 @@ namespace SalmonEgg.Acp.Client
             Func<ElicitationAcceptContent?, Task<bool>> accept,
             Func<Task<bool>> decline,
             Func<Task<bool>> cancel)
+            : this(messageId, request, accept, decline, cancel, new ElicitationRequestState())
+        {
+            Accept = content => RespondStandaloneAsync(() => accept(content), ElicitationActions.Accept);
+            Decline = () => RespondStandaloneAsync(decline, ElicitationActions.Decline);
+            Cancel = () => RespondStandaloneAsync(cancel, ElicitationActions.Cancel);
+        }
+
+        internal ElicitationRequestEventArgs(
+            object messageId,
+            CreateElicitationRequest request,
+            Func<ElicitationAcceptContent?, Task<bool>> accept,
+            Func<Task<bool>> decline,
+            Func<Task<bool>> cancel,
+            ElicitationRequestState state)
         {
             MessageId = messageId ?? throw new ArgumentNullException(nameof(messageId));
             Request = request ?? throw new ArgumentNullException(nameof(request));
-            Accept = accept ?? throw new ArgumentNullException(nameof(accept));
-            Decline = decline ?? throw new ArgumentNullException(nameof(decline));
-            Cancel = cancel ?? throw new ArgumentNullException(nameof(cancel));
+            ArgumentNullException.ThrowIfNull(accept);
+            ArgumentNullException.ThrowIfNull(decline);
+            ArgumentNullException.ThrowIfNull(cancel);
+            State = state ?? throw new ArgumentNullException(nameof(state));
+            Accept = accept;
+            Decline = decline;
+            Cancel = cancel;
         }
+
+        /// <summary>The authoritative lifetime of this request, including URL completion.</summary>
+        public ElicitationRequestState State { get; }
 
         /// <summary>
         /// The JSON-RPC id the response must echo.
@@ -66,6 +90,30 @@ namespace SalmonEgg.Acp.Client
         /// Cancels the request when the user dismisses it without choosing.
         /// </summary>
         public Func<Task<bool>> Cancel { get; }
+
+        private async Task<bool> RespondStandaloneAsync(Func<Task<bool>> respond, string action)
+        {
+            if (!State.CanRespond || Interlocked.CompareExchange(ref _standaloneResponseInFlight, 1, 0) != 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!await respond().ConfigureAwait(false))
+                {
+                    return false;
+                }
+
+                State.MarkResponseSent(action);
+                State.NotifyChanged();
+                return true;
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _standaloneResponseInFlight, 0);
+            }
+        }
     }
 
     /// <summary>

--- a/src/SalmonEgg.Acp/Client/ElicitationRequestState.cs
+++ b/src/SalmonEgg.Acp/Client/ElicitationRequestState.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>
+/// Read-only lifetime of one inbound elicitation, owned by the client that received it.
+/// </summary>
+/// <remarks>
+/// Completion is independent of consent: an early completion never authorizes opening a URL.
+/// Consumers must stop interacting when <see cref="ConnectionClosed"/> is cancelled.
+/// </remarks>
+public sealed class ElicitationRequestState
+{
+    private string? _responseAction;
+    private int _cancellationRequested;
+    private int _isCompleted;
+    private int _isUnavailable;
+
+    internal ElicitationRequestState(CancellationToken connectionClosed = default)
+    {
+        ConnectionClosed = connectionClosed;
+    }
+
+    /// <summary>Whether this exact request can still receive the user's response.</summary>
+    public bool CanRespond => CanCancel && !IsCancellationRequested;
+
+    /// <summary>Whether cancellation may still be sent, including retrying a failed cancel.</summary>
+    public bool CanCancel => ResponseAction is null && Volatile.Read(ref _isUnavailable) == 0
+        && !ConnectionClosed.IsCancellationRequested;
+
+    /// <summary>The successfully sent response action, or null until a response succeeds.</summary>
+    public string? ResponseAction => Volatile.Read(ref _responseAction);
+
+    /// <summary>Whether the Agent reported completion of this URL interaction.</summary>
+    public bool IsCompleted => Volatile.Read(ref _isCompleted) != 0;
+
+    /// <summary>Cancelled when the connection that owns this request ends.</summary>
+    public CancellationToken ConnectionClosed { get; }
+
+    internal bool IsResponseInFlight { get; set; }
+
+    internal bool IsCancellationRequested => Volatile.Read(ref _cancellationRequested) != 0;
+
+    /// <summary>Raised when response availability or external completion changes.</summary>
+    public event EventHandler? Changed;
+
+    internal void MarkResponseSent(string action)
+    {
+        Interlocked.CompareExchange(ref _responseAction, action, null);
+    }
+
+    internal void RequestCancellation()
+    {
+        Interlocked.Exchange(ref _cancellationRequested, 1);
+    }
+
+    internal void Invalidate()
+    {
+        Interlocked.Exchange(ref _isUnavailable, 1);
+    }
+
+    internal void MarkCompleted()
+    {
+        Interlocked.Exchange(ref _isCompleted, 1);
+    }
+
+    internal void NotifyChanged()
+    {
+        var subscribers = Changed;
+        if (subscribers is null)
+        {
+            return;
+        }
+
+        // Observer exceptions cannot undo a committed transition or skip the remaining consumers.
+        foreach (EventHandler subscriber in subscribers.GetInvocationList())
+        {
+            try
+            {
+                subscriber(this, EventArgs.Empty);
+            }
+            catch
+            {
+                // This is a best-effort notification; the authoritative snapshot remains readable.
+            }
+        }
+    }
+}

--- a/src/SalmonEgg.Acp/PublicSurface.Types.txt
+++ b/src/SalmonEgg.Acp/PublicSurface.Types.txt
@@ -29,6 +29,7 @@ SalmonEgg.Acp.Client.AcpTransportMessageReceivedEventArgs stable
 SalmonEgg.Acp.Client.AcpTransportSendOptions stable
 SalmonEgg.Acp.Client.ElicitationCompletedEventArgs stable
 SalmonEgg.Acp.Client.ElicitationRequestEventArgs stable
+SalmonEgg.Acp.Client.ElicitationRequestState stable
 SalmonEgg.Acp.Client.FileSystemRequestEventArgs stable
 SalmonEgg.Acp.Client.FileSystemRequestKind stable
 SalmonEgg.Acp.Client.IAcpClient stable

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -42,7 +42,7 @@ hosts must enable optional capabilities only after implementing their interactio
 | Agent authentication | Only an absent discriminator or the exact `agent` type can reach `authenticate`. Unsupported strings round-trip without being selected; non-string discriminators are rejected. | Hosts must implement interactive login before opting into `ClientCapabilities.Auth.Terminal`. The Windows PTY host is implemented, but SalmonEgg does not advertise it until packaged-application acceptance completes; see [#147](https://github.com/salmonloop/salmon-egg/issues/147). SalmonEgg credential injection binds a stored value to an explicit transport destination independently of the ACP `authenticate` request. |
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
-| URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
+| URL elicitation | The SDK owns consent-response availability, connection lifetime, and completion in `ElicitationRequestEventArgs.State`. URL mode stays off in SDK defaults; SalmonEgg enables it only on WASM through its platform capability service. | Native GUI consent-to-browser validation and independent real-Agent interoperability remain open in [#154](https://github.com/salmonloop/salmon-egg/issues/154). [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
 | ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, message/tool/terminal projections, permission request handling, and version-gated JSON-RPC batches are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Configuration workflows, application UI integration, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
 
 Internal v2 batch validation follows the upstream schema at
@@ -207,6 +207,26 @@ through that constructor, the SDK cannot query a client lifetime: `CanRespond` r
 normal completion of the supplied `Task` callback makes `TryRespondAsync` return true. Exceptions
 from that callback remain observable. Callbacks received from `AcpClient` retain the actual send
 result without casting a `Task` to `Task<bool>`.
+
+### URL consent and completion
+
+Hosts display the complete URL and destination host before navigation. Opening requires an explicit
+user action and an isolated external browser context; WASM uses native `noopener,noreferrer` and
+rejects application-origin URLs. A browser dispatch does not prove that a popup opened, so the UI
+allows a new explicit **Open again** action without sending a second ACP response. An `accept`
+response carries no form content and acknowledges consent only; `elicitation/complete` independently
+marks the existing request complete. Unknown or duplicate completion IDs do nothing.
+
+The state is scoped to the connection that received the request. Hosts observe `State.Changed` and
+`State.ConnectionClosed`, marshal updates to their UI thread, and stop using expired callbacks.
+Connection shutdown marks the token cancelled and clears pending requests synchronously; host
+cancellation callbacks run asynchronously and cannot delay disconnect. Callback failures are
+observed without logging their potentially private data.
+
+SalmonEgg currently presents session-scoped requests. Request-scoped requests are explicitly
+cancelled when no conversation surface can present them. Windows, Linux, macOS, Android, and iOS do
+not advertise URL elicitation yet. The separate Linux launcher probe verifies real `xdg-open` and
+browser isolation; it does not substitute for native GUI acceptance or five-platform validation.
 
 ## ACP v2 draft surface (SEACP002)
 

--- a/src/SalmonEgg.Domain/Services/ExternalUriTarget.cs
+++ b/src/SalmonEgg.Domain/Services/ExternalUriTarget.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace SalmonEgg.Domain.Services;
+
+// A navigation intent is deliberately not a record: generated ToString must never print a URL/token.
+public sealed class ExternalUriTarget
+{
+    private ExternalUriTarget(string fullUrl, Uri uri)
+    {
+        FullUrl = fullUrl;
+        Uri = uri;
+        Host = uri.IdnHost;
+        HasAmbiguousHost = Host.Split('.').Any(label => label.StartsWith("xn--", StringComparison.OrdinalIgnoreCase))
+            || uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6
+            || !uri.IsDefaultPort || Host.EndsWith(".", StringComparison.Ordinal);
+    }
+
+    public string FullUrl { get; }
+
+    public string Host { get; }
+
+    public bool HasAmbiguousHost { get; }
+
+    public Uri Uri { get; }
+
+    public static bool TryCreate(string? value, out ExternalUriTarget? target)
+    {
+        target = null;
+        if (string.IsNullOrWhiteSpace(value)
+            || !string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            || value.Contains('\\')
+            || value.Any(character => char.IsControl(character)
+                || char.GetUnicodeCategory(character) == UnicodeCategory.Format)
+            || !Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || string.IsNullOrEmpty(uri.Host)
+            || !string.IsNullOrEmpty(uri.UserInfo)
+            || (uri.Scheme != Uri.UriSchemeHttps && !(uri.Scheme == Uri.UriSchemeHttp && IsDevelopmentHost(uri.Host))))
+        {
+            return false;
+        }
+
+        try
+        {
+            // IdnHost forces the platform IDNA validation before anything becomes an openable target.
+            target = new ExternalUriTarget(value, uri);
+            return true;
+        }
+        catch (UriFormatException)
+        {
+            return false;
+        }
+    }
+
+    public override string ToString() => nameof(ExternalUriTarget);
+
+    private static bool IsDevelopmentHost(string host)
+        => host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || host == "127.0.0.1" || host == "[::1]";
+}

--- a/src/SalmonEgg.Domain/Services/IExternalUriLauncher.cs
+++ b/src/SalmonEgg.Domain/Services/IExternalUriLauncher.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SalmonEgg.Domain.Services;
+
+public interface IExternalUriLauncher
+{
+    bool IsSupported { get; }
+
+    // Called synchronously from the consent command until the platform has consumed user activation.
+    Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken);
+}
+
+public enum ExternalUriOpenResult
+{
+    Opened,
+    // The platform accepted the navigation intent but cannot report whether a page opened.
+    Dispatched,
+    Unavailable,
+    Blocked,
+    Failed,
+    Cancelled
+}
+
+public sealed class UnsupportedExternalUriLauncher : IExternalUriLauncher
+{
+    public static UnsupportedExternalUriLauncher Instance { get; } = new();
+
+    public bool IsSupported => false;
+
+    public Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken)
+        => Task.FromResult(ExternalUriOpenResult.Unavailable);
+}

--- a/src/SalmonEgg.Domain/Services/IPlatformCapabilityService.cs
+++ b/src/SalmonEgg.Domain/Services/IPlatformCapabilityService.cs
@@ -15,6 +15,8 @@ public interface IPlatformCapabilityService
     bool SupportsTerminalAuthentication => false;
     bool SupportsGamepadInput { get; }
 
+    bool SupportsUrlElicitation => false;
+
     /// <summary>
     /// True when the app can tell whether its <c>salmon-egg</c> command is reachable from a shell. Needs a
     /// PATH to resolve and a process host to ask the resolved executable what version it is.

--- a/src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Domain.Services;
+
+namespace SalmonEgg.Infrastructure.Services;
+
+public sealed class DesktopElicitationUriLauncher : IExternalUriLauncher
+{
+    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(3);
+    private readonly IPlatformRuntimeCapabilityProbe _runtimeProbe;
+
+    public DesktopElicitationUriLauncher(IPlatformRuntimeCapabilityProbe runtimeProbe)
+    {
+        _runtimeProbe = runtimeProbe ?? throw new ArgumentNullException(nameof(runtimeProbe));
+    }
+
+    // Each additional native target requires its own real handler/isolation gate before advertising.
+    public bool IsSupported => OperatingSystem.IsLinux() && _runtimeProbe.IsDesktopProcessHost
+        && _runtimeProbe.HasExternalFileOpener;
+
+    public async Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (!IsSupported)
+        {
+            return ExternalUriOpenResult.Unavailable;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return ExternalUriOpenResult.Cancelled;
+        }
+
+        try
+        {
+            var startInfo = PlatformShellService.CreateLaunchProcessStartInfo(target.Uri.AbsoluteUri, _runtimeProbe);
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return ExternalUriOpenResult.Failed;
+            }
+
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(OpenTimeout);
+            using var readers = new CancellationTokenSource();
+            // Browser-handler output may contain the URL. Drain it without retaining or logging it.
+            var output = Task.WhenAll(DrainAsync(process.StandardOutput.BaseStream, readers.Token),
+                DrainAsync(process.StandardError.BaseStream, readers.Token));
+            try
+            {
+                await process.WaitForExitAsync(deadline.Token).ConfigureAwait(false);
+                await output.WaitAsync(deadline.Token).ConfigureAwait(false);
+                return process.ExitCode == 0 ? ExternalUriOpenResult.Opened : ExternalUriOpenResult.Failed;
+            }
+            catch (OperationCanceledException) when (deadline.IsCancellationRequested)
+            {
+                return cancellationToken.IsCancellationRequested ? ExternalUriOpenResult.Cancelled : ExternalUriOpenResult.Failed;
+            }
+            finally
+            {
+                await CleanupAsync(process, readers, output).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            return cancellationToken.IsCancellationRequested ? ExternalUriOpenResult.Cancelled : ExternalUriOpenResult.Failed;
+        }
+    }
+
+    private static async Task CleanupAsync(Process process, CancellationTokenSource readers, Task output)
+    {
+        try
+        {
+            // Only the short-lived opener is ours. Its browser descendants belong to the user.
+            if (!process.HasExited)
+            {
+                process.Kill();
+            }
+
+            using var deadline = new CancellationTokenSource(CleanupTimeout);
+            await process.WaitForExitAsync(deadline.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await readers.CancelAsync().ConfigureAwait(false);
+            process.StandardOutput.Dispose();
+            process.StandardError.Dispose();
+            await output.ConfigureAwait(false);
+        }
+    }
+
+    private static async Task DrainAsync(System.IO.Stream stream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await stream.CopyToAsync(System.IO.Stream.Null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (cancellationToken.IsCancellationRequested
+            && ex is OperationCanceledException or ObjectDisposedException or System.IO.IOException)
+        {
+            // Closing our read endpoints also releases inherited pipes held by a launched browser.
+        }
+    }
+}

--- a/src/SalmonEgg.Infrastructure/Network/WebSocketTransport.cs
+++ b/src/SalmonEgg.Infrastructure/Network/WebSocketTransport.cs
@@ -235,13 +235,14 @@ namespace SalmonEgg.Infrastructure.Network
 
             try
             {
-                _logger.Debug("Sending message: {Message}", message);
+                _logger.Debug("Sending WebSocket message. Length={Length}", message.Length);
                 client.Send(message);
                 await Task.CompletedTask; // Make method async-compatible
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to send message: {Message}", message);
+                _logger.Error("Failed to send WebSocket message. Length={Length} ExceptionType={ExceptionType}",
+                    message.Length, ex.GetType().FullName);
                 // A fatal send failure (the connection is actually gone) must be reflected in the
                 // transport state so downstream IsConnected projections flip and in-flight requests
                 // are faulted rather than hanging until timeout. A transient failure leaves the
@@ -301,7 +302,7 @@ namespace SalmonEgg.Infrastructure.Network
                             return;
                         }
 
-                        _logger.Debug("Received message: {Message}", text);
+                        _logger.Debug("Received WebSocket message. Length={Length}", text.Length);
                         PublishMessage(text);
                     }
                 }),

--- a/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
+++ b/src/SalmonEgg.Infrastructure/Services/PlatformCapabilityService.cs
@@ -8,6 +8,7 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
 {
     private readonly IPlatformRuntimeCapabilityProbe _runtimeProbe;
     private readonly Func<OSPlatform, bool> _isOSPlatform;
+    private readonly IExternalUriLauncher _externalUriLauncher;
 
     public PlatformCapabilityService()
         : this(new PlatformRuntimeCapabilityProbe())
@@ -19,12 +20,19 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
     {
     }
 
+    public PlatformCapabilityService(IPlatformRuntimeCapabilityProbe runtimeProbe, IExternalUriLauncher externalUriLauncher)
+        : this(runtimeProbe, RuntimeInformation.IsOSPlatform)
+    {
+        _externalUriLauncher = externalUriLauncher ?? throw new ArgumentNullException(nameof(externalUriLauncher));
+    }
+
     internal PlatformCapabilityService(
         IPlatformRuntimeCapabilityProbe runtimeProbe,
         Func<OSPlatform, bool> isOSPlatform)
     {
         _runtimeProbe = runtimeProbe ?? throw new ArgumentNullException(nameof(runtimeProbe));
         _isOSPlatform = isOSPlatform ?? throw new ArgumentNullException(nameof(isOSPlatform));
+        _externalUriLauncher = UnsupportedExternalUriLauncher.Instance;
     }
 
     public bool SupportsLaunchOnStartup => IsWindowsDesktopProcessHost;
@@ -55,6 +63,8 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
     public bool SupportsTerminalAuthentication => false;
 
     public bool SupportsGamepadInput => IsBrowserRuntime || IsWindowsDesktopProcessHost;
+
+    public bool SupportsUrlElicitation => _externalUriLauncher.IsSupported;
 
     public bool SupportsCliCommandInspection => _runtimeProbe.IsDesktopProcessHost;
 

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1477,4 +1477,7 @@ Create the corresponding Markdown file in:
   <data name="Elicitation_RequestExpired" xml:space="preserve">
     <value>This request has expired. Reconnect to continue.</value>
   </data>
+  <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
+    <value>Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1450,4 +1450,31 @@ Create the corresponding Markdown file in:
   <data name="ChatAuth_TerminalCancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="Elicitation_OpenBrowser" xml:space="preserve">
+    <value>Open in browser</value>
+  </data>
+  <data name="Elicitation_RetryResponse" xml:space="preserve">
+    <value>Retry response</value>
+  </data>
+  <data name="Elicitation_Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Elicitation_UrlCompleted" xml:space="preserve">
+    <value>The agent reports that the external step is complete.</value>
+  </data>
+  <data name="Elicitation_UrlWaiting" xml:space="preserve">
+    <value>Opening was requested. If no page appeared, allow popups and choose Open again. Waiting for the agent to confirm completion.</value>
+  </data>
+  <data name="Elicitation_UnsafeUrl" xml:space="preserve">
+    <value>This address cannot be opened safely. Decline or cancel this request.</value>
+  </data>
+  <data name="Elicitation_UrlUnavailable" xml:space="preserve">
+    <value>This device cannot safely open this request. Decline or cancel it.</value>
+  </data>
+  <data name="Elicitation_OpenFailed" xml:space="preserve">
+    <value>The browser could not be opened. Allow popups and try again, or cancel.</value>
+  </data>
+  <data name="Elicitation_RequestExpired" xml:space="preserve">
+    <value>This request has expired. Reconnect to continue.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1477,4 +1477,7 @@ Create the corresponding Markdown file in:
   <data name="Elicitation_RequestExpired" xml:space="preserve">
     <value>This request has expired. Reconnect to continue.</value>
   </data>
+  <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
+    <value>Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1450,4 +1450,31 @@ Create the corresponding Markdown file in:
   <data name="ChatAuth_TerminalCancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="Elicitation_OpenBrowser" xml:space="preserve">
+    <value>Open in browser</value>
+  </data>
+  <data name="Elicitation_RetryResponse" xml:space="preserve">
+    <value>Retry response</value>
+  </data>
+  <data name="Elicitation_Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Elicitation_UrlCompleted" xml:space="preserve">
+    <value>The agent reports that the external step is complete.</value>
+  </data>
+  <data name="Elicitation_UrlWaiting" xml:space="preserve">
+    <value>Opening was requested. If no page appeared, allow popups and choose Open again. Waiting for the agent to confirm completion.</value>
+  </data>
+  <data name="Elicitation_UnsafeUrl" xml:space="preserve">
+    <value>This address cannot be opened safely. Decline or cancel this request.</value>
+  </data>
+  <data name="Elicitation_UrlUnavailable" xml:space="preserve">
+    <value>This device cannot safely open this request. Decline or cancel it.</value>
+  </data>
+  <data name="Elicitation_OpenFailed" xml:space="preserve">
+    <value>The browser could not be opened. Allow popups and try again, or cancel.</value>
+  </data>
+  <data name="Elicitation_RequestExpired" xml:space="preserve">
+    <value>This request has expired. Reconnect to continue.</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1456,4 +1456,31 @@
   <data name="ChatAuth_TerminalCancel" xml:space="preserve">
     <value>取消</value>
   </data>
+  <data name="Elicitation_OpenBrowser" xml:space="preserve">
+    <value>在浏览器中打开</value>
+  </data>
+  <data name="Elicitation_RetryResponse" xml:space="preserve">
+    <value>重试发送回复</value>
+  </data>
+  <data name="Elicitation_Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+  <data name="Elicitation_UrlCompleted" xml:space="preserve">
+    <value>智能体已确认外部操作完成。</value>
+  </data>
+  <data name="Elicitation_UrlWaiting" xml:space="preserve">
+    <value>已请求打开网页。如果没有出现，请允许弹出窗口后选择“再次打开”。正在等待智能体确认完成。</value>
+  </data>
+  <data name="Elicitation_UnsafeUrl" xml:space="preserve">
+    <value>无法安全打开这个地址。请拒绝或取消本次请求。</value>
+  </data>
+  <data name="Elicitation_UrlUnavailable" xml:space="preserve">
+    <value>此设备暂不支持安全打开本次请求。请拒绝或取消。</value>
+  </data>
+  <data name="Elicitation_OpenFailed" xml:space="preserve">
+    <value>浏览器未能打开。请允许弹出窗口后重试，或取消请求。</value>
+  </data>
+  <data name="Elicitation_RequestExpired" xml:space="preserve">
+    <value>这个请求已失效。请重新连接后继续。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1483,4 +1483,7 @@
   <data name="Elicitation_RequestExpired" xml:space="preserve">
     <value>这个请求已失效。请重新连接后继续。</value>
   </data>
+  <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
+    <value>无法取消未能显示的请求，已断开此连接。请重新连接 Agent。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1456,4 +1456,31 @@
   <data name="ChatAuth_TerminalCancel" xml:space="preserve">
     <value>取消</value>
   </data>
+  <data name="Elicitation_OpenBrowser" xml:space="preserve">
+    <value>在浏览器中打开</value>
+  </data>
+  <data name="Elicitation_RetryResponse" xml:space="preserve">
+    <value>重试发送回复</value>
+  </data>
+  <data name="Elicitation_Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+  <data name="Elicitation_UrlCompleted" xml:space="preserve">
+    <value>智能体已确认外部操作完成。</value>
+  </data>
+  <data name="Elicitation_UrlWaiting" xml:space="preserve">
+    <value>已请求打开网页。如果没有出现，请允许弹出窗口后选择“再次打开”。正在等待智能体确认完成。</value>
+  </data>
+  <data name="Elicitation_UnsafeUrl" xml:space="preserve">
+    <value>无法安全打开这个地址。请拒绝或取消本次请求。</value>
+  </data>
+  <data name="Elicitation_UrlUnavailable" xml:space="preserve">
+    <value>此设备暂不支持安全打开本次请求。请拒绝或取消。</value>
+  </data>
+  <data name="Elicitation_OpenFailed" xml:space="preserve">
+    <value>浏览器未能打开。请允许弹出窗口后重试，或取消请求。</value>
+  </data>
+  <data name="Elicitation_RequestExpired" xml:space="preserve">
+    <value>这个请求已失效。请重新连接后继续。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1483,4 +1483,7 @@
   <data name="Elicitation_RequestExpired" xml:space="preserve">
     <value>这个请求已失效。请重新连接后继续。</value>
   </data>
+  <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
+    <value>无法取消未能显示的请求，已断开此连接。请重新连接 Agent。</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
@@ -33,6 +33,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
     private readonly ITransportSupportPolicy _transportSupportPolicy;
     private readonly ILogger<AcpChatCoordinator> _logger;
     private readonly int _sessionUpdateBufferLimit;
+    private readonly IPlatformCapabilityService? _platformCapabilities;
     private AcpChatServiceAdapter? _activeChatServiceAdapter;
     private readonly object _applyScopeLock = new();
     private readonly object _poolConnectionGateSync = new();
@@ -51,7 +52,8 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         IAcpConnectionSessionCleaner? sessionCleaner = null,
         IAcpConnectionPoolManager? connectionPoolManager = null,
         IAcpConnectionDependencySnapshotProvider? connectionDependencySnapshotProvider = null,
-        int sessionUpdateBufferLimit = DefaultSessionUpdateBufferLimit)
+        int sessionUpdateBufferLimit = DefaultSessionUpdateBufferLimit,
+        IPlatformCapabilityService? platformCapabilities = null)
     {
         _chatServiceFactory = chatServiceFactory ?? throw new ArgumentNullException(nameof(chatServiceFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -80,6 +82,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             ?? throw new ArgumentNullException(nameof(sessionCommandOrchestrator));
         _transportSupportPolicy = transportSupportPolicy ?? throw new ArgumentNullException(nameof(transportSupportPolicy));
         _sessionUpdateBufferLimit = sessionUpdateBufferLimit;
+        _platformCapabilities = platformCapabilities;
     }
 
     public async Task<AcpTransportApplyResult> ConnectToProfileAsync(
@@ -1092,7 +1095,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         return new ApplyScope(this, scopeCts, callerToken);
     }
 
-    private static async Task<InitializeResponse> InitializeCandidateAsync(
+    private async Task<InitializeResponse> InitializeCandidateAsync(
         IChatService chatService,
         TransportType transportType,
         string? profileId,
@@ -1106,7 +1109,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             profileId,
             conversationId,
             initializeTimeout,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken, _platformCapabilities).ConfigureAwait(false);
     }
 
     private static TimeSpan ResolveInitializeTimeout(ServerConfiguration? profile)

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeRequestFactory.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeRequestFactory.cs
@@ -1,10 +1,11 @@
 using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Services;
 
 namespace SalmonEgg.Presentation.Core.Services.Chat;
 
 internal static class AcpInitializeRequestFactory
 {
-    public static InitializeParams CreateDefault()
+    public static InitializeParams CreateDefault(IPlatformCapabilityService? platformCapabilities = null)
         => new()
         {
             ProtocolVersion = AcpProtocolVersion.Default,
@@ -14,6 +15,18 @@ internal static class AcpInitializeRequestFactory
                 Title = "SalmonEgg",
                 Version = "1.0.0"
             },
-            ClientCapabilities = ClientCapabilityDefaults.Create()
+            ClientCapabilities = CreateCapabilities(platformCapabilities)
         };
+
+    private static ClientCapabilities CreateCapabilities(IPlatformCapabilityService? platformCapabilities)
+    {
+        var defaults = ClientCapabilityDefaults.Create();
+        return defaults with
+        {
+            Elicitation = defaults.Elicitation! with
+            {
+                Url = platformCapabilities?.SupportsUrlElicitation == true ? new ElicitationUrlCapabilities() : null
+            }
+        };
+    }
 }

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeTimeout.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeTimeout.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using SalmonEgg.Application.Services.Chat;
 using SalmonEgg.Domain.Models;
 using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Services;
 
 namespace SalmonEgg.Presentation.Core.Services.Chat;
 
@@ -18,12 +19,13 @@ internal static class AcpInitializeTimeout
         string? profileId,
         string? conversationId,
         TimeSpan timeout,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IPlatformCapabilityService? platformCapabilities = null)
     {
         try
         {
             return await chatService
-                .InitializeAsync(AcpInitializeRequestFactory.CreateDefault())
+                .InitializeAsync(AcpInitializeRequestFactory.CreateDefault(platformCapabilities))
                 .WaitAsync(timeout, cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -1764,21 +1764,23 @@ public partial class ChatViewModel
         });
     }
 
-    private void OnElicitationRequestReceived(object? sender, ElicitationRequestEventArgs e)
+    private void ProcessElicitationRequest(IChatService service, int foregroundGeneration, ElicitationRequestEventArgs request)
     {
-        var requestingAgent = (sender as IChatService)?.AgentInfo;
-        _ = ProcessElicitationRequestAsync(e, requestingAgent?.Title ?? requestingAgent?.Name ?? CurrentAgentDisplayText);
+        var requestingAgent = service.AgentInfo;
+        _ = ProcessElicitationRequestAsync(service, foregroundGeneration, request,
+            requestingAgent?.Title ?? requestingAgent?.Name ?? CurrentAgentDisplayText);
     }
 
-    private async Task ProcessElicitationRequestAsync(ElicitationRequestEventArgs e, string agentName)
+    private async Task ProcessElicitationRequestAsync(
+        IChatService service, int foregroundGeneration, ElicitationRequestEventArgs request, string agentName)
     {
-        var foregroundServiceGeneration = Volatile.Read(ref _foregroundChatServiceGeneration);
         try
         {
             var projection = await _interactionEventBridge.BuildElicitationRequestAsync(
-                e,
+                request,
                 (conversationId, request) => PostToUiAsync(() => RemovePendingElicitationRequestState(conversationId, request)),
-                Logger, PostToUiAsync, agentName).ConfigureAwait(false);
+                Logger, PostToUiAsync, agentName,
+                unshown => CancelUndisplayedElicitationAsync(service, foregroundGeneration, unshown)).ConfigureAwait(false);
             if (projection is null)
             {
                 return;
@@ -1789,7 +1791,8 @@ public partial class ChatViewModel
             {
                 // Routing and dispatcher work may finish after the foreground owner was replaced.
                 // A stale form must not occupy the new connection's only interaction slot.
-                if (_disposed || !e.State.CanRespond || foregroundServiceGeneration != Volatile.Read(ref _foregroundChatServiceGeneration))
+                if (_disposed || !request.State.CanRespond || !service.IsConnected
+                    || foregroundGeneration != Volatile.Read(ref _foregroundChatServiceGeneration))
                 {
                     return;
                 }
@@ -1802,14 +1805,32 @@ public partial class ChatViewModel
                 projection.Value.ViewModel.Dispose();
                 // This surface holds one form per conversation. Keep the visible request and cancel
                 // the unshown one instead of replacing an interaction the user still needs to answer.
-                await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(e, Logger).ConfigureAwait(false);
+                await CancelUndisplayedElicitationAsync(service, foregroundGeneration, request).ConfigureAwait(false);
             }
         }
         catch (Exception)
         {
-            Logger.LogError("Error processing elicitation request");
-            await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(e, Logger).ConfigureAwait(false);
+            await CancelUndisplayedElicitationAsync(service, foregroundGeneration, request).ConfigureAwait(false);
         }
+    }
+
+    private async Task CancelUndisplayedElicitationAsync(
+        IChatService service, int foregroundGeneration, ElicitationRequestEventArgs request)
+    {
+        if (await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(request, Logger).ConfigureAwait(false)) return;
+
+        await PostToUiAsync(async () =>
+        {
+            if (_disposed || foregroundGeneration != Volatile.Read(ref _foregroundChatServiceGeneration)
+                || !service.IsConnected || !request.State.CanCancel) return;
+
+            // This surface has no request-scoped retry. Release only the service captured when
+            // subscribing; forwarded senders and the current service may identify a different owner.
+            await _acpConnectionCommands.DisconnectAfterInteractionFailureAsync(service, this,
+                ResolveLocalizerText("Elicitation_CancellationFailedDisconnected",
+                    "Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent."))
+                .ConfigureAwait(true);
+        }).ConfigureAwait(false);
     }
 
     private void RemovePendingElicitationRequestState(string conversationId, ElicitationRequestViewModel request)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -1766,10 +1766,11 @@ public partial class ChatViewModel
 
     private void OnElicitationRequestReceived(object? sender, ElicitationRequestEventArgs e)
     {
-        _ = ProcessElicitationRequestAsync(e);
+        var requestingAgent = (sender as IChatService)?.AgentInfo;
+        _ = ProcessElicitationRequestAsync(e, requestingAgent?.Title ?? requestingAgent?.Name ?? CurrentAgentDisplayText);
     }
 
-    private async Task ProcessElicitationRequestAsync(ElicitationRequestEventArgs e)
+    private async Task ProcessElicitationRequestAsync(ElicitationRequestEventArgs e, string agentName)
     {
         var foregroundServiceGeneration = Volatile.Read(ref _foregroundChatServiceGeneration);
         try
@@ -1777,7 +1778,7 @@ public partial class ChatViewModel
             var projection = await _interactionEventBridge.BuildElicitationRequestAsync(
                 e,
                 (conversationId, request) => PostToUiAsync(() => RemovePendingElicitationRequestState(conversationId, request)),
-                Logger).ConfigureAwait(false);
+                Logger, PostToUiAsync, agentName).ConfigureAwait(false);
             if (projection is null)
             {
                 return;
@@ -1788,7 +1789,7 @@ public partial class ChatViewModel
             {
                 // Routing and dispatcher work may finish after the foreground owner was replaced.
                 // A stale form must not occupy the new connection's only interaction slot.
-                if (_disposed || foregroundServiceGeneration != Volatile.Read(ref _foregroundChatServiceGeneration))
+                if (_disposed || !e.State.CanRespond || foregroundServiceGeneration != Volatile.Read(ref _foregroundChatServiceGeneration))
                 {
                     return;
                 }
@@ -1798,14 +1799,15 @@ public partial class ChatViewModel
             }).ConfigureAwait(true);
             if (!displayed)
             {
+                projection.Value.ViewModel.Dispose();
                 // This surface holds one form per conversation. Keep the visible request and cancel
                 // the unshown one instead of replacing an interaction the user still needs to answer.
                 await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(e, Logger).ConfigureAwait(false);
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Logger.LogError(ex, "Error processing elicitation request");
+            Logger.LogError("Error processing elicitation request");
             await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(e, Logger).ConfigureAwait(false);
         }
     }

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
@@ -457,7 +457,7 @@ public partial class ChatViewModel
             IsPromptSubmitInFlight: IsPromptSubmitInFlight,
             IsVoiceInputListening: IsVoiceInputListening,
             VoiceInputTransportState: _voiceInputTransportState,
-            HasPendingAskUserRequest: PendingAskUserRequest is not null || PendingElicitationRequest is not null,
+            HasPendingAskUserRequest: PendingAskUserRequest is not null || PendingElicitationRequest is { IsAwaitingCompletion: false },
             ShouldShowLoadingOverlayPresenter: ShouldShowLoadingOverlayPresenter,
             IsSessionActive: IsSessionActive,
             HasChatService: _chatService is not null,
@@ -1767,6 +1767,7 @@ public partial class ChatViewModel
         OnPropertyChanged(nameof(ElicitationSubmitCommand));
         OnPropertyChanged(nameof(ElicitationDeclineCommand));
         OnPropertyChanged(nameof(ElicitationCancelCommand));
+        NotifyElicitationUrlProjectionChanged();
         NotifyComposerProjectionChanged();
     }
 
@@ -1777,6 +1778,23 @@ public partial class ChatViewModel
         OnPropertyChanged(nameof(ElicitationSubmitCommand));
         OnPropertyChanged(nameof(ElicitationDeclineCommand));
         OnPropertyChanged(nameof(ElicitationCancelCommand));
+        NotifyElicitationUrlProjectionChanged();
+        NotifyComposerProjectionChanged();
+    }
+
+    private void NotifyElicitationUrlProjectionChanged()
+    {
+        OnPropertyChanged(nameof(ElicitationAgentName));
+        OnPropertyChanged(nameof(ElicitationIsUrl));
+        OnPropertyChanged(nameof(ElicitationFullUrl));
+        OnPropertyChanged(nameof(ElicitationUrlHost));
+        OnPropertyChanged(nameof(ElicitationHasUrlWarning));
+        OnPropertyChanged(nameof(ElicitationIsAwaitingCompletion));
+        OnPropertyChanged(nameof(ElicitationUrlStatus));
+        OnPropertyChanged(nameof(ElicitationSubmitText));
+        OnPropertyChanged(nameof(ElicitationDismissCommand));
+        OnPropertyChanged(nameof(ElicitationReopenCommand));
+        OnPropertyChanged(nameof(ElicitationShowReopen));
     }
 
     partial void OnPendingAskUserRequestChanged(AskUserRequestViewModel? value)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -231,6 +231,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
     private readonly Dictionary<RemoteSessionRecoveryLeaseKey, RemoteSessionRecoveryRequest> _remoteSessionRecoveryRequests = new();
     private int _foregroundChatServiceGeneration;
     private EventHandler<PermissionRequestEventArgs>? _permissionRequestHandler;
+    private EventHandler<ElicitationRequestEventArgs>? _elicitationRequestHandler;
     private HydrationOverlayPhase _hydrationOverlayPhase = HydrationOverlayPhase.None;
     private string? _hydrationOverlayPhaseConversationId;
     private int _pendingSessionUpdateCount;
@@ -3390,7 +3391,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         chatService.TerminalRequestReceived += OnTerminalRequestReceived;
         chatService.TerminalStateChangedReceived += OnTerminalStateChangedReceived;
         chatService.AskUserRequestReceived += OnAskUserRequestReceived;
-        chatService.ElicitationRequestReceived += OnElicitationRequestReceived;
+        _elicitationRequestHandler = (_, request) => ProcessElicitationRequest(chatService, foregroundGeneration, request);
+        chatService.ElicitationRequestReceived += _elicitationRequestHandler;
         chatService.ErrorOccurred += OnErrorOccurred;
 
         _ = _authenticationCoordinator.UpdateAgentInfoAsync(_chatService, _chatStore, SelectedProfileId);
@@ -3408,7 +3410,11 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         chatService.TerminalRequestReceived -= OnTerminalRequestReceived;
         chatService.TerminalStateChangedReceived -= OnTerminalStateChangedReceived;
         chatService.AskUserRequestReceived -= OnAskUserRequestReceived;
-        chatService.ElicitationRequestReceived -= OnElicitationRequestReceived;
+        if (_elicitationRequestHandler is not null)
+        {
+            chatService.ElicitationRequestReceived -= _elicitationRequestHandler;
+            _elicitationRequestHandler = null;
+        }
         chatService.ErrorOccurred -= OnErrorOccurred;
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -986,6 +986,28 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
 
     public IAsyncRelayCommand? ElicitationCancelCommand => PendingElicitationRequest?.CancelCommand;
 
+    public string ElicitationAgentName => PendingElicitationRequest?.AgentName ?? string.Empty;
+
+    public bool ElicitationIsUrl => PendingElicitationRequest?.IsUrl ?? false;
+
+    public string ElicitationFullUrl => PendingElicitationRequest?.FullUrl ?? string.Empty;
+
+    public string ElicitationUrlHost => PendingElicitationRequest?.UrlHost ?? string.Empty;
+
+    public bool ElicitationHasUrlWarning => PendingElicitationRequest?.HasUrlWarning ?? false;
+
+    public bool ElicitationIsAwaitingCompletion => PendingElicitationRequest?.IsAwaitingCompletion ?? false;
+
+    public string ElicitationUrlStatus => PendingElicitationRequest?.UrlStatus ?? string.Empty;
+
+    public string ElicitationSubmitText => PendingElicitationRequest?.SubmitText ?? string.Empty;
+
+    public IAsyncRelayCommand? ElicitationDismissCommand => PendingElicitationRequest?.DismissCommand;
+
+    public IAsyncRelayCommand? ElicitationReopenCommand => PendingElicitationRequest?.ReopenCommand;
+
+    public bool ElicitationShowReopen => PendingElicitationRequest?.ShowReopen ?? false;
+
     // UI-BOUND PROPERTIES: Handlers for WinUI/Uno property change notifications.
     // These ensure the View reflects internal state changes that might not trigger automatically.
     public bool CanSendPromptUi => ResolveInputState().CanSendPrompt;
@@ -1411,7 +1433,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         IAiContentReportLauncher? aiContentReportLauncher = null,
         IShellLayoutMetricsSink? shellLayoutMetricsSink = null,
         IRemoteDirectoryRegistrar? remoteDirectoryRegistrar = null,
-        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null)
+        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null,
+        IExternalUriLauncher? externalUriLauncher = null)
         : base(logger)
     {
         _chatStore = chatStore ?? throw new ArgumentNullException(nameof(chatStore));
@@ -1475,7 +1498,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         NewSessionDraftModeOptions = new ReadOnlyObservableCollection<SessionModeViewModel>(_newSessionDraftModeOptions);
         NewSessionDraftModelOptions = new ReadOnlyObservableCollection<OptionValueViewModel>(_newSessionDraftModelOptions);
         _terminalProjectionCoordinator = new ChatTerminalProjectionCoordinator();
-        _interactionEventBridge = new ChatInteractionEventBridge(_authoritativeRemoteSessionRouter, _terminalProjectionCoordinator, _localizer);
+        _interactionEventBridge = new ChatInteractionEventBridge(_authoritativeRemoteSessionRouter, _terminalProjectionCoordinator, _localizer, externalUriLauncher);
         _authenticationCoordinator = new ChatAuthenticationCoordinator();
         _sessionHeaderActionCoordinator = new ChatSessionHeaderActionCoordinator();
         _localSlashCommandSource = localSlashCommandSource ?? StaticSlashCommandSource.Empty;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/ElicitationInteractionViewModels.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/ElicitationInteractionViewModels.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -11,14 +12,23 @@ using Microsoft.Extensions.Localization;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Domain.Services;
 
 namespace SalmonEgg.Presentation.ViewModels.Chat.Elicitation;
 
-public sealed partial class ElicitationRequestViewModel : ObservableObject
+public sealed partial class ElicitationRequestViewModel : ObservableObject, IDisposable
 {
     private readonly IStringLocalizer<CoreStrings>? _localizer;
     private readonly bool _hasUnsupportedRequiredFields;
     private string? _errorResourceKey;
+    private ElicitationRequestState? _requestState;
+    private IExternalUriLauncher _uriLauncher = UnsupportedExternalUriLauncher.Instance;
+    private ExternalUriTarget? _urlTarget;
+    private Func<Action, Task>? _dispatchAsync;
+    private CancellationTokenRegistration _connectionClosedRegistration;
+    private Func<Task>? _dismiss;
+    private bool _urlDispatched;
+    private bool _disposed;
 
     public ElicitationRequestViewModel(
         object messageId,
@@ -54,11 +64,42 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
 
     public ObservableCollection<ElicitationFieldViewModel> Fields { get; } = new();
 
-    public Func<ElicitationAcceptContent, Task<bool>>? OnAccept { get; set; }
+    public Func<ElicitationAcceptContent?, Task<bool>>? OnAccept { get; set; }
 
     public Func<Task<bool>>? OnDecline { get; set; }
 
     public Func<Task<bool>>? OnCancel { get; set; }
+
+    public bool IsUrl { get; private set; }
+
+    public string FullUrl { get; private set; } = string.Empty;
+
+    public string UrlHost => _urlTarget?.Host ?? string.Empty;
+
+    public bool HasUrlWarning => _urlTarget?.HasAmbiguousHost ?? false;
+
+    public string AgentName { get; private set; } = string.Empty;
+
+    public bool IsAwaitingCompletion => IsUrl && _requestState?.ResponseAction == ElicitationActions.Accept;
+
+    public bool IsCompleted => IsUrl && (_requestState?.IsCompleted ?? false);
+
+    public bool ShowReopen => IsAwaitingCompletion && !IsCompleted;
+
+    public bool CanReopen => ShowReopen && !_disposed && !IsSubmitting && _urlTarget is not null
+        && _uriLauncher.IsSupported && !(_requestState?.ConnectionClosed.IsCancellationRequested ?? false);
+
+    public bool CanRespond => !_disposed && !IsSubmitting && (_requestState?.CanRespond ?? true);
+
+    public bool CanCancel => !_disposed && !IsSubmitting && (_requestState?.CanCancel ?? true);
+
+    public string SubmitText => IsUrl
+        ? (_urlDispatched ? Localize("Elicitation_RetryResponse", "Retry response") : Localize("Elicitation_OpenBrowser", "Open in browser"))
+        : Localize("Elicitation_Submit", "Submit");
+
+    public string UrlStatus => IsCompleted
+        ? Localize("Elicitation_UrlCompleted", "The agent reports that the external step is complete.")
+        : Localize("Elicitation_UrlWaiting", "Opening was requested. If no page appeared, allow popups and choose Open again. Waiting for the agent to confirm completion.");
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanSubmit))]
@@ -70,14 +111,27 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
 
     public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
 
-    public bool CanSubmit => !IsSubmitting && !_hasUnsupportedRequiredFields && ValidateFields();
+    public bool CanSubmit => CanRespond && (IsUrl
+        ? _urlTarget is not null && _uriLauncher.IsSupported
+        : !_hasUnsupportedRequiredFields && ValidateFields());
 
     [RelayCommand(CanExecute = nameof(CanSubmit))]
     private async Task SubmitAsync()
     {
+        if (!CanRespond)
+        {
+            return;
+        }
+
         if (OnAccept is null)
         {
             SetLocalizedError("Elicitation_SubmitUnavailable", "This form cannot be submitted right now.");
+            return;
+        }
+
+        if (IsUrl)
+        {
+            await OpenAndAcceptAsync().ConfigureAwait(true);
             return;
         }
 
@@ -103,9 +157,14 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
         await RespondAsync(() => OnAccept(content)).ConfigureAwait(true);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanRespond))]
     private async Task DeclineAsync()
     {
+        if (!CanRespond)
+        {
+            return;
+        }
+
         if (OnDecline is null)
         {
             SetLocalizedError("Elicitation_ResponseUnavailable", "This request can no longer be answered.");
@@ -115,9 +174,14 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
         await RespondAsync(OnDecline).ConfigureAwait(true);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanCancel))]
     private async Task CancelAsync()
     {
+        if (!CanCancel)
+        {
+            return;
+        }
+
         if (OnCancel is null)
         {
             SetLocalizedError("Elicitation_ResponseUnavailable", "This request can no longer be answered.");
@@ -129,7 +193,103 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
 
     partial void OnIsSubmittingChanged(bool value)
     {
-        SubmitCommand.NotifyCanExecuteChanged();
+        RefreshCommands();
+    }
+
+    [RelayCommand]
+    private async Task DismissAsync()
+    {
+        if (_dismiss is not null && IsAwaitingCompletion)
+        {
+            await _dismiss().ConfigureAwait(true);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanReopen))]
+    private async Task ReopenAsync()
+    {
+        if (!CanReopen)
+        {
+            return;
+        }
+
+        ClearError();
+        IsSubmitting = true;
+        try
+        {
+            // This is a new explicit user gesture. It never sends another ACP response.
+            var result = await _uriLauncher.OpenAsync(_urlTarget!,
+                _requestState?.ConnectionClosed ?? CancellationToken.None).ConfigureAwait(true);
+            if (result is not (ExternalUriOpenResult.Opened or ExternalUriOpenResult.Dispatched))
+            {
+                SetLocalizedError("Elicitation_OpenFailed", "The browser could not be opened. Allow popups and try again, or cancel.");
+            }
+        }
+        catch
+        {
+            SetLocalizedError("Elicitation_OpenFailed", "The browser could not be opened. Allow popups and try again, or cancel.");
+        }
+        finally
+        {
+            IsSubmitting = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_requestState is not null)
+        {
+            _requestState.Changed -= OnRequestStateChanged;
+        }
+
+        _connectionClosedRegistration.Dispose();
+        FullUrl = string.Empty;
+        _urlTarget = null;
+        OnAccept = null;
+        OnDecline = null;
+        OnCancel = null;
+        foreach (var field in Fields)
+        {
+            field.Changed -= OnFieldChanged;
+        }
+
+        RefreshCommands();
+    }
+
+    internal void AttachRequest(
+        ElicitationRequestEventArgs args,
+        IExternalUriLauncher uriLauncher,
+        Func<Action, Task> dispatchAsync,
+        Func<Task> dismiss,
+        string agentName)
+    {
+        _requestState = args.State;
+        _dispatchAsync = dispatchAsync;
+        _dismiss = dismiss;
+        AgentName = agentName;
+        _uriLauncher = uriLauncher;
+        if (args.Request is UrlElicitationRequest url)
+        {
+            IsUrl = true;
+            FullUrl = url.Url;
+            if (!ExternalUriTarget.TryCreate(url.Url, out _urlTarget))
+            {
+                SetLocalizedError("Elicitation_UnsafeUrl", "This address cannot be opened safely. Decline or cancel this request.");
+            }
+            else if (!uriLauncher.IsSupported)
+            {
+                SetLocalizedError("Elicitation_UrlUnavailable", "This device cannot safely open this request. Decline or cancel it.");
+            }
+        }
+
+        _requestState.Changed += OnRequestStateChanged;
+        _connectionClosedRegistration = _requestState.ConnectionClosed.Register(OnConnectionClosed);
     }
 
     public void ReprojectLocalizedState()
@@ -142,6 +302,56 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
         if (!string.IsNullOrWhiteSpace(_errorResourceKey))
         {
             ErrorMessage = Localize(_errorResourceKey, ErrorMessage);
+        }
+
+        OnPropertyChanged(nameof(SubmitText));
+        OnPropertyChanged(nameof(UrlStatus));
+    }
+
+    private async Task OpenAndAcceptAsync()
+    {
+        if (_urlTarget is null || !_uriLauncher.IsSupported)
+        {
+            return;
+        }
+
+        ClearError();
+        IsSubmitting = true;
+        try
+        {
+            // No await may precede the launcher: browser popup permission belongs to this click.
+            if (!_urlDispatched)
+            {
+                var result = await _uriLauncher.OpenAsync(_urlTarget,
+                    _requestState?.ConnectionClosed ?? CancellationToken.None).ConfigureAwait(true);
+                if (result is not (ExternalUriOpenResult.Opened or ExternalUriOpenResult.Dispatched))
+                {
+                    SetLocalizedError("Elicitation_OpenFailed", "The browser could not be opened. Allow popups and try again, or cancel.");
+                    return;
+                }
+
+                _urlDispatched = true;
+            }
+
+            if (_disposed || !(_requestState?.CanRespond ?? true))
+            {
+                return;
+            }
+
+            if (!await OnAccept!(null).ConfigureAwait(true))
+            {
+                SetLocalizedError("Elicitation_ResponseFailed", "The response could not be sent. Please try again.");
+            }
+        }
+        catch
+        {
+            // A launcher or response exception can contain an OAuth URL. Only bounded copy is shown.
+            SetLocalizedError("Elicitation_ResponseFailed", "The response could not be sent. Please try again.");
+        }
+        finally
+        {
+            IsSubmitting = false;
+            RefreshUrlState();
         }
     }
 
@@ -156,16 +366,91 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject
                 SetLocalizedError("Elicitation_ResponseFailed", "The response could not be sent. Please try again.");
             }
         }
-        catch (Exception ex)
+        catch
         {
-            SetRawError(string.IsNullOrWhiteSpace(ex.Message)
-                ? Localize("Elicitation_ResponseFailed", "The response could not be sent. Please try again.")
-                : ex.Message);
+            SetLocalizedError("Elicitation_ResponseFailed", "The response could not be sent. Please try again.");
         }
         finally
         {
             IsSubmitting = false;
         }
+    }
+
+    private void OnRequestStateChanged(object? sender, EventArgs args)
+    {
+        _ = ProjectRequestStateAsync(connectionClosed: false);
+    }
+
+    private void OnConnectionClosed()
+    {
+        _ = ProjectRequestStateAsync(connectionClosed: true);
+    }
+
+    private async Task ProjectRequestStateAsync(bool connectionClosed)
+    {
+        if (_dispatchAsync is null)
+        {
+            return;
+        }
+
+        try
+        {
+            Task? dismissTask = null;
+            await _dispatchAsync(() =>
+            {
+                if (!_disposed)
+                {
+                    // Session cancellation also answers through the SDK, without a card command.
+                    // Only a committed terminal response retires this exact projection.
+                    if (IsUrl && _requestState?.ResponseAction is ElicitationActions.Cancel or ElicitationActions.Decline)
+                    {
+                        dismissTask = _dismiss?.Invoke();
+                        return;
+                    }
+
+                    if (connectionClosed)
+                    {
+                        FullUrl = string.Empty;
+                        _urlTarget = null;
+                        SetLocalizedError("Elicitation_RequestExpired", "This request has expired. Reconnect to continue.");
+                        OnPropertyChanged(nameof(FullUrl));
+                        OnPropertyChanged(nameof(UrlHost));
+                    }
+
+                    RefreshUrlState();
+                }
+            }).ConfigureAwait(false);
+            if (dismissTask is not null)
+            {
+                await dismissTask.ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // A shutting-down dispatcher cannot project; command guards still read the SDK state.
+        }
+    }
+
+    private void RefreshUrlState()
+    {
+        OnPropertyChanged(nameof(IsAwaitingCompletion));
+        OnPropertyChanged(nameof(IsCompleted));
+        OnPropertyChanged(nameof(ShowReopen));
+        OnPropertyChanged(nameof(UrlStatus));
+        OnPropertyChanged(nameof(SubmitText));
+        RefreshCommands();
+    }
+
+    private void RefreshCommands()
+    {
+        OnPropertyChanged(nameof(CanRespond));
+        OnPropertyChanged(nameof(CanCancel));
+        OnPropertyChanged(nameof(CanSubmit));
+        OnPropertyChanged(nameof(CanReopen));
+        SubmitCommand.NotifyCanExecuteChanged();
+        DeclineCommand.NotifyCanExecuteChanged();
+        CancelCommand.NotifyCanExecuteChanged();
+        ReopenCommand.NotifyCanExecuteChanged();
     }
 
     private bool ValidateFields()
@@ -711,13 +996,28 @@ public static class ElicitationInteractionViewModelFactory
     public static ElicitationRequestViewModel Create(
         ElicitationRequestEventArgs args,
         Func<ElicitationRequestViewModel, Task> clearPendingRequestAsync,
-        IStringLocalizer<CoreStrings>? localizer = null)
+        IStringLocalizer<CoreStrings>? localizer = null,
+        IExternalUriLauncher? uriLauncher = null,
+        Func<Action, Task>? dispatchAsync = null,
+        string agentName = "")
     {
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(clearPendingRequestAsync);
 
+        if (args.Request is UrlElicitationRequest)
+        {
+            var urlViewModel = new ElicitationRequestViewModel(args.MessageId, args.SessionId, args.Request.Message, [], localizer);
+            urlViewModel.OnAccept = args.Accept;
+            urlViewModel.OnDecline = args.Decline;
+            urlViewModel.OnCancel = args.Cancel;
+            urlViewModel.AttachRequest(args, uriLauncher ?? UnsupportedExternalUriLauncher.Instance,
+                dispatchAsync ?? (action => { action(); return Task.CompletedTask; }),
+                () => clearPendingRequestAsync(urlViewModel), agentName);
+            return urlViewModel;
+        }
+
         var form = args.Request as FormElicitationRequest
-            ?? throw new ArgumentException("Only form elicitation requests can be rendered.", nameof(args));
+            ?? throw new ArgumentException("Unknown elicitation modes cannot be rendered.", nameof(args));
         var required = new HashSet<string>(form.RequestedSchema.Required ?? new List<string>(), StringComparer.Ordinal);
         var fields = new List<ElicitationFieldViewModel>();
         foreach (var property in form.RequestedSchema.Properties)
@@ -737,6 +1037,9 @@ public static class ElicitationInteractionViewModelFactory
         viewModel.OnAccept = async content => await RespondAndClearAsync(() => args.Accept(content), () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
         viewModel.OnDecline = async () => await RespondAndClearAsync(args.Decline, () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
         viewModel.OnCancel = async () => await RespondAndClearAsync(args.Cancel, () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
+        viewModel.AttachRequest(args, UnsupportedExternalUriLauncher.Instance,
+            dispatchAsync ?? (action => { action(); return Task.CompletedTask; }),
+            () => clearPendingRequestAsync(viewModel), agentName);
         return viewModel;
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
@@ -85,18 +85,17 @@ public sealed class ChatInteractionEventBridge
         Func<string, ElicitationRequestViewModel, Task> clearPendingRequestAsync,
         ILogger logger,
         Func<Action, Task>? dispatchAsync = null,
-        string agentName = "")
+        string agentName = "",
+        Func<ElicitationRequestEventArgs, Task>? cancelUndisplayedAsync = null)
     {
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(clearPendingRequestAsync);
         ArgumentNullException.ThrowIfNull(logger);
+        cancelUndisplayedAsync ??= request => CancelUndisplayedElicitationAsync(request, logger);
 
         if (args.Request is not (FormElicitationRequest or UrlElicitationRequest) || string.IsNullOrWhiteSpace(args.SessionId))
         {
-            logger.LogWarning(
-                "Elicitation request cannot be displayed because it is not a supported session-scoped request. Mode={ElicitationMode}",
-                args.Request.Mode);
-            await CancelUndisplayedElicitationAsync(args, logger).ConfigureAwait(false);
+            await cancelUndisplayedAsync(args).ConfigureAwait(false);
             return null;
         }
 
@@ -107,20 +106,15 @@ public sealed class ChatInteractionEventBridge
                 .ResolveConversationIdAsync(args.SessionId)
                 .ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            logger.LogWarning("Elicitation request could not be routed to its conversation. ExceptionType={ExceptionType}",
-                ex.GetType().FullName);
-            await CancelUndisplayedElicitationAsync(args, logger).ConfigureAwait(false);
+            await cancelUndisplayedAsync(args).ConfigureAwait(false);
             return null;
         }
 
         if (string.IsNullOrWhiteSpace(conversationId))
         {
-            logger.LogWarning(
-                "Elicitation request cannot be displayed because no bound conversation matched remote session {RemoteSessionId}",
-                args.SessionId);
-            await CancelUndisplayedElicitationAsync(args, logger).ConfigureAwait(false);
+            await cancelUndisplayedAsync(args).ConfigureAwait(false);
             return null;
         }
 
@@ -132,22 +126,29 @@ public sealed class ChatInteractionEventBridge
                 _localizer, _uriLauncher, dispatchAsync, agentName));
     }
 
-    internal static async Task CancelUndisplayedElicitationAsync(ElicitationRequestEventArgs args, ILogger logger)
+    internal static async Task<bool> CancelUndisplayedElicitationAsync(ElicitationRequestEventArgs args, ILogger logger)
     {
         // Request scope is valid ACP. This conversation surface cannot present it, so dismiss it
         // explicitly instead of inventing a session or leaving the peer waiting for user input.
         try
         {
-            if (!await args.Cancel().ConfigureAwait(false))
-            {
-                logger.LogWarning("Could not send cancellation for undisplayed elicitation request {MessageId}", args.MessageId);
-            }
+            if (await args.Cancel().ConfigureAwait(false)) return true;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            logger.LogWarning("Could not cancel undisplayed elicitation request {MessageId}. ExceptionType={ExceptionType}",
-                args.MessageId, ex.GetType().FullName);
+            // The host still owns failed cancellation; a private transport exception is not UI copy.
         }
+
+        try
+        {
+            logger.LogWarning("Could not cancel undisplayed elicitation request {MessageId}", args.MessageId);
+        }
+        catch (Exception)
+        {
+            // A logger cannot prevent the host from closing the original unresolved connection.
+        }
+
+        return false;
     }
 
     public async Task<(string ConversationId, ChatConversationPanelSelection Selection)?> BuildTerminalRequestSelectionAsync(

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
@@ -18,15 +18,18 @@ public sealed class ChatInteractionEventBridge
     private readonly IAuthoritativeRemoteSessionRouter _authoritativeRemoteSessionRouter;
     private readonly ChatTerminalProjectionCoordinator _terminalProjectionCoordinator;
     private readonly IStringLocalizer<CoreStrings>? _localizer;
+    private readonly IExternalUriLauncher _uriLauncher;
 
     public ChatInteractionEventBridge(
         IAuthoritativeRemoteSessionRouter authoritativeRemoteSessionRouter,
         ChatTerminalProjectionCoordinator terminalProjectionCoordinator,
-        IStringLocalizer<CoreStrings>? localizer = null)
+        IStringLocalizer<CoreStrings>? localizer = null,
+        IExternalUriLauncher? uriLauncher = null)
     {
         _authoritativeRemoteSessionRouter = authoritativeRemoteSessionRouter ?? throw new ArgumentNullException(nameof(authoritativeRemoteSessionRouter));
         _terminalProjectionCoordinator = terminalProjectionCoordinator ?? throw new ArgumentNullException(nameof(terminalProjectionCoordinator));
         _localizer = localizer;
+        _uriLauncher = uriLauncher ?? UnsupportedExternalUriLauncher.Instance;
     }
 
     public PermissionRequestViewModel CreatePermissionRequestViewModel(
@@ -80,16 +83,18 @@ public sealed class ChatInteractionEventBridge
     public async Task<(string ConversationId, ElicitationRequestViewModel ViewModel)?> BuildElicitationRequestAsync(
         ElicitationRequestEventArgs args,
         Func<string, ElicitationRequestViewModel, Task> clearPendingRequestAsync,
-        ILogger logger)
+        ILogger logger,
+        Func<Action, Task>? dispatchAsync = null,
+        string agentName = "")
     {
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(clearPendingRequestAsync);
         ArgumentNullException.ThrowIfNull(logger);
 
-        if (args.Request is not FormElicitationRequest || string.IsNullOrWhiteSpace(args.SessionId))
+        if (args.Request is not (FormElicitationRequest or UrlElicitationRequest) || string.IsNullOrWhiteSpace(args.SessionId))
         {
             logger.LogWarning(
-                "Elicitation request cannot be displayed because it is not a session-scoped form. Mode={ElicitationMode}",
+                "Elicitation request cannot be displayed because it is not a supported session-scoped request. Mode={ElicitationMode}",
                 args.Request.Mode);
             await CancelUndisplayedElicitationAsync(args, logger).ConfigureAwait(false);
             return null;
@@ -104,7 +109,8 @@ public sealed class ChatInteractionEventBridge
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Elicitation request could not be routed to its conversation");
+            logger.LogWarning("Elicitation request could not be routed to its conversation. ExceptionType={ExceptionType}",
+                ex.GetType().FullName);
             await CancelUndisplayedElicitationAsync(args, logger).ConfigureAwait(false);
             return null;
         }
@@ -123,7 +129,7 @@ public sealed class ChatInteractionEventBridge
             ElicitationInteractionViewModelFactory.Create(
                 args,
                 viewModel => clearPendingRequestAsync(conversationId, viewModel),
-                _localizer));
+                _localizer, _uriLauncher, dispatchAsync, agentName));
     }
 
     internal static async Task CancelUndisplayedElicitationAsync(ElicitationRequestEventArgs args, ILogger logger)
@@ -139,7 +145,8 @@ public sealed class ChatInteractionEventBridge
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Could not cancel undisplayed elicitation request {MessageId}", args.MessageId);
+            logger.LogWarning("Could not cancel undisplayed elicitation request {MessageId}. ExceptionType={ExceptionType}",
+                args.MessageId, ex.GetType().FullName);
         }
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
@@ -85,6 +85,13 @@ public sealed class ChatConversationPanelStateCoordinator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentNullException.ThrowIfNull(request);
+        var existing = GetPendingElicitationRequest(conversationId);
+        if (existing is { IsAwaitingCompletion: true })
+        {
+            existing.Dispose();
+            _pendingElicitationRequestsByConversation.Remove(conversationId);
+        }
+
         return _pendingElicitationRequestsByConversation.TryAdd(conversationId, request);
     }
 
@@ -98,11 +105,19 @@ public sealed class ChatConversationPanelStateCoordinator
             return false;
         }
 
+        request.Dispose();
         return _pendingElicitationRequestsByConversation.Remove(conversationId);
     }
 
     public void ClearElicitationRequests()
-        => _pendingElicitationRequestsByConversation.Clear();
+    {
+        foreach (var request in _pendingElicitationRequestsByConversation.Values)
+        {
+            request.Dispose();
+        }
+
+        _pendingElicitationRequestsByConversation.Clear();
+    }
 
     public PermissionRequestViewModel? GetPendingPermissionRequest(string? conversationId, string? toolCallId = null)
         => GetPendingPermissionRequest(conversationId, toolCallId, currentRequest: null);
@@ -278,7 +293,10 @@ public sealed class ChatConversationPanelStateCoordinator
         _terminalSessionsByConversation.Remove(conversationId);
         _selectedTerminalIdByConversation.Remove(conversationId);
         _pendingAskUserRequestsByConversation.Remove(conversationId);
-        _pendingElicitationRequestsByConversation.Remove(conversationId);
+        if (_pendingElicitationRequestsByConversation.Remove(conversationId, out var request))
+        {
+            request.Dispose();
+        }
         if (_pendingPermissionRequestsByConversation.Remove(conversationId, out var permissions))
         {
             foreach (var permission in permissions) permission.DetachRequest();

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
@@ -302,6 +302,142 @@ public sealed class AcpClientBatchTests
         Assert.Empty(peer.Errors);
     }
 
+    [Theory]
+    [InlineData("accept")]
+    [InlineData("cancel")]
+    public async Task Batch_UrlSiblingRetries_CommitsStateAndNotifiesEveryOriginalRequest(string action)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var requests = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, request) => requests.Add(request);
+        peer.Deliver("[" + Url("1", "first-url") + "," + Url("2", "second-url") + "]");
+        var committed = new List<string>();
+        requests[0].State.Changed += (_, _) =>
+        {
+            if (requests[0].State.ResponseAction is { } value) committed.Add(value);
+        };
+        peer.FailNextResponse = true;
+        var firstAnswer = action == "accept" ? requests[0].Accept(null) : requests[0].Cancel();
+        var secondAnswer = requests[1].Decline();
+        Assert.False(await firstAnswer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await secondAnswer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Null(requests[0].State.ResponseAction);
+        Assert.Empty(committed);
+
+        // Act
+        Assert.True(await requests[1].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Assert
+        Assert.Equal(action, requests[0].State.ResponseAction);
+        Assert.Equal(action, Assert.Single(committed));
+        Assert.False(requests[0].State.CanRespond);
+        Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+        peer.Deliver("""{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"first-url"}}""");
+        Assert.Equal(action == "accept", requests[0].State.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Batch_UrlCancellationFailure_ProjectsCancellationWithoutInventingDelivery()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? request = null;
+        peer.Client.ElicitationRequestReceived += (_, value) => request = value;
+        peer.Deliver("[" + Url("1", "cancel-url") + "]");
+        Assert.NotNull(request);
+        var cancellationObserved = false;
+        request.State.Changed += (_, _) => cancellationObserved |= !request.State.CanRespond && request.State.CanCancel;
+        peer.FailNextResponse = true;
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.True(cancellationObserved);
+        Assert.False(request.State.CanRespond);
+        Assert.True(request.State.CanCancel);
+        Assert.Null(request.State.ResponseAction);
+        Assert.Empty(peer.Responses);
+        Assert.True(await request.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal("cancel", request.State.ResponseAction);
+        Assert.False(request.State.CanCancel);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task UrlPeerCancellation_CompletesOrRetainsTheOriginalResponseOwner(bool batched, bool firstSendFails)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? request = null;
+        peer.Client.ElicitationRequestReceived += (_, value) => request = value;
+        var url = Url("1", "peer-cancel");
+        peer.Deliver(batched ? "[" + url + "]" : url);
+        Assert.NotNull(request);
+        var completed = 0;
+        request.State.Changed += (_, _) =>
+        {
+            if (!request.State.CanRespond && !request.State.CanCancel) completed++;
+        };
+        peer.FailNextResponse = firstSendFails;
+
+        // Act
+        peer.Deliver(Cancel("1"));
+
+        // Assert
+        Assert.False(request.State.CanRespond);
+        if (firstSendFails)
+        {
+            Assert.True(request.State.CanCancel);
+            Assert.Null(request.State.ResponseAction);
+            Assert.Empty(peer.Responses);
+            Assert.True(await request.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        }
+        Assert.Null(request.State.ResponseAction);
+        Assert.False(request.State.CanCancel);
+        Assert.True(completed > 0);
+        var frame = Assert.Single(peer.Responses);
+        var response = batched ? frame[0] : frame;
+        Assert.Equal(JsonRpcErrorCode.Cancelled, response.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.False(await request.Accept(null));
+        peer.Deliver("""{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"peer-cancel"}}""");
+        Assert.False(request.State.IsCompleted);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UrlPeerCancellation_OriginalAcceptWriteWinsOrCancellationFollows(bool acceptSent)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? request = null;
+        peer.Client.ElicitationRequestReceived += (_, value) => request = value;
+        peer.Deliver(Url("1", "during-write"));
+        Assert.NotNull(request);
+        var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.NextResponseWrite = write.Task;
+        var answer = request.Accept(null);
+
+        // Act
+        peer.Deliver(Cancel("1"));
+        write.TrySetResult(acceptSent);
+        await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.Equal(acceptSent ? ElicitationActions.Accept : null, request.State.ResponseAction);
+        Assert.False(request.State.CanCancel);
+        Assert.False(request.State.CanRespond);
+        var response = Assert.Single(peer.Responses);
+        if (acceptSent) Assert.Equal("accept", response.GetProperty("result").GetProperty("action").GetString());
+        else Assert.Equal(JsonRpcErrorCode.Cancelled, response.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
     [Fact]
     public async Task Batch_V1OnlyMethods_AreRejectedInsideDraftBatch()
     {
@@ -936,6 +1072,7 @@ public sealed class AcpClientBatchTests
 
         // Assert
         Assert.Equal(sent ? "accept" : "cancel", Assert.Single(peer.Responses)[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal(sent ? "accept" : "cancel", url.State.ResponseAction);
         Assert.Equal(sent ? 1 : 0, completions.Count);
         Assert.False(await url.Accept(null));
     }
@@ -1186,6 +1323,11 @@ public sealed class AcpClientBatchTests
 
     private static string SessionResponse(JsonRpcRequest request, string sessionId)
         => "{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":{\"sessionId\":\"" + sessionId + "\"}}";
+
+    private static string Url(string id, string elicitationId)
+        => "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"method\":\"elicitation/create\",\"params\":{"
+            + "\"sessionId\":\"session\",\"mode\":\"url\",\"elicitationId\":\"" + elicitationId
+            + "\",\"url\":\"https://agent.example/authorize\",\"message\":\"Authorize\"}}";
 
     private sealed class BatchPeer : IAcpTransport
     {

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
@@ -410,15 +410,18 @@ public sealed class AcpClientBatchTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task UrlPeerCancellation_OriginalAcceptWriteWinsOrCancellationFollows(bool acceptSent)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task UrlPeerCancellation_OriginalAcceptWriteWinsOrCancellationFollows(bool batched, bool acceptSent)
     {
         // Arrange
         using var peer = await BatchPeer.CreateAsync();
         ElicitationRequestEventArgs? request = null;
         peer.Client.ElicitationRequestReceived += (_, value) => request = value;
-        peer.Deliver(Url("1", "during-write"));
+        var url = Url("1", "during-write");
+        peer.Deliver(batched ? "[" + url + "]" : url);
         Assert.NotNull(request);
         var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         peer.NextResponseWrite = write.Task;
@@ -433,7 +436,8 @@ public sealed class AcpClientBatchTests
         Assert.Equal(acceptSent ? ElicitationActions.Accept : null, request.State.ResponseAction);
         Assert.False(request.State.CanCancel);
         Assert.False(request.State.CanRespond);
-        var response = Assert.Single(peer.Responses);
+        var frame = Assert.Single(peer.Responses);
+        var response = batched ? frame[0] : frame;
         if (acceptSent) Assert.Equal("accept", response.GetProperty("result").GetProperty("action").GetString());
         else Assert.Equal(JsonRpcErrorCode.Cancelled, response.GetProperty("error").GetProperty("code").GetInt32());
     }

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
@@ -97,6 +97,279 @@ public sealed class AcpClientElicitationTests
         Assert.Equal("""["api","ui"]""", accepted.Content["targets"].RawValue.GetRawText());
     }
 
+    [Fact]
+    public async Task ElicitationState_CompletionBeforeConsent_PreservesIndependentFacts()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var sent = CaptureSentMessages();
+        var request = ReceiveRequest(client, parser, 601, UrlParamsJson);
+
+        // Act
+        RaiseNotification(parser, ElicitationMethods.Complete, """{"elicitationId":"oauth-1"}""");
+
+        // Assert
+        Assert.True(request.State.IsCompleted);
+        Assert.True(request.State.CanRespond);
+        Assert.Empty(sent);
+        Assert.True(await request.Accept(null));
+        Assert.False(request.State.CanRespond);
+        Assert.True(request.State.IsCompleted);
+        var response = await WaitForResponseAsync(parser, sent, 601);
+        Assert.Equal("""{"action":"accept"}""", response.Result!.Value.GetRawText());
+    }
+
+    [Fact]
+    public async Task ElicitationState_ThrowingObserver_DoesNotUndoResponseOrStopOtherObservers()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var sent = CaptureSentMessages();
+        var request = ReceiveRequest(client, parser, 602, UrlParamsJson);
+        var notifications = 0;
+        request.State.Changed += (_, _) => throw new InvalidOperationException("Subscriber failure");
+        request.State.Changed += (_, _) => notifications++;
+
+        // Act
+        Assert.True(await request.Accept(null));
+        RaiseNotification(parser, ElicitationMethods.Complete, """{"elicitationId":"oauth-1"}""");
+
+        // Assert
+        Assert.False(request.State.CanRespond);
+        Assert.True(request.State.IsCompleted);
+        Assert.True(notifications >= 2);
+        Assert.False(await request.Cancel());
+        Assert.Single(sent);
+    }
+
+    [Fact]
+    public async Task ElicitationState_Disconnect_InvalidatesOldRequest()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var sent = CaptureSentMessages();
+        var request = ReceiveRequest(client, parser, 603, UrlParamsJson);
+
+        // Act
+        await client.DisconnectAsync();
+
+        // Assert
+        Assert.True(request.State.ConnectionClosed.IsCancellationRequested);
+        Assert.False(request.State.CanRespond);
+        Assert.False(await request.Accept(null));
+        Assert.Empty(sent);
+    }
+
+    [Fact]
+    public async Task ElicitationState_ThrowingDisconnectObserver_DoesNotInterruptTeardown()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var request = ReceiveRequest(client, parser, 605, UrlParamsJson);
+        var logged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _loggerMock.Setup(l => l.Log(AcpClientLogLevel.Warning, "CONNECTION_OBSERVER_FAILED",
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<Exception?>()))
+            .Callback(() => logged.TrySetResult());
+        using var registration = request.State.ConnectionClosed.Register(
+            () => throw new InvalidOperationException("private-url-canary"));
+
+        // Act
+        await client.DisconnectAsync();
+
+        // Assert
+        await logged.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.False(client.IsInitialized);
+        Assert.False(request.State.CanRespond);
+        _transportMock.Verify(t => t.DisconnectAsync(), Times.Once);
+        _loggerMock.Verify(l => l.Log(It.IsAny<AcpClientLogLevel>(), It.IsAny<string>(),
+            It.Is<string>(message => message.Contains("private-url-canary", StringComparison.Ordinal))), Times.Never);
+    }
+
+    [Fact]
+    public async Task ElicitationState_DisconnectObservers_RunAfterPendingRequestsAreReleased()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        CaptureSentMessages();
+        var request = ReceiveRequest(client, parser, 606, UrlParamsJson);
+        Task<bool>? pendingRead = null;
+        var observerCouldRead = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = request.State.ConnectionClosed.Register(() =>
+        {
+            pendingRead = Task.Run(request.Cancel, TestContext.Current.CancellationToken);
+            observerCouldRead.TrySetResult(pendingRead.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+        });
+
+        // Act
+        await client.DisconnectAsync();
+
+        // Assert
+        Assert.True(await observerCouldRead.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            "Disconnect must not invoke consumers while holding the pending-request lock.");
+        Assert.NotNull(pendingRead);
+        Assert.False(await pendingRead.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ElicitationState_BlockingDisconnectObserver_DoesNotDelayDisconnectOrPendingCancellation()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        CaptureSentMessages();
+        var request = ReceiveRequest(client, parser, 607, UrlParamsJson);
+        var pending = client.CreateSessionAsync(new SessionNewParams(Path.GetTempPath(), null), TestContext.Current.CancellationToken);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = request.State.ConnectionClosed.Register(() =>
+        {
+            started.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+        });
+        var disconnect = Task.Run(client.DisconnectAsync, TestContext.Current.CancellationToken);
+
+        try
+        {
+            // Act
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            await disconnect.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.False(client.IsInitialized);
+            Assert.False(request.State.CanRespond);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await disconnect.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task ElicitationState_DisconnectObserver_CanReconnectWithoutOldCleanupClearingNewState()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var previous = ReceiveRequest(client, parser, 608, UrlParamsJson);
+        var allowReconnect = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = previous.State.ConnectionClosed.Register(() =>
+        {
+            try
+            {
+                allowReconnect.Task.GetAwaiter().GetResult();
+                client.DisconnectAsync().GetAwaiter().GetResult();
+                InitializeClientAsync(client, UrlCapabilities()).GetAwaiter().GetResult();
+                reconnected.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                reconnected.TrySetException(ex);
+            }
+        });
+
+        // Act
+        try
+        {
+            await client.DisconnectAsync().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            allowReconnect.TrySetResult();
+        }
+
+        await reconnected.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await registration.DisposeAsync();
+        var sent = CaptureSentMessages();
+        var current = ReceiveRequest(client, parser, 608, UrlParamsJson);
+
+        // Assert
+        Assert.True(client.IsInitialized);
+        Assert.False(await previous.Accept(null));
+        Assert.False(current.State.ConnectionClosed.IsCancellationRequested);
+        Assert.True(await current.Accept(null));
+        Assert.Single(sent);
+    }
+
+    [Fact]
+    public async Task ElicitationState_DisposeObserver_CannotReinitializeDisposedClient()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var request = ReceiveRequest(client, parser, 611, UrlParamsJson);
+        var sent = CaptureSentMessages();
+        var attempted = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = request.State.ConnectionClosed.Register(() =>
+        {
+            try
+            {
+                client.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"), UrlCapabilities()),
+                    TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+                attempted.TrySetResult(null);
+            }
+            catch (Exception ex)
+            {
+                attempted.TrySetResult(ex);
+            }
+        });
+
+        // Act
+        client.Dispose();
+
+        // Assert
+        Assert.IsType<ObjectDisposedException>(
+            await attempted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.False(client.IsInitialized);
+        Assert.Empty(sent);
+        _transportMock.Verify(t => t.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ElicitationState_CompletedRequestIdReused_KeepsOldProjectionUnavailable()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        CaptureSentMessages();
+        var previous = ReceiveRequest(client, parser, 604, UrlParamsJson);
+
+        // Act
+        Assert.True(await previous.Decline());
+        var current = ReceiveRequest(client, parser, 604, UrlParamsJson.Replace("oauth-1", "oauth-2", StringComparison.Ordinal));
+
+        // Assert
+        Assert.False(previous.State.CanRespond);
+        Assert.True(current.State.CanRespond);
+        Assert.False(await previous.Accept(null));
+        Assert.True(await current.Cancel());
+    }
+
+    [Fact]
+    public async Task ElicitationState_PublicConstructor_ResponseUpdatesAvailability()
+    {
+        // Arrange
+        var replies = 0;
+        var request = new ElicitationRequestEventArgs("legacy", new FormElicitationRequest(),
+            _ => { replies++; return Task.FromResult(true); },
+            () => Task.FromResult(true), () => Task.FromResult(true));
+
+        // Act
+        Assert.True(await request.Accept(null));
+
+        // Assert
+        Assert.False(request.State.CanRespond);
+        Assert.False(await request.Accept(null));
+        Assert.Equal(1, replies);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -953,6 +1226,57 @@ public sealed class AcpClientElicitationTests
         Assert.False(await request.Decline());
         Assert.False(await request.Cancel());
         Assert.Empty(sentMessages);
+    }
+
+    [Fact]
+    public async Task ElicitationComplete_ThrowingObserver_DoesNotLeakPrivateDataOrSkipOtherObservers()
+    {
+        // Arrange
+        const string canary = "private-url-canary";
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var request = ReceiveRequest(client, parser, 609, UrlParamsJson);
+        var completed = false;
+        var errors = new List<string>();
+        client.ErrorOccurred += (_, message) => errors.Add(message);
+        client.ElicitationCompleted += (_, _) => throw new InvalidOperationException(canary);
+        client.ElicitationCompleted += (_, _) => completed = true;
+
+        // Act
+        RaiseNotification(parser, ElicitationMethods.Complete, """{"elicitationId":"oauth-1"}""");
+
+        // Assert
+        Assert.True(request.State.IsCompleted);
+        Assert.True(completed);
+        Assert.Empty(errors);
+        _loggerMock.Verify(l => l.Log(It.IsAny<AcpClientLogLevel>(), It.IsAny<string>(),
+            It.Is<string>(message => message.Contains(canary, StringComparison.Ordinal)),
+            It.IsAny<string?>(), It.IsAny<Exception?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ElicitationResponse_PrivateTransportException_ProducesOnlyBoundedDiagnostic()
+    {
+        // Arrange
+        const string canary = "private-url-canary";
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var request = ReceiveRequest(client, parser, 610, UrlParamsJson);
+        var errors = new List<string>();
+        client.ErrorOccurred += (_, message) => errors.Add(message);
+        _transportMock.Setup(t => t.SendMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException(canary));
+
+        // Act
+        var sent = await request.Accept(null);
+
+        // Assert
+        Assert.False(sent);
+        Assert.True(request.State.CanRespond);
+        Assert.DoesNotContain(canary, Assert.Single(errors), StringComparison.Ordinal);
+        _loggerMock.Verify(l => l.Log(It.IsAny<AcpClientLogLevel>(), It.IsAny<string>(),
+            It.Is<string>(message => message.Contains(canary, StringComparison.Ordinal)),
+            It.IsAny<string?>(), It.IsAny<Exception?>()), Times.Never);
     }
 
     private static ClientCapabilities UrlCapabilities()

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientLifecycleTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientLifecycleTests.cs
@@ -108,6 +108,54 @@ public sealed class AcpClientLifecycleTests
     }
 
     [Fact]
+    public async Task DisconnectAsync_ReentrantObserverCannotInitializeUntilPhysicalTeardownCompletes()
+    {
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        var request = fixture.ReceiveUrlRequest();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observed = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Transport.Setup(x => x.DisconnectAsync()).Returns(async () =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return true;
+        });
+        using var registration = request.State.ConnectionClosed.Register(() =>
+        {
+            try
+            {
+                started.Task.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+                fixture.InitializeAsync().GetAwaiter().GetResult();
+                observed.TrySetResult(null);
+            }
+            catch (Exception exception)
+            {
+                observed.TrySetResult(exception);
+            }
+        });
+        var disconnect = fixture.Client.DisconnectAsync();
+        try
+        {
+            Assert.True(request.State.ConnectionClosed.IsCancellationRequested);
+            Assert.False(await request.Cancel());
+            Assert.IsType<InvalidOperationException>(await observed.Task.WaitAsync(
+                TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken));
+            Assert.Equal(1, fixture.InitializeFrames);
+            Assert.False(disconnect.IsCompleted);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await disconnect;
+        }
+
+        await fixture.InitializeAsync();
+        Assert.True(fixture.Client.IsInitialized);
+    }
+
+    [Fact]
     public async Task DisconnectAsync_DisposeDuringTeardownCannotReinitialize()
     {
         using var fixture = new LifecycleFixture();
@@ -160,8 +208,20 @@ public sealed class AcpClientLifecycleTests
         }
 
         public Task<InitializeResponse> InitializeAsync() => Client.InitializeAsync(
-            new InitializeParams(new ClientInfo("lifecycle", "1"), new ClientCapabilities()), TestContext.Current.CancellationToken)
+            new InitializeParams(new ClientInfo("lifecycle", "1"), new ClientCapabilities
+            {
+                Elicitation = new ElicitationCapabilities { Url = new ElicitationUrlCapabilities() }
+            }), TestContext.Current.CancellationToken)
             .WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        public ElicitationRequestEventArgs ReceiveUrlRequest()
+        {
+            ElicitationRequestEventArgs? received = null;
+            Client.ElicitationRequestReceived += (_, request) => received = request;
+            Transport.Raise(x => x.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+                """{"jsonrpc":"2.0","id":71,"method":"elicitation/create","params":{"mode":"url","sessionId":"session","elicitationId":"consent","url":"https://example.com/authorize","message":"Authorize"}}"""));
+            return Assert.IsType<ElicitationRequestEventArgs>(received);
+        }
 
         public void Dispose() => Client.Dispose();
     }

--- a/tests/SalmonEgg.Domain.Tests/Services/ExternalUriTargetTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Services/ExternalUriTargetTests.cs
@@ -1,0 +1,52 @@
+using SalmonEgg.Domain.Services;
+using Xunit;
+
+namespace SalmonEgg.Domain.Tests.Services;
+
+public sealed class ExternalUriTargetTests
+{
+    [Theory]
+    [InlineData("https://example.com/authorize?canary=private#step", "example.com", false)]
+    [InlineData("https://xn--bcher-kva.example/path", "xn--bcher-kva.example", true)]
+    [InlineData("https://bücher.example/path", "xn--bcher-kva.example", true)]
+    [InlineData("http://127.0.0.1:1234/authorize", "127.0.0.1", true)]
+    [InlineData("http://[::1]:1234/authorize", "::1", true)]
+    [InlineData("http://localhost/authorize", "localhost", false)]
+    public void TryCreate_AllowedTarget_PreservesFullUrlAndHighlightsHost(string url, string host, bool warning)
+    {
+        // Act
+        var success = ExternalUriTarget.TryCreate(url, out var target);
+
+        // Assert
+        Assert.True(success);
+        Assert.NotNull(target);
+        Assert.Equal(url, target.FullUrl);
+        Assert.Equal(host, target.Host);
+        Assert.Equal(warning, target.HasAmbiguousHost);
+        Assert.DoesNotContain(url, target.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("data:text/html,secret")]
+    [InlineData("http://example.com/path")]
+    [InlineData("https://trusted.example@evil.example/authorize")]
+    [InlineData("https://example.com\\@evil.example/")]
+    [InlineData("https://example.com/\u202Esecret")]
+    [InlineData("https://example.com/\nsecret")]
+    [InlineData(" https://example.com/")]
+    [InlineData("http://127.0.0.2/authorize")]
+    [InlineData("http://localhost./authorize")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryCreate_UnsafeTarget_DoesNotCreateNavigationIntent(string? url)
+    {
+        // Act
+        var success = ExternalUriTarget.TryCreate(url, out var target);
+
+        // Assert
+        Assert.False(success);
+        Assert.Null(target);
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Network/TransportTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Network/TransportTests.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using SalmonEgg.Domain.Models;
 using SalmonEgg.Infrastructure.Network;
 using Websocket.Client;
@@ -227,6 +229,53 @@ namespace SalmonEgg.Infrastructure.Tests.Network
                 transport.SendAsync("{}", CancellationToken.None));
 
             Assert.Contains(TransportState.Error, states);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WebSocketTransport_PrivateElicitationPayload_NeverEntersLogs(bool sendFails)
+        {
+            // Arrange
+            const string canary = "private-url-canary";
+            const string message = """{"jsonrpc":"2.0","id":1,"method":"elicitation/create","params":{"mode":"url","url":"https://example.com/authorize?token=private-url-canary"}}""";
+            using var reconnections = new Subject<ReconnectionInfo>();
+            using var disconnections = new Subject<DisconnectionInfo>();
+            using var messages = new Subject<ResponseMessage>();
+            var client = CreateMockClient(reconnections, disconnections, messages, out var running);
+            client.Setup(x => x.Start()).Returns(Task.CompletedTask).Callback(() => running.Value = true);
+            if (sendFails)
+            {
+                client.Setup(x => x.Send(message)).Throws(new WebSocketException(canary));
+            }
+            else
+            {
+                client.Setup(x => x.Send(message)).Returns(true);
+            }
+            var sink = new CapturingLogSink();
+            using var logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(sink).CreateLogger();
+            using var transport = new WebSocketTransport(logger, null, TimeSpan.FromSeconds(5), (_, _) => client.Object);
+            var delivered = new List<string>();
+            using var subscription = transport.Messages.Subscribe(delivered.Add);
+            await transport.ConnectAsync("ws://localhost:3012/acp/ws", TestContext.Current.CancellationToken);
+
+            // Act
+            messages.OnNext(ResponseMessage.TextMessage(message));
+            if (sendFails)
+            {
+                await Assert.ThrowsAsync<WebSocketException>(() => transport.SendAsync(message, TestContext.Current.CancellationToken));
+            }
+            else
+            {
+                await transport.SendAsync(message, TestContext.Current.CancellationToken);
+            }
+
+            // Assert
+            Assert.Equal(message, Assert.Single(delivered));
+            Assert.NotEmpty(sink.Events);
+            Assert.DoesNotContain(sink.Events, entry => entry.RenderMessage().Contains(canary, StringComparison.Ordinal)
+                || (entry.Exception?.ToString().Contains(canary, StringComparison.Ordinal) ?? false)
+                || entry.Properties.Values.Any(value => value.ToString().Contains(canary, StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -563,6 +612,13 @@ namespace SalmonEgg.Infrastructure.Tests.Network
         private sealed class Box<T>(T value)
         {
             public T Value { get; set; } = value;
+        }
+
+        private sealed class CapturingLogSink : ILogEventSink
+        {
+            public List<LogEvent> Events { get; } = [];
+
+            public void Emit(LogEvent logEvent) => Events.Add(logEvent);
         }
     }
 }

--- a/tests/SalmonEgg.Infrastructure.Tests/Services/DesktopElicitationUriLauncherTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Services/DesktopElicitationUriLauncherTests.cs
@@ -1,0 +1,92 @@
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Services;
+
+namespace SalmonEgg.Infrastructure.Tests.Services;
+
+public sealed class DesktopElicitationUriLauncherTests
+{
+    [Theory]
+    [InlineData(0, ExternalUriOpenResult.Opened)]
+    [InlineData(1, ExternalUriOpenResult.Failed)]
+    public async Task OpenAsync_OpenerExits_UsesExitStatusAndDrainsPrivateOutput(int exitCode, ExternalUriOpenResult expected)
+    {
+        // Arrange
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "The launcher owns Linux desktop shell behavior.");
+        await using var command = await CliCommandProcessFixture.CreateAsync($"""
+            printf '%131072s' ''
+            printf 'private-canary'
+            printf '%131072s' '' >&2
+            printf 'private-canary' >&2
+            exit {exitCode}
+            """);
+        var launcher = new DesktopElicitationUriLauncher(new Probe(command.ExecutablePath));
+        Assert.True(ExternalUriTarget.TryCreate("https://example.com/authorize?private-canary", out var target));
+
+        // Act
+        var result = await launcher.OpenAsync(target!, TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, result);
+        var process = await command.ObserveStartedProcessAsync();
+        Assert.True(process is null || process.HasExited);
+    }
+
+    [Fact]
+    public async Task OpenAsync_Cancelled_ReapsOwnedOpenerAndObservesReaders()
+    {
+        // Arrange
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "The launcher owns Linux desktop shell behavior.");
+        await using var command = await CliCommandProcessFixture.CreateAsync("exec /bin/sleep 600");
+        var launcher = new DesktopElicitationUriLauncher(new Probe(command.ExecutablePath));
+        Assert.True(ExternalUriTarget.TryCreate("https://example.com/authorize", out var target));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var opening = launcher.OpenAsync(target!, cancellation.Token);
+        try
+        {
+            var process = await command.ObserveStartedProcessAsync();
+
+            // Act
+            await cancellation.CancelAsync();
+            var result = await opening.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(ExternalUriOpenResult.Cancelled, result);
+            Assert.True(process is null || process.HasExited);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            await command.StopAsync();
+            await opening.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task OpenAsync_AlreadyCancelled_DoesNotLaunch()
+    {
+        // Arrange
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "The launcher owns Linux desktop shell behavior.");
+        await using var command = await CliCommandProcessFixture.CreateAsync("exit 0");
+        var launcher = new DesktopElicitationUriLauncher(new Probe(command.ExecutablePath));
+        Assert.True(ExternalUriTarget.TryCreate("https://example.com/authorize", out var target));
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        // Act
+        var result = await launcher.OpenAsync(target!, cancellation.Token);
+
+        // Assert
+        Assert.Equal(ExternalUriOpenResult.Cancelled, result);
+        Assert.False(File.Exists(command.ExecutablePath + ".pid"));
+    }
+
+    private sealed class Probe(string executable) : IPlatformRuntimeCapabilityProbe
+    {
+        public bool IsDesktopProcessHost => true;
+        public bool HasExternalFileOpener => true;
+        public bool HasInteractiveTerminalSurface => false;
+        public string ResolveExternalFileOpener() => executable;
+        public bool CanLoadNativeLibrary(string libraryName) => false;
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
@@ -1,0 +1,307 @@
+using System.Globalization;
+using System.Resources;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    private const string ElicitationDisconnectedMessage = "无法取消未能显示的请求，已断开此连接。请重新连接 Agent。";
+
+    [Theory]
+    [InlineData("url", "request")]
+    [InlineData("url", "unbound-session")]
+    [InlineData("form", "request")]
+    [InlineData("form", "unbound-session")]
+    public async Task ElicitationDelivery_UnshownCancellationFails_ClosesOriginalConnection(string mode, string scope)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        var attempts = 0;
+        peer.ResponseSend = (_, _) => { attempts++; return Task.FromResult(false); };
+
+        // Act
+        peer.Elicit("unshown", mode, scope);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert: the actual connection owner settles the request and publishes a localized fault.
+        var state = await fixture.ConnectionStore.GetCurrentStateAsync();
+        Assert.False(peer.IsConnected);
+        Assert.False(Assert.Single(peer.Elicitations).State.CanCancel);
+        Assert.Equal(ConnectionPhase.Disconnected, state.Phase);
+        Assert.Equal(ElicitationDisconnectedMessage, state.Error);
+        Assert.Null(fixture.ViewModel.CurrentChatService);
+        Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+        Assert.Equal(1, attempts);
+        Assert.Empty(peer.Responses);
+    }
+
+    [Theory]
+    [InlineData("url", "request")]
+    [InlineData("url", "unbound-session")]
+    [InlineData("form", "request")]
+    [InlineData("form", "unbound-session")]
+    public async Task ElicitationDelivery_UnshownCancellationSucceeds_KeepsConnectionAvailable(string mode, string scope)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+
+        // Act
+        peer.Elicit("unshown", mode, scope);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        Assert.True(peer.IsConnected);
+        Assert.Same(peer.Service, fixture.ViewModel.CurrentChatService);
+        Assert.False(Assert.Single(peer.Elicitations).State.CanCancel);
+        Assert.Equal("cancel", Assert.Single(peer.Responses).GetProperty("result").GetProperty("action").GetString());
+        Assert.Null((await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+        peer.Elicit("next", "form", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        Assert.Equal("next", fixture.ViewModel.PendingElicitationRequest?.MessageId.ToString());
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_DecoratorForwardsInnerSender_ClosesSubscribedService()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        using var adapter = new AcpChatServiceAdapter(peer.Service, new AcpEventAdapter(_ => { }, dispatcher));
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer, adapter);
+        peer.ResponseSend = (_, _) => Task.FromResult(false);
+
+        // Act
+        peer.Elicit("unshown", "url", "request");
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert: using the forwarded inner sender would fail this outer service identity check.
+        Assert.Null(fixture.ViewModel.CurrentChatService);
+        Assert.False(peer.IsConnected);
+        Assert.Equal(ElicitationDisconnectedMessage, (await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_LoggerThrows_StillClosesUnresolvedConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        fixture.ViewModelLogger.Setup(logger => logger.Log(
+                LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Throws(new InvalidOperationException("Logger unavailable"));
+        peer.ResponseSend = (_, _) => Task.FromException<bool>(new IOException("Transport send failed"));
+
+        // Act
+        peer.Elicit("unshown", "url", "unbound-session");
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        Assert.False(peer.IsConnected);
+        Assert.Null(fixture.ViewModel.CurrentChatService);
+        Assert.Equal(ElicitationDisconnectedMessage, (await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_CancellationFailsAfterReplacement_PreservesNewConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var oldPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        using var currentPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
+        var started = NewPermissionSignal();
+        var release = NewPermissionSignal();
+        var changed = NewPermissionSignal();
+        oldPeer.ResponseSend = (_, token) => { started.TrySetResult(true); return release.Task.WaitAsync(token); };
+        oldPeer.Elicit("same-id", "url", "request");
+        Assert.Single(oldPeer.Elicitations).State.Changed += (_, _) => changed.TrySetResult(true);
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, started.Task);
+            await AttachPermissionPeerAsync(fixture, dispatcher, currentPeer);
+            currentPeer.Elicit("same-id", "form", "bound-session");
+            await dispatcher.RunUntilIdleAsync();
+            var current = fixture.ViewModel.PendingElicitationRequest;
+            Assert.NotNull(current);
+
+            // Act
+            release.TrySetResult(false);
+            await AwaitPermissionUiSignalAsync(dispatcher, changed.Task);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert
+            Assert.Same(currentPeer.Service, fixture.ViewModel.CurrentChatService);
+            Assert.Same(current, fixture.ViewModel.PendingElicitationRequest);
+            Assert.True(currentPeer.IsConnected);
+            Assert.False(currentPeer.ServiceDisposed.Task.IsCompleted);
+            Assert.Null((await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+            Assert.Empty(currentPeer.Responses);
+        }
+        finally
+        {
+            release.TrySetResult(false);
+            await dispatcher.RunUntilIdleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_DisconnectFinishesAfterReplacement_PreservesNewConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var oldPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        using var currentPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
+        var started = NewPermissionSignal();
+        var release = NewPermissionSignal();
+        oldPeer.DisconnectSend = () => { started.TrySetResult(true); return release.Task; };
+        oldPeer.ResponseSend = (_, _) => Task.FromResult(false);
+        oldPeer.Elicit("same-id", "url", "request");
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, started.Task);
+            await AttachPermissionPeerAsync(fixture, dispatcher, currentPeer);
+            currentPeer.Elicit("same-id", "form", "bound-session");
+            await dispatcher.RunUntilIdleAsync();
+            var current = fixture.ViewModel.PendingElicitationRequest;
+
+            // Act
+            release.TrySetResult(true);
+            await AwaitPermissionUiSignalAsync(dispatcher, oldPeer.ServiceDisposed.Task);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert
+            Assert.NotNull(current);
+            Assert.Same(currentPeer.Service, fixture.ViewModel.CurrentChatService);
+            Assert.Same(current, fixture.ViewModel.PendingElicitationRequest);
+            Assert.True(currentPeer.IsConnected);
+            Assert.Null((await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+        }
+        finally
+        {
+            release.TrySetResult(true);
+            await AwaitPermissionUiSignalAsync(dispatcher, oldPeer.ServiceDisposed.Task);
+        }
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_CancellationFailsAfterPoolReplacement_ClosesOnlyOriginalConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var oldPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        using var currentPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
+        var started = NewPermissionSignal();
+        var release = NewPermissionSignal();
+        oldPeer.ResponseSend = (_, token) => { started.TrySetResult(true); return release.Task.WaitAsync(token); };
+        oldPeer.Elicit("unshown", "url", "request");
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, started.Task);
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.ViewModel.ReplaceChatServiceWithIntentAsync(currentPeer.Service, ServiceReplaceIntent.PoolOnly,
+                    TestContext.Current.CancellationToken));
+            Assert.True(oldPeer.IsConnected);
+
+            // Act
+            release.TrySetResult(false);
+            await AwaitPermissionUiSignalAsync(dispatcher, oldPeer.ServiceDisposed.Task);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert: same-generation background requests retain their captured connection owner.
+            Assert.False(oldPeer.IsConnected);
+            Assert.False(Assert.Single(oldPeer.Elicitations).State.CanCancel);
+            Assert.Same(currentPeer.Service, fixture.ViewModel.CurrentChatService);
+            Assert.True(currentPeer.IsConnected);
+            Assert.Null((await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+            Assert.Empty(currentPeer.Responses);
+        }
+        finally
+        {
+            release.TrySetResult(false);
+            await dispatcher.RunUntilIdleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ElicitationDelivery_OccupiedSurfaceCannotCancelSecondRequest_ClosesItsConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("visible", "form", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        Assert.NotNull(fixture.ViewModel.PendingElicitationRequest);
+        peer.ResponseSend = (_, _) => Task.FromResult(false);
+
+        // Act
+        peer.Elicit("unshown", "url", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        Assert.False(peer.IsConnected);
+        Assert.Null(fixture.ViewModel.CurrentChatService);
+        Assert.All(peer.Elicitations, request => Assert.False(request.State.CanCancel));
+        Assert.Equal(ElicitationDisconnectedMessage, (await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("zh-Hans")]
+    [InlineData("en")]
+    [InlineData("en-US")]
+    public void ElicitationDelivery_ConnectionFailure_HasPackagedLocalizedMessage(string language)
+    {
+        // Arrange
+        var resources = new ResourceManager(typeof(CoreStrings));
+
+        // Act
+        var message = resources.GetString("Elicitation_CancellationFailedDisconnected", CultureInfo.GetCultureInfo(language));
+
+        // Assert
+        Assert.Equal(language.StartsWith("en", StringComparison.Ordinal)
+            ? "Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent."
+            : ElicitationDisconnectedMessage, message);
+    }
+
+    private static ClientCapabilities UrlElicitationCapabilities()
+        => ClientCapabilityDefaults.Create() with { Elicitation = new() { Form = new(), Url = new() } };
+
+    private static ViewModelFixture CreateElicitationDeliveryFixture(QueueingSynchronizationContext dispatcher)
+    {
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", "Elicitation_CancellationFailedDisconnected", ElicitationDisconnectedMessage);
+        var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
+            NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
+            Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
+        return CreateViewModel(dispatcher, acpConnectionCommands: commands, localizer: localizer,
+            acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
+                NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
+                Mock.Of<IAcpRemoteSessionRecoveryContextResolver>()));
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
@@ -673,17 +673,21 @@ public partial class ChatViewModelTests
     private sealed class PermissionUiPeer : IAcpTransport
     {
         private readonly AcpClient _client;
+        private readonly ClientCapabilities _capabilities;
         private bool _disposed;
 
-        private PermissionUiPeer()
+        private PermissionUiPeer(ClientCapabilities? capabilities = null)
         {
+            _capabilities = capabilities ?? ClientCapabilityDefaults.Create();
             _client = new AcpClient(this, Mock.Of<IAcpClientLogger>());
             _client.PermissionRequestReceived += (_, request) => Requests.Enqueue(request);
+            _client.ElicitationRequestReceived += (_, request) => Elicitations.Enqueue(request);
             Service = new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>());
         }
 
         public ChatService Service { get; }
         public ConcurrentQueue<PermissionRequestEventArgs> Requests { get; } = new();
+        public ConcurrentQueue<ElicitationRequestEventArgs> Elicitations { get; } = new();
         public ConcurrentQueue<JsonElement> Responses { get; } = new();
         public Func<JsonElement, CancellationToken, Task<bool>>? ResponseSend { get; set; }
         public Func<Task<bool>>? DisconnectSend { get; set; }
@@ -692,9 +696,9 @@ public partial class ChatViewModelTests
         public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
         public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
 
-        public static async Task<PermissionUiPeer> CreateAsync()
+        public static async Task<PermissionUiPeer> CreateAsync(ClientCapabilities? capabilities = null)
         {
-            var peer = new PermissionUiPeer();
+            var peer = new PermissionUiPeer(capabilities);
             await peer.InitializeAsync();
             return peer;
         }
@@ -712,6 +716,16 @@ public partial class ChatViewModelTests
 
         public void CancelPermission(string id)
             => Receive($$$"""{"jsonrpc":"2.0","method":"$/cancel_request","params":{"requestId":"{{{id}}}"}}""");
+
+        public void Elicit(string id, string mode, string scope = "unbound-session")
+        {
+            var scopeJson = scope == "request" ? "\"requestId\":12"
+                : "\"sessionId\":\"" + (scope == "bound-session" ? "remote-1" : "unbound") + "\"";
+            var modeJson = mode == "url"
+                ? "\"elicitationId\":\"url-" + id + "\",\"url\":\"https://example.com/authorize\""
+                : "\"requestedSchema\":{\"type\":\"object\",\"properties\":{}}";
+            Receive($$$"""{"jsonrpc":"2.0","id":"{{{id}}}","method":"elicitation/create","params":{ {{{scopeJson}}},"mode":"{{{mode}}}","message":"Choose",{{{modeJson}}} }}""");
+        }
 
         public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
         {
@@ -763,6 +777,6 @@ public partial class ChatViewModelTests
 
         private Task<InitializeResponse> InitializeAsync()
             => _client.InitializeAsync(new InitializeParams(new ClientInfo("Permission UI test", "1"),
-                ClientCapabilityDefaults.Create()), TestContext.Current.CancellationToken);
+                _capabilities), TestContext.Current.CancellationToken);
     }
 }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/Elicitation/UrlElicitationInteractionTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/Elicitation/UrlElicitationInteractionTests.cs
@@ -1,0 +1,282 @@
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.ViewModels.Chat.Elicitation;
+using SalmonEgg.Presentation.ViewModels.Chat.Panels;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat.Elicitation;
+
+public sealed class UrlElicitationInteractionTests
+{
+    [Theory]
+    [InlineData(ExternalUriOpenResult.Opened)]
+    [InlineData(ExternalUriOpenResult.Dispatched)]
+    public async Task Submit_UserConsent_OpensOnceAndAcceptsWithoutContent(ExternalUriOpenResult outcome)
+    {
+        // Arrange
+        var launcher = new Launcher { Outcome = outcome };
+        var responses = new List<ElicitationAcceptContent?>();
+        using var request = Create(launcher, content => { responses.Add(content); return Task.FromResult(true); });
+
+        // Assert: creating and inspecting the request never navigates or responds.
+        Assert.Equal(0, launcher.Opens);
+        Assert.Empty(responses);
+        Assert.Equal("https://xn--bcher-kva.example/authorize?canary=private", request.FullUrl);
+        Assert.Equal("xn--bcher-kva.example", request.UrlHost);
+        Assert.True(request.HasUrlWarning);
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+        await request.SubmitCommand.ExecuteAsync(null);
+        await request.CancelCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(1, launcher.Opens);
+        Assert.Null(Assert.Single(responses));
+        Assert.True(request.IsAwaitingCompletion);
+        Assert.False(request.CanSubmit);
+        Assert.False(request.IsCompleted);
+        Assert.Contains("Opening was requested", request.UrlStatus);
+        Assert.DoesNotContain("browser is open", request.UrlStatus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Reopen_ExplicitSecondConsent_NavigatesWithoutAnotherProtocolResponse()
+    {
+        // Arrange
+        var launcher = new Launcher { Outcome = ExternalUriOpenResult.Dispatched };
+        var accepted = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); });
+        await request.ReopenCommand.ExecuteAsync(null);
+        Assert.Equal(0, launcher.Opens);
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+        await request.SubmitCommand.ExecuteAsync(null);
+        Assert.Equal(1, launcher.Opens);
+        await request.ReopenCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(2, launcher.Opens);
+        Assert.Equal(1, accepted);
+        Assert.False(request.IsCompleted);
+        request.Dispose();
+        await request.ReopenCommand.ExecuteAsync(null);
+        Assert.Equal(2, launcher.Opens);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Respond_DeclineOrCancel_NeverOpens(bool decline)
+    {
+        // Arrange
+        var launcher = new Launcher();
+        var accepted = 0;
+        var declined = 0;
+        var cancelled = 0;
+        var cleared = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); },
+            () => { declined++; return Task.FromResult(true); },
+            () => { cancelled++; return Task.FromResult(true); },
+            _ => { cleared++; return Task.CompletedTask; });
+
+        // Act
+        await (decline ? request.DeclineCommand : request.CancelCommand).ExecuteAsync(null);
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(0, launcher.Opens);
+        Assert.Equal(0, accepted);
+        Assert.Equal(decline ? 1 : 0, declined);
+        Assert.Equal(decline ? 0 : 1, cancelled);
+        Assert.Equal(1, cleared);
+    }
+
+    [Theory]
+    [InlineData(ExternalUriOpenResult.Blocked)]
+    [InlineData(ExternalUriOpenResult.Failed)]
+    [InlineData(ExternalUriOpenResult.Unavailable)]
+    public async Task Submit_OpenFails_DoesNotAcceptAndAllowsExplicitRetry(ExternalUriOpenResult outcome)
+    {
+        // Arrange
+        var launcher = new Launcher { Outcome = outcome };
+        var accepted = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); });
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(0, accepted);
+        Assert.True(request.HasError);
+        Assert.False(request.IsAwaitingCompletion);
+        launcher.Outcome = ExternalUriOpenResult.Opened;
+        await request.SubmitCommand.ExecuteAsync(null);
+        Assert.Equal(1, accepted);
+        Assert.Equal(2, launcher.Opens);
+    }
+
+    [Fact]
+    public async Task Submit_ResponseFails_RetriesReplyWithoutReopening()
+    {
+        // Arrange
+        var launcher = new Launcher();
+        var accepted = 0;
+        using var request = Create(launcher, _ => Task.FromResult(++accepted > 1));
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+        Assert.Equal("Retry response", request.SubmitText);
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(1, launcher.Opens);
+        Assert.Equal(2, accepted);
+        Assert.True(request.IsAwaitingCompletion);
+    }
+
+    [Fact]
+    public async Task Submit_ConcurrentCommands_SendsOneResponseAndOpensOnce()
+    {
+        // Arrange
+        var opened = new TaskCompletionSource<ExternalUriOpenResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var launcher = new Launcher { Pending = opened.Task };
+        var accepted = 0;
+        var cancelled = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); },
+            cancel: () => { cancelled++; return Task.FromResult(true); });
+
+        // Act
+        var first = request.SubmitCommand.ExecuteAsync(null);
+        await request.SubmitCommand.ExecuteAsync(null);
+        await request.CancelCommand.ExecuteAsync(null);
+        opened.SetResult(ExternalUriOpenResult.Opened);
+        await first;
+
+        // Assert
+        Assert.Equal(1, launcher.Opens);
+        Assert.Equal(1, accepted);
+        Assert.Equal(0, cancelled);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("https://user:password@example.com/")]
+    public async Task Submit_InvalidUrl_NeverOpensOrAccepts(string url)
+    {
+        // Arrange
+        var launcher = new Launcher();
+        var accepted = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); }, url: url);
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(request.CanSubmit);
+        Assert.True(request.HasError);
+        Assert.Equal(0, launcher.Opens);
+        Assert.Equal(0, accepted);
+    }
+
+    [Fact]
+    public async Task Submit_DisposedProjection_NeverOpensOrAccepts()
+    {
+        // Arrange
+        var launcher = new Launcher();
+        var accepted = 0;
+        var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); });
+        request.Dispose();
+
+        // Act
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(request.CanSubmit);
+        Assert.Equal(0, launcher.Opens);
+        Assert.Equal(0, accepted);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RemoveConversation_PendingOrAcceptedUrl_CannotNavigateFromStaleCommands(bool acceptedFirst)
+    {
+        // Arrange
+        var panels = new ChatConversationPanelStateCoordinator();
+        var launcher = new Launcher();
+        var accepted = 0;
+        using var request = Create(launcher, _ => { accepted++; return Task.FromResult(true); });
+        Assert.True(panels.TryStoreElicitationRequest("first", request));
+        if (acceptedFirst)
+        {
+            await request.SubmitCommand.ExecuteAsync(null);
+        }
+
+        // Act
+        panels.RemoveConversation("first", isCurrentConversation: false);
+        await request.SubmitCommand.ExecuteAsync(null);
+        await request.ReopenCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Empty(request.FullUrl);
+        Assert.Null(panels.GetPendingElicitationRequest("first"));
+        Assert.Equal(acceptedFirst ? 1 : 0, launcher.Opens);
+        Assert.Equal(acceptedFirst ? 1 : 0, accepted);
+    }
+
+    [Fact]
+    public async Task NewRequest_AfterUrlConsent_ReplacesNoticeAndExpiresOldReopenCommand()
+    {
+        // Arrange
+        var panels = new ChatConversationPanelStateCoordinator();
+        var launcher = new Launcher();
+        using var previous = Create(launcher, _ => Task.FromResult(true));
+        using var current = Create(launcher, _ => Task.FromResult(true));
+        Assert.True(panels.TryStoreElicitationRequest("first", previous));
+        Assert.False(panels.TryStoreElicitationRequest("first", current));
+        await previous.SubmitCommand.ExecuteAsync(null);
+
+        // Act
+        Assert.True(panels.TryStoreElicitationRequest("first", current));
+        await previous.ReopenCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Empty(previous.FullUrl);
+        Assert.Same(current, panels.SyncConversation("first").PendingElicitationRequest);
+        Assert.Equal(1, launcher.Opens);
+        Assert.False(panels.RemoveElicitationRequest("first", previous));
+    }
+
+    private static ElicitationRequestViewModel Create(
+        Launcher launcher,
+        Func<ElicitationAcceptContent?, Task<bool>> accept,
+        Func<Task<bool>>? decline = null,
+        Func<Task<bool>>? cancel = null,
+        Func<ElicitationRequestViewModel, Task>? clear = null,
+        string url = "https://xn--bcher-kva.example/authorize?canary=private")
+        => ElicitationInteractionViewModelFactory.Create(new ElicitationRequestEventArgs(
+            "request-1", new UrlElicitationRequest
+            {
+                Scope = ElicitationScope.ForSession("session-1"),
+                Message = "Authorize access",
+                ElicitationId = "opaque-1",
+                Url = url
+            }, accept, decline ?? (() => Task.FromResult(true)), cancel ?? (() => Task.FromResult(true))),
+            clear ?? (_ => Task.CompletedTask), uriLauncher: launcher);
+
+    private sealed class Launcher : IExternalUriLauncher
+    {
+        public bool IsSupported => true;
+        public int Opens { get; private set; }
+        public ExternalUriOpenResult Outcome { get; set; } = ExternalUriOpenResult.Opened;
+        public Task<ExternalUriOpenResult>? Pending { get; set; }
+
+        public Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken)
+        {
+            Opens++;
+            return Pending ?? Task.FromResult(Outcome);
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/ChatElicitationRoutingTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/ChatElicitationRoutingTests.cs
@@ -88,6 +88,140 @@ public sealed class ChatElicitationRoutingTests
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildElicitationRequestAsync_UrlCompletionBeforeOrAfterConsent_UsesSameRequestState(bool earlyCompletion)
+    {
+        // Arrange
+        var transport = new Mock<IAcpTransport>();
+        var responses = new List<JsonElement>();
+        SetupTransport(transport, responses);
+        using var client = new AcpClient(transport.Object, Mock.Of<IAcpClientLogger>());
+        var capabilities = ClientCapabilityDefaults.Create() with
+        {
+            Elicitation = new ElicitationCapabilities { Form = new(), Url = new() }
+        };
+        await client.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"), capabilities), TestContext.Current.CancellationToken);
+        var router = new Mock<IAuthoritativeRemoteSessionRouter>();
+        router.Setup(x => x.ResolveConversationIdAsync("remote", It.IsAny<CancellationToken>())).ReturnsAsync("conversation");
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(x => x.IsSupported).Returns(true);
+        launcher.Setup(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>())).ReturnsAsync(ExternalUriOpenResult.Opened);
+        var bridge = new ChatInteractionEventBridge(router.Object, new ChatTerminalProjectionCoordinator(), uriLauncher: launcher.Object);
+        ElicitationRequestEventArgs? args = null;
+        client.ElicitationRequestReceived += (_, value) => args = value;
+        transport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+            """{"jsonrpc":"2.0","id":201,"method":"elicitation/create","params":{"sessionId":"remote","mode":"url","elicitationId":"opaque","url":"https://example.com/authorize?canary=private","message":"Approve access"}}"""));
+        Assert.NotNull(args);
+        if (earlyCompletion)
+        {
+            Complete();
+        }
+
+        // Act
+        var projection = await bridge.BuildElicitationRequestAsync(args, (_, _) => Task.CompletedTask, NullLogger.Instance);
+        using var request = projection!.Value.ViewModel;
+
+        // Assert
+        launcher.Verify(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.True(request.CanSubmit);
+        Assert.Equal(earlyCompletion, request.IsCompleted);
+        await request.SubmitCommand.ExecuteAsync(null);
+        Assert.Equal("{\"action\":\"accept\"}", Assert.Single(responses).GetProperty("result").GetRawText());
+        Complete();
+        Complete();
+        Assert.True(request.IsCompleted);
+        Assert.True(request.IsAwaitingCompletion);
+        await request.ReopenCommand.ExecuteAsync(null);
+        launcher.Verify(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        void Complete() => transport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+            """{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"opaque"}}"""));
+    }
+
+    [Fact]
+    public async Task BuildElicitationRequestAsync_DisconnectedUrl_NeverOpens()
+    {
+        // Arrange
+        var transport = new Mock<IAcpTransport>();
+        var responses = new List<JsonElement>();
+        SetupTransport(transport, responses);
+        using var client = new AcpClient(transport.Object, Mock.Of<IAcpClientLogger>());
+        await client.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"),
+            new ClientCapabilities { Elicitation = new() { Url = new() } }), TestContext.Current.CancellationToken);
+        ElicitationRequestEventArgs? args = null;
+        client.ElicitationRequestReceived += (_, value) => args = value;
+        transport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+            """{"jsonrpc":"2.0","id":202,"method":"elicitation/create","params":{"sessionId":"remote","mode":"url","elicitationId":"opaque","url":"https://example.com/authorize?canary=private","message":"Approve access"}}"""));
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(x => x.IsSupported).Returns(true);
+        using var request = ElicitationInteractionViewModelFactory.Create(args!, _ => Task.CompletedTask, uriLauncher: launcher.Object);
+        var cleared = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        request.PropertyChanged += (_, change) =>
+        {
+            if (change.PropertyName == nameof(request.FullUrl) && request.FullUrl.Length == 0)
+            {
+                cleared.TrySetResult();
+            }
+        };
+
+        // Act
+        await client.DisconnectAsync();
+        await cleared.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await request.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(request.CanSubmit);
+        Assert.Empty(request.FullUrl);
+        Assert.Empty(responses);
+        launcher.Verify(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BuildElicitationRequestAsync_OldConnectionReusesIds_DoesNotOpenOrCompleteNewRequest()
+    {
+        // Arrange
+        var oldTransport = new Mock<IAcpTransport>();
+        var newTransport = new Mock<IAcpTransport>();
+        var oldResponses = new List<JsonElement>();
+        var newResponses = new List<JsonElement>();
+        SetupTransport(oldTransport, oldResponses);
+        SetupTransport(newTransport, newResponses);
+        using var oldClient = new AcpClient(oldTransport.Object);
+        using var newClient = new AcpClient(newTransport.Object);
+        var capabilities = new ClientCapabilities { Elicitation = new() { Url = new() } };
+        await oldClient.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"), capabilities), TestContext.Current.CancellationToken);
+        await newClient.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"), capabilities), TestContext.Current.CancellationToken);
+        ElicitationRequestEventArgs? oldArgs = null;
+        ElicitationRequestEventArgs? newArgs = null;
+        oldClient.ElicitationRequestReceived += (_, args) => oldArgs = args;
+        newClient.ElicitationRequestReceived += (_, args) => newArgs = args;
+        const string message = """{"jsonrpc":"2.0","id":203,"method":"elicitation/create","params":{"sessionId":"remote","mode":"url","elicitationId":"opaque","url":"https://example.com/authorize","message":"Approve access"}}""";
+        oldTransport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(message));
+        newTransport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(message));
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(x => x.IsSupported).Returns(true);
+        launcher.Setup(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>())).ReturnsAsync(ExternalUriOpenResult.Dispatched);
+        using var previous = ElicitationInteractionViewModelFactory.Create(oldArgs!, _ => Task.CompletedTask, uriLauncher: launcher.Object);
+        using var current = ElicitationInteractionViewModelFactory.Create(newArgs!, _ => Task.CompletedTask, uriLauncher: launcher.Object);
+
+        // Act
+        await oldClient.DisconnectAsync();
+        oldTransport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+            """{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"opaque"}}"""));
+        await previous.SubmitCommand.ExecuteAsync(null);
+        await current.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Empty(previous.FullUrl);
+        Assert.Empty(oldResponses);
+        Assert.Equal("{\"action\":\"accept\"}", Assert.Single(newResponses).GetProperty("result").GetRawText());
+        Assert.True(current.IsAwaitingCompletion);
+        Assert.False(current.IsCompleted);
+        launcher.Verify(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
     [InlineData(false, "", false)]
     [InlineData(false, "", true)]
     [InlineData(true, "", false)]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/UrlElicitationLifecycleTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/UrlElicitationLifecycleTests.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.ViewModels.Chat.Elicitation;
+using SalmonEgg.Presentation.ViewModels.Chat.Interactions;
+using SalmonEgg.Presentation.ViewModels.Chat.Panels;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat.Interactions;
+
+public sealed class UrlElicitationLifecycleTests
+{
+    [Fact]
+    public async Task SessionCancellation_RetiresUrlPromptAndAllowsNextRequest()
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        using var first = await fixture.DeliverAsync(901);
+        var firstEvent = Assert.Single(fixture.Requests);
+        Assert.True(first.CanSubmit);
+
+        // Act: use the same Application operation as the chat stop command.
+        await fixture.Service.CancelSessionAsync(new SessionCancelParams("remote"));
+
+        // Assert
+        Assert.Equal("cancel", firstEvent.State.ResponseAction);
+        Assert.Equal("cancel", Assert.Single(fixture.Responses).GetProperty("result").GetProperty("action").GetString());
+        Assert.Null(fixture.Panels.GetPendingElicitationRequest("conversation"));
+        using var next = await fixture.DeliverAsync(902);
+        Assert.Same(next, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.True(next.CanSubmit);
+        Assert.Empty(first.FullUrl);
+        Assert.Equal(1, fixture.Dismissals);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TerminalResponse_SentOutsideCardCommand_RetiresOnUiDispatcher(bool decline)
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        var dispatcher = new QueuedDispatcher();
+        fixture.DispatchAsync = dispatcher.Enqueue;
+        fixture.BeforeDismiss = () => Assert.True(dispatcher.IsExecuting);
+        using var card = await fixture.DeliverAsync(11);
+        var request = Assert.Single(fixture.Requests);
+
+        // Act
+        Assert.True(await (decline ? request.Decline() : request.Cancel()));
+
+        // Assert: SDK completion may happen off-thread; only the UI projection may clear the slot.
+        Assert.Same(card, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(0, fixture.Dismissals);
+        dispatcher.Drain();
+        Assert.Null(fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(1, fixture.Dismissals);
+        Assert.Equal(decline ? "decline" : "cancel", request.State.ResponseAction);
+        Assert.Single(fixture.Responses);
+        Assert.False(await request.Cancel());
+        dispatcher.Drain();
+        Assert.Equal(1, fixture.Dismissals);
+    }
+
+    [Fact]
+    public async Task CancelSession_FailedResponse_RetainsCardUntilSuccessfulRetry()
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        using var card = await fixture.DeliverAsync(12);
+        var request = Assert.Single(fixture.Requests);
+        fixture.WriteResponseAsync = _ => Task.FromResult(false);
+
+        // Act
+        await fixture.Service.CancelSessionAsync(new SessionCancelParams("remote"));
+
+        // Assert
+        Assert.Null(request.State.ResponseAction);
+        Assert.Same(card, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.False(card.CanSubmit);
+        Assert.True(card.CanCancel);
+        Assert.Equal(0, fixture.Dismissals);
+        fixture.WriteResponseAsync = _ => Task.FromResult(true);
+        await card.CancelCommand.ExecuteAsync(null);
+        Assert.Equal("cancel", request.State.ResponseAction);
+        Assert.Null(fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(1, fixture.Dismissals);
+        Assert.Equal("cancel", Assert.Single(fixture.Responses).GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task CancelSession_ResponseStillWriting_DoesNotRetireBeforeSendCompletes()
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        using var card = await fixture.DeliverAsync(13);
+        var request = Assert.Single(fixture.Requests);
+        var writeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.WriteResponseAsync = _ =>
+        {
+            writeStarted.TrySetResult();
+            return writeCompleted.Task;
+        };
+
+        // Act
+        var cancelling = fixture.Service.CancelSessionAsync(new SessionCancelParams("remote"));
+        await writeStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(request.State.ResponseAction);
+        Assert.Same(card, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(0, fixture.Dismissals);
+        writeCompleted.SetResult(true);
+        await cancelling.WaitAsync(TestContext.Current.CancellationToken);
+        Assert.Null(fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(1, fixture.Dismissals);
+    }
+
+    [Fact]
+    public async Task Accept_ResponseAndCompletion_KeepNoticeUntilDismissed()
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        using var card = await fixture.DeliverAsync(14);
+
+        // Act
+        await card.SubmitCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(card.IsAwaitingCompletion);
+        Assert.False(card.IsCompleted);
+        Assert.Same(card, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(0, fixture.Dismissals);
+        fixture.CompleteUrl(14);
+        Assert.True(card.IsCompleted);
+        Assert.Same(card, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        await card.DismissCommand.ExecuteAsync(null);
+        Assert.Null(fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.Equal(1, fixture.Dismissals);
+        Assert.Equal("accept", Assert.Single(fixture.Responses).GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task CancelledNotification_ReconnectReusesIds_DoesNotClearReplacement()
+    {
+        // Arrange
+        using var fixture = new LifecycleFixture();
+        await fixture.InitializeAsync();
+        var dispatcher = new QueuedDispatcher();
+        fixture.DispatchAsync = dispatcher.Enqueue;
+        using var original = await fixture.DeliverAsync(15);
+
+        // Act: defer the old state notification until a new connection owns the same wire ids.
+        await fixture.Service.CancelSessionAsync(new SessionCancelParams("remote"));
+        Assert.Same(original, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        fixture.Panels.RemoveConversation("conversation", isCurrentConversation: false);
+        await fixture.Client.DisconnectAsync();
+        await fixture.InitializeAsync();
+        using var replacement = await fixture.DeliverAsync(15);
+        dispatcher.Drain();
+
+        // Assert
+        Assert.Same(replacement, fixture.Panels.GetPendingElicitationRequest("conversation"));
+        Assert.True(replacement.CanSubmit);
+        Assert.Empty(original.FullUrl);
+        Assert.Equal(0, fixture.Dismissals);
+        Assert.False(await fixture.Requests[0].Cancel());
+        Assert.Null(fixture.Requests[1].State.ResponseAction);
+    }
+
+    private sealed class LifecycleFixture : IDisposable
+    {
+        private readonly Mock<IAcpTransport> _transport = new();
+        private readonly ChatInteractionEventBridge _bridge;
+
+        public LifecycleFixture()
+        {
+            _transport.SetupGet(value => value.IsConnected).Returns(true);
+            _transport.Setup(value => value.DisconnectAsync()).ReturnsAsync(true);
+            _transport.Setup(value => value.SendMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(SendAsync);
+            Client = new AcpClient(_transport.Object, Mock.Of<IAcpClientLogger>());
+            Service = new ChatService(Client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>());
+            Service.ElicitationRequestReceived += OnRequest;
+            var router = new Mock<IAuthoritativeRemoteSessionRouter>();
+            router.Setup(value => value.ResolveConversationIdAsync("remote", It.IsAny<CancellationToken>()))
+                .ReturnsAsync("conversation");
+            var launcher = new Mock<IExternalUriLauncher>();
+            launcher.SetupGet(value => value.IsSupported).Returns(true);
+            launcher.Setup(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ExternalUriOpenResult.Opened);
+            _bridge = new ChatInteractionEventBridge(router.Object, new ChatTerminalProjectionCoordinator(), uriLauncher: launcher.Object);
+        }
+
+        public AcpClient Client { get; }
+        public ChatService Service { get; }
+        public ChatConversationPanelStateCoordinator Panels { get; } = new();
+        public List<ElicitationRequestEventArgs> Requests { get; } = [];
+        public List<JsonElement> Responses { get; } = [];
+        public int Dismissals { get; private set; }
+        public Action? BeforeDismiss { get; set; }
+        public Func<JsonElement, Task<bool>> WriteResponseAsync { get; set; } = _ => Task.FromResult(true);
+        public Func<Action, Task> DispatchAsync { get; set; } = action => { action(); return Task.CompletedTask; };
+
+        public Task InitializeAsync() => Client.InitializeAsync(new InitializeParams(new ClientInfo("Test", "1"),
+            new ClientCapabilities { Elicitation = new() { Url = new() } }), TestContext.Current.CancellationToken);
+
+        public async Task<ElicitationRequestViewModel> DeliverAsync(int id)
+        {
+            _transport.Raise(value => value.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+                $$$"""{"jsonrpc":"2.0","id":{{{id}}},"method":"elicitation/create","params":{"sessionId":"remote","mode":"url","elicitationId":"url-{{{id}}}","url":"https://example.com/authorize","message":"Authorize"}}"""));
+            var projection = await _bridge.BuildElicitationRequestAsync(Requests[^1],
+                (conversationId, card) =>
+                {
+                    BeforeDismiss?.Invoke();
+                    Dismissals++;
+                    Panels.RemoveElicitationRequest(conversationId, card);
+                    return Task.CompletedTask;
+                }, NullLogger.Instance, DispatchAsync);
+            Assert.NotNull(projection);
+            Assert.True(Panels.TryStoreElicitationRequest(projection.Value.ConversationId, projection.Value.ViewModel));
+            return projection.Value.ViewModel;
+        }
+
+        public void CompleteUrl(int id) => _transport.Raise(value => value.MessageReceived += null,
+            new AcpTransportMessageReceivedEventArgs(
+                $$$"""{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"url-{{{id}}}"}}"""));
+
+        public void Dispose()
+        {
+            Service.ElicitationRequestReceived -= OnRequest;
+            Panels.ClearElicitationRequests();
+            Service.Dispose();
+            Client.Dispose();
+        }
+
+        private void OnRequest(object? sender, ElicitationRequestEventArgs request) => Requests.Add(request);
+
+        private async Task<bool> SendAsync(string message, CancellationToken cancellationToken)
+        {
+            using var document = JsonDocument.Parse(message);
+            var root = document.RootElement;
+            if (root.TryGetProperty("method", out var method))
+            {
+                if (method.GetString() == "initialize")
+                {
+                    var id = root.GetProperty("id").GetRawText();
+                    _transport.Raise(value => value.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+                        $$$$"""{"jsonrpc":"2.0","id":{{{{id}}}},"result":{"protocolVersion":1,"agentInfo":{"name":"Test","version":"1"},"agentCapabilities":{}}}"""));
+                }
+                return true;
+            }
+
+            var response = root.Clone();
+            if (!await WriteResponseAsync(response).WaitAsync(cancellationToken)) return false;
+            Responses.Add(response);
+            return true;
+        }
+    }
+
+    private sealed class QueuedDispatcher
+    {
+        private readonly System.Collections.Concurrent.ConcurrentQueue<(Action Action, TaskCompletionSource Completion)> _queue = new();
+
+        public bool IsExecuting { get; private set; }
+
+        public Task Enqueue(Action action)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _queue.Enqueue((action, completion));
+            return completion.Task;
+        }
+
+        public void Drain()
+        {
+            while (_queue.TryDequeue(out var item))
+            {
+                IsExecuting = true;
+                try
+                {
+                    item.Action();
+                    item.Completion.TrySetResult();
+                }
+                catch (Exception exception)
+                {
+                    item.Completion.TrySetException(exception);
+                    throw;
+                }
+                finally
+                {
+                    IsExecuting = false;
+                }
+            }
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Services/Chat/AcpUrlCapabilityTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Services/Chat/AcpUrlCapabilityTests.cs
@@ -1,0 +1,36 @@
+using Moq;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Services.Chat;
+
+public sealed class AcpUrlCapabilityTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreateDefault_PlatformCapability_AdvertisesOnlyVerifiedUrlSupport(bool supported)
+    {
+        // Arrange
+        var capabilities = new Mock<IPlatformCapabilityService>();
+        capabilities.SetupGet(x => x.SupportsUrlElicitation).Returns(supported);
+
+        // Act
+        var request = AcpInitializeRequestFactory.CreateDefault(capabilities.Object);
+
+        // Assert
+        Assert.NotNull(request.ClientCapabilities.Elicitation?.Form);
+        Assert.Equal(supported, request.ClientCapabilities.Elicitation?.Url is not null);
+    }
+
+    [Fact]
+    public void CreateDefault_NoPlatformEvidence_DoesNotAdvertiseUrl()
+    {
+        // Act
+        var request = AcpInitializeRequestFactory.CreateDefault();
+
+        // Assert
+        Assert.NotNull(request.ClientCapabilities.Elicitation?.Form);
+        Assert.Null(request.ClientCapabilities.Elicitation?.Url);
+    }
+}


### PR DESCRIPTION
URL elicitation 需要明确同意后打开隔离的浏览器，并把“同意打开”和“外部流程完成”分开。本 PR 展示 Agent、完整 URL 与主机名，用户确认后才打开并回复无 content 的 accept；支持取消、拒绝、再次打开和原连接的 completion 通知。

URL 状态与原请求共用一个 owner。回复未送达或发送失败时不提前退卡；批次重试按实际发送的响应数组提交全部状态，旧 accept 回调不能覆盖已经发送的取消错误。协议错误 -32800 不伪造成用户的 cancel action。连接结束、重复 ID 和迟到回调均不能更新另一请求。

无法显示的 request-scope、未绑定会话或被占用的交互会先取消；若取消发送失败且原请求仍待处理，调用既有连接收尾逻辑结束原服务并显示本地化重连提示。实际订阅服务在接收事件时捕获，不能根据装饰器转发的 sender 或后来建立的新连接猜测归属。

平台能力只在 WASM 广告。浏览器在原生用户操作中隔离打开，无 opener/referrer、无远程调试通道；其他平台产品入口暂未启用。Linux opener 有独立真实沙箱浏览器门禁，其冷启动等待按实际导航/回报与进程退出判定，保留有界总时限。

整合基线：main `c91d201f`，已保留鉴权、凭据、取消、V2 生命周期/投影/权限/批次和终端登录修复。生产仍默认 ACP V1，公开 live V2 与终端登录能力继续禁用。

验证：最终 SDK 源码 1214/1214、Presentation 3571/3571，均零失败、零跳过。真实 nupkg 消费、1.0.0 传输二进制兼容、46 个草案诊断与离线消费者通过；新增批次/取消回归有修前失败、修后通过证据。最终提交 `6c4d5141` 的 19 项检查通过、1 项仓库条件检查跳过；包含实际 WASM 表单/URL/权限/凭据流程、Linux 独立沙箱浏览器、真实 Windows ConPTY、SDK 包消费和各平台构建。Refs #146、#154；独立 Agent 与原生平台产品 GUI 验收仍在总单跟踪。
