### PR TITLE
feat(acp): project draft session updates into immutable snapshots

### DIFF
--- a/scripts/gates/acp-v2-projection-consumer.cs
+++ b/scripts/gates/acp-v2-projection-consumer.cs
@@ -1,0 +1,78 @@
+// Compiled against the packed SDK by run-acp-consumer-package-smoke.sh, never a ProjectReference.
+#pragma warning disable SEACP002
+using System.Text;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Tool;
+
+var history = new List<JsonElement>
+{
+    Parse("""{"sessionUpdate":"user_message","messageId":"u","content":[{"type":"text","text":"prompt"}]}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":"old"}}"""),
+    Parse("""{"sessionUpdate":"agent_message","messageId":"a","content":[{"type":"text","text":"replacement","_meta":{"private":"kept"}}],"future":1e2}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":" tail"}}"""),
+    Parse("""{"sessionUpdate":"agent_message","messageId":"a"}"""),
+    Parse("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"content","content":{"type":"text","text":"discarded"}}}"""),
+    Parse("""{"sessionUpdate":"tool_call_update","toolCallId":"t","status":"completed","content":[{"type":"terminal","terminalId":"term"}]}"""),
+    Parse("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"content","content":{"type":"text","text":"tool tail"}}}"""),
+    Parse("""{"sessionUpdate":"terminal_output_chunk","terminalId":"term","data":"eA=="}"""),
+    Parse("""{"sessionUpdate":"terminal_update","terminalId":"term","command":"echo","output":{"data":"YQ=="}}"""),
+    Parse("""{"sessionUpdate":"terminal_output_chunk","terminalId":"term","data":"YmM="}"""),
+    Parse("""{"sessionUpdate":"terminal_update","terminalId":"term","exitStatus":{}}"""),
+    Parse("""{"sessionUpdate":"_vendor","value":1e2}""")
+};
+
+var snapshot = AcpSessionDraftExtensions.ReplaySession("recorded-session", history);
+Require(snapshot.Messages.Length == 2, "Message ids must upsert instead of creating duplicates.");
+Require(snapshot.Messages[0].Kind == AcpMessageKind.User, "First-seen order must be retained.");
+Require(Text(snapshot.Messages[1]) == "replacement tail", "A whole message replaces chunks; later chunks append.");
+Require(snapshot.ToolCalls.Length == 1 && snapshot.ToolCalls[0].Status == ToolCallStatus.Completed,
+    "Tool chunks and patches must share an id owner.");
+Require(snapshot.ToolCalls[0].Content.Length == 2
+    && snapshot.ToolCalls[0].Content[0] is TerminalToolCallContent { TerminalId: "term" },
+    "Tool upserts must replace previous content and keep agent-owned terminal references.");
+Require(Encoding.UTF8.GetString(snapshot.Terminals[0].Output.AsSpan()) == "abc",
+    "Terminal snapshots replace output and each base64 chunk must decode independently.");
+Require(snapshot.Terminals[0].HasExited && snapshot.Terminals[0].ExitStatus!.ExitCode is null,
+    "An empty exit-status object still means the terminal exited.");
+Require(snapshot.UnprojectedUpdates.Single().GetRawText() == history[^1].GetRawText(),
+    "Unknown updates must survive replay verbatim.");
+Require(snapshot.Messages[1].ExtensionData["future"].GetRawText() == "1e2",
+    "Current unknown entity fields must retain raw values.");
+
+var detached = snapshot.Messages[1].Content;
+detached[0].Meta!["private"] = "mutated";
+Require(((JsonElement)snapshot.Messages[1].Content[0].Meta!["private"]!).GetString() == "kept",
+    "Mutable wire DTOs must not allow callers to edit the snapshot.");
+
+history.Add(Parse("""{"sessionUpdate":"agent_message","messageId":"a","content":null}"""));
+history.Add(Parse("""{"sessionUpdate":"tool_call_update","toolCallId":"t","content":[],"status":null}"""));
+history.Add(Parse("""{"sessionUpdate":"terminal_update","terminalId":"term","output":null,"exitStatus":null}"""));
+var cleared = AcpSessionDraftExtensions.ReplaySession("recorded-session", history);
+Require(cleared.Messages[1].Content.IsEmpty && cleared.ToolCalls[0].Content.IsEmpty
+    && cleared.ToolCalls[0].Status is null && cleared.Terminals[0].Output.IsEmpty && !cleared.Terminals[0].HasExited,
+    "Explicit null and empty-array patches must clear prior state.");
+Require(Text(snapshot.Messages[1]) == "replacement tail" && snapshot.Terminals[0].HasExited,
+    "Replaying another history must not mutate a prior snapshot.");
+var recent = AcpSessionDraftExtensions.ReplaySession("bounded-history",
+    Enumerable.Repeat(snapshot.UnprojectedUpdates.Single(), AcpSessionSnapshot.MaxUnprojectedUpdates + 1));
+Require(recent.UnprojectedUpdates.Length == AcpSessionSnapshot.MaxUnprojectedUpdates
+    && recent.OmittedUnprojectedUpdateCount == 1 && snapshot.OmittedUnprojectedUpdateCount == 0,
+    "Unprojected evidence must be bounded and omissions must remain visible on each snapshot.");
+Console.WriteLine("draft-projection-consumer-ok");
+
+static JsonElement Parse(string json)
+{
+    using var document = JsonDocument.Parse(json);
+    return document.RootElement.Clone();
+}
+
+static string Text(AcpMessageSnapshot message)
+    => string.Concat(message.Content.Select(static value => ((TextContentBlock)value).Text));
+
+static void Require(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}
+#pragma warning restore SEACP002

--- a/scripts/gates/run-acp-consumer-package-smoke.sh
+++ b/scripts/gates/run-acp-consumer-package-smoke.sh
@@ -435,4 +435,20 @@ fi
 
 echo "[smoke] Both documented suppressions compile and run"
 
+# A host evaluates draft replay through the shipped package, with real mixed history and immutable
+# snapshots. This is deliberately offline: suppression must not enable unsupported live negotiation.
+cp "$repo_root/scripts/gates/acp-v2-projection-consumer.cs" "$draft_dir/Program.cs"
+capture_build "$DOTNET_BIN" build "$draft_dir/ACPDraftConsumerSmoke.csproj" --configuration "$CONFIGURATION" --no-restore -v minimal
+require_no_infrastructure_failure "[smoke] Draft projection consumer"
+if [ "$build_rc" -ne 0 ]; then
+  cat "$build_log" >&2
+  exit 1
+fi
+projection_output="$("$DOTNET_BIN" run --project "$draft_dir/ACPDraftConsumerSmoke.csproj" --configuration "$CONFIGURATION" --no-build --no-restore -v minimal)"
+if [ "$projection_output" != "draft-projection-consumer-ok" ]; then
+  echo "[smoke] Unexpected draft projection consumer output: $projection_output" >&2
+  exit 1
+fi
+echo "[smoke] Offline draft projection consumer: mixed replay, clears, terminal bytes, immutable snapshots passed"
+
 echo "[smoke] ACP SDK package consumer smoke passed"

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -249,6 +249,16 @@ namespace SalmonEgg.Acp.Client
         internal SessionWorkSnapshot? GetSessionWorkSnapshot(string sessionId)
             => _sessionWork.GetSnapshot(sessionId);
 
+        internal AcpSessionSnapshot? GetDraftSessionSnapshot(string sessionId)
+        {
+            lock (_lock)
+            {
+                return _isInitialized && _wire.Version == AcpProtocolVersion.V2
+                    ? _sessionWork.GetProjectionSnapshot(sessionId)
+                    : null;
+            }
+        }
+
         private async Task<InitializeResponse> InitializeCoreAsync(
             InitializeParams @params,
             bool allowDraftRuntime,
@@ -542,7 +552,8 @@ namespace SalmonEgg.Acp.Client
                 "session/resume",
                 ToElement<SessionResumeParams>(@params));
 
-            var response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            var response = await SendSessionResumeRequestAsync(
+                request, @params, connectionToken, cancellationToken).ConfigureAwait(false);
 
             if (response.IsError)
             {
@@ -564,6 +575,48 @@ namespace SalmonEgg.Acp.Client
 
             return sessionResumeResponse ?? SessionResumeResponse.Completed;
         }
+
+        private async Task<JsonRpcResponse> SendSessionResumeRequestAsync(
+            JsonRpcRequest request,
+            SessionResumeParams @params,
+            CancellationToken connectionToken,
+            CancellationToken cancellationToken)
+        {
+            if (ProtocolVersion != AcpProtocolVersion.V2 || !RequestsFullReplay(request))
+            {
+                return await SendRequestAsync(request, cancellationToken, connectionToken).ConfigureAwait(false);
+            }
+
+            AcpSessionProjection? replay = null;
+            try
+            {
+                return await SendRequestAsync(
+                    request,
+                    cancellationToken,
+                    connectionToken,
+                    responseObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
+                    beforeSend: () => replay = _sessionWork.BeginReplay(@params.SessionId, connectionToken)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && replay is not null)
+            {
+                // Cancelling the wait cannot retract streamed replay. Its response or disconnect
+                // releases the claim; another full replay must not interleave uncorrelated updates.
+                throw;
+            }
+            catch
+            {
+                _sessionWork.EndReplay(@params.SessionId, replay, connectionToken);
+                throw;
+            }
+        }
+
+        private static bool RequestsFullReplay(JsonRpcRequest request)
+            => request.Params is { } parameters
+                && parameters.TryGetProperty("replayFrom", out var cursor)
+                && cursor.ValueKind == JsonValueKind.Object
+                && cursor.TryGetProperty("type", out var type)
+                && type.ValueKind == JsonValueKind.String
+                && type.ValueEquals("start");
 
         /// <summary>
         /// Closes an existing session and releases the resources held on the agent side.
@@ -1486,7 +1539,8 @@ namespace SalmonEgg.Acp.Client
             CancellationToken cancellationToken,
             CancellationToken connectionToken = default,
             Action<JsonRpcResponse>? responseObserver = null,
-            Action<Exception>? requestNotSentObserver = null)
+            Action<Exception>? requestNotSentObserver = null,
+            Action? beforeSend = null)
         {
             Activity? activity = null;
             CancellationTokenSource? sendCancellation = null;
@@ -1520,9 +1574,10 @@ namespace SalmonEgg.Acp.Client
                         throw new OperationCanceledException("The ACP connection changed before sending the request.");
                     }
                     ClearLastTransportError();
-                    // Pending registration must precede synchronous peer replies,
+                    // Lifecycle claims and pending registration must precede synchronous peer replies,
                     // under the same connection lock as starting transport I/O. The linked token also
                     // prevents a transport's delayed write from crossing a subsequent reconnect.
+                    beforeSend?.Invoke();
                     _pendingRequests[requestIdStr] = new PendingOutboundRequest(tcs, responseObserver);
                     requestWriteStarted = true;
                     sendTask = _transport.SendMessageAsync(json, sendCancellation.Token);
@@ -2177,7 +2232,11 @@ namespace SalmonEgg.Acp.Client
                     return;
                 }
                 if (connectionToken.CanBeCanceled
-                    && !_sessionWork.ReceiveUpdate(updateParams.SessionId, updateParams.Update, connectionToken))
+                    && !_sessionWork.ReceiveUpdate(
+                        updateParams.SessionId,
+                        updateParams.Update,
+                        connectionToken,
+                        wire.Version == AcpProtocolVersion.V2 ? notification.Params.Value.GetProperty("update") : null))
                 {
                     return;
                 }

--- a/src/SalmonEgg.Acp/Client/AcpSessionDraftExtensions.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionDraftExtensions.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>Opt-in access to ACP v2 session projections and offline history replay.</summary>
+/// <remarks>
+/// These helpers do not enable live v2 negotiation. The public client continues to reject v2 until
+/// its complete lifecycle and feature gates are delivered. Replay consumes recorded update objects
+/// without connecting to an Agent or modifying a client's state.
+/// </remarks>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public static class AcpSessionDraftExtensions
+{
+    /// <summary>
+    /// Returns a point-in-time snapshot from the client's normal session/update handler, or null
+    /// when no draft session is currently tracked. Closed and disconnected sessions are not exposed.
+    /// </summary>
+    public static AcpSessionSnapshot? GetSessionSnapshot(this AcpClient client, string sessionId)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(sessionId);
+        return client.GetDraftSessionSnapshot(sessionId);
+    }
+
+    /// <summary>Replays a recorded ACP v2 session history using the same projection as the live handler.</summary>
+    /// <param name="sessionId">The identity of the recorded session.</param>
+    /// <param name="updates">
+    /// Update objects, each containing the protocol's sessionUpdate discriminator. The sequence must
+    /// be in receive order and scoped to this session. Input objects are not mutated or retained.
+    /// </param>
+    /// <returns>
+    /// An immutable current-view snapshot, including bounded recent unprojected updates and their
+    /// omission count. Keep the input history when a complete archive is required.
+    /// </returns>
+    /// <exception cref="JsonException">A required update field violates its ACP v2 contract.</exception>
+    public static AcpSessionSnapshot ReplaySession(string sessionId, IEnumerable<JsonElement> updates)
+    {
+        ArgumentNullException.ThrowIfNull(sessionId);
+        ArgumentNullException.ThrowIfNull(updates);
+        var projection = new AcpSessionProjection();
+        SessionWorkState? workState = null;
+        foreach (var payload in updates)
+        {
+            var update = ReadUpdate(sessionId, payload);
+            projection.Apply(update, payload);
+            if (update is StateSessionUpdate state)
+            {
+                workState = state.State;
+            }
+        }
+        return projection.Snapshot(sessionId, workState);
+    }
+
+    private static SessionUpdate ReadUpdate(string sessionId, JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("Recorded session updates must be JSON objects.");
+        }
+
+        // Use the existing params converter, including flattened state and negotiated variant gates.
+        // Building the envelope avoids a second discriminator parser for the offline host API.
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("sessionId", sessionId);
+            writer.WritePropertyName("update");
+            payload.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+
+        var value = JsonSerializer.Deserialize(
+            stream.GetBuffer().AsSpan(0, checked((int)stream.Length)),
+            AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<SessionUpdateParams>());
+        return value?.Update ?? throw new JsonException("Recorded history requires session/update content.");
+    }
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Tool;
+
+namespace SalmonEgg.Acp.Client;
+
+// The work controller owns lifetime and locking. This owned value holds only projection state;
+// offline replay uses the same receive-order rules without constructing a connection or process.
+internal sealed class AcpSessionProjection
+{
+    private readonly Dictionary<string, MessageState> _messages = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ToolState> _tools = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, TerminalState> _terminals = new(StringComparer.Ordinal);
+    private readonly List<MessageState> _messageOrder = [];
+    private readonly List<ToolState> _toolOrder = [];
+    private readonly List<TerminalState> _terminalOrder = [];
+    private readonly Queue<(JsonElement Payload, int ByteCount)> _unprojected = new();
+    private int _unprojectedBytes;
+    private long _omittedUnprojectedUpdateCount;
+
+    internal void Apply(SessionUpdate update, JsonElement payload)
+    {
+        switch (update)
+        {
+            case WholeMessageUpdate message:
+                ApplyMessage(message, payload);
+                break;
+            case AgentMessageUpdate chunk:
+                AppendMessage(chunk.MessageId!, AcpMessageKind.Agent, chunk.Content, payload);
+                break;
+            case UserMessageUpdate chunk:
+                AppendMessage(chunk.MessageId!, AcpMessageKind.User, chunk.Content, payload);
+                break;
+            case AgentThoughtUpdate chunk:
+                AppendMessage(chunk.MessageId!, AcpMessageKind.Thought, chunk.Content, payload);
+                break;
+            case ToolCallStatusUpdate tool:
+                ApplyTool(tool, payload);
+                break;
+            case ToolCallContentChunkUpdate chunk:
+                if (chunk.Content is null) throw new JsonException("Tool content chunks require content.");
+                GetTool(chunk.ToolCallId).Content.Add(payload.GetProperty("content").Clone());
+                break;
+            case TerminalSessionUpdate terminal:
+                ApplyTerminal(terminal, payload);
+                break;
+            case TerminalOutputChunkSessionUpdate chunk:
+                // Decode before changing state: a malformed chunk must not create a phantom terminal.
+                var bytes = AcpSessionProjectionJson.DecodeOutput(chunk.Data
+                    ?? throw new JsonException("Terminal chunks require data."));
+                GetTerminal(chunk.TerminalId).Output.AddRange(bytes);
+                break;
+            case StateSessionUpdate:
+                break;
+            default:
+                RetainUnprojected(payload);
+                break;
+        }
+    }
+
+    internal AcpSessionSnapshot Snapshot(string sessionId, SessionWorkState? state)
+        => new(
+            sessionId,
+            _messageOrder.Select(static value => value.Snapshot()).ToImmutableArray(),
+            _toolOrder.Select(static value => value.Snapshot()).ToImmutableArray(),
+            _terminalOrder.Select(static value => value.Snapshot()).ToImmutableArray(),
+            _unprojected.Select(static entry => entry.Payload).ToImmutableArray(),
+            _omittedUnprojectedUpdateCount,
+            state is null ? null : AcpSessionProjectionJson.Store<SessionWorkState>(state));
+
+    private void RetainUnprojected(JsonElement payload)
+    {
+        // Unknown variants have no defined replacement key. Keep bounded recent evidence rather
+        // than inventing merge semantics or duplicating the host's complete event history.
+        var byteCount = Encoding.UTF8.GetByteCount(payload.GetRawText());
+        if (byteCount > AcpSessionSnapshot.MaxUnprojectedUtf8Bytes)
+        {
+            _omittedUnprojectedUpdateCount++;
+            return;
+        }
+        while (_unprojected.Count >= AcpSessionSnapshot.MaxUnprojectedUpdates
+            || _unprojectedBytes + byteCount > AcpSessionSnapshot.MaxUnprojectedUtf8Bytes)
+        {
+            _unprojectedBytes -= _unprojected.Dequeue().ByteCount;
+            _omittedUnprojectedUpdateCount++;
+        }
+        _unprojected.Enqueue((payload.Clone(), byteCount));
+        _unprojectedBytes += byteCount;
+    }
+
+    private void ApplyMessage(WholeMessageUpdate update, JsonElement payload)
+    {
+        var kind = update switch
+        {
+            AgentWholeMessageUpdate => AcpMessageKind.Agent,
+            UserWholeMessageUpdate => AcpMessageKind.User,
+            AgentWholeThoughtUpdate => AcpMessageKind.Thought,
+            _ => throw new JsonException("Unsupported whole-message variant.")
+        };
+        var message = GetMessage(update.MessageId, kind);
+        if (payload.TryGetProperty("content", out _))
+        {
+            Replace(message.Content, AcpSessionProjectionJson.ReadPatchArray<ContentBlock>(payload, "content"));
+        }
+        if (payload.TryGetProperty("_meta", out _))
+        {
+            message.Meta = AcpSessionProjectionJson.ReadMetadata(payload);
+        }
+        MergeExtensions(message.ExtensionData, update);
+    }
+
+    private void AppendMessage(string messageId, AcpMessageKind kind, ContentBlock? content, JsonElement payload)
+    {
+        if (content is null) throw new JsonException("Message chunks require content.");
+        var item = payload.GetProperty("content").Clone();
+        GetMessage(messageId, kind).Content.Add(item);
+    }
+
+    private void ApplyTool(ToolCallStatusUpdate update, JsonElement payload)
+    {
+        var tool = GetTool(update.ToolCallId!);
+        if (payload.TryGetProperty("title", out _)) tool.Title = update.Title;
+        if (payload.TryGetProperty("kind", out _)) tool.Kind = update.Kind;
+        if (payload.TryGetProperty("status", out _)) tool.Status = update.Status;
+        if (payload.TryGetProperty("content", out _))
+        {
+            Replace(tool.Content, AcpSessionProjectionJson.ReadPatchArray<ToolCallContent>(payload, "content"));
+        }
+        if (payload.TryGetProperty("locations", out _))
+        {
+            Replace(tool.Locations, AcpSessionProjectionJson.ReadPatchArray<ToolCallLocation>(payload, "locations"));
+        }
+        if (payload.TryGetProperty("rawInput", out _)) tool.RawInput = AcpSessionProjectionJson.CloneValue(update.RawInput);
+        if (payload.TryGetProperty("rawOutput", out _)) tool.RawOutput = AcpSessionProjectionJson.CloneValue(update.RawOutput);
+        if (payload.TryGetProperty("_meta", out _)) tool.Meta = AcpSessionProjectionJson.ReadMetadata(payload);
+        MergeExtensions(tool.ExtensionData, update);
+    }
+
+    private void ApplyTerminal(TerminalSessionUpdate update, JsonElement payload)
+    {
+        // A replacement snapshot's containing field permits default-on-error. Invalid base64 is an
+        // invalid snapshot, so it clears output like other malformed optional output values; a
+        // standalone output chunk has no such recovery grant and is rejected before any mutation.
+        byte[]? output = null;
+        if (update.Output is { } snapshot)
+        {
+            try
+            {
+                output = AcpSessionProjectionJson.DecodeOutput(snapshot.Data);
+            }
+            catch (JsonException)
+            {
+                // schema/v2 TerminalUpdate.output explicitly permits default-on-error.
+            }
+        }
+
+        var terminal = GetTerminal(update.TerminalId);
+        if (payload.TryGetProperty("command", out _)) terminal.Command = update.Command;
+        if (payload.TryGetProperty("cwd", out _)) terminal.Cwd = update.Cwd;
+        if (payload.TryGetProperty("output", out _))
+        {
+            Replace(terminal.Output, output ?? []);
+            terminal.OutputMeta = output is not null && payload.GetProperty("output") is { ValueKind: JsonValueKind.Object } raw
+                ? AcpSessionProjectionJson.ReadMetadata(raw)
+                : null;
+        }
+        if (payload.TryGetProperty("exitStatus", out _))
+        {
+            terminal.ExitStatus = update.ExitStatus is null ? null : payload.GetProperty("exitStatus").Clone();
+        }
+        if (payload.TryGetProperty("_meta", out _)) terminal.Meta = AcpSessionProjectionJson.ReadMetadata(payload);
+        MergeExtensions(terminal.ExtensionData, update);
+    }
+
+    private MessageState GetMessage(string id, AcpMessageKind kind)
+    {
+        if (!_messages.TryGetValue(id, out var state))
+        {
+            state = new MessageState(id, kind);
+            _messages.Add(id, state);
+            _messageOrder.Add(state);
+        }
+        else
+        {
+            state.Kind = kind;
+        }
+        return state;
+    }
+
+    private ToolState GetTool(string id)
+    {
+        if (!_tools.TryGetValue(id, out var state))
+        {
+            state = new ToolState(id);
+            _tools.Add(id, state);
+            _toolOrder.Add(state);
+        }
+        return state;
+    }
+
+    private TerminalState GetTerminal(string id)
+    {
+        if (!_terminals.TryGetValue(id, out var state))
+        {
+            state = new TerminalState(id);
+            _terminals.Add(id, state);
+            _terminalOrder.Add(state);
+        }
+        return state;
+    }
+
+    private static void Replace<T>(List<T> current, IEnumerable<T> replacement)
+    {
+        current.Clear();
+        current.AddRange(replacement);
+    }
+
+    private static void MergeExtensions(Dictionary<string, JsonElement> current, SessionUpdate update)
+    {
+        if (update.ExtensionData is null) return;
+        foreach (var field in update.ExtensionData)
+        {
+            // The extension owns its semantics. Retain the last value, including explicit null,
+            // without treating an unknown field as an application-defined delete instruction.
+            current[field.Key] = field.Value.Clone();
+        }
+    }
+
+    private sealed class MessageState(string id, AcpMessageKind kind)
+    {
+        internal AcpMessageKind Kind { get; set; } = kind;
+        internal List<JsonElement> Content { get; } = [];
+        internal JsonElement? Meta { get; set; }
+        internal Dictionary<string, JsonElement> ExtensionData { get; } = new(StringComparer.Ordinal);
+        internal AcpMessageSnapshot Snapshot()
+            => new(id, Kind, Content.ToImmutableArray(), Meta, ExtensionData.ToImmutableDictionary(StringComparer.Ordinal));
+    }
+
+    private sealed class ToolState(string id)
+    {
+        internal string? Title { get; set; }
+        internal ToolCallKind? Kind { get; set; }
+        internal ToolCallStatus? Status { get; set; }
+        internal List<JsonElement> Content { get; } = [];
+        internal List<JsonElement> Locations { get; } = [];
+        internal JsonElement? RawInput { get; set; }
+        internal JsonElement? RawOutput { get; set; }
+        internal JsonElement? Meta { get; set; }
+        internal Dictionary<string, JsonElement> ExtensionData { get; } = new(StringComparer.Ordinal);
+        internal AcpToolCallSnapshot Snapshot()
+            => new(id, Title, Kind, Status, Content.ToImmutableArray(), Locations.ToImmutableArray(), RawInput, RawOutput,
+                Meta, ExtensionData.ToImmutableDictionary(StringComparer.Ordinal));
+    }
+
+    private sealed class TerminalState(string id)
+    {
+        internal string? Command { get; set; }
+        internal string? Cwd { get; set; }
+        internal List<byte> Output { get; } = [];
+        internal JsonElement? OutputMeta { get; set; }
+        internal JsonElement? ExitStatus { get; set; }
+        internal JsonElement? Meta { get; set; }
+        internal Dictionary<string, JsonElement> ExtensionData { get; } = new(StringComparer.Ordinal);
+        internal AcpTerminalSnapshot Snapshot()
+            => new(id, Command, Cwd, Output.ToImmutableArray(), OutputMeta, ExitStatus, Meta,
+                ExtensionData.ToImmutableDictionary(StringComparer.Ordinal));
+    }
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionProjectionJson.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionProjectionJson.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Client;
+
+internal static class AcpSessionProjectionJson
+{
+    internal static JsonElement Store<T>(T value)
+        => JsonSerializer.SerializeToElement(value, AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<T>());
+
+    internal static T? Read<T>(JsonElement? value) where T : class
+        => value?.Deserialize(AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<T>());
+
+    internal static ImmutableArray<T> ReadArray<T>(ImmutableArray<JsonElement> values) where T : class
+    {
+        var result = ImmutableArray.CreateBuilder<T>(values.Length);
+        foreach (var value in values)
+        {
+            result.Add(Read<T>(value)!);
+        }
+        return result.MoveToImmutable();
+    }
+
+    internal static ImmutableArray<JsonElement> ReadPatchArray<T>(JsonElement payload, string name) where T : class
+    {
+        if (!payload.TryGetProperty(name, out var values) || values.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var result = ImmutableArray.CreateBuilder<JsonElement>();
+        var typeInfo = AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<T>();
+        foreach (var value in values.EnumerateArray())
+        {
+            try
+            {
+                if (value.Deserialize(typeInfo) is not null)
+                {
+                    result.Add(value.Clone());
+                }
+            }
+            catch (JsonException)
+            {
+                // These patch arrays alone carry skip-invalid-items in the pinned v2 schema.
+            }
+        }
+        return result.ToImmutable();
+    }
+
+    internal static JsonElement? ReadMetadata(JsonElement payload)
+        => payload.TryGetProperty("_meta", out var value) && value.ValueKind == JsonValueKind.Object
+            ? value.Clone()
+            : null;
+
+    internal static JsonElement? CloneValue(JsonElement? value)
+        => value is { ValueKind: not JsonValueKind.Null and not JsonValueKind.Undefined } item ? item.Clone() : null;
+
+    internal static byte[] DecodeOutput(string data)
+    {
+        try
+        {
+            return Convert.FromBase64String(data);
+        }
+        catch (FormatException error)
+        {
+            throw new JsonException("ACP terminal output must contain base64-encoded bytes.", error);
+        }
+    }
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionSnapshot.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionSnapshot.cs
@@ -1,0 +1,217 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Tool;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>The kind of an ACP v2 message, including agent reasoning kept separately from output.</summary>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public enum AcpMessageKind
+{
+    /// <summary>A user message reported by the Agent.</summary>
+    User,
+    /// <summary>A response from the Agent.</summary>
+    Agent,
+    /// <summary>Agent reasoning.</summary>
+    Thought
+}
+
+/// <summary>An immutable point-in-time projection of ACP v2 session updates.</summary>
+/// <remarks>
+/// Messages, tool calls and terminals retain first-seen order. Protocol DTO getters return detached
+/// values because their wire contracts contain mutable collections. Changing one cannot change this
+/// snapshot, any later snapshot, or the client's state. This is a current-view projection, not a
+/// lossless archive. Hosts retain original events when they require complete update history.
+/// </remarks>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public sealed class AcpSessionSnapshot
+{
+    /// <summary>The maximum number of recent unprojected updates retained per session.</summary>
+    public const int MaxUnprojectedUpdates = 64;
+    /// <summary>The maximum combined UTF-8 JSON size of retained unprojected updates.</summary>
+    public const int MaxUnprojectedUtf8Bytes = 256 * 1024;
+
+    private readonly JsonElement? _workState;
+
+    internal AcpSessionSnapshot(
+        string sessionId,
+        ImmutableArray<AcpMessageSnapshot> messages,
+        ImmutableArray<AcpToolCallSnapshot> toolCalls,
+        ImmutableArray<AcpTerminalSnapshot> terminals,
+        ImmutableArray<JsonElement> unprojectedUpdates,
+        long omittedUnprojectedUpdateCount,
+        JsonElement? workState)
+    {
+        SessionId = sessionId;
+        Messages = messages;
+        ToolCalls = toolCalls;
+        Terminals = terminals;
+        UnprojectedUpdates = unprojectedUpdates;
+        OmittedUnprojectedUpdateCount = omittedUnprojectedUpdateCount;
+        _workState = workState;
+    }
+
+    /// <summary>The session whose history was projected.</summary>
+    public string SessionId { get; }
+
+    /// <summary>Messages indexed by the Agent's message ids and retained in first-seen order.</summary>
+    public ImmutableArray<AcpMessageSnapshot> Messages { get; }
+
+    /// <summary>Tool calls retained in first-seen order.</summary>
+    public ImmutableArray<AcpToolCallSnapshot> ToolCalls { get; }
+
+    /// <summary>Agent-owned terminals retained in first-seen order.</summary>
+    public ImmutableArray<AcpTerminalSnapshot> Terminals { get; }
+
+    /// <summary>
+    /// Recent updates outside the message/tool/terminal projection, including unknown future variants,
+    /// retained verbatim in receive order within the count and byte limits. Oversized updates are
+    /// omitted; fitting updates evict the oldest entries as needed. Work state is exposed separately.
+    /// </summary>
+    public ImmutableArray<JsonElement> UnprojectedUpdates { get; }
+
+    /// <summary>Unprojected updates omitted or evicted since this projection began or was replayed.</summary>
+    public long OmittedUnprojectedUpdateCount { get; }
+
+    /// <summary>The latest reported work state, detached from the client's work controller.</summary>
+    public SessionWorkState? WorkState => AcpSessionProjectionJson.Read<SessionWorkState>(_workState);
+}
+
+/// <summary>The current content of one Agent-identified message.</summary>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public sealed class AcpMessageSnapshot
+{
+    private readonly ImmutableArray<JsonElement> _content;
+
+    internal AcpMessageSnapshot(
+        string messageId,
+        AcpMessageKind kind,
+        ImmutableArray<JsonElement> content,
+        JsonElement? meta,
+        ImmutableDictionary<string, JsonElement> extensionData)
+    {
+        MessageId = messageId;
+        Kind = kind;
+        _content = content;
+        Meta = meta;
+        ExtensionData = extensionData;
+    }
+
+    /// <summary>The message id supplied by the Agent.</summary>
+    public string MessageId { get; }
+
+    /// <summary>The message's role.</summary>
+    public AcpMessageKind Kind { get; }
+
+    /// <summary>Content after ordered upserts and chunks. Each access returns detached wire DTOs.</summary>
+    public ImmutableArray<ContentBlock> Content => AcpSessionProjectionJson.ReadArray<ContentBlock>(_content);
+
+    /// <summary>Message-scoped metadata. Chunk metadata never replaces it.</summary>
+    public JsonElement? Meta { get; }
+
+    /// <summary>Last-seen values of unknown message fields; chunk fields remain on their events.</summary>
+    public ImmutableDictionary<string, JsonElement> ExtensionData { get; }
+}
+
+/// <summary>The current patch-merged state of one tool call.</summary>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public sealed class AcpToolCallSnapshot
+{
+    private readonly ImmutableArray<JsonElement> _content;
+    private readonly ImmutableArray<JsonElement> _locations;
+
+    internal AcpToolCallSnapshot(
+        string toolCallId,
+        string? title,
+        ToolCallKind? kind,
+        ToolCallStatus? status,
+        ImmutableArray<JsonElement> content,
+        ImmutableArray<JsonElement> locations,
+        JsonElement? rawInput,
+        JsonElement? rawOutput,
+        JsonElement? meta,
+        ImmutableDictionary<string, JsonElement> extensionData)
+    {
+        ToolCallId = toolCallId;
+        Title = title;
+        Kind = kind;
+        Status = status;
+        _content = content;
+        _locations = locations;
+        RawInput = rawInput;
+        RawOutput = rawOutput;
+        Meta = meta;
+        ExtensionData = extensionData;
+    }
+
+    /// <summary>The tool call id supplied by the Agent.</summary>
+    public string ToolCallId { get; }
+    /// <summary>The latest title, or null when unknown or cleared.</summary>
+    public string? Title { get; }
+    /// <summary>The latest kind, preserving unknown protocol values.</summary>
+    public ToolCallKind? Kind { get; }
+    /// <summary>The latest status, preserving unknown protocol values.</summary>
+    public ToolCallStatus? Status { get; }
+    /// <summary>Content after replacement and append updates. Each access returns detached DTOs.</summary>
+    public ImmutableArray<ToolCallContent> Content => AcpSessionProjectionJson.ReadArray<ToolCallContent>(_content);
+    /// <summary>Latest affected locations. Each access returns detached DTOs.</summary>
+    public ImmutableArray<ToolCallLocation> Locations => AcpSessionProjectionJson.ReadArray<ToolCallLocation>(_locations);
+    /// <summary>The latest raw input value.</summary>
+    public JsonElement? RawInput { get; }
+    /// <summary>The latest raw output value.</summary>
+    public JsonElement? RawOutput { get; }
+    /// <summary>Tool-call-scoped metadata.</summary>
+    public JsonElement? Meta { get; }
+    /// <summary>Last-seen values of unknown tool-call fields; chunk fields remain on their events.</summary>
+    public ImmutableDictionary<string, JsonElement> ExtensionData { get; }
+}
+
+/// <summary>The current state and decoded output of an Agent-owned terminal.</summary>
+/// <remarks>This describes a terminal; it never creates or controls a local process.</remarks>
+[Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]
+public sealed class AcpTerminalSnapshot
+{
+    private readonly JsonElement? _exitStatus;
+
+    internal AcpTerminalSnapshot(
+        string terminalId,
+        string? command,
+        string? cwd,
+        ImmutableArray<byte> output,
+        JsonElement? outputMeta,
+        JsonElement? exitStatus,
+        JsonElement? meta,
+        ImmutableDictionary<string, JsonElement> extensionData)
+    {
+        TerminalId = terminalId;
+        Command = command;
+        Cwd = cwd;
+        Output = output;
+        OutputMeta = outputMeta;
+        _exitStatus = exitStatus;
+        Meta = meta;
+        ExtensionData = extensionData;
+    }
+
+    /// <summary>The terminal id supplied by the Agent.</summary>
+    public string TerminalId { get; }
+    /// <summary>The latest command, or null when unknown or cleared.</summary>
+    public string? Command { get; }
+    /// <summary>The latest working directory, or null when unknown or cleared.</summary>
+    public string? Cwd { get; }
+    /// <summary>Output bytes after replacement snapshots and independently decoded chunks.</summary>
+    public ImmutableArray<byte> Output { get; }
+    /// <summary>Metadata belonging to the latest output replacement snapshot.</summary>
+    public JsonElement? OutputMeta { get; }
+    /// <summary>Whether an exit-status object has been reported, even if its fields are unknown.</summary>
+    public bool HasExited => _exitStatus is not null;
+    /// <summary>The latest exit information. Each access returns a detached DTO.</summary>
+    public TerminalExitStatus? ExitStatus => AcpSessionProjectionJson.Read<TerminalExitStatus>(_exitStatus);
+    /// <summary>Terminal-scoped metadata.</summary>
+    public JsonElement? Meta { get; }
+    /// <summary>Last-seen values of unknown terminal fields; chunk fields remain on their events.</summary>
+    public ImmutableDictionary<string, JsonElement> ExtensionData { get; }
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
@@ -162,7 +162,11 @@ internal sealed class AcpSessionWorkController
         }
     }
 
-    internal bool ReceiveUpdate(string sessionId, SessionUpdate update, CancellationToken connectionToken)
+    internal bool ReceiveUpdate(
+        string sessionId,
+        SessionUpdate update,
+        CancellationToken connectionToken,
+        JsonElement? draftPayload = null)
     {
         lock (_gate)
         {
@@ -171,12 +175,18 @@ internal sealed class AcpSessionWorkController
                 return false;
             }
 
+            var session = GetOrCreateSession(sessionId);
+            if (draftPayload is { } payload)
+            {
+                session.Projection ??= new AcpSessionProjection();
+                session.Projection.Apply(update, payload);
+            }
+
             if (update is not StateSessionUpdate workUpdate)
             {
                 return true;
             }
 
-            var session = GetOrCreateSession(sessionId);
             session.State = CloneState(workUpdate.State);
             if (workUpdate.State is IdleSessionWorkState idle)
             {
@@ -222,6 +232,49 @@ internal sealed class AcpSessionWorkController
                     session.Prompts.Count,
                     session.Prompts.Count(static prompt => prompt.Accepted is not null))
                 : null;
+        }
+    }
+
+    internal AcpSessionSnapshot? GetProjectionSnapshot(string sessionId)
+    {
+        lock (_gate)
+        {
+            return _sessions.TryGetValue(sessionId, out var session)
+                ? (session.Projection ?? new AcpSessionProjection()).Snapshot(sessionId, session.State)
+                : null;
+        }
+    }
+
+    internal AcpSessionProjection BeginReplay(string sessionId, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (!IsCurrent(connectionToken))
+            {
+                throw new OperationCanceledException("The ACP connection changed before session replay.");
+            }
+            var session = GetOrCreateSession(sessionId);
+            if (session.ReplayInProgress)
+            {
+                // session/update has no request id: overlapping full replays cannot be separated.
+                throw new InvalidOperationException("A full history replay is already in progress for this session.");
+            }
+            _closedSessions.Remove(sessionId);
+            session.ReplayInProgress = true;
+            session.Projection = new AcpSessionProjection();
+            return session.Projection;
+        }
+    }
+
+    internal void EndReplay(string sessionId, AcpSessionProjection? projection, CancellationToken connectionToken)
+    {
+        lock (_gate)
+        {
+            if (IsCurrent(connectionToken) && _sessions.TryGetValue(sessionId, out var session)
+                && ReferenceEquals(session.Projection, projection))
+            {
+                session.ReplayInProgress = false;
+            }
         }
     }
 
@@ -292,6 +345,8 @@ internal sealed class AcpSessionWorkController
         internal SessionWorkState? State { get; set; }
         internal bool CancellationRequested { get; set; }
         internal TaskCompletionSource<SessionPromptCompletion>? CancellationCompletion { get; set; }
+        internal AcpSessionProjection? Projection { get; set; }
+        internal bool ReplayInProgress { get; set; }
     }
 }
 

--- a/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/SessionUpdateTypes.cs
@@ -354,6 +354,13 @@ namespace SalmonEgg.Acp.Protocol
             SessionUpdate? update = null;
             if (root.TryGetProperty("update", out var updateElement) && updateElement.ValueKind == JsonValueKind.Object)
             {
+                if (AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
+                    && (!updateElement.TryGetProperty("sessionUpdate", out var updateKind)
+                        || updateKind.ValueKind != JsonValueKind.String))
+                {
+                    throw new JsonException("ACP v2 updates require string 'sessionUpdate'.");
+                }
+
                 // state_update carries a second discriminator ("state") flattened alongside
                 // "sessionUpdate". STJ polymorphism resolves exactly one discriminator per hierarchy, so
                 // this variant is handled here instead of through a JsonDerivedType registration.

--- a/src/SalmonEgg.Acp/PublicSurface.Types.txt
+++ b/src/SalmonEgg.Acp/PublicSurface.Types.txt
@@ -15,6 +15,12 @@
 # Sorted by type name, ordinal. Asserted by PublicSurfaceBaselineTests and DraftProtocolSurfaceTests.
 SalmonEgg.Acp.Client.AcpClient stable
 SalmonEgg.Acp.Client.AcpClientLogLevel stable
+SalmonEgg.Acp.Client.AcpMessageKind draft
+SalmonEgg.Acp.Client.AcpMessageSnapshot draft
+SalmonEgg.Acp.Client.AcpSessionDraftExtensions draft
+SalmonEgg.Acp.Client.AcpSessionSnapshot draft
+SalmonEgg.Acp.Client.AcpTerminalSnapshot draft
+SalmonEgg.Acp.Client.AcpToolCallSnapshot draft
 SalmonEgg.Acp.Client.AcpTransportErrorEventArgs stable
 SalmonEgg.Acp.Client.AcpTransportErrorKind stable
 SalmonEgg.Acp.Client.AcpTransportMessageReceivedEventArgs stable

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -43,15 +43,16 @@ hosts must enable optional capabilities only after implementing their interactio
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
-| ACP v2 | Explicit v2 wire contracts and the internal prompt/work-state lifecycle are covered by deterministic protocol peers. Live initialization rejects v2. | Update projections, permission handling, batch processing, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, and message/tool/terminal projections are covered by deterministic protocol peers. Draft SDK helpers support offline history replay. Live initialization rejects v2. | Permission handling, configuration workflows, batch processing, application UI integration, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
 
 V2 wire coverage includes `configId`/`groupId`, required `messageId` values, text/custom command
 inputs, and v1-only session fields and MCP variants. Unknown extension fields are preserved;
 default-on-error and skip-invalid-item behavior applies only where the upstream schema permits it.
 Resource-link icons are available through the experimental `ResourceLinkDraftExtensions` helper,
 so constructing them requires an explicit draft opt-in. Permission subject types are still not
-connected to live request handling. These contracts do not supply message upserts, streaming tool
-and terminal projections.
+connected to live request handling. Draft session snapshots now supply message upserts, streaming
+tool content, and Agent-owned terminal projections; the production application does not consume
+them until its complete v2 feature gate is ready.
 
 `SendPromptAsync` always waits for completed foreground work. The internal v2 development path
 records the prompt acknowledgement separately and finishes on an idle `state_update`; cancellation
@@ -65,6 +66,41 @@ says an ending idle must carry a stop reason, while its
 [schema](https://github.com/agentclientprotocol/agent-client-protocol/blob/5ebaf0aceb04a4ba6574cd63fa6355352dc6d931/schema/v2/schema.json)
 allows an omitted/null/default-on-error reason. The client preserves that unknown reason and still
 finishes on idle (`HasStopReason == false`), without fabricating `end_turn` or waiting indefinitely.
+
+`AcpSessionDraftExtensions.ReplaySession(sessionId, updates)` is an **offline** SDK host API for
+recorded histories. Each input is a JSON update object with `sessionUpdate`, in receive order and
+scoped to the supplied session. It uses the same v2 reader and projection as the normal client
+handler without connecting, executing terminal commands, or changing a client's state.
+`client.GetSessionSnapshot(sessionId)` reads the same owner on an internally staged v2 connection;
+it returns null on the public v1 runtime and after session close or disconnect. Suppressing
+`SEACP002` does not enable live v2 initialization.
+
+Snapshots expose messages, tool calls, and terminal output in first-seen order. Patch omission
+keeps a value, null clears it, and arrays replace complete content; chunks append. Terminal chunks
+are independently decoded into immutable bytes. Message/tool/terminal metadata is separate from
+chunk metadata. Entity `ExtensionData` retains the last-seen value of each unknown top-level field,
+including explicit null, without interpreting its semantics. Protocol DTO getters return detached
+copies because wire DTO collections are mutable; editing a returned
+DTO cannot alter an existing snapshot or client state. A full `replayFrom: { type: "start" }` begins
+a fresh projection, while resume without replay retains prior history. Overlapping full replays
+are rejected because session updates carry no request id that could separate them; cancelling the
+local wait retains this claim until the peer responds or the connection ends.
+
+A snapshot is a current view, not a lossless event archive. `UnprojectedUpdates` retains recent
+unhandled updates verbatim within `MaxUnprojectedUpdates` (64 entries) and
+`MaxUnprojectedUtf8Bytes` (256 KiB of JSON). A fitting update evicts the oldest entries as needed;
+a single oversized update is omitted without evicting existing entries. Both cases increment
+`OmittedUnprojectedUpdateCount`. A fresh full replay resets this accounting. These limits do not
+truncate known message/tool/terminal content or suppress `SessionUpdateReceived`. Hosts record that
+event for complete update history, or raw transport messages for a wire-exact archive; snapshots
+do not retain replaced entity values or chunk-scoped metadata and extension history.
+
+The [pinned v2 schema](https://github.com/agentclientprotocol/agent-client-protocol/blob/5ebaf0aceb04a4ba6574cd63fa6355352dc6d931/schema/v2/schema.json)
+explicitly allows default-on-error for optional patch fields and skip-invalid-items for message,
+tool-content, and location arrays. Those recoveries apply only to the v2 contracts that declare
+them. Required identities and chunks remain strict, unknown string discriminators survive, and
+v1 optional-field type validation is unchanged. The actual nupkg consumer gate replays mixed
+history and asserts replacement, append, clear, terminal bytes, and snapshot isolation.
 
 Keep the v1 runtime and public API compatible while these gaps are addressed. Enabling v2 needs
 both the upstream stabilization/Agent prerequisites and end-to-end verification of the complete
@@ -136,10 +172,12 @@ result without casting a `Task` to `Task<bool>`.
 Every v2 draft contract on the public surface carries `[Experimental("SEACP002")]`, so naming one is
 a **compile error** by default rather than a warning. That is deliberate: v2 is still an upstream
 draft, no live client negotiates it (`AcpProtocolVersion.RuntimeServed` is v1), and code built on
-these types cannot reach a real Agent today. The 38 marked types are the `state_update` work-state
+these types cannot reach a real Agent today. The 44 marked types are the `state_update` work-state
 family, the whole-message upsert updates, the terminal updates, streaming tool-call content, the
 v2 `plan_update` envelope, permission subjects, the v2 capability markers, the structured diff,
-and `ResourceLinkDraftExtensions` for resource-link icons.
+`ResourceLinkDraftExtensions` for resource-link icons, and six session-projection types (the draft
+entry point, message kind, and session/message/tool/terminal snapshots). The projection types are
+not source-generated wire DTOs and introduce no serialization-context bypass.
 
 To evaluate them anyway, opt in explicitly:
 

--- a/src/SalmonEgg.Acp/Serialization/AcpWireFormat.cs
+++ b/src/SalmonEgg.Acp/Serialization/AcpWireFormat.cs
@@ -128,6 +128,8 @@ namespace SalmonEgg.Acp.Serialization
                 return;
             }
 
+            SessionProjectionWireContract.Apply(info);
+
             if (info.Type == typeof(SessionNewResponse) || info.Type == typeof(SessionResumeResponse))
             {
                 IgnoreProperty(info, "modes", new IgnoredProtocolPropertyJsonConverter<SessionModesState>());

--- a/src/SalmonEgg.Acp/Serialization/DefaultableProtocolJsonConverters.cs
+++ b/src/SalmonEgg.Acp/Serialization/DefaultableProtocolJsonConverters.cs
@@ -62,6 +62,82 @@ internal sealed class DefaultableObjectJsonConverter<T> : JsonConverter<T> where
         => JsonSerializer.Serialize(writer, value, (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T)));
 }
 
+internal sealed class DefaultableNullableJsonConverter<T> : JsonConverter<T?> where T : struct
+{
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        if (document.RootElement.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return document.RootElement.Deserialize((JsonTypeInfo<T>)options.GetTypeInfo(typeof(T)));
+        }
+        catch (JsonException)
+        {
+            // Only properties explicitly annotated x-deserialize-default-on-error use this converter.
+            return null;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+    {
+        if (value is { } item)
+        {
+            JsonSerializer.Serialize(writer, item, (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T)));
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}
+
+internal sealed class DefaultableListJsonConverter<T> : JsonConverter<List<T>> where T : class
+{
+    public override List<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var result = new List<T>();
+        var typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+        foreach (var item in document.RootElement.EnumerateArray())
+        {
+            try
+            {
+                if (item.Deserialize(typeInfo) is { } value)
+                {
+                    result.Add(value);
+                }
+            }
+            catch (JsonException)
+            {
+                // Collection recovery is valid only when the schema also permits skip-invalid-items.
+            }
+        }
+
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<T> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        var typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+        foreach (var item in value)
+        {
+            JsonSerializer.Serialize(writer, item, typeInfo);
+        }
+        writer.WriteEndArray();
+    }
+}
+
 internal sealed class DefaultableProtocolListJsonConverter<T> : JsonConverter<List<T>> where T : class
 {
     public override bool HandleNull => true;

--- a/src/SalmonEgg.Acp/Serialization/SessionProjectionWireContract.cs
+++ b/src/SalmonEgg.Acp/Serialization/SessionProjectionWireContract.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Tool;
+
+namespace SalmonEgg.Acp.Serialization;
+
+// The v2 schema explicitly grants recovery to patch fields, not to the ids or streamed items.
+// Keep this on the negotiated resolver so v1 and unversioned serializers retain their contracts.
+internal static class SessionProjectionWireContract
+{
+    internal static void Apply(JsonTypeInfo info)
+    {
+        if (typeof(WholeMessageUpdate).IsAssignableFrom(info.Type))
+        {
+            Property(info, "content").CustomConverter = new DefaultableListJsonConverter<ContentBlock>();
+            DefaultMetadata(info);
+        }
+        else if (typeof(ContentChunkUpdate).IsAssignableFrom(info.Type))
+        {
+            Property(info, "content").IsRequired = true;
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(ToolCallStatusUpdate))
+        {
+            RequireId(info, "toolCallId", static value => ((ToolCallStatusUpdate)value).ToolCallId);
+            Property(info, "title").CustomConverter = new DefaultableStringJsonConverter();
+            Property(info, "kind").CustomConverter = new DefaultableNullableJsonConverter<ToolCallKind>();
+            Property(info, "status").CustomConverter = new DefaultableNullableJsonConverter<ToolCallStatus>();
+            Property(info, "content").CustomConverter = new DefaultableListJsonConverter<ToolCallContent>();
+            Property(info, "locations").CustomConverter = new DefaultableListJsonConverter<ToolCallLocation>();
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(ToolCallContentChunkUpdate))
+        {
+            RequireId(info, "toolCallId", static value => ((ToolCallContentChunkUpdate)value).ToolCallId);
+            Property(info, "content").IsRequired = true;
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(TerminalSessionUpdate))
+        {
+            ApplyTerminal(info);
+        }
+        else if (info.Type == typeof(TerminalOutputChunkSessionUpdate))
+        {
+            RequireId(info, "terminalId", static value => ((TerminalOutputChunkSessionUpdate)value).TerminalId);
+            RequireId(info, "data", static value => ((TerminalOutputChunkSessionUpdate)value).Data);
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(TerminalOutput))
+        {
+            RequireId(info, "data", static value => ((TerminalOutput)value).Data);
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(TerminalExitStatus))
+        {
+            Property(info, "exitCode").CustomConverter = new DefaultableNullableJsonConverter<uint>();
+            Property(info, "signal").CustomConverter = new DefaultableStringJsonConverter();
+            DefaultMetadata(info);
+        }
+        else if (info.Type == typeof(ToolCallLocation))
+        {
+            RequireId(info, "path", static value => ((ToolCallLocation)value).Path);
+            Property(info, "line").CustomConverter = new DefaultableNullableJsonConverter<uint>();
+            DefaultMetadata(info);
+        }
+    }
+
+    private static void ApplyTerminal(JsonTypeInfo info)
+    {
+        RequireId(info, "terminalId", static value => ((TerminalSessionUpdate)value).TerminalId);
+        Property(info, "command").CustomConverter = new DefaultableStringJsonConverter();
+        Property(info, "cwd").CustomConverter = new DefaultableStringJsonConverter();
+        Property(info, "output").CustomConverter = new DefaultableObjectJsonConverter<TerminalOutput>();
+        Property(info, "exitStatus").CustomConverter = new DefaultableObjectJsonConverter<TerminalExitStatus>();
+        DefaultMetadata(info);
+    }
+
+    private static void RequireId(JsonTypeInfo info, string name, Func<object, string?> read)
+    {
+        Property(info, name).IsRequired = true;
+        var previous = info.OnDeserialized;
+        info.OnDeserialized = value =>
+        {
+            previous?.Invoke(value);
+            if (read(value) is null)
+            {
+                throw new JsonException($"ACP v2 update requires string '{name}'.");
+            }
+        };
+    }
+
+    private static void DefaultMetadata(JsonTypeInfo info)
+        => Property(info, "_meta").CustomConverter = new DefaultableObjectJsonConverter<Dictionary<string, object?>>();
+
+    private static JsonPropertyInfo Property(JsonTypeInfo info, string name)
+    {
+        foreach (var property in info.Properties)
+        {
+            if (property.Name == name)
+            {
+                return property;
+            }
+        }
+
+        throw new InvalidOperationException($"Missing generated property {info.Type.Name}.{name}.");
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionProjectionTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionProjectionTests.cs
@@ -1,0 +1,1061 @@
+using System.Text;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Acp.Tool;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpSessionProjectionTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Theory]
+    [InlineData("agent_message", "agent_message_chunk", AcpMessageKind.Agent)]
+    [InlineData("user_message", "user_message_chunk", AcpMessageKind.User)]
+    [InlineData("agent_thought", "agent_thought_chunk", AcpMessageKind.Thought)]
+    public async Task SessionUpdate_MixedMessageUpsertsAndChunks_ReplacesThenAppends(
+        string wholeKind, string chunkKind, AcpMessageKind kind)
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Message(chunkKind, "m", "first"));
+        peer.Update("one", Whole(wholeKind, "m", "replacement"));
+        var replaced = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        peer.Update("one", Message(chunkKind, "m", "tail"));
+        peer.Update("one", "{\"sessionUpdate\":\"" + wholeKind + "\",\"messageId\":\"m\"}");
+
+        // Assert
+        var message = Assert.Single(peer.Client.GetSessionSnapshot("one")!.Messages);
+        Assert.Equal(kind, message.Kind);
+        Assert.Equal(["replacement", "tail"], Texts(message));
+        Assert.Equal(["replacement"], Texts(Assert.Single(replaced.Messages)));
+        Assert.Empty(peer.Errors);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("27")]
+    [InlineData("\"broken\"")]
+    public void ReplaySession_MessageContentClearOrDefault_ClearsPreviousChunks(string value)
+    {
+        // Arrange
+        var updates = new[]
+        {
+            Json(Message("agent_message_chunk", "m", "previous")),
+            Json("{\"sessionUpdate\":\"agent_message\",\"messageId\":\"m\",\"content\":" + value + "}")
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", updates);
+
+        // Assert
+        Assert.Empty(Assert.Single(snapshot.Messages).Content);
+    }
+
+    [Fact]
+    public void ReplaySession_MessageMetadata_UpsertsOnlyAtMessageScope()
+    {
+        // Arrange
+        var initial = Json("""{"sessionUpdate":"agent_message","messageId":"m","_meta":{"message":"owned"}}""");
+        var chunk = Json("""{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"text","text":"hi"},"_meta":{"chunk":"only"}}""");
+
+        // Act
+        var beforeClear = AcpSessionDraftExtensions.ReplaySession("one", [initial, chunk]);
+        var afterClear = AcpSessionDraftExtensions.ReplaySession("one", [initial, chunk,
+            Json("""{"sessionUpdate":"agent_message","messageId":"m","_meta":null}""")]);
+
+        // Assert
+        Assert.Equal("owned", Assert.Single(beforeClear.Messages).Meta!.Value.GetProperty("message").GetString());
+        Assert.False(beforeClear.Messages[0].Meta!.Value.TryGetProperty("chunk", out _));
+        Assert.Null(Assert.Single(afterClear.Messages).Meta);
+        Assert.Equal(["hi"], Texts(afterClear.Messages[0]));
+    }
+
+    [Fact]
+    public void ReplaySession_NewMessageWithoutContent_UsesEmptyDefaultAndFirstSeenOrder()
+    {
+        // Arrange
+        var updates = new[]
+        {
+            Json("""{"sessionUpdate":"user_message","messageId":"second"}"""),
+            Json(Whole("agent_message", "first", "one")),
+            Json(Whole("user_message", "second", "two"))
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", updates);
+
+        // Assert
+        Assert.Equal(["second", "first"], snapshot.Messages.Select(static m => m.MessageId));
+        Assert.Equal(["two"], Texts(snapshot.Messages[0]));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_ToolUpsert_ReplacesCollectionsAndPatchesOnlyPresentFields()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","title":"Read file","kind":"read","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"old"}}],"locations":[{"path":"/workspace/old"}],"rawInput":{"path":"one"},"rawOutput":{"value":1},"_meta":{"tool":"owned"}}""");
+        var before = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","title":null,"status":"completed","content":[{"type":"content","content":{"type":"text","text":"new"}}],"locations":[],"rawOutput":null}""");
+        peer.Update("one", """{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"content","content":{"type":"text","text":"tail"}},"_meta":{"chunk":true}}""");
+
+        // Assert
+        var tool = Assert.Single(peer.Client.GetSessionSnapshot("one")!.ToolCalls);
+        Assert.Null(tool.Title);
+        Assert.Equal(ToolCallKind.Read, tool.Kind);
+        Assert.Equal(ToolCallStatus.Completed, tool.Status);
+        Assert.Equal(["new", "tail"], ToolTexts(tool));
+        Assert.Empty(tool.Locations);
+        Assert.Equal("one", tool.RawInput!.Value.GetProperty("path").GetString());
+        Assert.Null(tool.RawOutput);
+        Assert.Equal("owned", tool.Meta!.Value.GetProperty("tool").GetString());
+        Assert.Equal(["old"], ToolTexts(before.ToolCalls[0]));
+    }
+
+    [Fact]
+    public void ReplaySession_ToolPatchNulls_ClearAllOptionalState()
+    {
+        // Arrange
+        var initial = Json("""{"sessionUpdate":"tool_call_update","toolCallId":"t","title":"title","kind":"read","status":"pending","content":[{"type":"terminal","terminalId":"x"}],"locations":[{"path":"/x"}],"rawInput":{},"rawOutput":{},"_meta":{}}""");
+        var clear = Json("""{"sessionUpdate":"tool_call_update","toolCallId":"t","title":null,"kind":null,"status":null,"content":null,"locations":null,"rawInput":null,"rawOutput":null,"_meta":null}""");
+
+        // Act
+        var tool = Assert.Single(AcpSessionDraftExtensions.ReplaySession("one", [initial, clear]).ToolCalls);
+
+        // Assert
+        Assert.Null(tool.Title);
+        Assert.Null(tool.Kind);
+        Assert.Null(tool.Status);
+        Assert.Empty(tool.Content);
+        Assert.Empty(tool.Locations);
+        Assert.Null(tool.RawInput);
+        Assert.Null(tool.RawOutput);
+        Assert.Null(tool.Meta);
+    }
+
+    [Fact]
+    public void ReplaySession_ToolChunkBeforeUpsert_CreatesUnknownStateThenPatches()
+    {
+        // Arrange
+        var chunk = Json("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"terminal","terminalId":"term"}}""");
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [chunk,
+            Json("""{"sessionUpdate":"tool_call_update","toolCallId":"t","status":"future_status","kind":"future_kind"}""")]);
+
+        // Assert
+        var tool = Assert.Single(snapshot.ToolCalls);
+        Assert.Null(tool.Title);
+        Assert.Equal("future_status", tool.Status!.Value.Value);
+        Assert.Equal("future_kind", tool.Kind!.Value.Value);
+        Assert.Equal("term", Assert.IsType<TerminalToolCallContent>(Assert.Single(tool.Content)).TerminalId);
+    }
+
+    [Fact]
+    public void ReplaySession_DefaultablePatchAndCollections_RecoversOnlyInvalidItems()
+    {
+        // Arrange
+        var updates = new[]
+        {
+            Json("""{"sessionUpdate":"agent_message","messageId":"m","content":[17,{"type":"text","text":"kept"},{"type":"_future","payload":{"x":1}}],"_meta":"bad"}"""),
+            Json("""{"sessionUpdate":"tool_call_update","toolCallId":"t","title":5,"kind":{},"status":[],"content":[false,{"type":"terminal","terminalId":"term"}],"locations":[{"line":4},{"path":"/valid","line":"bad"}],"_meta":3}""")
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", updates);
+
+        // Assert
+        Assert.Equal(2, snapshot.Messages[0].Content.Length);
+        Assert.Null(snapshot.Messages[0].Meta);
+        Assert.Null(snapshot.ToolCalls[0].Title);
+        Assert.Null(snapshot.ToolCalls[0].Kind);
+        Assert.Null(snapshot.ToolCalls[0].Status);
+        Assert.Single(snapshot.ToolCalls[0].Content);
+        var location = Assert.Single(snapshot.ToolCalls[0].Locations);
+        Assert.Equal("/valid", location.Path);
+        Assert.Null(location.Line);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_TerminalSnapshotsAndChunks_DecodesEachChunkAndReplacesOutput()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", """{"sessionUpdate":"terminal_output_chunk","terminalId":"t","data":"YQ=="}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_output_chunk","terminalId":"t","data":"YmM="}""");
+        var before = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        peer.Update("one", """{"sessionUpdate":"terminal_update","terminalId":"t","command":"echo","cwd":"/workspace","output":{"data":"eA==","_meta":{"snapshot":true}},"exitStatus":{},"_meta":{"terminal":true}}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_output_chunk","terminalId":"t","data":"eXo=","_meta":{"chunk":true}}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_update","terminalId":"t"}""");
+
+        // Assert
+        var terminal = Assert.Single(peer.Client.GetSessionSnapshot("one")!.Terminals);
+        Assert.Equal("abc", Encoding.UTF8.GetString(before.Terminals[0].Output.AsSpan()));
+        Assert.Equal("xyz", Encoding.UTF8.GetString(terminal.Output.AsSpan()));
+        Assert.Equal("echo", terminal.Command);
+        Assert.Equal("/workspace", terminal.Cwd);
+        Assert.True(terminal.HasExited);
+        Assert.Null(terminal.ExitStatus!.ExitCode);
+        Assert.True(terminal.OutputMeta!.Value.GetProperty("snapshot").GetBoolean());
+        Assert.False(terminal.Meta!.Value.TryGetProperty("chunk", out _));
+        Assert.DoesNotContain(peer.Sent, static request => request.Method.StartsWith("terminal/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ReplaySession_TerminalExplicitNulls_ClearStateAndExitFlag()
+    {
+        // Arrange
+        var initial = Json("""{"sessionUpdate":"terminal_update","terminalId":"t","command":"cmd","cwd":"/x","output":{"data":"eA=="},"exitStatus":{"exitCode":0},"_meta":{}}""");
+        var clear = Json("""{"sessionUpdate":"terminal_update","terminalId":"t","command":null,"cwd":null,"output":null,"exitStatus":null,"_meta":null}""");
+
+        // Act
+        var terminal = Assert.Single(AcpSessionDraftExtensions.ReplaySession("one", [initial, clear]).Terminals);
+
+        // Assert
+        Assert.Null(terminal.Command);
+        Assert.Null(terminal.Cwd);
+        Assert.Empty(terminal.Output);
+        Assert.False(terminal.HasExited);
+        Assert.Null(terminal.ExitStatus);
+        Assert.Null(terminal.Meta);
+    }
+
+    [Theory]
+    [InlineData("17")]
+    [InlineData("{}")]
+    [InlineData("{\"data\":null}")]
+    [InlineData("{\"data\":\"!invalid!\"}")]
+    public void ReplaySession_MalformedOptionalTerminalOutput_DefaultsToClear(string output)
+    {
+        // Arrange
+        var updates = new[]
+        {
+            Json("""{"sessionUpdate":"terminal_output_chunk","terminalId":"t","data":"eA=="}"""),
+            Json("{\"sessionUpdate\":\"terminal_update\",\"terminalId\":\"t\",\"command\":\"kept\",\"output\":" + output + "}")
+        };
+
+        // Act
+        var terminal = Assert.Single(AcpSessionDraftExtensions.ReplaySession("one", updates).Terminals);
+
+        // Assert
+        Assert.Equal("kept", terminal.Command);
+        Assert.Empty(terminal.Output);
+    }
+
+    [Fact]
+    public void ReplaySession_DefaultableTerminalExitFields_RetainsExitedObject()
+    {
+        // Arrange
+        var update = Json("""{"sessionUpdate":"terminal_update","terminalId":"t","command":1,"cwd":false,"exitStatus":{"exitCode":-1,"signal":2,"_meta":3}}""");
+
+        // Act
+        var terminal = Assert.Single(AcpSessionDraftExtensions.ReplaySession("one", [update]).Terminals);
+
+        // Assert
+        Assert.True(terminal.HasExited);
+        Assert.Null(terminal.Command);
+        Assert.Null(terminal.Cwd);
+        Assert.Null(terminal.ExitStatus!.ExitCode);
+        Assert.Null(terminal.ExitStatus.Signal);
+        Assert.Null(terminal.ExitStatus.Meta);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_MalformedTerminalChunk_DoesNotMutateProjectionOrRaiseUpdate()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        var received = 0;
+        peer.Client.SessionUpdateReceived += (_, _) => received++;
+
+        // Act
+        peer.Update("one", """{"sessionUpdate":"terminal_output_chunk","terminalId":"bad","data":"bad!"}""");
+
+        // Assert
+        Assert.Equal(0, received);
+        Assert.Empty(peer.Client.GetSessionSnapshot("one")!.Terminals);
+        Assert.Single(peer.Errors);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"sessionUpdate\":1}")]
+    [InlineData("{\"sessionUpdate\":\"agent_message\"}")]
+    [InlineData("{\"sessionUpdate\":\"agent_message\",\"messageId\":null}")]
+    [InlineData("{\"sessionUpdate\":\"agent_message_chunk\",\"messageId\":\"m\"}")]
+    [InlineData("{\"sessionUpdate\":\"agent_message_chunk\",\"messageId\":\"m\",\"content\":null}")]
+    [InlineData("{\"sessionUpdate\":\"tool_call_update\"}")]
+    [InlineData("{\"sessionUpdate\":\"tool_call_content_chunk\",\"toolCallId\":\"t\",\"content\":null}")]
+    [InlineData("{\"sessionUpdate\":\"terminal_update\",\"terminalId\":null}")]
+    [InlineData("{\"sessionUpdate\":\"terminal_output_chunk\",\"terminalId\":\"t\"}")]
+    [InlineData("{\"sessionUpdate\":\"terminal_output_chunk\",\"terminalId\":\"t\",\"data\":null}")]
+    public void ReplaySession_InvalidRequiredFields_RejectsInsteadOfInventingIdentity(string json)
+    {
+        // Arrange
+        var update = Json(json);
+
+        // Act / Assert
+        Assert.Throws<JsonException>(() => AcpSessionDraftExtensions.ReplaySession("one", [update]));
+    }
+
+    [Fact]
+    public void ReplaySession_EmptyStringIds_AreNotStricterThanSchema()
+    {
+        // Arrange
+        var updates = new[]
+        {
+            Json(Whole("agent_message", "", "text")),
+            Json("""{"sessionUpdate":"tool_call_update","toolCallId":""}"""),
+            Json("""{"sessionUpdate":"terminal_update","terminalId":""}""")
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("", updates);
+
+        // Assert
+        Assert.Equal("", Assert.Single(snapshot.Messages).MessageId);
+        Assert.Equal("", Assert.Single(snapshot.ToolCalls).ToolCallId);
+        Assert.Equal("", Assert.Single(snapshot.Terminals).TerminalId);
+    }
+
+    [Fact]
+    public void ReplaySession_UnknownPayloads_PreservesRawDataWithoutTreatingThemAsKnown()
+    {
+        // Arrange
+        const string unknown = """{"sessionUpdate":"future_update", "payload":1e2,"private":{"x":1}}""";
+        var updates = new[]
+        {
+            Json(unknown),
+            Json("""{"sessionUpdate":"agent_message","messageId":"m","content":[{"type":"_vendor","answer":[1,2]}]}"""),
+            Json("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"_vendor_tool","answer":{"a":1}}}""")
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", updates);
+
+        // Assert
+        Assert.Equal(unknown, Assert.Single(snapshot.UnprojectedUpdates).GetRawText());
+        var toolContent = Assert.IsType<CustomToolCallContent>(Assert.Single(snapshot.ToolCalls[0].Content));
+        Assert.Equal(1, toolContent.RawPayload.GetProperty("answer").GetProperty("a").GetInt32());
+        Assert.Equal(2, snapshot.Messages[0].Content[0].RawPayload!.Value.GetProperty("answer").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task SessionUpdate_UnprojectedCountLimit_RetainsRecentValuesWithoutSuppressingEvents()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        var received = new List<JsonElement>();
+        peer.Client.SessionUpdateReceived += (_, args) =>
+        {
+            if (args.Update is { UnknownUpdateKind: not null } update)
+            {
+                received.Add(update.ExtensionData!["sequence"]);
+            }
+        };
+        var history = Enumerable.Range(0, AcpSessionSnapshot.MaxUnprojectedUpdates + 2)
+            .Select(static index => Json("{\"sessionUpdate\":\"_vendor\",\"sequence\":" + index + "}"))
+            .ToArray();
+        foreach (var update in history.Take(AcpSessionSnapshot.MaxUnprojectedUpdates))
+        {
+            peer.Update("one", update.GetRawText());
+        }
+        var before = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        foreach (var update in history.Skip(AcpSessionSnapshot.MaxUnprojectedUpdates))
+        {
+            peer.Update("one", update.GetRawText());
+        }
+        peer.Update("one", Whole("agent_message", "m", "unaffected"));
+        var after = peer.Client.GetSessionSnapshot("one")!;
+        var replay = AcpSessionDraftExtensions.ReplaySession("one", history);
+
+        // Assert
+        Assert.Equal(AcpSessionSnapshot.MaxUnprojectedUpdates, after.UnprojectedUpdates.Length);
+        Assert.Equal(2, after.OmittedUnprojectedUpdateCount);
+        Assert.Equal(history.Skip(2).Select(static value => value.GetRawText()),
+            after.UnprojectedUpdates.Select(static value => value.GetRawText()));
+        Assert.Equal(after.UnprojectedUpdates.Select(static value => value.GetRawText()),
+            replay.UnprojectedUpdates.Select(static value => value.GetRawText()));
+        Assert.Equal(after.OmittedUnprojectedUpdateCount, replay.OmittedUnprojectedUpdateCount);
+        Assert.Equal(history.Length, received.Count);
+        Assert.Equal(0, before.OmittedUnprojectedUpdateCount);
+        Assert.Equal(0, before.UnprojectedUpdates[0].GetProperty("sequence").GetInt32());
+        Assert.Equal(["unaffected"], Texts(Assert.Single(after.Messages)));
+    }
+
+    [Fact]
+    public void ReplaySession_UnprojectedByteLimit_UsesUtf8SizeAndEvictsOldestFirst()
+    {
+        // Arrange
+        var update = Json("{\"sessionUpdate\":\"_vendor\",\"text\":\""
+            + new string('界', AcpSessionSnapshot.MaxUnprojectedUtf8Bytes / 6) + "\"}");
+        Assert.True(update.GetRawText().Length * 2 < AcpSessionSnapshot.MaxUnprojectedUtf8Bytes);
+        Assert.True(Encoding.UTF8.GetByteCount(update.GetRawText()) * 2 > AcpSessionSnapshot.MaxUnprojectedUtf8Bytes);
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [update, update]);
+
+        // Assert
+        Assert.Equal(update.GetRawText(), Assert.Single(snapshot.UnprojectedUpdates).GetRawText());
+        Assert.Equal(1, snapshot.OmittedUnprojectedUpdateCount);
+    }
+
+    [Fact]
+    public void ReplaySession_OversizedUnprojectedUpdate_RecordsOmissionWithoutEvictingFittingHistory()
+    {
+        // Arrange
+        var first = Json("""{"sessionUpdate":"_first","value":1e2}""");
+        var oversized = Json("{\"sessionUpdate\":\"_large\",\"text\":\""
+            + new string('x', AcpSessionSnapshot.MaxUnprojectedUtf8Bytes) + "\"}");
+        var last = Json("""{"sessionUpdate":"_last","value":true}""");
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [first, oversized, last]);
+
+        // Assert
+        Assert.Equal([first.GetRawText(), last.GetRawText()],
+            snapshot.UnprojectedUpdates.Select(static value => value.GetRawText()));
+        Assert.Equal(1, snapshot.OmittedUnprojectedUpdateCount);
+    }
+
+    [Fact]
+    public void ReplaySession_UnprojectedUpdateAtByteLimit_RetainsItVerbatim()
+    {
+        // Arrange
+        const string prefix = "{\"sessionUpdate\":\"_vendor\",\"text\":\"";
+        const string suffix = "\"}";
+        var payload = prefix + new string('x', AcpSessionSnapshot.MaxUnprojectedUtf8Bytes - prefix.Length - suffix.Length) + suffix;
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [Json(payload)]);
+
+        // Assert
+        Assert.Equal(payload, Assert.Single(snapshot.UnprojectedUpdates).GetRawText());
+        Assert.Equal(0, snapshot.OmittedUnprojectedUpdateCount);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_EntityExtensions_KeepLastSeenValuesWithoutAbsorbingChunkFields()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", """{"sessionUpdate":"agent_message","messageId":"m","future":{"value":1e2},"kept":true}""");
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","future":{"value":1e2},"kept":true}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_update","terminalId":"term","future":{"value":1e2},"kept":true}""");
+        var before = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        peer.Update("one", """{"sessionUpdate":"agent_message","messageId":"m","future":null}""");
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","future":null}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_update","terminalId":"term","future":null}""");
+        peer.Update("one", """{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"text","text":"tail"},"future":"chunk-only"}""");
+        peer.Update("one", """{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"terminal","terminalId":"term"},"future":"chunk-only"}""");
+        peer.Update("one", """{"sessionUpdate":"terminal_output_chunk","terminalId":"term","data":"eA==","future":"chunk-only"}""");
+        var after = peer.Client.GetSessionSnapshot("one")!;
+
+        // Assert
+        foreach (var extensions in new[] { before.Messages[0].ExtensionData, before.ToolCalls[0].ExtensionData, before.Terminals[0].ExtensionData })
+        {
+            Assert.Equal("1e2", extensions["future"].GetProperty("value").GetRawText());
+        }
+        foreach (var extensions in new[] { after.Messages[0].ExtensionData, after.ToolCalls[0].ExtensionData, after.Terminals[0].ExtensionData })
+        {
+            Assert.Equal(JsonValueKind.Null, extensions["future"].ValueKind);
+            Assert.True(extensions["kept"].GetBoolean());
+            Assert.Equal(2, extensions.Count);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("_future")]
+    public void ReplaySession_UnknownContentDiscriminator_DoesNotInvokeStricterWriter(string type)
+    {
+        // Arrange
+        var content = "{\"type\":\"" + type + "\",\"opaque\":1e2}";
+        var update = Json("{\"sessionUpdate\":\"agent_message\",\"messageId\":\"m\",\"content\":[" + content + "]}");
+
+        // Act
+        var message = Assert.Single(AcpSessionDraftExtensions.ReplaySession("one", [update]).Messages);
+
+        // Assert
+        Assert.Equal(content, Assert.Single(message.Content).RawPayload!.Value.GetRawText());
+    }
+
+    [Fact]
+    public async Task SessionUpdate_MutatingEventAndSnapshotDtos_CannotChangeStoredProjection()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Client.SessionUpdateReceived += (_, args) =>
+        {
+            if (args.Update is AgentWholeMessageUpdate update)
+            {
+                update.Content!.Clear();
+            }
+        };
+        peer.Update("one", """{"sessionUpdate":"agent_message","messageId":"m","content":[{"type":"text","text":"kept","_meta":{"a":1}}]}""");
+        var snapshot = peer.Client.GetSessionSnapshot("one")!;
+
+        // Act
+        snapshot.Messages[0].Content[0].Meta!["a"] = "mutated";
+        peer.Update("one", Message("agent_message_chunk", "m", "later"));
+
+        // Assert
+        Assert.Equal(["kept"], Texts(snapshot.Messages[0]));
+        Assert.Equal(1, Assert.IsType<JsonElement>(snapshot.Messages[0].Content[0].Meta!["a"]).GetInt32());
+        Assert.Equal(["kept", "later"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_ObserverReadsSnapshot_SeesTheCurrentUpdate()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        AcpSessionSnapshot? observed = null;
+        peer.Client.SessionUpdateReceived += (_, _) => observed = peer.Client.GetSessionSnapshot("one");
+
+        // Act
+        peer.Update("one", Whole("user_message", "m", "current"));
+
+        // Assert
+        Assert.Equal(["current"], Texts(Assert.Single(observed!.Messages)));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_SameIdsAcrossSessions_RemainIsolated()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+
+        // Act
+        peer.Update("one", Whole("agent_message", "m", "first"));
+        peer.Update("two", Whole("agent_message", "m", "second"));
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","title":"one"}""");
+        peer.Update("two", """{"sessionUpdate":"tool_call_update","toolCallId":"t","title":"two"}""");
+
+        // Assert
+        Assert.Equal(["first"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+        Assert.Equal(["second"], Texts(peer.Client.GetSessionSnapshot("two")!.Messages[0]));
+        Assert.Equal("one", peer.Client.GetSessionSnapshot("one")!.ToolCalls[0].Title);
+        Assert.Equal("two", peer.Client.GetSessionSnapshot("two")!.ToolCalls[0].Title);
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_FullReplay_ReplacesPriorHistoryBeforeFirstReplayedChunk()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "removed", "old"));
+        peer.Update("one", Message("agent_message_chunk", "m", "old duplicate"));
+        peer.Update("one", "{\"sessionUpdate\":\"_large\",\"text\":\""
+            + new string('x', AcpSessionSnapshot.MaxUnprojectedUtf8Bytes) + "\"}");
+        Assert.Equal(1, peer.Client.GetSessionSnapshot("one")!.OmittedUnprojectedUpdateCount);
+        peer.OnResume = _ => peer.Update("one", Message("agent_message_chunk", "m", "replayed"));
+
+        // Act
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), TestToken);
+
+        // Assert
+        var snapshot = peer.Client.GetSessionSnapshot("one")!;
+        Assert.Equal("m", Assert.Single(snapshot.Messages).MessageId);
+        Assert.Equal(["replayed"], Texts(snapshot.Messages[0]));
+        Assert.Empty(snapshot.UnprojectedUpdates);
+        Assert.Equal(0, snapshot.OmittedUnprojectedUpdateCount);
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_WithoutReplay_KeepsPriorHistory()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "kept"));
+
+        // Act
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", []), TestToken);
+
+        // Assert
+        Assert.Equal(["kept"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_EmptyHistory_ExposesAnEmptyTrackedSnapshot()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+
+        // Act
+        var created = await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+
+        // Assert
+        var snapshot = peer.Client.GetSessionSnapshot(created.SessionId);
+        Assert.NotNull(snapshot);
+        Assert.Empty(snapshot.Messages);
+        Assert.Empty(snapshot.ToolCalls);
+        Assert.Empty(snapshot.Terminals);
+        Assert.Null(snapshot.WorkState);
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_CustomRawCursor_DoesNotPretendTypedStartWasSent()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "kept"));
+        var cursor = SessionReplayFrom.Start with { RawPayload = Json("""{"type":"_vendor_cursor","position":7}""") };
+
+        // Act
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [], replayFrom: cursor), TestToken);
+
+        // Assert
+        Assert.Equal(["kept"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+        var sent = Assert.Single(peer.Sent, static request => request.Method == "session/resume");
+        Assert.Equal("_vendor_cursor", sent.Params!.Value.GetProperty("replayFrom").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_ClosedSession_ReplayIsAcceptedBeforeResumeResponse()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "old", "removed"));
+        await peer.Client.CloseSessionAsync(new SessionCloseParams("one"), TestToken);
+        peer.OnResume = _ => peer.Update("one", Whole("agent_message", "new", "restored"));
+
+        // Act
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), TestToken);
+
+        // Assert
+        Assert.Equal(["restored"], Texts(Assert.Single(peer.Client.GetSessionSnapshot("one")!.Messages)));
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_AlreadyCancelled_DoesNotClearHistoryOrSend()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "kept"));
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        // Act / Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => peer.Client.ResumeSessionAsync(
+            new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), cancelled.Token));
+        Assert.Equal(["kept"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+        Assert.DoesNotContain(peer.Sent, static request => request.Method == "session/resume");
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_CancelledWait_PreventsInterleavedReplayUntilPeerResponse()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.HoldResume = true;
+        using var caller = new CancellationTokenSource();
+        var first = peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), caller.Token);
+        peer.Update("one", Message("user_message_chunk", "m", "replay"));
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+
+        // Act / Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.Client.ResumeSessionAsync(
+            new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), TestToken));
+        Assert.Equal(1, peer.Sent.Count(static request => request.Method == "session/resume"));
+        Assert.Equal(["replay"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+        peer.ReplyResume();
+        peer.HoldResume = false;
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), TestToken);
+        Assert.Empty(peer.Client.GetSessionSnapshot("one")!.Messages);
+    }
+
+    [Theory]
+    [InlineData("close")]
+    [InlineData("delete")]
+    public async Task SessionRemoval_LateUpdate_DoesNotResurrectProjection(string operation)
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "removed"));
+
+        // Act
+        if (operation == "close") await peer.Client.CloseSessionAsync(new SessionCloseParams("one"), TestToken);
+        else await peer.Client.DeleteSessionAsync(new SessionDeleteParams("one"), TestToken);
+        peer.Update("one", Whole("agent_message", "late", "rejected"));
+
+        // Assert
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_DisconnectAndQueuedOldCallback_CannotRepopulateNewConnection()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "old"));
+        var oldDelivery = peer.CaptureDelivery();
+        await peer.Client.DisconnectAsync();
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+        await peer.InitializeAsync();
+        peer.Update("one", Whole("agent_message", "m", "new"));
+
+        // Act
+        oldDelivery(ProjectionPeer.UpdateFrame("one", Whole("agent_message", "m", "stale")));
+
+        // Assert
+        Assert.Equal(["new"], Texts(peer.Client.GetSessionSnapshot("one")!.Messages[0]));
+    }
+
+    [Fact]
+    public async Task SessionUpdate_ConnectionDrop_HidesProjectionImmediately()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "old"));
+
+        // Act
+        peer.DropConnection();
+
+        // Assert
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_DelayedOldConnectionWrite_CannotEnterReplacementConnection()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "old", "old"));
+        var blockedWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.BeforeResumeWrite = () => blockedWrite.Task;
+        var oldResume = peer.Client.ResumeSessionAsync(
+            new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start), TestToken);
+        await peer.Client.DisconnectAsync();
+        await peer.InitializeAsync();
+        peer.Update("one", Whole("agent_message", "new", "replacement"));
+
+        // Act
+        blockedWrite.SetResult(true);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => oldResume.WaitAsync(TestToken));
+        Assert.DoesNotContain(peer.Sent, static request => request.Method == "session/resume");
+        var current = peer.Client.GetSessionSnapshot("one")!;
+        Assert.Equal("new", Assert.Single(current.Messages).MessageId);
+        Assert.Equal(["replacement"], Texts(current.Messages[0]));
+    }
+
+    [Fact]
+    public async Task CancelSessionAsync_TrailingUpdatesUntilIdle_RemainProjected()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        peer.Update("one", """{"sessionUpdate":"state_update","state":"running"}""");
+        var cancel = peer.Client.CancelSessionAsync(new SessionCancelParams("one"), TestToken);
+
+        // Act
+        peer.Update("one", Message("agent_message_chunk", "m", "trailing"));
+        Assert.False(cancel.IsCompleted);
+        peer.Update("one", """{"sessionUpdate":"state_update","state":"idle","stopReason":"cancelled"}""");
+        await cancel.WaitAsync(TestToken);
+
+        // Assert
+        var snapshot = peer.Client.GetSessionSnapshot("one")!;
+        Assert.Equal(["trailing"], Texts(snapshot.Messages[0]));
+        Assert.Equal(StopReason.Cancelled, Assert.IsType<IdleSessionWorkState>(snapshot.WorkState).StopReason);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_V1Connection_RemainsPassthroughWithoutDraftProjection()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync(AcpProtocolVersion.V1);
+        var received = new List<SessionUpdate>();
+        peer.Client.SessionUpdateReceived += (_, args) => received.Add(Assert.IsAssignableFrom<SessionUpdate>(args.Update));
+
+        // Act
+        peer.Update("one", Whole("agent_message", "m", "future"));
+        peer.Update("one", """{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"stable"}}""");
+
+        // Assert
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+        Assert.Equal("agent_message", Assert.IsType<SessionUpdate>(received[0]).UnknownUpdateKind);
+        Assert.Equal("stable", Assert.IsType<TextContentBlock>(Assert.IsType<AgentMessageUpdate>(received[1]).Content).Text);
+    }
+
+    [Fact]
+    public async Task SessionUpdate_V1InvalidOptionalToolField_StillFailsExistingTypeContract()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync(AcpProtocolVersion.V1);
+        var received = false;
+        peer.Client.SessionUpdateReceived += (_, _) => received = true;
+
+        // Act
+        peer.Update("one", """{"sessionUpdate":"tool_call_update","toolCallId":"t","title":42}""");
+
+        // Assert
+        Assert.False(received);
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task ReplaySession_MixedHistory_MatchesNormalHandlerSnapshots()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        var history = new[]
+        {
+            Json(Whole("user_message", "user", "prompt")),
+            Json(Message("agent_message_chunk", "agent", "first")),
+            Json(Whole("agent_message", "agent", "replacement")),
+            Json("""{"sessionUpdate":"tool_call_update","toolCallId":"tool","status":"in_progress"}"""),
+            Json("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"tool","content":{"type":"terminal","terminalId":"term"}}"""),
+            Json("""{"sessionUpdate":"terminal_output_chunk","terminalId":"term","data":"aGk="}"""),
+            Json("""{"sessionUpdate":"state_update","state":"idle","stopReason":"end_turn"}""")
+        };
+
+        // Act
+        foreach (var update in history) peer.Update("one", update.GetRawText());
+        var replay = AcpSessionDraftExtensions.ReplaySession("one", history);
+        var live = peer.Client.GetSessionSnapshot("one")!;
+
+        // Assert
+        Assert.Equal(live.Messages.SelectMany(Texts), replay.Messages.SelectMany(Texts));
+        Assert.Equal(live.ToolCalls[0].Status, replay.ToolCalls[0].Status);
+        Assert.Equal(live.Terminals[0].Output, replay.Terminals[0].Output);
+        Assert.Equal(Assert.IsType<IdleSessionWorkState>(live.WorkState).StopReason,
+            Assert.IsType<IdleSessionWorkState>(replay.WorkState).StopReason);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public void ReplaySession_ArbitraryTerminalChunkBoundaries_PreservesOriginalBytes()
+    {
+        FsCheckPropertyRunner.Run(this, nameof(ArbitraryTerminalChunkBoundariesProperty));
+    }
+
+    [Fact]
+    public void ReplaySession_ArbitraryMessageReplacements_ReplaceAllPriorChunks()
+    {
+        FsCheckPropertyRunner.Run(this, nameof(ArbitraryMessageReplacementsProperty));
+    }
+
+    private void ArbitraryTerminalChunkBoundariesProperty(byte[]? first, byte[]? second, byte[]? replacement, byte[]? tail)
+    {
+        // Arrange
+        first ??= [];
+        second ??= [];
+        replacement ??= [];
+        tail ??= [];
+        var chunks = new[]
+        {
+            TerminalChunk(first),
+            TerminalChunk(second)
+        };
+        var replay = new[]
+        {
+            chunks[0], chunks[1],
+            Json("{\"sessionUpdate\":\"terminal_update\",\"terminalId\":\"t\",\"output\":{\"data\":\""
+                + Convert.ToBase64String(replacement) + "\"}}"),
+            TerminalChunk(tail)
+        };
+
+        // Act
+        var accumulated = AcpSessionDraftExtensions.ReplaySession("one", chunks);
+        var replaced = AcpSessionDraftExtensions.ReplaySession("one", replay);
+
+        // Assert
+        Assert.Equal(first.Concat(second), accumulated.Terminals[0].Output);
+        Assert.Equal(replacement.Concat(tail), replaced.Terminals[0].Output);
+    }
+
+    private void ArbitraryMessageReplacementsProperty(byte[]? before, byte[]? replacement, byte[]? after)
+    {
+        // Arrange
+        var originalText = Convert.ToBase64String(before ?? []);
+        var replacementText = Convert.ToBase64String(replacement ?? []);
+        var tail = Convert.ToBase64String(after ?? []);
+        var history = new[]
+        {
+            Json(Message("agent_message_chunk", "m", originalText)),
+            Json(Whole("agent_message", "m", replacementText)),
+            Json(Message("agent_message_chunk", "m", tail))
+        };
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", history);
+
+        // Assert
+        Assert.Equal([replacementText, tail], Texts(Assert.Single(snapshot.Messages)));
+    }
+
+    private static JsonElement TerminalChunk(byte[] bytes)
+        => Json("{\"sessionUpdate\":\"terminal_output_chunk\",\"terminalId\":\"t\",\"data\":\""
+            + Convert.ToBase64String(bytes) + "\"}");
+
+    private static string[] Texts(AcpMessageSnapshot message)
+        => message.Content.Select(static item => Assert.IsType<TextContentBlock>(item).Text).ToArray();
+
+    private static string[] ToolTexts(AcpToolCallSnapshot tool)
+        => tool.Content.Select(static item => Assert.IsType<TextContentBlock>(Assert.IsType<ContentToolCallContent>(item).Content).Text).ToArray();
+
+    private static JsonElement Json(string text)
+    {
+        using var document = JsonDocument.Parse(text);
+        return document.RootElement.Clone();
+    }
+
+    private static string Message(string kind, string id, string text)
+        => "{\"sessionUpdate\":\"" + kind + "\",\"messageId\":\"" + id + "\",\"content\":{\"type\":\"text\",\"text\":\"" + text + "\"}}";
+
+    private static string Whole(string kind, string id, string text)
+        => "{\"sessionUpdate\":\"" + kind + "\",\"messageId\":\"" + id + "\",\"content\":[{\"type\":\"text\",\"text\":\"" + text + "\"}]}";
+
+    private sealed class ProjectionPeer : IAcpTransport
+    {
+        private readonly MessageParser _parser = new();
+        private readonly int _version;
+        private JsonRpcRequest? _resume;
+
+        private ProjectionPeer(int version)
+        {
+            _version = version;
+            Client = new AcpClient(this);
+            Client.ErrorOccurred += (_, error) => Errors.Add(error);
+        }
+
+        public bool IsConnected { get; private set; }
+        internal AcpClient Client { get; }
+        internal List<string> Errors { get; } = [];
+        internal List<JsonRpcRequest> Sent { get; } = [];
+        internal Action<JsonRpcRequest>? OnResume { get; set; }
+        internal Func<Task>? BeforeResumeWrite { get; set; }
+        internal bool HoldResume { get; set; }
+
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred;
+
+        internal static async Task<ProjectionPeer> CreateAsync(int version = AcpProtocolVersion.V2)
+        {
+            var peer = new ProjectionPeer(version);
+            await peer.InitializeAsync();
+            return peer;
+        }
+
+        internal Task<InitializeResponse> InitializeAsync()
+        {
+            var parameters = new InitializeParams(new ClientInfo("projection-peer", "1.0"), new ClientCapabilities())
+            {
+                ProtocolVersion = _version
+            };
+            return _version == AcpProtocolVersion.V2
+                ? Client.InitializeDraftAsync(parameters, TestToken)
+                : Client.InitializeAsync(parameters, TestToken);
+        }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_parser.ParseMessage(message) is not JsonRpcRequest request) return Task.FromResult(true);
+            if (request.Method == "session/resume" && BeforeResumeWrite is { } beforeWrite)
+            {
+                return SendAfterGateAsync(request, beforeWrite(), cancellationToken);
+            }
+            return Send(request);
+        }
+
+        private Task<bool> Send(JsonRpcRequest request)
+        {
+            Sent.Add(request);
+            if (request.Method == "initialize")
+            {
+                var response = new InitializeResponse(_version, new AgentInfo("projection-agent", "1.0"), new AgentCapabilities
+                {
+                    SessionCapabilities = new SessionCapabilities
+                    {
+                        Close = new SessionCloseCapabilities(),
+                        Resume = new SessionResumeCapabilities(),
+                        Delete = new SessionDeleteCapabilities()
+                    }
+                });
+                Reply(request, JsonSerializer.Serialize(response, AcpWireFormat.For(_version).TypeInfo<InitializeResponse>()));
+            }
+            else if (request.Method == "session/resume")
+            {
+                _resume = request;
+                OnResume?.Invoke(request);
+                if (!HoldResume) ReplyResume();
+            }
+            else
+            {
+                Reply(request, request.Method == "session/new" ? "{\"sessionId\":\"one\"}" : "{}");
+            }
+            return Task.FromResult(true);
+        }
+
+        private async Task<bool> SendAfterGateAsync(JsonRpcRequest request, Task gate, CancellationToken cancellationToken)
+        {
+            await gate.ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            return await Send(request).ConfigureAwait(false);
+        }
+
+        internal void ReplyResume() => Reply(_resume!, "{}");
+
+        internal void Update(string sessionId, string update) => Deliver(UpdateFrame(sessionId, update));
+
+        internal static string UpdateFrame(string sessionId, string update)
+            => "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"" + sessionId + "\",\"update\":" + update + "}}";
+
+        internal Action<string> CaptureDelivery()
+        {
+            var handlers = MessageReceived;
+            return json => handlers?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+        }
+
+        internal void DropConnection()
+        {
+            IsConnected = false;
+            ErrorOccurred?.Invoke(this, new AcpTransportErrorEventArgs("connection lost"));
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            IsConnected = false;
+        }
+
+        private void Reply(JsonRpcRequest request, string result)
+            => Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":" + result + "}");
+
+        private void Deliver(string json) => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+    }
+}


### PR DESCRIPTION
按ACP V2 authoritative messageId/toolCallId/terminalId把整消息、chunk、tool/terminal更新投影为不可变SDK快照：缺省保留、null清除、值替换、chunk追加，未知报文有界保留，离线replay仍使用同一state owner。

本轮只重放C投影净增量到最新B/main链，当前head c0cba20b（base B978df1e4）。源码树与已验证0fb96397相同；15文件净差，C八个实现/测试/consumer文件与已审C逐字相同。保留main的MCP/auth恢复、permission物理送达/失败清理、draft最新投影，B新增requestNotSentObserver与C beforeSend回调合并，没有覆盖发送准备故障收尾。

独立规范/需求复审通过。整合定向98/98、完整SDK1053/1053，SDK/test零警告错误与format通过；实际nupkg1.0.0基线、44个草案类型编译门禁、offline snapshot consumer均通过。最终SHA的远端CI正在运行；B合并后重放actualmain复核再合入。

公开V2仍connect前拒绝；SDK快照不等于完整应用transcript/tool/terminal接线。Refs #149，总单继续保留完整产品与第三方Agent验收。

最新整合head `914c53d7` 已继承凭据main `c93a7533`。以该提交的新CI为准，前一个基线的通过结果不代替当前门禁。

最终经过实际main重放、全部CI通过后已rebase合并：`8e978953679b615f02781120abf3f3b5b09b0f86`。
