### PR TITLE
feat(acp): handle version-gated JSON-RPC response batches

### DIFF
--- a/.github/workflows/ci-acp-sdk.yml
+++ b/.github/workflows/ci-acp-sdk.yml
@@ -7,6 +7,10 @@ on:
       - "src/SalmonEgg.Acp/**"
       - "src/SalmonEgg.Acp/README.md"
       - "tests/SalmonEgg.Acp.Tests/**"
+      - "tests/SalmonEgg.Acp.Desktop.Tests/**"
+      - "src/SalmonEgg.Infrastructure.Desktop/Transport/**"
+      - "src/SalmonEgg.Infrastructure/Client/DomainAcpClientAdapters.cs"
+      - "scripts/gates/run-acp-batch-stdio-gate.sh"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
       - "scripts/gates/acp-v2-*-consumer.cs"
@@ -22,6 +26,10 @@ on:
       - "src/SalmonEgg.Acp/**"
       - "src/SalmonEgg.Acp/README.md"
       - "tests/SalmonEgg.Acp.Tests/**"
+      - "tests/SalmonEgg.Acp.Desktop.Tests/**"
+      - "src/SalmonEgg.Infrastructure.Desktop/Transport/**"
+      - "src/SalmonEgg.Infrastructure/Client/DomainAcpClientAdapters.cs"
+      - "scripts/gates/run-acp-batch-stdio-gate.sh"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
       - "scripts/gates/acp-v2-*-consumer.cs"
@@ -48,6 +56,32 @@ env:
   PACKAGE_OUTPUT: "artifacts/acp-sdk-pack"
 
 jobs:
+  batch-stdio:
+    name: ACP Batch Stdio (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DOTNET_PROCESSOR_COUNT: "2"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "0"
+      MSBUILDDISABLENODEREUSE: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Verify real stdio batches without skips
+        run: bash scripts/gates/run-acp-batch-stdio-gate.sh Release
+      - name: Upload stdio evidence
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: acp-batch-stdio
+          path: artifacts/acp-batch-stdio/
+
   sdk-gates:
     name: ACP SDK Gates
     runs-on: ubuntu-latest

--- a/scripts/gates/run-acp-batch-stdio-gate.sh
+++ b/scripts/gates/run-acp-batch-stdio-gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "This gate requires Linux; real stdio cases must not be skipped." >&2
+  exit 1
+fi
+
+dotnet_bin="${DOTNET_BIN:-dotnet}"
+configuration="${1:-Release}"
+results_dir="${2:-artifacts/acp-batch-stdio}"
+mkdir -p "$results_dir"
+log_file="$results_dir/stdio.log"
+
+timeout --signal=TERM --kill-after=10s 180s "$dotnet_bin" test \
+  --project tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj \
+  --configuration "$configuration" \
+  -p:UseSharedCompilation=false \
+  --timeout 1m --no-ansi --minimum-expected-tests 2 --output Detailed > "$log_file" 2>&1 || {
+    cat "$log_file"
+    exit 1
+  }
+cat "$log_file"
+python3 - "$log_file" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+counts = {name: re.findall(r'^\s+' + name + r':\s+(\d+)\s*$', text, re.M)
+          for name in ('succeeded', 'failed', 'skipped')}
+if any(not values for values in counts.values()) or int(counts['succeeded'][-1]) < 2 \
+        or int(counts['failed'][-1]) != 0 or int(counts['skipped'][-1]) != 0:
+    raise SystemExit('Both real stdio version contracts must execute successfully with zero skips.')
+print('[gate] Real stdio v1 refusal and v2 batch dispatch/cancellation/response passed.')
+PY

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
@@ -35,6 +36,11 @@ namespace SalmonEgg.Acp.Client
         private sealed record PendingOutboundRequest(
             TaskCompletionSource<JsonRpcResponse> Completion,
             Action<JsonRpcResponse>? ResponseObserver);
+
+        private sealed record InboundResponseRoute(
+            CancellationToken ConnectionToken,
+            InboundResponseBatch? Batch = null,
+            int Index = -1);
 
         private sealed class PendingInboundRequest
         {
@@ -76,9 +82,21 @@ namespace SalmonEgg.Acp.Client
 
             public bool IsPermissionCancellationRequested { get; set; }
 
-            public JsonRpcResponse? PreparedCancellationResponse { get; set; }
+            public JsonRpcResponse? PreparedPermissionResponse { get; set; }
 
             public PermissionRequestEventArgs? PermissionEvent { get; set; }
+
+            public CreateElicitationResponse? PreparedElicitationResponse { get; set; }
+
+            public bool HasPreparedElicitationFailure { get; set; }
+
+            public bool IsAskUserResponseInFlight { get; set; }
+
+            public JsonRpcResponse? PreparedAskUserResponse { get; set; }
+
+            public JsonRpcResponse? AskUserCancellationResponse { get; set; }
+
+            public JsonRpcResponse? PreparedCancellationResponse { get; set; }
 
             public PendingInboundRequest WithSessionId(string sessionId)
                 => new(Method, MessageId, ConnectionToken, sessionId, AskUserRequest, ElicitationRequest);
@@ -99,9 +117,14 @@ namespace SalmonEgg.Acp.Client
         private readonly IAcpTerminalSessionManager _terminalSessionManager;
         private readonly IAcpClientLogger _logger;
         private readonly AcpSessionWorkController _sessionWork = new();
-        private readonly ConcurrentDictionary<string, PendingOutboundRequest> _pendingRequests = new();
+        private readonly ConcurrentDictionary<AcpRequestId, PendingOutboundRequest> _pendingRequests = new();
         // Inbound tool requests (agent -> client) are correlated by request id so we can format responses correctly.
-        private readonly ConcurrentDictionary<string, PendingInboundRequest> _pendingInboundRequests = new();
+        private readonly ConcurrentDictionary<AcpRequestId, PendingInboundRequest> _pendingInboundRequests = new();
+        // Routes belong to the parsed id object, not just its value: an old callback must never
+        // answer a new request that reuses the id. Weak keys retain that protection after teardown
+        // without retaining every completed request for the lifetime of the client.
+        private readonly ConditionalWeakTable<object, InboundResponseRoute> _responseRoutes = new();
+        private readonly HashSet<InboundResponseBatch> _responseBatches = [];
         // URL completion outlives the JSON-RPC response. Both indexes refer to the same request identity;
         // the lock also protects response claims and connection teardown from stale callbacks.
         private readonly Dictionary<string, PendingInboundRequest> _pendingUrlElicitations = new(StringComparer.Ordinal);
@@ -1108,7 +1131,7 @@ namespace SalmonEgg.Acp.Client
             object messageId,
             CreateElicitationResponse response)
         {
-            var idStr = messageId?.ToString() ?? string.Empty;
+            var idStr = RequestKey(messageId);
             return TryGetPendingInboundRequest(idStr, out var pending)
                 ? TrySendElicitationResponseAsync(pending, response)
                 : Task.FromResult(false);
@@ -1119,13 +1142,14 @@ namespace SalmonEgg.Acp.Client
             CreateElicitationResponse response,
             bool cancelForSession = false)
         {
-            var idStr = pending.MessageId?.ToString() ?? string.Empty;
+            var idStr = RequestKey(pending.MessageId);
             CancellationToken connectionCancellation;
             lock (_lock)
             {
                 if (_disposed || !_transport.IsConnected || pending.ElicitationRequest is null
                     || !TryGetPendingInboundRequest(idStr, out var current)
-                    || !ReferenceEquals(current, pending))
+                    || !ReferenceEquals(current, pending)
+                    || (pending.PreparedCancellationResponse is not null && response is not ElicitationCancelResponse))
                 {
                     return false;
                 }
@@ -1145,6 +1169,8 @@ namespace SalmonEgg.Acp.Client
                 // cannot race the first one onto the wire. The callback owns this exact request object,
                 // so reusing its JSON-RPC id never lets an old form answer a later request.
                 pending.IsElicitationResponseInFlight = true;
+                pending.PreparedElicitationResponse = response;
+                pending.HasPreparedElicitationFailure = false;
                 connectionCancellation = _messageLoopCts?.Token ?? CancellationToken.None;
             }
 
@@ -1167,12 +1193,12 @@ namespace SalmonEgg.Acp.Client
 
         private bool CompleteElicitationResponse(PendingInboundRequest pending, CreateElicitationResponse? response, bool sent)
         {
-            var idStr = pending.MessageId?.ToString() ?? string.Empty;
+            var idStr = RequestKey(pending.MessageId);
             lock (_lock)
             {
                 if (sent)
                 {
-                    _pendingInboundRequests.TryRemove(new KeyValuePair<string, PendingInboundRequest>(idStr, pending));
+                    _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(idStr, pending));
                     if (response is not ElicitationAcceptResponse)
                     {
                         RemovePendingUrlElicitation(pending);
@@ -1214,9 +1240,10 @@ namespace SalmonEgg.Acp.Client
             Task<bool> responseTask;
             lock (_lock)
             {
-                if (!TryGetPendingInboundRequest(pending.MessageId?.ToString() ?? string.Empty, out var current)
+                if (!TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
                     || !ReferenceEquals(current, pending) || !IsInboundRequestCurrent(pending)
-                    || pending.IsElicitationResponseInFlight || pending.IsElicitationCancellationRequested)
+                    || pending.IsElicitationResponseInFlight || pending.IsElicitationCancellationRequested
+                    || pending.PreparedCancellationResponse is not null)
                 {
                     return;
                 }
@@ -1224,6 +1251,7 @@ namespace SalmonEgg.Acp.Client
                 // Host failures share the original response claim. They cannot overwrite a reply
                 // already sent, consume a replacement id, or escape onto a later connection.
                 pending.IsElicitationResponseInFlight = true;
+                pending.HasPreparedElicitationFailure = true;
                 responseTask = SendResponseAsync(new JsonRpcResponse(pending.MessageId,
                     JsonRpcError.CreateInternalError("Failed to process elicitation/create request.")),
                     pending.ConnectionToken);
@@ -1267,11 +1295,7 @@ namespace SalmonEgg.Acp.Client
 
             // Only respond once per inbound request id. Unknown or stale ids are not a
             // protocol payload, so they should not fail ACP schema validation.
-            var idStr = messageId.ToString() ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return false;
-            }
+            var idStr = RequestKey(messageId);
 
             PendingInboundRequest pending;
             Task<bool> responseTask;
@@ -1279,7 +1303,8 @@ namespace SalmonEgg.Acp.Client
             {
                 if (!TryGetPendingInboundRequest(idStr, out pending)
                     || (expectedRequest is not null && !ReferenceEquals(pending, expectedRequest))
-                    || pending.Method != "session/request_permission" || !IsInboundRequestCurrent(pending))
+                    || pending.Method != "session/request_permission" || !IsInboundRequestCurrent(pending)
+                    || (pending.PreparedCancellationResponse is not null && outcome != "cancelled"))
                 {
                     return false;
                 }
@@ -1288,19 +1313,33 @@ namespace SalmonEgg.Acp.Client
                     pending.IsPermissionCancellationRequested = true;
                     pending.PermissionEvent?.NotifyChanged();
                 }
-                if (pending.IsPermissionResponseInFlight
-                    || (pending.IsPermissionCancellationRequested && outcome != "cancelled"))
+                if (outcome == "cancelled" && pending.MessageId is not null
+                    && _responseRoutes.TryGetValue(pending.MessageId, out var route) && route.Batch is { } batch)
                 {
-                    return false;
+                    // A prepared slot is still owned by this batch. Withdraw it before waiting for
+                    // sibling inputs; the immutable in-flight array may already be the single reply.
+                    pending.PreparedCancellationResponse ??= new JsonRpcResponse(pending.MessageId,
+                        ToElement<PermissionOutcomeResult>(CreatePermissionOutcome(pending, "cancelled", null)));
+                    pending.PreparedPermissionResponse = pending.PreparedCancellationResponse;
+                    pending.IsPermissionResponseInFlight = true;
+                    responseTask = batch.SubmitCancellation(route.Index, pending.PreparedCancellationResponse);
                 }
+                else
+                {
+                    if (pending.IsPermissionResponseInFlight
+                        || (pending.IsPermissionCancellationRequested && outcome != "cancelled"))
+                    {
+                        return false;
+                    }
 
-                // Invalid UI choices must not consume the request or enable a second response. The
-                // offered ids are captured before invoking consumers, whose DTO lists are mutable.
-                var response = pending.PreparedCancellationResponse
-                    ?? new JsonRpcResponse(pending.MessageId,
-                        ToElement<PermissionOutcomeResult>(CreatePermissionOutcome(pending, outcome, optionId)));
-                pending.IsPermissionResponseInFlight = true;
-                responseTask = SendResponseAsync(response, pending.ConnectionToken);
+                    // Invalid UI choices must not consume the request or enable a second response.
+                    // Offered ids are captured before consumers can mutate their DTO lists.
+                    pending.PreparedPermissionResponse = pending.PreparedCancellationResponse
+                        ?? new JsonRpcResponse(pending.MessageId,
+                            ToElement<PermissionOutcomeResult>(CreatePermissionOutcome(pending, outcome, optionId)));
+                    pending.IsPermissionResponseInFlight = true;
+                    responseTask = SendResponseAsync(pending.PreparedPermissionResponse, pending.ConnectionToken);
+                }
                 pending.PermissionEvent?.NotifyChanged();
             }
 
@@ -1312,16 +1351,17 @@ namespace SalmonEgg.Acp.Client
             Task<bool> responseTask;
             lock (_lock)
             {
-                if (!TryGetPendingInboundRequest(pending.MessageId?.ToString() ?? string.Empty, out var current)
+                if (!TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
                     || !ReferenceEquals(current, pending) || !IsInboundRequestCurrent(pending)
-                    || pending.IsPermissionResponseInFlight || pending.IsPermissionCancellationRequested)
+                    || pending.IsPermissionResponseInFlight || pending.IsPermissionCancellationRequested
+                    || pending.PreparedCancellationResponse is not null)
                 {
                     return false;
                 }
                 pending.IsPermissionResponseInFlight = true;
-                responseTask = SendResponseAsync(new JsonRpcResponse(pending.MessageId,
-                    JsonRpcError.CreateInternalError("Client failed to process inbound permission request.")),
-                    pending.ConnectionToken);
+                pending.PreparedPermissionResponse = new JsonRpcResponse(pending.MessageId,
+                    JsonRpcError.CreateInternalError("Client failed to process inbound permission request."));
+                responseTask = SendResponseAsync(pending.PreparedPermissionResponse, pending.ConnectionToken);
                 pending.PermissionEvent?.NotifyChanged();
             }
 
@@ -1374,33 +1414,30 @@ namespace SalmonEgg.Acp.Client
             lock (_lock)
             {
                 pending.IsPermissionResponseInFlight = false;
-                if (!TryGetPendingInboundRequest(pending.MessageId?.ToString() ?? string.Empty, out var current)
+                if (!TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
                     || !ReferenceEquals(current, pending))
                 {
                     return false;
                 }
                 if (sent)
                 {
-                    _pendingInboundRequests.TryRemove(new KeyValuePair<string, PendingInboundRequest>(
-                        pending.MessageId!.ToString()!, pending));
+                    _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(
+                        RequestKey(pending.MessageId), pending));
                     pending.PermissionEvent?.NotifyChanged();
                     return false;
                 }
                 pending.PermissionEvent?.NotifyChanged();
                 // A cancellation that arrived while the user's answer was in flight still owns the
                 // next attempt. A failed cancellation stays retryable without a background retry loop.
-                return !isCancellation && pending.IsPermissionCancellationRequested
+                return !IsBatchedResponse(pending) && !isCancellation && pending.IsPermissionCancellationRequested
                     && IsInboundRequestCurrent(pending);
             }
         }
 
         private bool IsInboundRequestCurrent(PendingInboundRequest pending)
-            => IsCurrentConnection(pending.ConnectionToken);
-
-        private bool IsCurrentConnection(CancellationToken connectionToken)
-            => !_disposed && _transport.IsConnected && !connectionToken.IsCancellationRequested
-                && (connectionToken.CanBeCanceled
-                    ? _messageLoopCts?.Token == connectionToken
+            => !_disposed && _transport.IsConnected && !pending.ConnectionToken.IsCancellationRequested
+                && (pending.ConnectionToken.CanBeCanceled
+                    ? _messageLoopCts?.Token == pending.ConnectionToken
                     : _messageLoopCts is null);
 
         private bool CanRespondToPermissionRequest(PendingInboundRequest pending)
@@ -1408,7 +1445,7 @@ namespace SalmonEgg.Acp.Client
             lock (_lock)
             {
                 return IsInboundRequestCurrent(pending)
-                    && TryGetPendingInboundRequest(pending.MessageId?.ToString() ?? string.Empty, out var current)
+                    && TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
                     && ReferenceEquals(current, pending);
             }
         }
@@ -1417,7 +1454,11 @@ namespace SalmonEgg.Acp.Client
         {
             lock (_lock)
             {
-                return CanRespondToPermissionRequest(pending) && pending.IsPermissionResponseInFlight;
+                if (!CanRespondToPermissionRequest(pending)) return false;
+                return pending.MessageId is not null && _responseRoutes.TryGetValue(pending.MessageId, out var route)
+                    && route.Batch is { } batch
+                    ? batch.IsResponsePrepared(route.Index)
+                    : pending.IsPermissionResponseInFlight;
             }
         }
 
@@ -1429,9 +1470,19 @@ namespace SalmonEgg.Acp.Client
             }
         }
 
+        private bool IsPermissionResponseSending(PendingInboundRequest pending)
+        {
+            lock (_lock)
+            {
+                if (!CanRespondToPermissionRequest(pending)) return false;
+                return pending.MessageId is not null && _responseRoutes.TryGetValue(pending.MessageId, out var route)
+                    && route.Batch is { } batch ? batch.IsSending : pending.IsPermissionResponseInFlight;
+            }
+        }
+
         private async Task<bool> TrySendFileSystemResponseAsync(object messageId, bool success, string? content, string? message)
         {
-            var idStr = messageId?.ToString() ?? string.Empty;
+            var idStr = RequestKey(messageId);
             if (!TryTakePendingInboundRequest(idStr, out var pending))
             {
                 return false;
@@ -1443,7 +1494,7 @@ namespace SalmonEgg.Acp.Client
                 var error = new JsonRpcError(
                     JsonRpcErrorCode.PermissionDenied,
                     string.IsNullOrWhiteSpace(message) ? "Permission denied" : message);
-                return await SendResponseAsync(new JsonRpcResponse(messageId, error)).ConfigureAwait(false);
+                return await SendResponseAsync(new JsonRpcResponse(pending.MessageId, error), pending.ConnectionToken).ConfigureAwait(false);
             }
 
             JsonElement result;
@@ -1458,33 +1509,104 @@ namespace SalmonEgg.Acp.Client
                 result = NullJsonElement();
             }
 
-            return await SendResponseAsync(new JsonRpcResponse(messageId, result)).ConfigureAwait(false);
+            return await SendResponseAsync(new JsonRpcResponse(pending.MessageId, result), pending.ConnectionToken).ConfigureAwait(false);
         }
 
-        private async Task<bool> TrySendAskUserResponseAsync(object messageId, IReadOnlyDictionary<string, string> answers)
+        private Task<bool> TrySendAskUserResponseAsync(object messageId, IReadOnlyDictionary<string, string> answers,
+            PendingInboundRequest? expectedRequest = null)
         {
-            var idStr = messageId?.ToString() ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(idStr))
+            var idStr = RequestKey(messageId);
+            PendingInboundRequest pending;
+            JsonRpcResponse response;
+            lock (_lock)
             {
-                return false;
-            }
+                if (!TryGetPendingInboundRequest(idStr, out pending)
+                    || (expectedRequest is not null && !ReferenceEquals(pending, expectedRequest))
+                    || pending.AskUserRequest is null || !IsCurrentConnection(pending.ConnectionToken)
+                    || pending.IsAskUserResponseInFlight || pending.AskUserCancellationResponse is not null
+                    || pending.PreparedCancellationResponse is not null)
+                {
+                    return Task.FromResult(false);
+                }
 
-            if (!TryTakePendingInboundRequest(idStr, out var pending))
+                // Invalid UI answers must leave the same interaction available for correction.
+                AskUserContract.ValidateAnswers(pending.AskUserRequest, answers);
+                response = new JsonRpcResponse(pending.MessageId,
+                    ToElement(new AskUserResponse(pending.AskUserRequest.Questions, answers)));
+                pending.IsAskUserResponseInFlight = true;
+                pending.PreparedAskUserResponse = response;
+            }
+            return AwaitAskUserResponseAsync(pending, response);
+        }
+
+        private Task<bool> TrySendAskUserFailureResponseAsync(PendingInboundRequest pending, JsonRpcError error,
+            bool cancelForSession = false)
+        {
+            JsonRpcResponse response;
+            lock (_lock)
             {
-                return false;
-            }
+                if (!TryGetPendingInboundRequest(RequestKey(pending.MessageId), out var current)
+                    || !ReferenceEquals(current, pending) || !IsCurrentConnection(pending.ConnectionToken)
+                    || pending.PreparedCancellationResponse is not null)
+                {
+                    return Task.FromResult(false);
+                }
 
-            if (pending.AskUserRequest == null)
+                response = new JsonRpcResponse(pending.MessageId, error);
+                if (cancelForSession)
+                {
+                    pending.AskUserCancellationResponse = response;
+                }
+                if (pending.IsAskUserResponseInFlight
+                    || (!cancelForSession && pending.PreparedAskUserResponse is not null))
+                {
+                    return Task.FromResult(false);
+                }
+                pending.IsAskUserResponseInFlight = true;
+                pending.PreparedAskUserResponse = response;
+            }
+            return AwaitAskUserResponseAsync(pending, response);
+        }
+
+        private async Task<bool> AwaitAskUserResponseAsync(PendingInboundRequest pending, JsonRpcResponse response)
+        {
+            var sent = false;
+            try
             {
-                return false;
+                sent = await SendResponseAsync(response, pending.ConnectionToken).ConfigureAwait(false);
+                return sent;
             }
+            finally
+            {
+                var cancellation = CompleteAskUserResponse(pending, response, sent);
+                if (cancellation is not null)
+                {
+                    // One bounded follow-up preserves a cancel that arrived while a failed write
+                    // was in flight. The cancellation response cannot schedule itself again.
+                    await AwaitAskUserResponseAsync(pending, cancellation).ConfigureAwait(false);
+                }
+            }
+        }
 
-            AskUserContract.ValidateAnswers(pending.AskUserRequest, answers);
-            var response = new AskUserResponse(pending.AskUserRequest.Questions, answers);
-            return await SendResponseAsync(
-                new JsonRpcResponse(
-                    messageId,
-                    ToElement<AskUserResponse>(response))).ConfigureAwait(false);
+        private JsonRpcResponse? CompleteAskUserResponse(PendingInboundRequest pending, JsonRpcResponse response, bool sent)
+        {
+            lock (_lock)
+            {
+                var key = RequestKey(pending.MessageId);
+                if (sent)
+                {
+                    _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(key, pending));
+                }
+                else if (pending.AskUserCancellationResponse is { } cancellation && !ReferenceEquals(response, cancellation)
+                    && IsCurrentConnection(pending.ConnectionToken)
+                    && TryGetPendingInboundRequest(key, out var current) && ReferenceEquals(current, pending))
+                {
+                    pending.PreparedAskUserResponse = cancellation;
+                    return cancellation;
+                }
+                pending.IsAskUserResponseInFlight = false;
+                return null;
+            }
         }
 
         /// <summary>
@@ -1544,7 +1666,7 @@ namespace SalmonEgg.Acp.Client
         {
             Activity? activity = null;
             CancellationTokenSource? sendCancellation = null;
-            var requestIdStr = request.Id?.ToString() ?? string.Empty;
+            var requestIdStr = RequestKey(request.Id);
             var tcs = new TaskCompletionSource<JsonRpcResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestWriteStarted = false;
             var retainPendingRequest = false;
@@ -1852,13 +1974,47 @@ namespace SalmonEgg.Acp.Client
         /// <summary>
         /// Sends a response (used to answer inbound requests).
         /// </summary>
-        private async Task<bool> SendResponseAsync(JsonRpcResponse response, CancellationToken cancellationToken = default)
+        private Task<bool> SendResponseAsync(JsonRpcResponse response, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                if (response.Id is not null && _responseRoutes.TryGetValue(response.Id, out var route))
+                {
+                    if (!IsCurrentConnection(route.ConnectionToken))
+                    {
+                        return Task.FromResult(false);
+                    }
+                    if (route.Batch is not null)
+                    {
+                        return route.Batch.SubmitAsync(route.Index, response);
+                    }
+                    cancellationToken = route.ConnectionToken;
+                }
+                else if (!cancellationToken.CanBeCanceled)
+                {
+                    cancellationToken = _messageLoopCts?.Token ?? default;
+                }
+            }
+
+            return SendResponseFrameAsync(_parser.SerializeMessage(response), cancellationToken);
+        }
+
+        private async Task<bool> SendResponseFrameAsync(string json, CancellationToken cancellationToken)
         {
             try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var json = _parser.SerializeMessage(response);
-                return await _transport.SendMessageAsync(json, cancellationToken).ConfigureAwait(false);
+                Task<bool> send;
+                lock (_lock)
+                {
+                    if (!IsCurrentConnection(cancellationToken))
+                    {
+                        return false;
+                    }
+                    // Claim the physical write before teardown can replace the connection. The
+                    // transport keeps the same token until that write has finished or cancelled.
+                    send = _transport.SendMessageAsync(json, cancellationToken);
+                }
+                return await send.ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1870,6 +2026,17 @@ namespace SalmonEgg.Acp.Client
                 return false;
             }
         }
+
+        private bool IsCurrentConnection(CancellationToken connectionToken)
+            => !_disposed && _transport.IsConnected && !connectionToken.IsCancellationRequested
+                && (connectionToken.CanBeCanceled
+                    ? _messageLoopCts?.Token == connectionToken
+                    : _messageLoopCts is null);
+
+        private static AcpRequestId RequestKey(object? messageId)
+            => AcpRequestId.TryFromEnvelopeId(messageId, out var key)
+                ? key
+                : throw new AcpException(JsonRpcErrorCode.InvalidRequest, "Invalid JSON-RPC request id.");
 
         /// <summary>
         /// Handles the transport message-received event.
@@ -1922,55 +2089,26 @@ namespace SalmonEgg.Acp.Client
 
             try
             {
-                var message = _parser.ParseMessage(AcpFrame.StripByteOrderMark(e.Message));
-
-
-                if (message is JsonRpcResponse response)
+                lock (_lock)
                 {
-                    var responseIdStr = response.Id?.ToString() ?? string.Empty;
-                    // Match the pending request.
-                    if (_pendingRequests.TryRemove(responseIdStr, out var pending))
+                    if (!IsCurrentConnection(connectionToken))
                     {
-                        pending.ResponseObserver?.Invoke(response);
-                        if (pending.Completion.TrySetResult(response))
-                        {
-                            return;
-                        }
-                        // The entry was still correlated, so the only thing that can already have
-                        // completed it is the caller's own cancellation: this is the terminal
-                        // response ACP requires the peer to send for a cancelled request (a partial
-                        // result, or -32800). Nobody is awaiting it, so record the outcome and let
-                        // the removal above close the correlation rather than dropping it silently.
-                        _logger.Log(
-                            AcpClientLogLevel.Information,
-                            "CANCELLED_REQUEST_SETTLED",
-                            response.IsError
-                                ? $"Cancelled request {responseIdStr} was settled by the peer with error {response.Error!.Code} ({JsonRpcErrorCode.GetErrorMessage(response.Error.Code)})."
-                                : $"Cancelled request {responseIdStr} was settled by the peer with a result.",
-                            nameof(OnMessageReceived));
+                        return;
                     }
-                }
-
-                else if (message is JsonRpcRequest request)
-                {
-                    // Agent -> client tool invocation (requires a JSON-RPC response).
-                    HandleRequest(request);
-                }
-                else if (message is JsonRpcNotification notification)
-                {
-                    // Handle the notification.
-                    HandleNotification(notification, connectionToken);
+                    var frame = _parser.ParseFrame(AcpFrame.StripByteOrderMark(e.Message), ProtocolVersion);
+                    DispatchFrame(frame, connectionToken);
                 }
             }
             catch (AcpException ex) when (ex.ErrorCode == JsonRpcErrorCode.ParseError)
             {
-                // The frame looked like an ACP message (the transport only forwards '{'-leading
-                // lines) but did not parse, so the agent did intend to send something. JSON-RPC 2.0
-                // covers exactly this: reply -32700 with an explicit null id, since no id could be
-                // recovered. Lines that never looked like frames are filtered upstream as
-                // StdoutProtocolViolation and deliberately get no reply.
                 OnErrorOccurred($"Failed to process message: {ex.Message}");
-                _ = SendParseErrorResponseAsync(ex.Message, connectionToken);
+                _ = SendResponseFrameAsync(_parser.SerializeMessage(new JsonRpcResponse(
+                    null, JsonRpcError.CreateParseError(ex.Message))), connectionToken);
+            }
+            catch (AcpException ex) when (ex.ErrorCode == JsonRpcErrorCode.InvalidRequest)
+            {
+                _ = SendResponseFrameAsync(_parser.SerializeMessage(new JsonRpcResponse(
+                    null, JsonRpcError.CreateInvalidRequest(ex.Message))), connectionToken);
             }
             catch (Exception ex)
             {
@@ -1978,32 +2116,188 @@ namespace SalmonEgg.Acp.Client
             }
         }
 
-        /// <summary>
-        /// Replies to an unparseable ACP frame per JSON-RPC 2.0: code -32700, id explicitly null.
-        /// </summary>
-        private async Task SendParseErrorResponseAsync(string detail, CancellationToken connectionToken)
+        private void DispatchFrame(ParsedMessageFrame frame, CancellationToken connectionToken)
         {
-            try
+            var responseCount = frame.IsBatch && !frame.IsResponseBatch
+                ? frame.Items.Count(item => item.Message is JsonRpcRequest || (item.Error is not null && !item.IsResponse))
+                : 0;
+            InboundResponseBatch? batch = null;
+            if (responseCount > 0)
             {
-                Task<bool> responseTask;
-                lock (_lock)
-                {
-                    // An error observer may reconnect synchronously before this courtesy reply.
-                    // Claim the send on the receiving connection, including pre-initialize frames.
-                    if (!IsCurrentConnection(connectionToken)) return;
-                    responseTask = SendResponseAsync(new JsonRpcResponse(
-                        id: null,
-                        error: JsonRpcError.CreateParseError(detail)), connectionToken);
-                }
-                await responseTask.ConfigureAwait(false);
+                batch = new InboundResponseBatch(responseCount,
+                    responses => SendResponseFrameAsync(_parser.SerializeResponses(responses), connectionToken),
+                    responses => CompleteResponseBatch(batch!, responses), _logger,
+                    () => NotifyResponseBatchChanged(batch!),
+                    () => RetireUnretryableResponseBatch(batch!));
+                _responseBatches.Add(batch);
             }
-            catch (Exception ex)
+
+            var responseIndex = 0;
+            foreach (var item in frame.Items)
             {
-                // Never let the courtesy reply become a second failure surface.
-                _logger.Log(
-                    AcpClientLogLevel.Warning,
-                    "PARSE_ERROR_REPLY_FAILED",
-                    ex.Message);
+                if (!IsCurrentConnection(connectionToken))
+                {
+                    batch?.Abandon();
+                    return;
+                }
+                if (item.Error is not null)
+                {
+                    if (frame.IsResponseBatch || item.IsResponse)
+                    {
+                        _logger.Log(AcpClientLogLevel.Warning, "INVALID_BATCH_RESPONSE", item.Error);
+                    }
+                    else
+                    {
+                        _ = batch!.SubmitAsync(responseIndex++, new JsonRpcResponse(null,
+                            JsonRpcError.CreateInvalidRequest(item.Error)));
+                    }
+                    continue;
+                }
+
+                try
+                {
+                    switch (item.Message)
+                    {
+                        case JsonRpcResponse response:
+                            HandleResponse(response);
+                            break;
+                        case JsonRpcRequest request:
+                            _responseRoutes.Add(request.Id, new InboundResponseRoute(connectionToken, batch, responseIndex++));
+                            if (_pendingInboundRequests.ContainsKey(RequestKey(request.Id)))
+                            {
+                                _ = SendResponseAsync(new JsonRpcResponse(request.Id,
+                                    JsonRpcError.CreateInvalidRequest("The request id is already pending on this connection.")));
+                                break;
+                            }
+                            HandleRequest(request);
+                            break;
+                        case JsonRpcNotification notification:
+                            HandleNotification(notification, connectionToken);
+                            break;
+                    }
+                }
+                catch (Exception exception) when (frame.IsBatch)
+                {
+                    // One host subscriber cannot suppress later, independently valid batch items.
+                    // Notifications never get a reply; calls retain any answer already prepared.
+                    _logger.Log(AcpClientLogLevel.Error, "BATCH_ITEM_HANDLER_FAILED",
+                        "Failed to handle a batch item.", exception: exception);
+                    if (item.Message is JsonRpcRequest failedRequest)
+                    {
+                        FailPendingInboundRequest(failedRequest,
+                            JsonRpcError.CreateInternalError("The client could not handle this request."));
+                    }
+                }
+            }
+        }
+
+        private void CompleteResponseBatch(InboundResponseBatch batch, IReadOnlyList<JsonRpcResponse> responses)
+        {
+            lock (_lock)
+            {
+                _responseBatches.Remove(batch);
+                // A retry may be initiated by only one sibling. The batch owner commits every
+                // prepared form after the shared write succeeds, including siblings whose first
+                // send attempt already returned false.
+                foreach (var pending in _pendingInboundRequests.Values)
+                {
+                    if (pending.PreparedCancellationResponse is not null
+                        && pending.ElicitationRequest is null && pending.MessageId is not null
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var cancelRoute) && cancelRoute.Batch == batch)
+                    {
+                        _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(
+                            RequestKey(pending.MessageId), pending));
+                        pending.PermissionEvent?.NotifyChanged();
+                        RemovePendingUrlElicitation(pending);
+                        continue;
+                    }
+                    if ((pending.PreparedElicitationResponse is not null || pending.HasPreparedElicitationFailure
+                            || (pending.ElicitationRequest is not null && pending.PreparedCancellationResponse is not null))
+                        && pending.MessageId is not null
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var route) && route.Batch == batch)
+                    {
+                        // A cancel may arrive while an already serialized accept is being written.
+                        // URL completion follows the response that actually reached the peer.
+                        var response = responses[route.Index];
+                        var elicitation = response.Result is { } result
+                            ? FromElement<CreateElicitationResponse>(result) : null;
+                        CompleteElicitationResponse(pending, elicitation, sent: true);
+                    }
+                    if (pending.PreparedAskUserResponse is not null && pending.MessageId is not null
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var askRoute) && askRoute.Batch == batch)
+                    {
+                        CompleteAskUserResponse(pending, pending.PreparedAskUserResponse, sent: true);
+                    }
+                    if (pending.PreparedPermissionResponse is not null && pending.MessageId is not null
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var permissionRoute) && permissionRoute.Batch == batch)
+                    {
+                        CompletePermissionResponse(pending, isCancellation: false, sent: true);
+                    }
+                }
+            }
+        }
+
+        private void NotifyResponseBatchChanged(InboundResponseBatch batch)
+        {
+            lock (_lock)
+            {
+                foreach (var pending in _pendingInboundRequests.Values)
+                {
+                    if (pending.MessageId is not null && pending.PermissionEvent is not null
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var route) && route.Batch == batch)
+                    {
+                        pending.PermissionEvent.NotifyChanged();
+                    }
+                }
+            }
+        }
+
+        private void RetireUnretryableResponseBatch(InboundResponseBatch batch)
+        {
+            lock (_lock)
+            {
+                foreach (var pending in _pendingInboundRequests.Values)
+                {
+                    if (pending.MessageId is not null && IsInboundRequestCurrent(pending)
+                        && _responseRoutes.TryGetValue(pending.MessageId, out var route) && route.Batch == batch)
+                    {
+                        return;
+                    }
+                }
+
+                // Invalid items and already rejected calls have no responder that can retry them.
+                // Keeping their failed array until disconnect would grow without bound on a live
+                // connection. Interactive siblings retain the whole batch through their owner.
+                if (_responseBatches.Remove(batch))
+                {
+                    batch.Abandon();
+                    try
+                    {
+                        _logger.Log(AcpClientLogLevel.Warning, "BATCH_RESPONSE_ABANDONED",
+                            "The response batch could not be sent and has no pending request available to retry it.");
+                    }
+                    catch (Exception)
+                    {
+                        // A host logger cannot restore an abandoned batch or leave its detached
+                        // completion task faulted. There is no second reliable diagnostic sink.
+                    }
+                }
+            }
+        }
+
+        private void HandleResponse(JsonRpcResponse response)
+        {
+            if (!_pendingRequests.TryRemove(RequestKey(response.Id), out var pending))
+            {
+                return;
+            }
+            pending.ResponseObserver?.Invoke(response);
+            if (!pending.Completion.TrySetResult(response))
+            {
+                // Caller cancellation leaves correlation alive until the peer sends its terminal
+                // result. Batched responses take this same path and settle it exactly once.
+                _logger.Log(AcpClientLogLevel.Information, "CANCELLED_REQUEST_SETTLED",
+                    "The peer settled a cancelled request.", nameof(OnMessageReceived));
             }
         }
 
@@ -2032,27 +2326,31 @@ namespace SalmonEgg.Acp.Client
         private void HandleInboundCancellation(JsonRpcNotification notification, CancellationToken connectionToken)
         {
             if (notification.Params is not { ValueKind: JsonValueKind.Object } parameters
-                || !parameters.TryGetProperty("requestId", out var id)
-                || !AcpRequestId.TryFromEnvelopeId(id, out var requestId))
+                || !parameters.TryGetProperty("requestId", out var id) || !AcpRequestId.TryFromEnvelopeId(id, out var key))
             {
                 return;
             }
             lock (_lock)
             {
-                if (!IsCurrentConnection(connectionToken)
-                    || !TryGetPendingInboundRequest(id.ToString(), out var pending)
-                    || pending.Method != "session/request_permission" || !IsInboundRequestCurrent(pending)
-                    || !AcpRequestId.TryFromEnvelopeId(pending.MessageId, out var pendingId) || pendingId != requestId)
+                if (!IsCurrentConnection(connectionToken) || !TryGetPendingInboundRequest(key, out var pending)
+                    || !IsInboundRequestCurrent(pending)) return;
+                var response = new JsonRpcResponse(pending.MessageId,
+                    new JsonRpcError(JsonRpcErrorCode.Cancelled, "The peer cancelled this request."));
+                if (pending.Method == "session/request_permission" && !IsBatchedResponse(pending))
                 {
+                    // ACP v1 and v2 both permit peer cancellation. Latch it on the original
+                    // request before a concurrent user choice can claim another terminal response.
+                    pending.PreparedCancellationResponse = response;
+                    pending.IsPermissionCancellationRequested = true;
+                    pending.PermissionEvent?.NotifyChanged();
+                    _ = TrySendPermissionOutcomeResponseAsync(pending.MessageId, "cancelled", null, pending);
                     return;
                 }
-                // Both ACP versions permit peer cancellation. The original owner keeps this error
-                // through failed writes; a numeric and a string id must never cancel one another.
-                pending.PreparedCancellationResponse = new JsonRpcResponse(pending.MessageId,
-                    new JsonRpcError(JsonRpcErrorCode.Cancelled, "The peer cancelled this request."));
-                pending.IsPermissionCancellationRequested = true;
-                pending.PermissionEvent?.NotifyChanged();
-                _ = TrySendPermissionOutcomeResponseAsync(pending.MessageId, "cancelled", null, pending);
+                if (ProtocolVersion != AcpProtocolVersion.V2) return;
+                RemovePendingUrlElicitation(pending);
+                if (TrySubmitBatchCancellation(pending, response)) return;
+                _pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(key, pending));
+                _ = SendResponseAsync(response, connectionToken);
             }
         }
 
@@ -2061,15 +2359,12 @@ namespace SalmonEgg.Acp.Client
         /// </summary>
         private void HandleRequest(JsonRpcRequest request)
         {
-            var requestIdStr = request.Id?.ToString() ?? string.Empty;
+            var requestIdStr = RequestKey(request.Id);
 
             switch (request.Method)
             {
                 case "session/request_permission":
-                    if (!string.IsNullOrWhiteSpace(requestIdStr))
-                    {
-                        TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
-                    }
+                    TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
                     HandlePermissionRequest(request);
                     break;
                 case "fs/read_text_file":
@@ -2080,10 +2375,7 @@ namespace SalmonEgg.Acp.Client
                         break;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(requestIdStr))
-                    {
-                        TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
-                    }
+                    TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
                     HandleFileSystemRequest(request);
                     break;
                 case "terminal/create":
@@ -2097,10 +2389,7 @@ namespace SalmonEgg.Acp.Client
                         break;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(requestIdStr))
-                    {
-                        TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
-                    }
+                    TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
                     _ = HandleTerminalRequestAsync(request);
                     break;
                 case ElicitationMethods.Create:
@@ -2119,15 +2408,12 @@ namespace SalmonEgg.Acp.Client
                         break;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(requestIdStr))
-                    {
-                        TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
-                    }
+                    TrackPendingInboundRequest(requestIdStr, request.Method, request.Id);
                     HandleAskUserRequest(request);
                     break;
                 default:
                     // Best-effort: respond with "method not found" so the agent doesn't hang waiting.
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(
                         request.Id,
                         JsonRpcError.CreateMethodNotFound(request.Method)));
@@ -2198,7 +2484,7 @@ namespace SalmonEgg.Acp.Client
 
         private void RejectUnsupportedClientRequest(JsonRpcRequest request)
         {
-            RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+            RemovePendingInboundTracking(RequestKey(request.Id));
             _ = SendResponseAsync(new JsonRpcResponse(
                 request.Id,
                 JsonRpcError.CreateMethodNotFound(request.Method)));
@@ -2265,7 +2551,7 @@ namespace SalmonEgg.Acp.Client
             {
                 if (!request.Params.HasValue)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing params")));
                     return;
                 }
@@ -2274,7 +2560,7 @@ namespace SalmonEgg.Acp.Client
                 if (!rawParams.TryGetProperty("sessionId", out var sessionIdProp)
                     || sessionIdProp.ValueKind != JsonValueKind.String)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing sessionId")));
                     return;
                 }
@@ -2282,21 +2568,18 @@ namespace SalmonEgg.Acp.Client
                 var sessionId = sessionIdProp.GetString() ?? string.Empty;
                 if (request.Id == null)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidRequest("Missing request id")));
                     return;
                 }
 
                 var messageId = request.Id!;
-                var requestId = messageId.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(requestId))
-                {
-                    SetPendingInboundSessionId(requestId, sessionId);
-                }
+                var requestId = RequestKey(messageId);
+                SetPendingInboundSessionId(requestId, sessionId);
                 if (!rawParams.TryGetProperty("toolCall", out var toolCall)
                     || toolCall.ValueKind != JsonValueKind.Object)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing toolCall")));
                     return;
                 }
@@ -2305,7 +2588,7 @@ namespace SalmonEgg.Acp.Client
                     || toolCallId.ValueKind != JsonValueKind.String
                     || string.IsNullOrWhiteSpace(toolCallId.GetString()))
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing toolCallId")));
                     return;
                 }
@@ -2313,7 +2596,7 @@ namespace SalmonEgg.Acp.Client
                 if (!rawParams.TryGetProperty("options", out var optionsProp)
                     || optionsProp.ValueKind != JsonValueKind.Array)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing options")));
                     return;
                 }
@@ -2329,7 +2612,7 @@ namespace SalmonEgg.Acp.Client
                         || !option.TryGetProperty("kind", out var k)
                         || k.ValueKind != JsonValueKind.String)
                     {
-                        RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                        RemovePendingInboundTracking(RequestKey(request.Id));
                         _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Invalid permission option")));
                         return;
                     }
@@ -2356,7 +2639,7 @@ namespace SalmonEgg.Acp.Client
                     permissionResponseFunc,
                     () => CanRespondToPermissionRequest(pendingPermission),
                     () => IsPermissionResponsePrepared(pendingPermission),
-                    () => IsPermissionResponsePrepared(pendingPermission),
+                    () => IsPermissionResponseSending(pendingPermission),
                     () => IsPermissionCancellationRequested(pendingPermission), _logger);
                 pendingPermission.PermissionEvent = eventArgs;
 
@@ -2375,7 +2658,7 @@ namespace SalmonEgg.Acp.Client
 
         private void HandleDraftPermissionRequest(JsonRpcRequest request)
         {
-            var requestId = request.Id?.ToString() ?? string.Empty;
+            var requestId = RequestKey(request.Id);
             AcpPermissionRequestSnapshot snapshot;
             try
             {
@@ -2402,7 +2685,7 @@ namespace SalmonEgg.Acp.Client
                     (outcome, optionId) => TrySendPermissionOutcomeResponseAsync(pending.MessageId, outcome, optionId, pending),
                     () => CanRespondToPermissionRequest(pending),
                     () => IsPermissionResponsePrepared(pending),
-                    () => IsPermissionResponsePrepared(pending),
+                    () => IsPermissionResponseSending(pending),
                     () => IsPermissionCancellationRequested(pending), _logger)
                 {
                     DraftRequest = snapshot,
@@ -2452,7 +2735,7 @@ namespace SalmonEgg.Acp.Client
             {
                 if (!request.Params.HasValue)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing params")));
                     return;
                 }
@@ -2461,7 +2744,7 @@ namespace SalmonEgg.Acp.Client
                 if (!rawParams.TryGetProperty("sessionId", out var sessionIdProp) ||
                     !rawParams.TryGetProperty("path", out var pathProp))
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing sessionId or path")));
                     return;
                 }
@@ -2469,17 +2752,14 @@ namespace SalmonEgg.Acp.Client
                 var sessionId = sessionIdProp.GetString() ?? string.Empty;
                 if (request.Id == null)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidRequest("Missing request id")));
                     return;
                 }
 
                 var messageId = request.Id!;
-                var requestId = messageId.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(requestId))
-                {
-                    SetPendingInboundSessionId(requestId, sessionId);
-                }
+                var requestId = RequestKey(messageId);
+                SetPendingInboundSessionId(requestId, sessionId);
                 var path = pathProp.GetString() ?? string.Empty;
                 var content = rawParams.TryGetProperty("content", out var cont) ? cont.GetString() : null;
 
@@ -2527,67 +2807,57 @@ namespace SalmonEgg.Acp.Client
         /// </summary>
         private void HandleAskUserRequest(JsonRpcRequest request)
         {
+            AskUserRequest? askUserRequest;
             try
             {
                 if (!request.Params.HasValue)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing params")));
                     return;
                 }
 
-                var askUserRequest = FromElement<AskUserRequest>(request.Params.Value);
+                askUserRequest = FromElement<AskUserRequest>(request.Params.Value);
                 if (askUserRequest == null)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Failed to deserialize ask_user request.")));
                     return;
                 }
 
                 AskUserContract.ValidateRequest(askUserRequest);
-
-                if (request.Id == null)
-                {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
-                    _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidRequest("Missing request id")));
-                    return;
-                }
-
-                var messageId = request.Id!;
-                var requestId = messageId.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(requestId))
-                {
-                    SetPendingInboundAskUserRequest(requestId, askUserRequest);
-                }
-
-                if (AskUserRequestReceived == null)
-                {
-                    RemovePendingInboundTracking(requestId);
-                    _ = SendResponseAsync(new JsonRpcResponse(
-                        messageId,
-                        new JsonRpcError(
-                            JsonRpcErrorCode.CapabilityNotSupported,
-                            "Ask-user requests are not supported.")));
-                    return;
-                }
-
-                var eventArgs = new AskUserRequestEventArgs(
-                    messageId,
-                    askUserRequest,
-                    answers => RespondToAskUserRequestAsync(messageId, answers));
-
-                AskUserRequestReceived.Invoke(this, eventArgs);
             }
-            catch (InvalidOperationException ex)
+            catch (Exception ex) when (ex is InvalidOperationException or JsonException)
             {
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
-                _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams(ex.Message)));
+                FailPendingInboundRequest(request, JsonRpcError.CreateInvalidParams(ex.Message));
+                return;
+            }
+
+            var messageId = request.Id;
+            var requestId = RequestKey(messageId);
+            SetPendingInboundAskUserRequest(requestId, askUserRequest);
+            if (!TryGetPendingInboundRequest(requestId, out var pending))
+            {
+                return;
+            }
+            var handler = AskUserRequestReceived;
+            if (handler is null)
+            {
+                _ = TrySendAskUserFailureResponseAsync(pending, new JsonRpcError(
+                    JsonRpcErrorCode.CapabilityNotSupported, "Ask-user requests are not supported."));
+                return;
+            }
+
+            try
+            {
+                handler.Invoke(this, new AskUserRequestEventArgs(messageId, askUserRequest,
+                    answers => TrySendAskUserResponseAsync(messageId, answers, pending)));
             }
             catch (Exception ex)
             {
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
-                OnErrorOccurred($"Failed to process ask_user request: {ex.Message}");
-                _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInternalError(ex.Message)));
+                _ = TrySendAskUserFailureResponseAsync(pending,
+                    JsonRpcError.CreateInternalError("The client failed to display the question."));
+                OnErrorOccurred($"Failed to display ask_user request: {ex.Message}");
             }
         }
 
@@ -2727,7 +2997,7 @@ namespace SalmonEgg.Acp.Client
             {
                 if (!request.Params.HasValue)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing params")));
                     return;
                 }
@@ -2735,7 +3005,7 @@ namespace SalmonEgg.Acp.Client
                 var rawParams = request.Params.Value;
                 if (!rawParams.TryGetProperty("sessionId", out var sessionIdProp))
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing sessionId")));
                     return;
                 }
@@ -2743,24 +3013,21 @@ namespace SalmonEgg.Acp.Client
                 var sessionId = sessionIdProp.GetString() ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(sessionId))
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams("Missing sessionId")));
                     return;
                 }
 
                 if (request.Id == null)
                 {
-                    RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                    RemovePendingInboundTracking(RequestKey(request.Id));
                     _ = SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidRequest("Missing request id")));
                     return;
                 }
 
                 var messageId = request.Id;
-                var requestId = request.Id?.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(requestId))
-                {
-                    SetPendingInboundSessionId(requestId, sessionId);
-                }
+                var requestId = RequestKey(request.Id);
+                SetPendingInboundSessionId(requestId, sessionId);
 
                 string? terminalId = null;
                 if (rawParams.TryGetProperty("terminalId", out var terminalIdProp))
@@ -2839,24 +3106,24 @@ namespace SalmonEgg.Acp.Client
                         break;
 
                     default:
-                        RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                        RemovePendingInboundTracking(RequestKey(request.Id));
                         await SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateMethodNotFound(request.Method))).ConfigureAwait(false);
                         break;
                 }
             }
             catch (KeyNotFoundException ex)
             {
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                RemovePendingInboundTracking(RequestKey(request.Id));
                 await SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams(ex.Message))).ConfigureAwait(false);
             }
             catch (ArgumentException ex)
             {
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                RemovePendingInboundTracking(RequestKey(request.Id));
                 await SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInvalidParams(ex.Message))).ConfigureAwait(false);
             }
             catch (NotSupportedException ex)
             {
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                RemovePendingInboundTracking(RequestKey(request.Id));
                 await SendResponseAsync(new JsonRpcResponse(
                     request.Id,
                     new JsonRpcError(JsonRpcErrorCode.CapabilityNotSupported, ex.Message))).ConfigureAwait(false);
@@ -2864,7 +3131,7 @@ namespace SalmonEgg.Acp.Client
             catch (Exception ex)
             {
                 OnErrorOccurred($"Failed to process terminal request: {ex.Message}");
-                RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+                RemovePendingInboundTracking(RequestKey(request.Id));
                 await SendResponseAsync(new JsonRpcResponse(request.Id, JsonRpcError.CreateInternalError(ex.Message))).ConfigureAwait(false);
             }
         }
@@ -2896,7 +3163,7 @@ namespace SalmonEgg.Acp.Client
 
         private async Task SendTerminalSuccessResponseAsync(object? messageId, JsonElement result)
         {
-            RemovePendingInboundTracking(messageId?.ToString() ?? string.Empty);
+            RemovePendingInboundTracking(RequestKey(messageId));
             await SendResponseAsync(new JsonRpcResponse(messageId, result)).ConfigureAwait(false);
         }
 
@@ -2935,7 +3202,7 @@ namespace SalmonEgg.Acp.Client
 
             // Each awaited send lets the peer finish and reuse other request ids. Cancellation
             // belongs to these request instances, never to a later request with the same id.
-            KeyValuePair<string, PendingInboundRequest>[] pendingRequests;
+            KeyValuePair<AcpRequestId, PendingInboundRequest>[] pendingRequests;
             lock (_lock)
             {
                 connectionToken.ThrowIfCancellationRequested();
@@ -2943,14 +3210,20 @@ namespace SalmonEgg.Acp.Client
                     .Where(pair => pair.Value.ConnectionToken == connectionToken
                         && string.Equals(pair.Value.SessionId, sessionId, StringComparison.Ordinal))
                     .ToArray();
+                PrepareSessionBatchCancellations(pendingRequests);
             }
 
             foreach (var (pendingId, pending) in pendingRequests)
             {
                 connectionToken.ThrowIfCancellationRequested();
+                if (IsBatchedResponse(pending))
+                {
+                    continue;
+                }
                 if (pending.ElicitationRequest is not null)
                 {
-                    await TrySendElicitationResponseAsync(pending, new ElicitationCancelResponse(), cancelForSession: true).ConfigureAwait(false);
+                    await TrySendElicitationResponseAsync(pending, new ElicitationCancelResponse(), cancelForSession: true)
+                        .ConfigureAwait(false);
                     continue;
                 }
 
@@ -2961,12 +3234,21 @@ namespace SalmonEgg.Acp.Client
                     continue;
                 }
 
+                if (pending.AskUserRequest is not null)
+                {
+                    await TrySendAskUserFailureResponseAsync(pending,
+                        new JsonRpcError(JsonRpcErrorCode.MethodNotAllowed,
+                            "Session was cancelled before the client completed this request."), cancelForSession: true)
+                        .ConfigureAwait(false);
+                    continue;
+                }
+
                 Task<bool> responseTask;
                 lock (_lock)
                 {
                     connectionToken.ThrowIfCancellationRequested();
                     if (!IsInboundRequestCurrent(pending)
-                        || !_pendingInboundRequests.TryRemove(new KeyValuePair<string, PendingInboundRequest>(pendingId, pending)))
+                        || !_pendingInboundRequests.TryRemove(new KeyValuePair<AcpRequestId, PendingInboundRequest>(pendingId, pending)))
                     {
                         continue;
                     }
@@ -2988,12 +3270,67 @@ namespace SalmonEgg.Acp.Client
             }
         }
 
-        private void RemovePendingInboundTracking(string idStr)
+        private void PrepareSessionBatchCancellations(KeyValuePair<AcpRequestId, PendingInboundRequest>[] requests)
         {
-            if (string.IsNullOrWhiteSpace(idStr))
+            var batches = new HashSet<InboundResponseBatch>();
+            try
             {
-                return;
+                foreach (var (_, pending) in requests)
+                {
+                    if (pending.MessageId is not null && _responseRoutes.TryGetValue(pending.MessageId, out var route)
+                        && route.Batch is { } batch && batches.Add(batch))
+                    {
+                        batch.DeferSending();
+                    }
+                }
+
+                // A retryable batch already has every slot filled. Prepare every cancellation
+                // before the first slot can trigger another write containing its old siblings.
+                foreach (var (_, pending) in requests)
+                {
+                    if (!IsBatchedResponse(pending)) continue;
+                    var response = pending.PreparedCancellationResponse;
+                    if (response is null)
+                    {
+                        response = pending.Method == "session/request_permission"
+                            ? new JsonRpcResponse(pending.MessageId,
+                                ToElement<PermissionOutcomeResult>(CreatePermissionOutcome(pending, "cancelled", null)))
+                            : pending.ElicitationRequest is not null
+                                ? new JsonRpcResponse(pending.MessageId,
+                                    ToElement<CreateElicitationResponse>(new ElicitationCancelResponse()))
+                                : new JsonRpcResponse(pending.MessageId, new JsonRpcError(JsonRpcErrorCode.MethodNotAllowed,
+                                    "Session was cancelled before the client completed this request."));
+                    }
+                    TrySubmitBatchCancellation(pending, response);
+                }
             }
+            finally
+            {
+                // A batch may also contain another session's input. Its owner waits for that input
+                // without holding up session/cancel, and commits all siblings after the shared write.
+                foreach (var batch in batches) batch.ResumeSending();
+            }
+        }
+
+        private bool TrySubmitBatchCancellation(PendingInboundRequest pending, JsonRpcResponse response)
+        {
+            if (pending.MessageId is null || !_responseRoutes.TryGetValue(pending.MessageId, out var route)
+                || route.Batch is null || !IsInboundRequestCurrent(pending))
+            {
+                return false;
+            }
+            pending.PreparedCancellationResponse = response;
+            route.Batch.SubmitCancellation(route.Index, response);
+            pending.PermissionEvent?.NotifyChanged();
+            return true;
+        }
+
+        private bool IsBatchedResponse(PendingInboundRequest pending)
+            => pending.MessageId is not null && _responseRoutes.TryGetValue(pending.MessageId, out var route)
+                && route.Batch is not null;
+
+        private void RemovePendingInboundTracking(AcpRequestId idStr)
+        {
 
             lock (_lock)
             {
@@ -3007,7 +3344,14 @@ namespace SalmonEgg.Acp.Client
 
         private void FailPendingInboundRequest(JsonRpcRequest request, JsonRpcError error)
         {
-            RemovePendingInboundTracking(request.Id?.ToString() ?? string.Empty);
+            if (request.Id is not null && _responseRoutes.TryGetValue(request.Id, out var route)
+                && route.Batch?.HasPreparedResponse(route.Index) == true)
+            {
+                // A handler may answer and then throw. That does not withdraw the prepared answer
+                // or its URL completion tracking while the batch is waiting for other calls.
+                return;
+            }
+            RemovePendingInboundTracking(RequestKey(request.Id));
             if (request.Id == null)
             {
                 return;
@@ -3016,12 +3360,8 @@ namespace SalmonEgg.Acp.Client
             _ = SendResponseAsync(new JsonRpcResponse(request.Id, error));
         }
 
-        private void TrackPendingInboundRequest(string idStr, string method, object? messageId)
+        private void TrackPendingInboundRequest(AcpRequestId idStr, string method, object? messageId)
         {
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return;
-            }
 
             lock (_lock)
             {
@@ -3032,34 +3372,22 @@ namespace SalmonEgg.Acp.Client
             }
         }
 
-        private bool TryGetPendingInboundRequest(string idStr, out PendingInboundRequest pending)
+        private bool TryGetPendingInboundRequest(AcpRequestId idStr, out PendingInboundRequest pending)
         {
             pending = default!;
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return false;
-            }
 
             return _pendingInboundRequests.TryGetValue(idStr, out pending!);
         }
 
-        private bool TryTakePendingInboundRequest(string idStr, out PendingInboundRequest pending)
+        private bool TryTakePendingInboundRequest(AcpRequestId idStr, out PendingInboundRequest pending)
         {
             pending = default!;
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return false;
-            }
 
             return _pendingInboundRequests.TryRemove(idStr, out pending!);
         }
 
-        private void SetPendingInboundSessionId(string idStr, string sessionId)
+        private void SetPendingInboundSessionId(AcpRequestId idStr, string sessionId)
         {
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return;
-            }
 
             while (_pendingInboundRequests.TryGetValue(idStr, out var existing))
             {
@@ -3094,20 +3422,13 @@ namespace SalmonEgg.Acp.Client
                     return null;
                 }
 
-                var requestId = messageId.ToString() ?? string.Empty;
-                _pendingInboundRequests.TryGetValue(requestId, out var previous);
-                _pendingInboundRequests[requestId] = pending;
-                previous?.PermissionEvent?.NotifyChanged();
+                _pendingInboundRequests[RequestKey(messageId)] = pending;
                 return pending;
             }
         }
 
-        private void SetPendingInboundAskUserRequest(string idStr, AskUserRequest request)
+        private void SetPendingInboundAskUserRequest(AcpRequestId idStr, AskUserRequest request)
         {
-            if (string.IsNullOrWhiteSpace(idStr))
-            {
-                return;
-            }
 
             _pendingInboundRequests.AddOrUpdate(
                 idStr,
@@ -3244,6 +3565,11 @@ namespace SalmonEgg.Acp.Client
                 _messageLoopCts?.Cancel();
                 _messageLoopCts?.Dispose();
                 _messageLoopCts = null;
+                foreach (var batch in _responseBatches)
+                {
+                    batch.Abandon();
+                }
+                _responseBatches.Clear();
                 var permissions = _pendingInboundRequests.Values.Select(static pending => pending.PermissionEvent).ToArray();
                 _pendingInboundRequests.Clear();
                 foreach (var permission in permissions) permission?.NotifyChanged();

--- a/src/SalmonEgg.Acp/Client/InboundResponseBatch.cs
+++ b/src/SalmonEgg.Acp/Client/InboundResponseBatch.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.JsonRpc;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>
+/// Owns one batch response until all calls have answered and the complete array reaches the peer.
+/// </summary>
+internal sealed class InboundResponseBatch
+{
+    private readonly object _gate = new();
+    private readonly JsonRpcResponse?[] _responses;
+    private readonly bool[] _cancelledResponses;
+    private readonly Func<IReadOnlyList<JsonRpcResponse>, Task<bool>> _send;
+    private readonly Action<IReadOnlyList<JsonRpcResponse>> _onSent;
+    private readonly Action _onChanged;
+    private readonly Action _onSendFailed;
+    private readonly IAcpClientLogger _logger;
+    private TaskCompletionSource<bool> _completion = NewCompletion();
+    private int _remaining;
+    private int _deferredSends;
+    private bool _sending;
+    private bool _finished;
+    private bool _retryable;
+    private bool _sendRequested;
+
+    internal InboundResponseBatch(int count, Func<IReadOnlyList<JsonRpcResponse>, Task<bool>> send,
+        Action<IReadOnlyList<JsonRpcResponse>> onSent, IAcpClientLogger logger, Action onChanged, Action onSendFailed)
+    {
+        _responses = new JsonRpcResponse[count];
+        _cancelledResponses = new bool[count];
+        _remaining = count;
+        _send = send;
+        _onSent = onSent;
+        _logger = logger;
+        _onChanged = onChanged;
+        _onSendFailed = onSendFailed;
+    }
+
+    internal bool IsSending
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return !_finished && _sending;
+            }
+        }
+    }
+
+    internal Task<bool> SubmitAsync(int index, JsonRpcResponse response)
+    {
+        TaskCompletionSource<bool> completion;
+        lock (_gate)
+        {
+            if (_finished || _sending || (_responses[index] is not null && !_retryable))
+            {
+                return Task.FromResult(false);
+            }
+
+            completion = _completion;
+            if (_responses[index] is null)
+            {
+                _remaining--;
+            }
+            if (!_cancelledResponses[index])
+            {
+                _responses[index] = response;
+            }
+            _sendRequested = true;
+        }
+
+        TrySendPreparedResponses();
+        _onChanged();
+        return completion.Task;
+    }
+
+    internal void DeferSending()
+    {
+        lock (_gate)
+        {
+            _deferredSends++;
+        }
+    }
+
+    internal void ResumeSending()
+    {
+        lock (_gate)
+        {
+            _deferredSends--;
+        }
+        TrySendPreparedResponses();
+    }
+
+    internal Task<bool> SubmitCancellation(int index, JsonRpcResponse response)
+    {
+        Task<bool> completion;
+        lock (_gate)
+        {
+            if (_finished)
+            {
+                return Task.FromResult(false);
+            }
+            completion = _completion.Task;
+            if (_responses[index] is null)
+            {
+                _remaining--;
+            }
+            _responses[index] = response;
+            _cancelledResponses[index] = true;
+            // The in-flight array is immutable. If its write fails, the new cancellation owns one
+            // follow-up attempt; a failed cancellation then waits for a new explicit retry.
+            _sendRequested = true;
+        }
+        TrySendPreparedResponses();
+        _onChanged();
+        return completion;
+    }
+
+    internal bool HasPreparedResponse(int index)
+    {
+        lock (_gate)
+        {
+            return _responses[index] is not null;
+        }
+    }
+
+    internal bool IsResponsePrepared(int index)
+    {
+        lock (_gate)
+        {
+            return !_finished && !_retryable && _responses[index] is not null;
+        }
+    }
+
+    internal void Abandon()
+    {
+        lock (_gate)
+        {
+            _finished = true;
+            Array.Clear(_responses);
+            _completion.TrySetResult(false);
+        }
+    }
+
+    private void TrySendPreparedResponses()
+    {
+        JsonRpcResponse[] ready;
+        TaskCompletionSource<bool> completion;
+        lock (_gate)
+        {
+            if (_finished || _sending || _deferredSends != 0 || _remaining != 0 || !_sendRequested)
+            {
+                return;
+            }
+            _sending = true;
+            _retryable = false;
+            _sendRequested = false;
+            completion = _completion;
+            ready = new JsonRpcResponse[_responses.Length];
+            for (var item = 0; item < ready.Length; item++)
+            {
+                ready[item] = _responses[item]!;
+            }
+        }
+        _ = SendAsync(ready, completion);
+        // ResumeSending and a follow-up cancellation can start a write without SubmitAsync.
+        // Publish that transition from the batch owner on every physical send path.
+        _onChanged();
+    }
+
+    private async Task SendAsync(IReadOnlyList<JsonRpcResponse> responses, TaskCompletionSource<bool> completion)
+    {
+        var sent = false;
+        try
+        {
+            sent = await _send(responses).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            // Even a host error subscriber may throw while reporting a failed write. The batch
+            // still owns every waiting responder and must release all of them for a later retry.
+            try
+            {
+                _logger.Log(AcpClientLogLevel.Error, "BATCH_RESPONSE_FAILED",
+                    "Failed to send the prepared response batch.", exception: exception);
+            }
+            catch (Exception)
+            {
+                // Logging is supplied by the host. A second failure has no reliable reporting
+                // channel, but it must not prevent the batch from releasing its waiting callers.
+            }
+        }
+        bool retryCancellation;
+        lock (_gate)
+        {
+            _sending = false;
+            if (_finished)
+            {
+                return;
+            }
+            _finished = sent;
+            retryCancellation = !sent && _sendRequested;
+            if (!sent && !retryCancellation)
+            {
+                // A failed write leaves every answer retryable as the same batch. Already answered
+                // siblings remain in the array, so retrying one UI action does not strand the rest.
+                _completion = NewCompletion();
+                _retryable = true;
+            }
+        }
+
+        if (retryCancellation)
+        {
+            TrySendPreparedResponses();
+            return;
+        }
+
+        try
+        {
+            if (sent)
+            {
+                _onSent(responses);
+            }
+            else
+            {
+                _onSendFailed();
+            }
+        }
+        finally
+        {
+            completion.TrySetResult(sent);
+            _onChanged();
+        }
+    }
+
+    private static TaskCompletionSource<bool> NewCompletion()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/SalmonEgg.Acp/JsonRpc/AcpFrame.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/AcpFrame.cs
@@ -8,8 +8,8 @@ namespace SalmonEgg.Acp.JsonRpc
     /// The single definition of what counts as an inbound ACP frame, shared by every transport.
     /// </summary>
     /// <remarks>
-    /// ACP carries individual JSON-RPC requests, notifications, or responses — never a batch — so a
-    /// frame must begin with '{'. Anything else was never an ACP message: over stdio the agent wrote
+    /// ACP carries JSON-RPC objects, and v2 also defines non-empty batch arrays. The connection owns
+    /// version validation; transports only recognize those shapes. Other text is not an ACP message: over stdio the agent wrote
     /// diagnostics to the stream reserved for the protocol (the spec directs those to stderr), and
     /// over a bridged transport the same line arrives verbatim as a text frame.
     ///
@@ -42,7 +42,7 @@ namespace SalmonEgg.Acp.JsonRpc
 
         /// <summary>
         /// True when <paramref name="message"/> looks like an ACP frame, i.e. its first
-        /// non-whitespace character (after any byte order mark) opens a JSON object.
+        /// non-whitespace character (after any byte order mark) opens a JSON object or batch array.
         /// </summary>
         /// <remarks>
         /// A shape test, not a validity test: a frame that looks like one but fails to parse is a
@@ -57,7 +57,31 @@ namespace SalmonEgg.Acp.JsonRpc
             }
 
             var payload = StripByteOrderMark(message!).AsSpan().TrimStart();
-            return payload.Length > 0 && payload[0] == '{';
+            return payload.Length > 0 && (payload[0] == '{'
+                || (payload[0] == '[' && LooksLikeArray(payload[1..].TrimStart())));
+        }
+
+        private static bool LooksLikeArray(ReadOnlySpan<char> contents)
+        {
+            if (contents.IsEmpty || contents[0] is '{' or '[' or ']' or '"')
+            {
+                return true;
+            }
+
+            // Bracketed logs such as [INFO] or [1;32mINFO are not batches. Recognize JSON value
+            // prefixes without parsing the frame here, so malformed batches still reach -32700.
+            if (contents.StartsWith("null") || contents.StartsWith("true") || contents.StartsWith("false"))
+            {
+                return true;
+            }
+            var index = 0;
+            while (index < contents.Length && (char.IsAsciiDigit(contents[index])
+                || contents[index] is '-' or '+' or '.' or 'e' or 'E'))
+            {
+                index++;
+            }
+            return index > 0 && (index == contents.Length || char.IsWhiteSpace(contents[index])
+                || contents[index] is ',' or ']');
         }
 
         /// <summary>

--- a/src/SalmonEgg.Acp/JsonRpc/MessageParser.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/MessageParser.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Acp.Protocol;
 
 namespace SalmonEgg.Acp.JsonRpc
 {
@@ -57,33 +61,8 @@ namespace SalmonEgg.Acp.JsonRpc
 
             try
             {
-                // First parse as a plain document in order to detect the message type
                 using var doc = JsonDocument.Parse(json);
-                var root = doc.RootElement;
-
-                // Detect the message type
-                var hasId = root.TryGetProperty("id", out _);
-                var hasResult = root.TryGetProperty("result", out _);
-                var hasError = root.TryGetProperty("error", out _);
-
-                if (hasResult || hasError)
-                {
-                    // Response message
-                    return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcResponse>())
-                        ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse response");
-                }
-                else if (hasId)
-                {
-                    // Request message
-                    return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcRequest>())
-                        ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse request");
-                }
-                else
-                {
-                    // Notification message (no id)
-                    return JsonSerializer.Deserialize(json, GetTypeInfo<JsonRpcNotification>())
-                        ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse notification");
-                }
+                return ParseMessage(doc.RootElement);
             }
             catch (JsonException ex)
             {
@@ -103,6 +82,155 @@ namespace SalmonEgg.Acp.JsonRpc
                     $"Error parsing message: {ex.Message}",
                     ex);
             }
+        }
+
+        internal ParsedMessageFrame ParseFrame(string json, int protocolVersion)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(json);
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Array)
+                {
+                    return new ParsedMessageFrame(false, false, [new ParsedMessageItem(ParseMessage(root))]);
+                }
+
+                if (protocolVersion != AcpProtocolVersion.V2 || root.GetArrayLength() == 0)
+                {
+                    throw new AcpException(JsonRpcErrorCode.InvalidRequest,
+                        protocolVersion == AcpProtocolVersion.V2
+                            ? "A JSON-RPC batch must contain at least one item."
+                            : "JSON-RPC batches require a negotiated ACP v2 connection.");
+                }
+
+                return ParseBatch(root);
+            }
+            catch (JsonException exception)
+            {
+                throw new AcpException(JsonRpcErrorCode.ParseError, exception.Message, exception);
+            }
+        }
+
+        internal string SerializeResponses(IReadOnlyList<JsonRpcResponse> responses)
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            using var writer = new Utf8JsonWriter(buffer);
+            writer.WriteStartArray();
+            foreach (var response in responses)
+            {
+                JsonSerializer.Serialize(writer, response, GetTypeInfo<JsonRpcResponse>());
+            }
+            writer.WriteEndArray();
+            writer.Flush();
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+        }
+
+        private JsonRpcMessage ParseMessage(JsonElement root)
+        {
+            if (root.TryGetProperty("result", out _) || root.TryGetProperty("error", out _))
+            {
+                return root.Deserialize(GetTypeInfo<JsonRpcResponse>())
+                    ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse response");
+            }
+
+            if (root.TryGetProperty("id", out var id))
+            {
+                var request = root.Deserialize(GetTypeInfo<JsonRpcRequest>())
+                    ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse request");
+                // Keep an explicit null id distinct from an absent id. Event callbacks require an
+                // object identity, while JsonElement preserves all three schema-defined wire forms.
+                request.Id = id.Clone();
+                return request;
+            }
+
+            return root.Deserialize(GetTypeInfo<JsonRpcNotification>())
+                ?? throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse notification");
+        }
+
+        private ParsedMessageFrame ParseBatch(JsonElement root)
+        {
+            var items = new List<ParsedMessageItem>(root.GetArrayLength());
+            var hasCalls = false;
+            var hasResponses = false;
+            foreach (var item in root.EnumerateArray())
+            {
+                var isResponse = item.ValueKind == JsonValueKind.Object
+                    && (item.TryGetProperty("result", out _) || item.TryGetProperty("error", out _));
+                hasResponses |= isResponse;
+                hasCalls |= item.ValueKind == JsonValueKind.Object && item.TryGetProperty("method", out _);
+                var error = ValidateBatchEnvelope(item);
+                try
+                {
+                    items.Add(error is null
+                        ? new ParsedMessageItem(ParseMessage(item), IsResponse: isResponse)
+                        : new ParsedMessageItem(null, error, isResponse));
+                }
+                catch (JsonException exception)
+                {
+                    items.Add(new ParsedMessageItem(null, exception.Message, isResponse));
+                }
+            }
+
+            // ACP's schema separates BatchCall from BatchResponse. A response smuggled into a call
+            // batch cannot settle a pending request, but it must not discard the legitimate calls.
+            if (hasCalls && hasResponses)
+            {
+                for (var index = 0; index < items.Count; index++)
+                {
+                    if (items[index].IsResponse)
+                    {
+                        items[index] = new ParsedMessageItem(null,
+                            "ACP call batches must not contain response items.", IsResponse: true);
+                    }
+                }
+            }
+
+            return new ParsedMessageFrame(true, hasResponses && !hasCalls, items);
+        }
+
+        private static string? ValidateBatchEnvelope(JsonElement item)
+        {
+            if (item.ValueKind != JsonValueKind.Object
+                || !item.TryGetProperty("jsonrpc", out var version)
+                || version.ValueKind != JsonValueKind.String || version.GetString() != "2.0")
+            {
+                return "A batch item must be a JSON-RPC 2.0 object.";
+            }
+
+            var hasId = item.TryGetProperty("id", out var id);
+            if (hasId && !AcpRequestId.TryFromEnvelopeId(id, out _))
+            {
+                return "A JSON-RPC id must be null, a number, or a string.";
+            }
+
+            var hasMethod = item.TryGetProperty("method", out var method);
+            var hasResult = item.TryGetProperty("result", out _);
+            var hasError = item.TryGetProperty("error", out var error);
+            if (hasMethod)
+            {
+                if (method.ValueKind != JsonValueKind.String || hasResult || hasError)
+                {
+                    return "A call must contain a string method and no result or error.";
+                }
+                if (item.TryGetProperty("params", out var parameters)
+                    && parameters.ValueKind is not (JsonValueKind.Object or JsonValueKind.Array))
+                {
+                    return "JSON-RPC params must be an object or an array when present.";
+                }
+                return null;
+            }
+
+            if (!hasId || hasResult == hasError)
+            {
+                return "A response must contain an id and exactly one of result or error.";
+            }
+            if (hasError && (error.ValueKind != JsonValueKind.Object
+                || !error.TryGetProperty("code", out var code) || code.ValueKind != JsonValueKind.Number || !code.TryGetInt32(out _)
+                || !error.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.String))
+            {
+                return "A JSON-RPC error must contain an integer code and a string message.";
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/SalmonEgg.Acp/JsonRpc/ParsedMessageFrame.cs
+++ b/src/SalmonEgg.Acp/JsonRpc/ParsedMessageFrame.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace SalmonEgg.Acp.JsonRpc;
+
+internal sealed record ParsedMessageFrame(
+    bool IsBatch,
+    bool IsResponseBatch,
+    IReadOnlyList<ParsedMessageItem> Items);
+
+internal sealed record ParsedMessageItem(
+    JsonRpcMessage? Message,
+    string? Error = null,
+    bool IsResponse = false);

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -43,7 +43,25 @@ hosts must enable optional capabilities only after implementing their interactio
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | URL wire contracts and SDK completion tracking exist, but URL mode is not advertised by default. | A host must provide explicit navigation consent, a context the Agent cannot inspect, and a UI driven by the SDK's completion events. SalmonEgg's platform integration is tracked in [#154](https://github.com/salmonloop/salmon-egg/issues/154); [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
-| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, message/tool/terminal projections, and permission request handling are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Configuration workflows, batch processing, application UI integration, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, message/tool/terminal projections, permission request handling, and version-gated JSON-RPC batches are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Configuration workflows, application UI integration, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+
+Internal v2 batch validation follows the upstream schema at
+`5ebaf0aceb04a4ba6574cd63fa6355352dc6d931` and JSON-RPC 2.0 section 6.
+Call batches may mix requests and notifications; responses are collected into one array after all
+requests have answers. Notification-only batches produce no response. Empty batches return a
+single `-32600` response; malformed JSON returns a single `-32700`, both with explicit `id: null`.
+An invalid call item receives `-32600` without discarding valid siblings. Response batches correlate
+each valid response by its original id type and value. Malformed response items, including responses
+embedded in a call batch, are logged and ignored without sending replies to responses.
+
+The transport recognizes object and array frames independently of negotiation; a v1 connection
+explicitly rejects batches. Cancellation and disconnect retain each response's original connection
+and batch ownership. Failed response batches remain retryable through their original pending
+requests. A batch with no remaining retry owner is abandoned after its failed send and releases
+its retained responses, without starting an automatic retry loop.
+`tests/SalmonEgg.Acp.Desktop.Tests` and `scripts/gates/run-acp-batch-stdio-gate.sh` exercise real
+Linux pipes through the production transport and adapter. This gate does not establish
+interoperability with a public v2 Agent, and it does not enable public live v2 initialization.
 
 V2 wire coverage includes `configId`/`groupId`, required `messageId` values, text/custom command
 inputs, and v1-only session fields and MCP variants. Unknown extension fields are preserved;

--- a/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
+++ b/src/SalmonEgg.Acp/SalmonEgg.Acp.csproj
@@ -94,6 +94,8 @@
   <!-- Internals remain available to first-party contract tests. External consumers use the public surface. -->
   <ItemGroup>
     <InternalsVisibleTo Include="SalmonEgg.Acp.Tests" />
+    <InternalsVisibleTo Include="SalmonEgg.Acp.Desktop.Tests" />
+    <InternalsVisibleTo Include="SalmonEgg.Presentation.Core.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/SalmonEgg.Infrastructure/SalmonEgg.Infrastructure.csproj
+++ b/src/SalmonEgg.Infrastructure/SalmonEgg.Infrastructure.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="SalmonEgg.Infrastructure.Tests" />
+    <InternalsVisibleTo Include="SalmonEgg.Acp.Desktop.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -2105,8 +2105,14 @@ public partial class ChatViewModel
         var conversationRequest = _panelStateCoordinator.GetPendingPermissionRequest(
             CurrentSessionId, toolCallId: null, PendingPermissionRequest);
         var unboundCancellation = _panelStateCoordinator.GetUnboundPermissionCancellation(PendingPermissionRequest);
-        PendingPermissionRequest = unboundCancellation is { IsSendingResponse: true }
-            ? unboundCancellation : conversationRequest ?? unboundCancellation;
+        // A bound answer and an unbound cancellation can share the same physical batch write.
+        // Keep the current member while either authoritative collection still selects that sender.
+        if (PendingPermissionRequest is not { IsSendingResponse: true } current
+            || (!ReferenceEquals(current, conversationRequest) && !ReferenceEquals(current, unboundCancellation)))
+        {
+            PendingPermissionRequest = unboundCancellation is { IsSendingResponse: true }
+                ? unboundCancellation : conversationRequest ?? unboundCancellation;
+        }
         ShowPermissionDialog = PendingPermissionRequest is not null;
         StandalonePermissionRequest = PendingPermissionRequest is { } pending
             && (pending.ToolCallId is null || !string.Equals(_visibleTranscriptConversationId, CurrentSessionId, StringComparison.Ordinal)

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -2102,8 +2102,9 @@ public partial class ChatViewModel
 
     private void SyncPermissionRequestProjection()
     {
-        var conversationRequest = _panelStateCoordinator.GetPendingPermissionRequest(CurrentSessionId);
-        var unboundCancellation = _panelStateCoordinator.GetUnboundPermissionCancellation();
+        var conversationRequest = _panelStateCoordinator.GetPendingPermissionRequest(
+            CurrentSessionId, toolCallId: null, PendingPermissionRequest);
+        var unboundCancellation = _panelStateCoordinator.GetUnboundPermissionCancellation(PendingPermissionRequest);
         PendingPermissionRequest = unboundCancellation is { IsSendingResponse: true }
             ? unboundCancellation : conversationRequest ?? unboundCancellation;
         ShowPermissionDialog = PendingPermissionRequest is not null;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
@@ -105,6 +105,10 @@ public sealed class ChatConversationPanelStateCoordinator
         => _pendingElicitationRequestsByConversation.Clear();
 
     public PermissionRequestViewModel? GetPendingPermissionRequest(string? conversationId, string? toolCallId = null)
+        => GetPendingPermissionRequest(conversationId, toolCallId, currentRequest: null);
+
+    internal PermissionRequestViewModel? GetPendingPermissionRequest(
+        string? conversationId, string? toolCallId, PermissionRequestViewModel? currentRequest)
     {
         if (string.IsNullOrWhiteSpace(conversationId)
             || !_pendingPermissionRequestsByConversation.TryGetValue(conversationId, out var requests))
@@ -113,6 +117,13 @@ public sealed class ChatConversationPanelStateCoordinator
         }
 
         RemoveUnavailablePermissionRequests(requests);
+        if (currentRequest is { IsSendingResponse: true } && requests.Contains(currentRequest)
+            && (toolCallId is null || string.Equals(currentRequest.ToolCallId, toolCallId, StringComparison.Ordinal)))
+        {
+            // Every prepared sibling becomes sending together. Preserve the visible member of
+            // that batch until delivery instead of jumping back to its first answered question.
+            return currentRequest;
+        }
         var candidates = requests.Where(request => (request.IsAwaitingInput || request.IsSendingResponse) && (toolCallId is null
             || string.Equals(request.ToolCallId, toolCallId, StringComparison.Ordinal)));
         return candidates.FirstOrDefault(static request => request.IsSendingResponse)
@@ -144,9 +155,13 @@ public sealed class ChatConversationPanelStateCoordinator
         return true;
     }
 
-    internal PermissionRequestViewModel? GetUnboundPermissionCancellation()
+    internal PermissionRequestViewModel? GetUnboundPermissionCancellation(PermissionRequestViewModel? currentRequest = null)
     {
         RemoveUnavailablePermissionRequests(_unboundPermissionCancellations);
+        if (currentRequest is { IsSendingResponse: true } && _unboundPermissionCancellations.Contains(currentRequest))
+        {
+            return currentRequest;
+        }
         return _unboundPermissionCancellations.FirstOrDefault(static request => request.IsSendingResponse)
             ?? _unboundPermissionCancellations.FirstOrDefault(static request => request.IsAwaitingInput);
     }

--- a/tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <ProjectReference Include="../../src/SalmonEgg.Infrastructure.Desktop/SalmonEgg.Infrastructure.Desktop.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SalmonEgg.Acp.Desktop.Tests/StdioBatchTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/StdioBatchTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Acp.Desktop.Tests;
+
+/// <summary>
+/// Linux gate for the actual stdio transport and production adapter. The peer records its stdin,
+/// so success requires both recognition of the stdout batch and the aggregated return pipe write.
+/// </summary>
+public sealed class StdioBatchTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task StdioBatch_NegotiatedVersion_RejectsV1OrDispatchesAndAggregatesV2(int version)
+    {
+        // Arrange
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "The real peer uses /bin/sh; run the Linux ACP batch gate.");
+        var directory = Path.Combine(Path.GetTempPath(), "salmon-egg-batch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var script = Path.Combine(directory, "peer.sh");
+        var frames = Path.Combine(directory, "received.ndjson");
+        var pidFile = Path.Combine(directory, "peer.pid");
+        await File.WriteAllTextAsync(script, AgentScript(frames, pidFile, version), TestToken);
+        int? peerPid = null;
+        try
+        {
+            using var transport = new StdioTransport("/bin/sh", [script]);
+            using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            var errors = new ConcurrentQueue<string>();
+            client.ErrorOccurred += (_, error) => errors.Enqueue(error);
+            var form = new TaskCompletionSource<ElicitationRequestEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.ElicitationRequestReceived += (_, value) => form.TrySetResult(value);
+            var parameters = new InitializeParams(new ClientInfo("stdio-batch", "1.0"), new ClientCapabilities
+            {
+                Elicitation = new ElicitationCapabilities { Form = new ElicitationFormCapabilities() }
+            })
+            { ProtocolVersion = version };
+            await (version == AcpProtocolVersion.V2
+                ? client.InitializeDraftAsync(parameters, TestToken)
+                : client.InitializeAsync(parameters, TestToken)).WaitAsync(TimeSpan.FromSeconds(10), TestToken);
+            peerPid = int.Parse(await File.ReadAllTextAsync(pidFile, TestToken));
+
+            // Act: session/new causes the real process to emit its batch on stdout.
+            var session = client.CreateSessionAsync(new SessionNewParams(directory, []), TestToken);
+            var received = await WaitForResponseAsync(frames);
+
+            // Assert
+            if (version == AcpProtocolVersion.V1)
+            {
+                Assert.Equal(JsonValueKind.Object, received.ValueKind);
+                Assert.Equal(JsonValueKind.Null, received.GetProperty("id").ValueKind);
+                Assert.Equal(-32600, received.GetProperty("error").GetProperty("code").GetInt32());
+                Assert.False(form.Task.IsCompleted);
+            }
+            else
+            {
+                Assert.Equal(JsonValueKind.Array, received.ValueKind);
+                Assert.Equal(2, received.GetArrayLength());
+                Assert.Equal(10, received[0].GetProperty("id").GetInt32());
+                Assert.Equal(-32800, received[0].GetProperty("error").GetProperty("code").GetInt32());
+                Assert.Equal("missing", received[1].GetProperty("id").GetString());
+                Assert.Equal(-32601, received[1].GetProperty("error").GetProperty("code").GetInt32());
+                Assert.False(await (await form.Task.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).Accept(null));
+            }
+            Assert.Equal("pipe-confirmed", (await session.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+            Assert.Empty(errors);
+            Assert.True(await client.DisconnectAsync());
+            await WaitForExitAsync(peerPid.Value);
+            peerPid = null;
+        }
+        finally
+        {
+            if (peerPid.HasValue)
+            {
+                try
+                {
+                    using var process = Process.GetProcessById(peerPid.Value);
+                    if (!process.HasExited) process.Kill(entireProcessTree: true);
+                    // Cleanup owns a separate bounded token: a cancelled test must still reap its peer.
+                    using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await process.WaitForExitAsync(cleanup.Token);
+                }
+                catch (ArgumentException) { }
+            }
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string AgentScript(string frames, string pidFile, int version)
+    {
+        var batch = """
+            [{"jsonrpc":"2.0","id":10,"method":"elicitation/create","params":{"sessionId":"session","mode":"form","message":"Choose","requestedSchema":{"type":"object","properties":{}}}},
+             {"jsonrpc":"2.0","method":"_ignored"},
+             {"jsonrpc":"2.0","method":"$/cancel_request","params":{"requestId":10}},
+             {"jsonrpc":"2.0","id":"missing","method":"_missing"}]
+            """.Replace("\n", "", StringComparison.Ordinal).Replace("\r", "", StringComparison.Ordinal);
+        var response = "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"sessionId\":\"pipe-confirmed\"}}";
+        if (version == AcpProtocolVersion.V2) response = "[" + response + "]";
+        var infoName = version == AcpProtocolVersion.V2 ? "info" : "agentInfo";
+        var capabilitiesName = version == AcpProtocolVersion.V2 ? "capabilities" : "agentCapabilities";
+        return "#!/bin/sh\n"
+            + "printf '%s\\n' \"$$\" > " + Quote(pidFile) + "\n"
+            + "while IFS= read -r frame; do\n"
+            + " printf '%s\\n' \"$frame\" >> " + Quote(frames) + "\n"
+            + " case \"$frame\" in\n"
+            + "  *'\"method\":\"initialize\"'*)\n"
+            + "   id=$(printf '%s' \"$frame\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n"
+            + "   printf '{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"protocolVersion\":" + version
+            + ",\"" + infoName + "\":{\"name\":\"pipe-peer\",\"version\":\"1\"},\"" + capabilitiesName + "\":{}}}\\n' \"$id\"\n"
+            + "   ;;\n"
+            + "  *'\"method\":\"session/new\"'*)\n"
+            + "   new_id=$(printf '%s' \"$frame\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n"
+            + "   printf '%s\\n' " + Quote(batch) + "\n"
+            + "   ;;\n"
+            + "  *'\"error\"'*)\n"
+            + "   printf '" + response + "\\n' \"$new_id\"\n"
+            + "   ;;\n"
+            + " esac\ndone\n";
+    }
+
+    private static string Quote(string value) => "'" + value.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+
+    private static async Task<JsonElement> WaitForResponseAsync(string frames)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(10));
+        while (true)
+        {
+            if (File.Exists(frames))
+            {
+                var text = await File.ReadAllTextAsync(frames, timeout.Token);
+                foreach (var line in text.Split('\n').SkipLast(1))
+                {
+                    using var document = JsonDocument.Parse(line);
+                    var item = document.RootElement;
+                    if (item.ValueKind == JsonValueKind.Array || item.TryGetProperty("error", out _))
+                    {
+                        return item.Clone();
+                    }
+                }
+            }
+            await Task.Delay(20, timeout.Token);
+        }
+    }
+
+    private static async Task WaitForExitAsync(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            await process.WaitForExitAsync(TestToken).WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            Assert.True(process.HasExited);
+        }
+        catch (ArgumentException) { }
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchLifecycleTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchLifecycleTests.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpClientBatchLifecycleTests
+{
+    private const string AbandonedBatchCode = "BATCH_RESPONSE_ABANDONED";
+
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Theory]
+    [InlineData("[1]", false)]
+    [InlineData("[1]", true)]
+    [InlineData("[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"_unsupported\"}]", false)]
+    [InlineData("[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"session/request_permission\",\"params\":{}}]", false)]
+    public async Task Batch_ResponseFailureWithoutRetryOwner_TerminatesOnceWithoutDisconnecting(string frame, bool throwOnWrite)
+    {
+        // Arrange
+        using var peer = await LifecyclePeer.CreateAsync();
+        peer.FailResponses = true;
+        peer.ThrowOnWrite = throwOnWrite;
+
+        // Act
+        peer.Deliver(frame);
+
+        // Assert
+        Assert.Equal(1, peer.ResponseAttempts);
+        Assert.Equal(AcpClientLogLevel.Warning, Assert.Single(peer.Logs, entry => entry.Code == AbandonedBatchCode).Level);
+        Assert.True(peer.Client.IsInitialized);
+        Assert.True(peer.Client.IsConnected);
+        peer.FailResponses = false;
+        peer.ThrowOnWrite = false;
+        peer.Deliver("[1]");
+        Assert.Equal(2, peer.ResponseAttempts);
+        Assert.Single(peer.Responses);
+        Assert.Single(peer.Logs, entry => entry.Code == AbandonedBatchCode);
+    }
+
+    [Fact]
+    public async Task Batch_UnretryableFailureLoggerThrows_ConnectionCanStillAnswerNewRequests()
+    {
+        // Arrange
+        using var peer = await LifecyclePeer.CreateAsync();
+        peer.FailResponses = true;
+        peer.ThrowOnAbandonLog = true;
+
+        // Act
+        peer.Deliver("[1]");
+        peer.ThrowOnAbandonLog = false;
+        peer.FailResponses = false;
+        peer.Deliver("[1]");
+
+        // Assert
+        Assert.Equal(2, peer.ResponseAttempts);
+        Assert.Single(peer.Responses);
+        Assert.Single(peer.Logs, entry => entry.Code == AbandonedBatchCode);
+        Assert.True(peer.Client.IsConnected);
+    }
+
+    [Fact]
+    public async Task Batch_RepeatedUnretryableFailures_ClosesEachAttemptOnTheLiveConnection()
+    {
+        // Arrange
+        using var peer = await LifecyclePeer.CreateAsync();
+        peer.FailResponses = true;
+
+        // Act
+        for (var attempt = 0; attempt < 16; attempt++) peer.Deliver("[1]");
+
+        // Assert
+        Assert.Equal(16, peer.ResponseAttempts);
+        Assert.Equal(16, peer.Logs.Count(entry => entry.Code == AbandonedBatchCode));
+        Assert.True(peer.Client.IsConnected);
+        Assert.Empty(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_MixedErrorAndFormFailure_PreservesTheOriginalRetryAndAllResponses()
+    {
+        // Arrange
+        using var peer = await LifecyclePeer.CreateAsync();
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.ElicitationRequestReceived += (_, request) => form = request;
+        peer.Deliver("[1," + Form() + "]");
+        Assert.NotNull(form);
+        peer.FailResponses = true;
+
+        // Act
+        Assert.False(await form.Cancel().WaitAsync(TestToken));
+        peer.FailResponses = false;
+        Assert.True(await form.Cancel().WaitAsync(TestToken));
+
+        // Assert
+        Assert.DoesNotContain(peer.Logs, entry => entry.Code == AbandonedBatchCode);
+        Assert.Equal(2, peer.ResponseAttempts);
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.Equal(JsonRpcErrorCode.InvalidRequest, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("cancel", response[1].GetProperty("result").GetProperty("action").GetString());
+        Assert.False(await form.Cancel().WaitAsync(TestToken));
+        Assert.Equal(2, peer.ResponseAttempts);
+    }
+
+    private static string Form()
+        => """
+           {"jsonrpc":"2.0","id":"form","method":"elicitation/create","params":{
+           "mode":"form","message":"Choose","requestedSchema":{"type":"object","properties":{}}}}
+           """;
+
+    private sealed class LifecyclePeer : IAcpTransport, IAcpClientLogger
+    {
+        private readonly MessageParser _parser = new();
+
+        private LifecyclePeer() => Client = new AcpClient(this, this);
+
+        internal AcpClient Client { get; }
+        public bool IsConnected { get; private set; }
+        internal bool FailResponses { get; set; }
+        internal bool ThrowOnWrite { get; set; }
+        internal bool ThrowOnAbandonLog { get; set; }
+        internal int ResponseAttempts { get; private set; }
+        internal ConcurrentQueue<JsonElement> Responses { get; } = new();
+        internal ConcurrentQueue<(AcpClientLogLevel Level, string Code)> Logs { get; } = new();
+
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var document = JsonDocument.Parse(message);
+            if (document.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                ResponseAttempts++;
+                if (ThrowOnWrite) throw new IOException("The response could not be sent.");
+                if (FailResponses) return Task.FromResult(false);
+                Responses.Enqueue(document.RootElement.Clone());
+            }
+            else if (_parser.ParseMessage(message) is JsonRpcRequest { Method: "initialize" } request)
+            {
+                var response = new InitializeResponse(AcpProtocolVersion.V2, new AgentInfo("lifecycle-peer", "1.0"), new AgentCapabilities());
+                Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":"
+                    + JsonSerializer.Serialize(response, AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<InitializeResponse>()) + "}");
+            }
+            return Task.FromResult(true);
+        }
+
+        public void Log(AcpClientLogLevel level, string code, string message, string? source = null, Exception? exception = null)
+        {
+            Logs.Enqueue((level, code));
+            if (ThrowOnAbandonLog && code == AbandonedBatchCode) throw new InvalidOperationException("Host logging failed.");
+        }
+
+        public void Dispose() => Client.Dispose();
+
+        internal static async Task<LifecyclePeer> CreateAsync()
+        {
+            var peer = new LifecyclePeer();
+            await peer.Client.InitializeDraftAsync(new InitializeParams(new ClientInfo("lifecycle-test", "1.0"),
+                new ClientCapabilities
+                {
+                    Elicitation = new ElicitationCapabilities { Form = new ElicitationFormCapabilities() }
+                })
+            { ProtocolVersion = AcpProtocolVersion.V2 }, TestToken);
+            return peer;
+        }
+
+        internal void Deliver(string message)
+            => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(message));
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
@@ -1,0 +1,1322 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpClientBatchTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Batch_MixedCallsAndNotifications_AggregatesOnlyRequestResponses()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+
+        // Act
+        peer.Deliver("[" + Form("1") + "," + Notification("_unknown") + "," + Form("\"1\"") + "]");
+
+        // Assert
+        Assert.Equal(2, forms.Count);
+        Assert.Empty(peer.Responses);
+        var second = forms[1].Decline();
+        Assert.False(second.IsCompleted);
+        Assert.Empty(peer.Responses);
+        var first = forms[0].Cancel();
+        Assert.True(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonValueKind.Array, response.ValueKind);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.Equal(JsonValueKind.Number, response[0].GetProperty("id").ValueKind);
+        Assert.Equal(JsonValueKind.String, response[1].GetProperty("id").ValueKind);
+        Assert.Equal("cancel", response[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal("decline", response[1].GetProperty("result").GetProperty("action").GetString());
+        Assert.False(await forms[0].Accept(null));
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_OnlyNotifications_SendsNoResponse()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+
+        // Act
+        peer.Deliver("[" + Notification("_unknown") + "," + Cancel("99") + "]");
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Theory]
+    [InlineData("[]", JsonRpcErrorCode.InvalidRequest)]
+    [InlineData("[{\"jsonrpc\":", JsonRpcErrorCode.ParseError)]
+    public async Task Batch_InvalidWholeFrame_RespondsWithSingleNullIdError(string frame, int code)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+
+        // Act
+        peer.Deliver(frame);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonValueKind.Object, response.ValueKind);
+        Assert.Equal(JsonValueKind.Null, response.GetProperty("id").ValueKind);
+        Assert.Equal(code, response.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task Batch_InvalidItems_DoNotDiscardValidCalls()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+
+        // Act
+        peer.Deliver("""
+            [1, {"method":"_missing","id":1}, {"jsonrpc":"2.0","method":2},
+             {"jsonrpc":"2.0","method":"_missing","id":true},
+             {"jsonrpc":"2.0","method":"_missing","id":"kept"},
+             {"jsonrpc":"2.0","method":"_ignored"}]
+            """);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(5, response.GetArrayLength());
+        foreach (var invalid in response.EnumerateArray().Take(4))
+        {
+            Assert.Equal(JsonValueKind.Null, invalid.GetProperty("id").ValueKind);
+            Assert.Equal(JsonRpcErrorCode.InvalidRequest, invalid.GetProperty("error").GetProperty("code").GetInt32());
+        }
+        Assert.Equal("kept", response[4].GetProperty("id").GetString());
+        Assert.Equal(JsonRpcErrorCode.MethodNotFound, response[4].GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("\"\"")]
+    [InlineData("\" \"")]
+    public async Task Batch_OpaqueRequestId_EchoesExactWireType(string id)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.ElicitationRequestReceived += (_, value) => form = value;
+
+        // Act
+        peer.Deliver("[" + Form(id) + "]");
+
+        // Assert
+        Assert.NotNull(form);
+        Assert.True(await form.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(id, Assert.Single(peer.Responses)[0].GetProperty("id").GetRawText());
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(0)]
+    public async Task Batch_WithoutNegotiatedV2_IsRejectedWithoutDispatch(int version)
+    {
+        // Arrange
+        using var peer = version == 0 ? new BatchPeer(AcpProtocolVersion.V2) : await BatchPeer.CreateAsync(version);
+        var delivered = false;
+        peer.Client.ElicitationRequestReceived += (_, _) => delivered = true;
+
+        // Act
+        peer.Deliver("[" + Form("11") + "]");
+
+        // Assert
+        Assert.False(delivered);
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonValueKind.Object, response.ValueKind);
+        Assert.Equal(JsonValueKind.Null, response.GetProperty("id").ValueKind);
+        Assert.Equal(JsonRpcErrorCode.InvalidRequest, response.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task Batch_ResponsesOutOfOrder_MatchesIdsWithoutStringCoercion()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var first = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        var second = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        var requests = peer.SessionRequests.ToArray();
+
+        // Act
+        peer.Deliver("[{\"jsonrpc\":\"2.0\",\"id\":\"" + requests[0].Id + "\",\"result\":{\"sessionId\":\"wrong\"}}]");
+        Assert.False(first.IsCompleted);
+        peer.Deliver("[" + SessionResponse(requests[1], "second") + "," + SessionResponse(requests[0], "first") + "]");
+
+        // Assert
+        Assert.Equal("first", (await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+        Assert.Equal("second", (await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+        Assert.Empty(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_ResponseSmuggledIntoCalls_DoesNotSettleRequestButKeepsCalls()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var pending = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        var request = Assert.Single(peer.SessionRequests);
+
+        // Act
+        peer.Deliver("[" + SessionResponse(request, "smuggled")
+            + ",{\"jsonrpc\":\"2.0\",\"method\":\"_missing\",\"id\":\"call\"}]");
+
+        // Assert
+        Assert.False(pending.IsCompleted);
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(1, response.GetArrayLength());
+        Assert.Equal("call", response[0].GetProperty("id").GetString());
+        peer.Deliver("[" + SessionResponse(request, "real") + "]");
+        Assert.Equal("real", (await pending.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+    }
+
+    [Fact]
+    public async Task Batch_InvalidResponseItem_DoesNotDiscardValidResponsesOrReplyToResponses()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var pending = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        var request = Assert.Single(peer.SessionRequests);
+
+        // Act
+        peer.Deliver("[17,{\"jsonrpc\":\"2.0\",\"id\":9,\"result\":{},\"error\":{\"code\":-1,\"message\":\"bad\"}},"
+            + SessionResponse(request, "kept") + "]");
+
+        // Assert
+        Assert.Equal("kept", (await pending.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+        Assert.Empty(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_CancelNotification_CancelsOnlyMatchingTypedRequest()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+
+        // Act
+        peer.Deliver("[" + Form("5") + "," + Form("\"5\"") + "," + Cancel("5") + "]");
+
+        // Assert
+        Assert.Equal(2, forms.Count);
+        Assert.False(await forms[0].Accept(null));
+        Assert.Empty(peer.Responses);
+        Assert.True(await forms[1].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.Cancelled, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("decline", response[1].GetProperty("result").GetProperty("action").GetString());
+        peer.Deliver(Cancel("5"));
+        Assert.Single(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_CallerCancellationAndBatchedTerminalResponse_SettlesWithoutError()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        using var cancelled = new CancellationTokenSource();
+        var first = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), cancelled.Token);
+        var second = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        var requests = peer.SessionRequests.ToArray();
+
+        // Act
+        await cancelled.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+        peer.Deliver("[{\"jsonrpc\":\"2.0\",\"id\":" + requests[0].Id
+            + ",\"error\":{\"code\":-32800,\"message\":\"Cancelled\"}}," + SessionResponse(requests[1], "kept") + "]");
+
+        // Assert
+        Assert.Single(peer.Notifications, item => item.GetProperty("method").GetString() == CancelRequestParams.Method);
+        Assert.Equal("kept", (await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken)).SessionId);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_DisconnectDuringWaiting_AbandonsBatchAndIgnoresStaleCallbacks()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        var oldDelivery = peer.CaptureDelivery();
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        var oldAnswer = forms[0].Accept(null);
+
+        // Act
+        Assert.True(await peer.Client.DisconnectAsync());
+        Assert.False(await oldAnswer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        await peer.InitializeAsync();
+        oldDelivery("[" + Form("9") + "]");
+        peer.Deliver("[" + Form("1") + "]");
+
+        // Assert
+        Assert.Equal(3, forms.Count);
+        Assert.False(await forms[1].Cancel());
+        Assert.False(await forms[0].Accept(null));
+        Assert.True(await forms[2].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Single(peer.Responses);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_FailedSend_RetryKeepsAllAnswersAndCommitsAllSiblings()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        peer.FailNextResponse = true;
+
+        // Act
+        var first = forms[0].Decline();
+        var second = forms[1].Cancel();
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+
+        // Assert
+        Assert.True(await forms[0].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.False(await forms[1].Accept(null));
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_V1OnlyMethods_AreRejectedInsideDraftBatch()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var delivered = false;
+        peer.Client.FileSystemRequestReceived += (_, _) => delivered = true;
+        peer.Client.TerminalRequestReceived += (_, _) => delivered = true;
+
+        // Act
+        peer.Deliver("""
+            [{"jsonrpc":"2.0","id":1,"method":"fs/read_text_file","params":{"sessionId":"session","path":"/file"}},
+             {"jsonrpc":"2.0","id":2,"method":"terminal/create","params":{"sessionId":"session","command":"echo"}}]
+            """);
+
+        // Assert
+        Assert.False(delivered);
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.All(response.EnumerateArray(), item =>
+            Assert.Equal(JsonRpcErrorCode.MethodNotFound, item.GetProperty("error").GetProperty("code").GetInt32()));
+    }
+
+    [Fact]
+    public async Task Batch_SessionCancel_SubmitsAllSiblingsBeforeAwaiting()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.All(response.EnumerateArray(), item =>
+            Assert.Equal("cancel", item.GetProperty("result").GetProperty("action").GetString()));
+        Assert.False(await forms[0].Accept(null));
+        Assert.False(await forms[1].Decline());
+    }
+
+    [Fact]
+    public async Task Batch_SessionCancelWithPreparedAnswerAndOtherSession_DoesNotWaitForUnrelatedInput()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Deliver("[" + Form("1") + "," + Form("2").Replace("\"session\"", "\"other\"", StringComparison.Ordinal) + "]");
+        var prepared = forms[0].Accept(null);
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.False(prepared.IsCompleted);
+        Assert.True(await forms[1].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await prepared.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal("cancel", response[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal("decline", response[1].GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task Batch_DuplicatePendingId_DoesNotReplaceOriginalResponder()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+
+        // Act
+        peer.Deliver("[" + Form("1") + "," + Form("1") + "]");
+
+        // Assert
+        var form = Assert.Single(forms);
+        Assert.True(await form.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.Equal("cancel", response[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal(JsonRpcErrorCode.InvalidRequest, response[1].GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task Batch_NotificationSubscriberThrows_KeepsLaterCalls()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? url = null;
+        peer.Client.ElicitationRequestReceived += (_, value) => url = value;
+        peer.Deliver("""
+            {"jsonrpc":"2.0","id":"url","method":"elicitation/create","params":{
+            "sessionId":"session","mode":"url","elicitationId":"connect","url":"https://agent.example/connect","message":"Connect"}}
+            """);
+        Assert.NotNull(url);
+        Assert.True(await url.Accept(null));
+        peer.Responses.Clear();
+        peer.Client.ElicitationCompleted += (_, _) => throw new InvalidOperationException("Host UI failed.");
+
+        // Act
+        peer.Deliver("""
+            [{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"connect"}},
+             {"jsonrpc":"2.0","id":"kept","method":"_missing"}]
+            """);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(1, response.GetArrayLength());
+        Assert.Equal("kept", response[0].GetProperty("id").GetString());
+        Assert.Equal(JsonRpcErrorCode.MethodNotFound, response[0].GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task Batch_HandlerAnswersThenThrows_KeepsPreparedAnswerAndSiblings()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        Task<bool>? prepared = null;
+        peer.Client.ElicitationRequestReceived += (_, value) =>
+        {
+            prepared = value.Decline();
+            throw new InvalidOperationException("Host failed after answering.");
+        };
+
+        // Act
+        peer.Deliver("[" + Form("1") + ","
+            + "{\"jsonrpc\":\"2.0\",\"id\":\"kept\",\"method\":\"_missing\"}]");
+
+        // Assert
+        Assert.NotNull(prepared);
+        Assert.True(await prepared.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal("decline", response[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal("kept", response[1].GetProperty("id").GetString());
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_SendAndErrorSubscriberThrow_ReleasesEveryResponderForRetry()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Client.ErrorOccurred += (_, _) => throw new InvalidOperationException("Host failed to display the send error.");
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        peer.ThrowNextResponse = true;
+
+        // Act
+        var first = forms[0].Decline();
+        var second = forms[1].Cancel();
+
+        // Assert
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+        Assert.True(await forms[0].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+        Assert.False(await forms[1].Accept(null));
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_PeerCancelsPreparedAnswer_ReplacesItBeforeTheSharedWrite()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        var prepared = forms[0].Accept(null);
+
+        // Act
+        peer.Deliver(Cancel("1"));
+
+        // Assert
+        Assert.False(await forms[0].Decline());
+        Assert.Empty(peer.Responses);
+        Assert.True(await forms[1].Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await prepared.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.Cancelled, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("cancel", response[1].GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task Batch_SessionCancelWithExtensionAndForm_SettlesBothWithoutDeadlock()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var questionCount = 0;
+        peer.Client.AskUserRequestReceived += (_, _) => questionCount++;
+        peer.Client.ElicitationRequestReceived += (_, _) => { };
+        var question = """
+            {"jsonrpc":"2.0","id":7,"method":"_interaction.ask_user","params":{"sessionId":"session",
+            "questions":[{"header":"Mode","question":"Choose","options":[{"label":"A","description":"First"},
+            {"label":"B","description":"Second"}]}]}}
+            """;
+        peer.Deliver("[" + question + "," + Form("2") + "]");
+        Assert.Equal(1, questionCount);
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.MethodNotAllowed, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("cancel", response[1].GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task Batch_LoggerThrowsOnSendFailure_ReleasesEveryPublicCallbackForRetry()
+    {
+        // Arrange
+        using var peer = new BatchPeer(AcpProtocolVersion.V2, new ThrowingLogger());
+        await peer.InitializeAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, form) => forms.Add(form);
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        peer.ThrowNextResponse = true;
+
+        // Act
+        var first = forms[0].Decline();
+        var second = forms[1].Cancel();
+
+        // Assert
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+        Assert.True(await forms[0].Decline().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+        Assert.False(await forms[1].Accept(null));
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task AskUser_InvalidAnswer_CanCorrectTheSameRequest(int version)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync(version);
+        AskUserRequestEventArgs? question = null;
+        peer.Client.AskUserRequestReceived += (_, value) => question = value;
+        peer.Deliver(WrapForVersion(Question("7"), version));
+        Assert.NotNull(question);
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => question.Respond(new Dictionary<string, string> { ["Choose"] = "C" }));
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.True(await question.Respond(Answer()).WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var frame = Assert.Single(peer.Responses);
+        var response = version == AcpProtocolVersion.V2 ? frame[0] : frame;
+        Assert.Equal("A", response.GetProperty("result").GetProperty("answers").GetProperty("Choose").GetString());
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task AskUser_OldCallbackAfterReconnect_CannotAnswerReusedId(int version)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync(version);
+        var questions = new List<AskUserRequestEventArgs>();
+        peer.Client.AskUserRequestReceived += (_, value) => questions.Add(value);
+        peer.Deliver(WrapForVersion(Question("7"), version));
+        Assert.True(await peer.Client.DisconnectAsync());
+        await peer.InitializeAsync();
+        peer.Deliver(WrapForVersion(Question("7"), version));
+
+        // Act
+        Assert.False(await questions[0].Respond(Answer()));
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.True(await questions[1].Respond(Answer()).WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Single(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_AskUserFailedSend_RetryCommitsAllPreparedQuestions()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var questions = new List<AskUserRequestEventArgs>();
+        peer.Client.AskUserRequestReceived += (_, value) => questions.Add(value);
+        peer.Deliver("[" + Question("7") + "," + Question("8") + "]");
+        peer.FailNextResponse = true;
+
+        // Act
+        var first = questions[0].Respond(Answer());
+        var second = questions[1].Respond(Answer());
+
+        // Assert
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await questions[0].Respond(Answer()).WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+        Assert.False(await questions[1].Respond(Answer()));
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task AskUser_HandlerAnswersThenThrows_DoesNotSendAnotherResponse(int version)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync(version);
+        Task<bool>? answer = null;
+        peer.Client.AskUserRequestReceived += (_, question) =>
+        {
+            answer = question.Respond(Answer());
+            throw new JsonException("Host failed after accepting the answer.");
+        };
+
+        // Act
+        peer.Deliver(WrapForVersion(Question("7"), version));
+
+        // Assert
+        Assert.NotNull(answer);
+        Assert.True(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var frame = Assert.Single(peer.Responses);
+        var response = version == AcpProtocolVersion.V2 ? frame[0] : frame;
+        Assert.Equal("A", response.GetProperty("result").GetProperty("answers").GetProperty("Choose").GetString());
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_AskUserPreparedAnswer_SessionCancelReplacesBeforeSharedWrite()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        AskUserRequestEventArgs? question = null;
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.AskUserRequestReceived += (_, value) => question = value;
+        peer.Client.ElicitationRequestReceived += (_, value) => form = value;
+        peer.Deliver("[" + Question("7") + "," + Form("2").Replace("\"session\"", "\"other\"", StringComparison.Ordinal) + "]");
+        Assert.NotNull(question);
+        Assert.NotNull(form);
+        var answer = question.Respond(Answer());
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.True(await form.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.MethodNotAllowed, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.False(await question.Respond(Answer()));
+    }
+
+    [Theory]
+    [InlineData(AcpProtocolVersion.V1)]
+    [InlineData(AcpProtocolVersion.V2)]
+    public async Task AskUser_HostThrowsBeforeAnswer_UsesInternalError(int version)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync(version);
+        peer.Client.AskUserRequestReceived += (_, _) => throw new JsonException("Host view failed.");
+
+        // Act
+        peer.Deliver(WrapForVersion(Question("7"), version));
+
+        // Assert
+        var frame = Assert.Single(peer.Responses);
+        var response = version == AcpProtocolVersion.V2 ? frame[0] : frame;
+        Assert.Equal(JsonRpcErrorCode.InternalError, response.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_PermissionsWithTypedIds_ValidateWithoutConsumingTheRequest()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("1") + "," + Permission("\"1\"") + "]");
+        Assert.Equal(2, permissions.Count);
+
+        // Act
+        await Assert.ThrowsAsync<AcpException>(() => peer.Client.RespondToPermissionRequestAsync(
+            permissions[0].MessageId, "selected", "unoffered"));
+        var first = peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow");
+        Assert.False(first.IsCompleted);
+        var second = peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "cancelled");
+
+        // Assert
+        Assert.True(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonValueKind.Number, response[0].GetProperty("id").ValueKind);
+        Assert.Equal(JsonValueKind.String, response[1].GetProperty("id").ValueKind);
+        Assert.Equal("selected", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.Equal("cancelled", response[1].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+    }
+
+    [Fact]
+    public async Task Batch_PermissionRetry_CommitsEveryPreparedSibling()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("7") + "," + Permission("8") + "]");
+        peer.FailNextResponse = true;
+        var first = peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow");
+        var second = peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "selected", "allow");
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+
+        // Act
+        Assert.True(await peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow")
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Assert
+        Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "cancelled"));
+        Assert.Single(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_SessionCancelAfterFailedWrite_CancelsEveryPreparedPermissionBeforeRetry()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("7") + "," + Permission("8") + "]");
+        peer.FailNextResponse = true;
+        var first = peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow");
+        var second = peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "selected", "allow");
+        Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.All(response.EnumerateArray(), item =>
+            Assert.Equal("cancelled", item.GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString()));
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow"));
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "selected", "allow"));
+    }
+
+    [Fact]
+    public async Task Batch_PeerCancelAfterFailedWrite_RetainsResponseUntilRetrySucceeds()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        PermissionRequestEventArgs? permission = null;
+        peer.Client.PermissionRequestReceived += (_, request) => permission = request;
+        peer.Deliver("[" + Permission("7") + "]");
+        Assert.NotNull(permission);
+        peer.FailNextResponse = true;
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow")
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Act
+        peer.FailNextResponse = true;
+        peer.Deliver(Cancel("7"));
+        Assert.Empty(peer.Responses);
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow"));
+        peer.Deliver(Cancel("7"));
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.Cancelled, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal(7, response[0].GetProperty("id").GetInt32());
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow"));
+        Assert.Single(peer.Responses);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Batch_SessionCancelDuringWrite_RetriesAllSiblingsAndRemainsExplicitlyRetryable(bool retryFails)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("7") + "," + Permission("8") + "]");
+        var releaseWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.NextResponseWrite = releaseWrite.Task;
+        var first = peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow");
+        var second = peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "selected", "allow");
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+        peer.FailNextResponse = retryFails;
+        releaseWrite.SetResult(false);
+        Assert.Equal(!retryFails, await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(!retryFails, await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        if (retryFails)
+        {
+            Assert.Empty(peer.Responses);
+            Assert.False(await peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow"));
+            Assert.True(await peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "cancelled")
+                .WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        }
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(2, response.GetArrayLength());
+        Assert.All(response.EnumerateArray(), item =>
+            Assert.Equal("cancelled", item.GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString()));
+    }
+
+    [Fact]
+    public async Task Batch_SessionCancelAfterMixedFailedWrite_PreservesOtherSessionAndCancelsAllMatchingInputs()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        ElicitationRequestEventArgs? form = null;
+        AskUserRequestEventArgs? question = null;
+        peer.Client.PermissionRequestReceived += (_, value) => permissions.Add(value);
+        peer.Client.ElicitationRequestReceived += (_, value) => form = value;
+        peer.Client.AskUserRequestReceived += (_, value) => question = value;
+        peer.Deliver("[" + Permission("7") + "," + Form("8") + "," + Question("9") + ","
+            + Permission("10").Replace("\"session\"", "\"other\"", StringComparison.Ordinal) + "]");
+        Assert.NotNull(form);
+        Assert.NotNull(question);
+        peer.FailNextResponse = true;
+        var answers = new[]
+        {
+            peer.Client.RespondToPermissionRequestAsync(permissions[0].MessageId, "selected", "allow"),
+            form.Accept(null),
+            question.Respond(Answer()),
+            peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "selected", "allow")
+        };
+        foreach (var answer in answers) Assert.False(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(4, response.GetArrayLength());
+        Assert.Equal("cancelled", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.Equal("cancel", response[1].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal(JsonRpcErrorCode.MethodNotAllowed, response[2].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("selected", response[3].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.False(await form.Accept(null));
+        Assert.False(await question.Respond(Answer()));
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permissions[1].MessageId, "cancelled"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Batch_PeerCancelDuringWrite_RetainsCancellationAfterFailureAndNeverRepliesTwice(bool sent)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        PermissionRequestEventArgs? permission = null;
+        peer.Client.PermissionRequestReceived += (_, request) => permission = request;
+        peer.Deliver("[" + Permission("7") + "]");
+        Assert.NotNull(permission);
+        var releaseWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.NextResponseWrite = releaseWrite.Task;
+        var answer = peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow");
+
+        // Act
+        peer.Deliver(Cancel("7"));
+        releaseWrite.SetResult(sent);
+        Assert.True(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        peer.Deliver(Cancel("7"));
+
+        // Assert
+        var response = Assert.Single(peer.Responses);
+        if (sent)
+        {
+            Assert.Equal("selected", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        }
+        else
+        {
+            Assert.Equal(JsonRpcErrorCode.Cancelled, response[0].GetProperty("error").GetProperty("code").GetInt32());
+        }
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Batch_UrlAcceptDuringSessionCancellation_CommitsTheResponseActuallyWritten(bool sent)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? url = null;
+        var completions = new List<string>();
+        peer.Client.ElicitationRequestReceived += (_, value) => url = value;
+        peer.Client.ElicitationCompleted += (_, value) => completions.Add(value.ElicitationId);
+        peer.Deliver("""
+            [{"jsonrpc":"2.0","id":7,"method":"elicitation/create","params":{
+              "sessionId":"session","mode":"url","elicitationId":"connect","url":"https://agent.example/connect","message":"Connect"}}]
+            """);
+        Assert.NotNull(url);
+        var releaseWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.NextResponseWrite = releaseWrite.Task;
+        var answer = url.Accept(null);
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+        releaseWrite.SetResult(sent);
+        Assert.True(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        peer.Deliver("""
+            {"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"connect"}}
+            """);
+
+        // Assert
+        Assert.Equal(sent ? "accept" : "cancel", Assert.Single(peer.Responses)[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal(sent ? 1 : 0, completions.Count);
+        Assert.False(await url.Accept(null));
+    }
+
+    [Fact]
+    public async Task Batch_PermissionCancellation_ReplacesPreparedAnswerWithoutWaitingForAnotherSession()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        PermissionRequestEventArgs? permission = null;
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.PermissionRequestReceived += (_, request) => permission = request;
+        peer.Client.ElicitationRequestReceived += (_, request) => form = request;
+        peer.Deliver("[" + Permission("7") + "," + Form("8").Replace("\"session\"", "\"other\"", StringComparison.Ordinal) + "]");
+        Assert.NotNull(permission);
+        Assert.NotNull(form);
+        var answer = peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow");
+
+        // Act
+        await peer.Client.CancelSessionAsync(new SessionCancelParams("session"), TestToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.Empty(peer.Responses);
+        Assert.Equal("session/cancel", Assert.Single(peer.Notifications).GetProperty("method").GetString());
+        Assert.True(await form.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal("cancelled", Assert.Single(peer.Responses)[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow"));
+    }
+
+    [Fact]
+    public async Task Batch_PermissionSubscriberThrowsAfterAnswer_DoesNotReplacePreparedSuccess()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        Task? answer = null;
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.PermissionRequestReceived += (_, request) =>
+        {
+            answer = request.Respond("selected", "allow");
+            throw new InvalidOperationException("Host failed after answering.");
+        };
+        peer.Client.ElicitationRequestReceived += (_, request) => form = request;
+
+        // Act
+        peer.Deliver("[" + Permission("7") + "," + Form("8") + "]");
+        Assert.NotNull(form);
+        Assert.NotNull(answer);
+        Assert.True(await form.Cancel().WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+        // Assert
+        Assert.Equal("selected", Assert.Single(peer.Responses)[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.Single(peer.Errors);
+    }
+
+    [Fact]
+    public async Task Batch_PermissionReplyWaitingForSibling_DisconnectReleasesOriginalCallback()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        PermissionRequestEventArgs? permission = null;
+        peer.Client.PermissionRequestReceived += (_, request) => permission = request;
+        peer.Client.ElicitationRequestReceived += (_, _) => { };
+        peer.Deliver("[" + Permission("7") + "," + Form("8") + "]");
+        Assert.NotNull(permission);
+        var answer = peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow");
+
+        // Act
+        await peer.Client.DisconnectAsync();
+        await peer.InitializeAsync();
+
+        // Assert
+        Assert.False(await answer.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Empty(peer.Responses);
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "cancelled"));
+    }
+
+    [Fact]
+    public async Task Batch_FailedSubscriberError_RetryBySiblingCommitsItsOriginalRequest()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        ElicitationRequestEventArgs? form = null;
+        PermissionRequestEventArgs? permission = null;
+        peer.Client.PermissionRequestReceived += (_, request) => permission = request;
+        peer.Client.ElicitationRequestReceived += (_, request) =>
+        {
+            form = request;
+            throw new JsonException("Private host failure.");
+        };
+        peer.Deliver("[" + Form("1") + "," + Permission("2") + "]");
+        Assert.NotNull(form);
+        Assert.NotNull(permission);
+        peer.FailNextResponse = true;
+        Assert.False(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow")
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Act
+        Assert.True(await peer.Client.RespondToPermissionRequestAsync(permission.MessageId, "selected", "allow")
+            .WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        // Assert
+        var frame = Assert.Single(peer.Responses);
+        Assert.Equal(JsonRpcErrorCode.InternalError, frame[0].GetProperty("error").GetProperty("code").GetInt32());
+        Assert.False(await form.Cancel());
+        Assert.Single(peer.Responses);
+    }
+
+    [Fact]
+    public async Task Batch_PermissionAvailabilityChanged_PreparationFailureAndRetryFollowSharedWrite()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("7") + "," + Permission("8") + "]");
+        var prepared = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var retryable = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var siblingPreparedOnRetry = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stage = 0;
+        void OnChanged(object? sender, EventArgs args)
+        {
+            var currentStage = Volatile.Read(ref stage);
+            if (currentStage == 0 && permissions[0].IsResponsePrepared && !permissions[1].IsResponsePrepared)
+                prepared.TrySetResult(true);
+            if (currentStage == 1 && permissions.All(request => request.CanRespond && !request.IsResponsePrepared))
+                retryable.TrySetResult(true);
+            if (currentStage == 2 && permissions.All(request => request.IsResponsePrepared))
+                siblingPreparedOnRetry.TrySetResult(true);
+            if (permissions.All(request => !request.CanRespond && !request.IsResponsePrepared))
+                completed.TrySetResult(true);
+        }
+        foreach (var permission in permissions) permission.Changed += OnChanged;
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<bool>? first = null;
+        Task<bool>? second = null;
+        Task<bool>? retry = null;
+        try
+        {
+            // Act: one prepared answer yields the interaction, but cannot claim delivery yet.
+            first = permissions[0].TryRespondAsync("selected", "allow");
+            await prepared.Task.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            Assert.False(first.IsCompleted);
+            Assert.Empty(peer.Responses);
+            Volatile.Write(ref stage, 1);
+            peer.FailNextResponse = true;
+            second = permissions[1].TryRespondAsync("selected", "allow");
+            Assert.False(await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+            Assert.False(await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+            await retryable.Task.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+            Volatile.Write(ref stage, 2);
+            peer.NextResponseWrite = release.Task;
+            retry = permissions[0].TryRespondAsync("selected", "allow");
+            await siblingPreparedOnRetry.Task.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            Assert.False(retry.IsCompleted);
+            release.TrySetResult(true);
+            Assert.True(await retry.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+
+            // Assert: the sibling did not retry, yet shares the same authoritative completion.
+            Assert.Equal(2, Assert.Single(peer.Responses).GetArrayLength());
+            Assert.All(permissions, request => Assert.False(request.CanRespond));
+            Assert.All(permissions, request => Assert.False(request.IsResponsePrepared));
+            Assert.Empty(peer.Errors);
+        }
+        finally
+        {
+            release.TrySetResult(false);
+            await peer.Client.DisconnectAsync().WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            foreach (var permission in permissions) permission.Changed -= OnChanged;
+            if (first is not null) await first.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            if (second is not null) await second.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            if (retry is not null) await retry.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+        }
+    }
+
+    [Fact]
+    public async Task Batch_ExplicitCancellationOfPreparedPermission_ReplacesSlotWithoutWaitingForSiblings()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var permissions = new List<PermissionRequestEventArgs>();
+        peer.Client.PermissionRequestReceived += (_, request) => permissions.Add(request);
+        peer.Deliver("[" + Permission("7") + "," + Permission("8") + "]");
+        var selected = permissions[0].TryRespondAsync("selected", "allow");
+        Task<bool>? cancelled = null;
+        Task<bool>? sibling = null;
+        try
+        {
+            Assert.True(permissions[0].IsResponsePrepared);
+            Assert.False(selected.IsCompleted);
+
+            // Act: cancellation takes its existing slot even though the original await is pending.
+            cancelled = permissions[0].TryRespondAsync("cancelled");
+            Assert.True(permissions[0].IsCancellationRequested);
+            Assert.False(cancelled.IsCompleted);
+            Assert.Empty(peer.Responses);
+            sibling = permissions[1].TryRespondAsync("selected", "allow");
+            Assert.True(await cancelled.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+            Assert.True(await sibling.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+            Assert.True(await selected.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+            // Assert: every callback confirms the one physical array, whose cancelled slot wins.
+            var response = Assert.Single(peer.Responses);
+            Assert.Equal("cancelled", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+            Assert.Equal("selected", response[1].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+            Assert.All(permissions, request => Assert.False(request.CanRespond));
+        }
+        finally
+        {
+            await peer.Client.DisconnectAsync().WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            await selected.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            if (cancelled is not null) await cancelled.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+            if (sibling is not null) await sibling.WaitAsync(TimeSpan.FromSeconds(5), TestToken);
+        }
+    }
+
+    private static string Permission(string id) => "{\"jsonrpc\":\"2.0\",\"id\":" + id + """
+        ,"method":"session/request_permission","params":{"sessionId":"session","title":"Run tool",
+        "options":[{"optionId":"allow","name":"Allow","kind":"allow_once"}]}}
+        """;
+
+    private static string WrapForVersion(string json, int version)
+        => version == AcpProtocolVersion.V2 ? "[" + json + "]" : json;
+
+    private static Dictionary<string, string> Answer() => new() { ["Choose"] = "A" };
+
+    private static string Question(string id) => "{\"jsonrpc\":\"2.0\",\"id\":" + id + """
+        ,"method":"_interaction.ask_user","params":{"sessionId":"session",
+        "questions":[{"header":"Mode","question":"Choose","options":[{"label":"A","description":"First"},
+        {"label":"B","description":"Second"}]}]}}
+        """;
+
+    private static string Form(string id) => "{\"jsonrpc\":\"2.0\",\"id\":" + id + """
+        ,"method":"elicitation/create","params":{"sessionId":"session","mode":"form","message":"Choose",
+        "requestedSchema":{"type":"object","properties":{}}}}
+        """;
+
+    private static string Cancel(string id)
+        => "{\"jsonrpc\":\"2.0\",\"method\":\"$/cancel_request\",\"params\":{\"requestId\":" + id + "}}";
+
+    private static string Notification(string method)
+        => "{\"jsonrpc\":\"2.0\",\"method\":\"" + method + "\"}";
+
+    private static string SessionResponse(JsonRpcRequest request, string sessionId)
+        => "{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":{\"sessionId\":\"" + sessionId + "\"}}";
+
+    private sealed class BatchPeer : IAcpTransport
+    {
+        private readonly int _version;
+        private readonly MessageParser _parser = new();
+
+        internal BatchPeer(int version, IAcpClientLogger? logger = null)
+        {
+            _version = version;
+            Client = new AcpClient(this, logger);
+            Client.ErrorOccurred += (_, error) => Errors.Enqueue(error);
+        }
+
+        public bool IsConnected { get; private set; } = true;
+        internal AcpClient Client { get; }
+        internal bool FailNextResponse { get; set; }
+        internal bool ThrowNextResponse { get; set; }
+        internal Task<bool>? NextResponseWrite { get; set; }
+        internal ConcurrentQueue<JsonElement> Responses { get; } = new();
+        internal ConcurrentQueue<JsonElement> Notifications { get; } = new();
+        internal ConcurrentQueue<JsonRpcRequest> SessionRequests { get; } = new();
+        internal ConcurrentQueue<string> Errors { get; } = new();
+
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        internal static async Task<BatchPeer> CreateAsync(int version = AcpProtocolVersion.V2)
+        {
+            var peer = new BatchPeer(version);
+            await peer.InitializeAsync();
+            return peer;
+        }
+
+        internal Task<InitializeResponse> InitializeAsync()
+        {
+            var parameters = new InitializeParams(new ClientInfo("batch-peer", "1.0"), new ClientCapabilities
+            {
+                Elicitation = new ElicitationCapabilities
+                {
+                    Form = new ElicitationFormCapabilities(),
+                    Url = new ElicitationUrlCapabilities()
+                },
+                Meta = ClientCapabilityMetadata.CreateDefault()
+            })
+            { ProtocolVersion = _version };
+            return _version == AcpProtocolVersion.V2
+                ? Client.InitializeDraftAsync(parameters, TestToken)
+                : Client.InitializeAsync(parameters, TestToken);
+        }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var document = JsonDocument.Parse(message);
+            var root = document.RootElement.Clone();
+            if (root.ValueKind == JsonValueKind.Array || root.TryGetProperty("result", out _) || root.TryGetProperty("error", out _))
+            {
+                if (NextResponseWrite is { } pendingWrite)
+                {
+                    NextResponseWrite = null;
+                    return CompleteResponseWriteAsync(root, pendingWrite, cancellationToken);
+                }
+                if (ThrowNextResponse)
+                {
+                    ThrowNextResponse = false;
+                    throw new InvalidOperationException("Transport write failed.");
+                }
+                if (FailNextResponse)
+                {
+                    FailNextResponse = false;
+                    return Task.FromResult(false);
+                }
+                Responses.Enqueue(root);
+                return Task.FromResult(true);
+            }
+
+            var parsed = _parser.ParseMessage(message);
+            if (parsed is JsonRpcNotification)
+            {
+                Notifications.Enqueue(root);
+            }
+            if (parsed is JsonRpcRequest request)
+            {
+                if (request.Method == "initialize")
+                {
+                    var response = new InitializeResponse(_version, new AgentInfo("batch-peer", "1.0"), new AgentCapabilities());
+                    Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":"
+                        + JsonSerializer.Serialize(response, AcpWireFormat.For(_version).TypeInfo<InitializeResponse>()) + "}");
+                }
+                else if (request.Method == "session/new")
+                {
+                    SessionRequests.Enqueue(request);
+                }
+            }
+            return Task.FromResult(true);
+        }
+
+        private async Task<bool> CompleteResponseWriteAsync(JsonElement response, Task<bool> pendingWrite,
+            CancellationToken cancellationToken)
+        {
+            var sent = await pendingWrite.WaitAsync(cancellationToken);
+            if (sent) Responses.Enqueue(response);
+            return sent;
+        }
+
+        internal void Deliver(string json) => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+
+        internal Action<string> CaptureDelivery()
+        {
+            var handler = MessageReceived;
+            return json => handler?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+        }
+
+        public void Dispose() => Client.Dispose();
+    }
+
+    private sealed class ThrowingLogger : IAcpClientLogger
+    {
+        public void Log(AcpClientLogLevel level, string code, string message, string? source = null, Exception? exception = null)
+            => throw new InvalidOperationException("Host logging failed.");
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
@@ -373,12 +373,14 @@ public sealed class AcpClientElicitationTests
     }
 
     [Fact]
-    public async Task ElicitationCreate_SubscriberThrowsAfterReplacement_PreservesNewRequest()
+    public async Task ElicitationCreate_SubscriberThrowsAfterCompletedIdIsReused_PreservesNewRequest()
     {
         // Arrange
         var parser = new MessageParser();
         using var client = await CreateInitializedClientAsync(ClientCapabilityDefaults.Create());
         var sent = CaptureSentMessages();
+        ElicitationRequestEventArgs? original = null;
+        Task<bool>? originalAnswer = null;
         ElicitationRequestEventArgs? current = null;
         var replacing = false;
         client.ElicitationRequestReceived += (_, request) =>
@@ -388,6 +390,9 @@ public sealed class AcpClientElicitationTests
                 current = request;
                 return;
             }
+            original = request;
+            originalAnswer = request.Accept(null);
+            Assert.True(originalAnswer.IsCompletedSuccessfully);
             replacing = true;
             RaiseRequest(parser, 342, ElicitationMethods.Create, FormParamsJson);
             throw new InvalidOperationException("Previous host failed.");
@@ -397,10 +402,16 @@ public sealed class AcpClientElicitationTests
         RaiseRequest(parser, 342, ElicitationMethods.Create, FormParamsJson);
 
         // Assert
-        Assert.Empty(sent);
+        Assert.NotNull(originalAnswer);
+        Assert.True(await originalAnswer);
+        Assert.NotNull(original);
+        Assert.False(await original.Cancel());
+        var first = Assert.IsType<JsonRpcResponse>(parser.ParseMessage(Assert.Single(sent)));
+        Assert.Equal(ElicitationActions.Accept, first.Result!.Value.GetProperty("action").GetString());
         Assert.NotNull(current);
         Assert.True(await current.Cancel());
-        var response = Assert.IsType<JsonRpcResponse>(parser.ParseMessage(Assert.Single(sent)));
+        Assert.Equal(2, sent.Count);
+        var response = Assert.IsType<JsonRpcResponse>(parser.ParseMessage(sent.Last()));
         Assert.Equal(ElicitationActions.Cancel, response.Result!.Value.GetProperty("action").GetString());
     }
 

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientPermissionCancellationOwnershipTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientPermissionCancellationOwnershipTests.cs
@@ -521,7 +521,7 @@ public sealed class AcpClientPermissionCancellationOwnershipTests
     }
 
     [Fact]
-    public async Task Changed_RequestIdReplaced_NotifiesOnlyOriginalRequestIsUnavailable()
+    public async Task Changed_CompletedRequestIdReused_NotifiesOnlyOriginalRequestIsUnavailable()
     {
         // Arrange
         using var peer = await PermissionPeer.CreateAsync();
@@ -536,17 +536,18 @@ public sealed class AcpClientPermissionCancellationOwnershipTests
         try
         {
             // Act
-            peer.Request();
+            Assert.True(await original.TryRespondAsync("selected", "allow").WaitAsync(WaitTimeout, TestToken));
             await replaced.Task.WaitAsync(WaitTimeout, TestToken);
+            peer.Request();
             var replacement = peer.Requests.Last();
 
             // Assert
             Assert.False(original.CanRespond);
             Assert.False(await original.TryRespondAsync("cancelled").WaitAsync(WaitTimeout, TestToken));
             Assert.True(replacement.CanRespond);
-            Assert.Empty(peer.Attempts);
+            Assert.Single(peer.Attempts);
             Assert.True(await replacement.TryRespondAsync("selected", "allow").WaitAsync(WaitTimeout, TestToken));
-            Assert.Single(peer.Responses);
+            Assert.Equal(2, peer.Responses.Count);
             Assert.Empty(peer.Errors);
         }
         finally

--- a/tests/SalmonEgg.Acp.Tests/Client/InboundResponseBatchLifecycleTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/InboundResponseBatchLifecycleTests.cs
@@ -1,0 +1,131 @@
+using System.Runtime.CompilerServices;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class InboundResponseBatchLifecycleTests
+{
+    [Fact]
+    public async Task ResumeSending_PreparedArrayPublishesItsPhysicalWriteBeforeCompletion()
+    {
+        // Arrange
+        var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var notifications = new List<bool>();
+        InboundResponseBatch? batch = null;
+        batch = new InboundResponseBatch(1, _ => write.Task, _ => { }, new NullAcpClientLogger(),
+            () => notifications.Add(batch!.IsSending), () => { });
+        batch.DeferSending();
+        var response = batch.SubmitAsync(0, ErrorResponse());
+        Assert.False(batch.IsSending);
+        notifications.Clear();
+
+        // Act
+        try
+        {
+            batch.ResumeSending();
+
+            // Assert
+            Assert.True(batch.IsSending);
+            Assert.Contains(true, notifications);
+            Assert.False(response.IsCompleted);
+        }
+        finally
+        {
+            write.TrySetResult(true);
+            await response.WaitAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SubmitAsync_UnretryableWriteFailure_TerminatesAndReleasesResponse(bool throwOnWrite)
+    {
+        // Arrange
+        var owner = new BatchOwner(throwOnWrite);
+        var response = SubmitWithWeakResponse(owner.Batch);
+
+        // Act
+        Assert.False(await response.Completion.WaitAsync(TestContext.Current.CancellationToken));
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        // Assert
+        Assert.Equal(1, owner.Failures);
+        Assert.False(response.Reference.IsAlive);
+        Assert.False(await owner.Batch.SubmitAsync(0, ErrorResponse()));
+        Assert.False(await owner.Batch.SubmitCancellation(0, ErrorResponse()));
+        Assert.Equal(1, owner.Writes);
+        GC.KeepAlive(owner);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RetryOwnerRetainsFailedBatch_ResendsAndCommitsOnlyOnSuccess()
+    {
+        // Arrange
+        var failWrite = true;
+        var committed = 0;
+        var failed = 0;
+        var writes = new List<IReadOnlyList<JsonRpcResponse>>();
+        var batch = new InboundResponseBatch(2, responses =>
+        {
+            writes.Add(responses);
+            return Task.FromResult(!failWrite);
+        }, _ => committed++, new NullAcpClientLogger(), () => { }, () => failed++);
+        var firstResponse = ErrorResponse();
+        var secondResponse = ErrorResponse();
+
+        // Act
+        var first = batch.SubmitAsync(0, firstResponse);
+        var second = batch.SubmitAsync(1, secondResponse);
+        Assert.False(await first.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.False(await second.WaitAsync(TestContext.Current.CancellationToken));
+        failWrite = false;
+        Assert.True(await batch.SubmitAsync(1, secondResponse).WaitAsync(TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(1, failed);
+        Assert.Equal(1, committed);
+        Assert.Equal(2, writes.Count);
+        Assert.Same(firstResponse, writes[1][0]);
+        Assert.Same(secondResponse, writes[1][1]);
+        Assert.False(await batch.SubmitAsync(0, firstResponse));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Reference, Task<bool> Completion) SubmitWithWeakResponse(InboundResponseBatch batch)
+    {
+        // Keep the allocation out of the test frame: the test deliberately holds the live batch,
+        // but no JIT-extended local may keep its discarded response alive through collection.
+        var response = ErrorResponse();
+        return (new WeakReference(response), batch.SubmitAsync(0, response));
+    }
+
+    private static JsonRpcResponse ErrorResponse()
+        => new(null, JsonRpcError.CreateInvalidRequest());
+
+    private sealed class BatchOwner
+    {
+        internal BatchOwner(bool throwOnWrite)
+        {
+            Batch = new InboundResponseBatch(1, _ =>
+            {
+                Writes++;
+                return throwOnWrite
+                    ? Task.FromException<bool>(new IOException("The write failed."))
+                    : Task.FromResult(false);
+            }, _ => throw new InvalidOperationException("A failed write must not commit."),
+                new NullAcpClientLogger(), () => { }, OnFailure);
+        }
+
+        internal InboundResponseBatch Batch { get; }
+        internal int Writes { get; private set; }
+        internal int Failures { get; private set; }
+
+        private void OnFailure()
+        {
+            Failures++;
+            Batch.Abandon();
+        }
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/JsonRpc/AcpFrameTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/JsonRpc/AcpFrameTests.cs
@@ -16,6 +16,14 @@ public sealed class AcpFrameTests
     [InlineData(@"{""jsonrpc"":""2.0""}")]
     [InlineData(@"  {""jsonrpc"":""2.0""}")]
     [InlineData("﻿{\"jsonrpc\":\"2.0\"}")]
+    [InlineData(@"[{""jsonrpc"":""2.0""}]")]
+    [InlineData("[]")]
+    [InlineData("[1,2,3]")]
+    [InlineData("[false]")]
+    [InlineData("[null]")]
+    [InlineData("[\"invalid item\"]")]
+    [InlineData("[")]
+    [InlineData("[{\"jsonrpc\":")]
     public void LooksLikeFrame_JsonObject_ShouldBeTrue(string message)
     {
         Assert.True(AcpFrame.LooksLikeFrame(message));
@@ -43,7 +51,7 @@ public sealed class AcpFrameTests
     [InlineData("Running database migrations")]
     [InlineData("[1;32mINFO[0m ready")] // ANSI-coloured logging
     [InlineData("Invalid command line argument: -C")]
-    [InlineData(@"[{""jsonrpc"":""2.0""}]")]        // batch: ACP messages are individual
+    [InlineData("[INFO] starting")]
     public void LooksLikeFrame_NonFrame_ShouldBeFalse(string message)
     {
         Assert.False(AcpFrame.IsBlank(message));

--- a/tests/SalmonEgg.Acp.Tests/JsonRpc/JsonRpcBatchProperties.cs
+++ b/tests/SalmonEgg.Acp.Tests/JsonRpc/JsonRpcBatchProperties.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using Xunit;
+
+namespace SalmonEgg.Acp.Tests.JsonRpc;
+
+public sealed class JsonRpcBatchProperties
+{
+    [Fact]
+    public void BatchRoundTrip_PreservesResponseIdsAndResultValues()
+        => FsCheckPropertyRunner.Run(this, nameof(BatchRoundTripProperty));
+
+    private void BatchRoundTripProperty(int numericId, string textId, int[] values)
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var value = JsonDocument.Parse(JsonSerializer.Serialize(values ?? []));
+        JsonRpcResponse[] responses =
+        [
+            new(numericId, value.RootElement.Clone()),
+            new(textId ?? string.Empty, value.RootElement.Clone()),
+            new(null, JsonRpcError.CreateInvalidRequest("invalid item"))
+        ];
+
+        // Act
+        var frame = parser.ParseFrame(parser.SerializeResponses(responses), AcpProtocolVersion.V2);
+
+        // Assert
+        Assert.True(frame.IsBatch);
+        Assert.True(frame.IsResponseBatch);
+        Assert.Equal(responses.Length, frame.Items.Count);
+        for (var index = 0; index < responses.Length; index++)
+        {
+            var actual = Assert.IsType<JsonRpcResponse>(frame.Items[index].Message);
+            Assert.True(AcpRequestId.TryFromEnvelopeId(responses[index].Id, out var expectedId));
+            Assert.True(AcpRequestId.TryFromEnvelopeId(actual.Id, out var actualId));
+            Assert.Equal(expectedId, actualId);
+            Assert.Equal(responses[index].Result?.GetRawText(), actual.Result?.GetRawText());
+            Assert.Equal(responses[index].Error?.Code, actual.Error?.Code);
+        }
+    }
+}

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioTransportStdoutFrameTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StdioTransportStdoutFrameTests.cs
@@ -13,6 +13,9 @@ public sealed class StdioTransportStdoutFrameTests
     [Theory]
     [InlineData("{\"jsonrpc\":\"2.0\",\"method\":\"session/update\"}")]
     [InlineData("  {\"jsonrpc\":\"2.0\"}")]
+    [InlineData("[{\"jsonrpc\":\"2.0\"}]")]
+    [InlineData("[]")]
+    [InlineData("[1,2,3]")]
     public void ClassifyStdoutLine_AcpFrame_ShouldDispatch(string line)
     {
         var kind = StdioTransport.ClassifyStdoutLine(line, out var frame);
@@ -59,7 +62,7 @@ public sealed class StdioTransportStdoutFrameTests
     [InlineData("Running database migrations")]         // agent startup logging
     [InlineData("[1;32mINFO[0m ready")]     // ANSI-coloured logging
     [InlineData("Invalid command line argument: -C")]
-    [InlineData("[{\"jsonrpc\":\"2.0\"}]")]             // batch: ACP messages are individual
+    [InlineData("[INFO] ready")]
     public void ClassifyStdoutLine_NonFrame_ShouldBeDiagnostic(string line)
     {
         var kind = StdioTransport.ClassifyStdoutLine(line, out var frame);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
@@ -115,7 +115,24 @@ public partial class ChatViewModelTests
         Assert.False(first.IsResponseSending);
         Assert.Same(second, fixture.ViewModel.PendingPermissionRequest);
         Assert.Empty(peer.Responses);
-        await AwaitPermissionUiSignalAsync(dispatcher, second.RespondCommand.ExecuteAsync(second.Options[0]));
+        var release = NewPermissionSignal();
+        peer.ResponseSend = (_, token) => release.Task.WaitAsync(token);
+        var sending = WaitForPermissionStateAsync(first, () => first.IsResponseSending);
+        var retry = second.RespondCommand.ExecuteAsync(second.Options[0]);
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, sending);
+            await dispatcher.RunUntilIdleAsync();
+            Assert.Same(second, fixture.ViewModel.PendingPermissionRequest);
+            Assert.Same(second, fixture.ViewModel.StandalonePermissionRequest);
+            Assert.True(first.IsResponseSending);
+            Assert.Empty(peer.Responses);
+        }
+        finally
+        {
+            release.TrySetResult(true);
+            await AwaitPermissionUiSignalAsync(dispatcher, retry);
+        }
         await dispatcher.RunUntilIdleAsync();
         var response = Assert.Single(peer.Responses);
         Assert.Equal("cancelled", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
@@ -1,0 +1,483 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Models.Navigation;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PermissionBatch_PhysicalArrayWrite_KeepsLastVisibleRequestUntilDelivery(bool succeeds)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.RequestBatch("remote-1", "remote-1");
+        await dispatcher.RunUntilIdleAsync();
+        var first = fixture.ViewModel.PendingPermissionRequest!;
+        var requests = peer.Requests.ToArray();
+        var firstPrepared = WaitForPermissionStateAsync(requests[0], () => requests[0].IsResponsePrepared);
+        var firstAnswer = first.RespondCommand.ExecuteAsync(first.Options[0]);
+        var release = NewPermissionSignal();
+        Task? secondAnswer = null;
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, firstPrepared);
+            Assert.False(requests[0].IsResponseSending);
+            var secondVisible = WaitForPermissionProjectionAsync(fixture.ViewModel,
+                () => fixture.ViewModel.PendingPermissionRequest?.MessageId.ToString() == "second");
+            await AwaitPermissionUiSignalAsync(dispatcher, secondVisible);
+            var second = fixture.ViewModel.PendingPermissionRequest!;
+            var allSending = WaitForPermissionStateAsync(requests[0],
+                () => requests.All(request => request.IsResponseSending));
+            peer.ResponseSend = (_, token) => release.Task.WaitAsync(token);
+
+            // Act
+            secondAnswer = second.RespondCommand.ExecuteAsync(second.Options[0]);
+            await AwaitPermissionUiSignalAsync(dispatcher, allSending);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert
+            Assert.Same(second, fixture.ViewModel.PendingPermissionRequest);
+            Assert.All(requests, request => Assert.True(request.IsResponseSending));
+            Assert.False(second.RespondCommand.CanExecute(second.Options[0]));
+            Assert.Empty(peer.Responses);
+            release.TrySetResult(succeeds);
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+            await dispatcher.RunUntilIdleAsync();
+            if (succeeds)
+            {
+                Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+                Assert.Single(peer.Responses);
+            }
+            else
+            {
+                Assert.Same(first, fixture.ViewModel.PendingPermissionRequest);
+                Assert.All(requests, request => Assert.False(request.IsResponseSending));
+                Assert.True(first.RespondCommand.CanExecute(first.Options[0]));
+                Assert.True(second.RespondCommand.CanExecute(second.Options[0]));
+            }
+        }
+        finally
+        {
+            release.TrySetResult(false);
+            await peer.DisconnectClientAsync();
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            if (secondAnswer is not null) await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+        }
+    }
+
+    [Fact]
+    public async Task PermissionBatch_UnboundCancellationAndFailedSibling_RetainsWholeArrayForRetry()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.RequestBatch("unknown-session", "remote-1");
+        var secondVisible = WaitForPermissionProjectionAsync(fixture.ViewModel,
+            () => fixture.ViewModel.PendingPermissionRequest?.MessageId.ToString() == "second");
+        await AwaitPermissionUiSignalAsync(dispatcher, secondVisible);
+        var first = peer.Requests.First();
+        var second = fixture.ViewModel.PendingPermissionRequest!;
+        Assert.True(first.IsCancellationRequested);
+        Assert.True(first.IsResponsePrepared);
+        Assert.False(first.IsResponseSending);
+        peer.FailNextResponse = true;
+
+        // Act
+        await AwaitPermissionUiSignalAsync(dispatcher, second.RespondCommand.ExecuteAsync(second.Options[0]));
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert: the original unbound cancellation remains one slot, never an authorization.
+        Assert.True(first.CanRespond);
+        Assert.False(first.IsResponseSending);
+        Assert.Same(second, fixture.ViewModel.PendingPermissionRequest);
+        Assert.Empty(peer.Responses);
+        await AwaitPermissionUiSignalAsync(dispatcher, second.RespondCommand.ExecuteAsync(second.Options[0]));
+        await dispatcher.RunUntilIdleAsync();
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal("cancelled", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.Equal("selected", response[1].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+        Assert.All(peer.Requests, request => Assert.False(request.CanRespond));
+    }
+
+    [Fact]
+    public async Task PermissionBatch_NoChatSurfaceAndFailedCancellation_ClosesOnlyOriginalConnection()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var shell = new ShellNavigationRuntimeStateStore { CurrentShellContent = ShellNavigationContent.Settings };
+        var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
+            NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
+            Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
+        await using var fixture = CreateViewModel(dispatcher, acpConnectionCommands: commands,
+            shellNavigationRuntimeState: shell,
+            acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
+                NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
+                Mock.Of<IAcpRemoteSessionRecoveryContextResolver>()));
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.FailNextResponse = true;
+
+        // Act
+        peer.RequestBatch("unknown-first", "unknown-second");
+        await AwaitPermissionUiSignalAsync(dispatcher, peer.ServiceDisposed.Task);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        Assert.False(peer.IsConnected);
+        Assert.True(stablePeer.IsConnected);
+        Assert.All(peer.Requests, request => Assert.False(request.CanRespond));
+        Assert.Null(fixture.ViewModel.CurrentChatService);
+        Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+        Assert.Empty(peer.Responses);
+        Assert.Equal(ConnectionPhase.Disconnected, (await fixture.ConnectionStore.GetCurrentStateAsync()).Phase);
+    }
+
+    [Fact]
+    public async Task PermissionBatch_CancelDuringPhysicalFailure_PreservesCurrentCardUntilCancellationWrites()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.RequestBatch("remote-1", "remote-1");
+        await dispatcher.RunUntilIdleAsync();
+        var first = fixture.ViewModel.PendingPermissionRequest!;
+        var requests = peer.Requests.ToArray();
+        var next = WaitForPermissionProjectionAsync(fixture.ViewModel,
+            () => fixture.ViewModel.PendingPermissionRequest?.MessageId.ToString() == "second");
+        var firstAnswer = first.RespondCommand.ExecuteAsync(first.Options[0]);
+        var write = NewPermissionSignal();
+        var cancelWrite = NewPermissionSignal();
+        var cancelStarted = NewPermissionSignal();
+        Task? secondAnswer = null;
+        var attempts = 0;
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, next);
+            var second = fixture.ViewModel.PendingPermissionRequest!;
+            peer.ResponseSend = (_, token) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1) return write.Task.WaitAsync(token);
+                cancelStarted.TrySetResult(true);
+                return cancelWrite.Task.WaitAsync(token);
+            };
+            var sending = WaitForPermissionStateAsync(requests[1], () => requests[1].IsResponseSending);
+            secondAnswer = second.RespondCommand.ExecuteAsync(second.Options[0]);
+            await AwaitPermissionUiSignalAsync(dispatcher, sending);
+
+            // Act
+            peer.CancelPermission("first");
+            write.TrySetResult(false);
+            await AwaitPermissionUiSignalAsync(dispatcher, cancelStarted.Task);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert
+            Assert.Same(second, fixture.ViewModel.PendingPermissionRequest);
+            Assert.All(requests, request => Assert.True(request.IsResponseSending));
+            Assert.True(requests[0].IsCancellationRequested);
+            Assert.Empty(peer.Responses);
+            cancelWrite.TrySetResult(true);
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+            await dispatcher.RunUntilIdleAsync();
+            var response = Assert.Single(peer.Responses);
+            Assert.Equal(JsonRpcErrorCode.Cancelled, response[0].GetProperty("error").GetProperty("code").GetInt32());
+            Assert.Equal("selected", response[1].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+            Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+            Assert.Equal(2, attempts);
+        }
+        finally
+        {
+            write.TrySetResult(false);
+            cancelWrite.TrySetResult(false);
+            await peer.DisconnectClientAsync();
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            if (secondAnswer is not null) await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+        }
+    }
+
+    [Fact]
+    public async Task PermissionBatch_PreparedAnswersAdvanceAndFailedArrayRestoresOriginalRequests()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.RequestBatch("remote-1", "remote-1");
+        await dispatcher.RunUntilIdleAsync();
+        var first = fixture.ViewModel.PendingPermissionRequest!;
+        Assert.Equal("First permission", first.Title);
+        Assert.Equal("Review first access", first.Description);
+        var secondVisible = WaitForPermissionProjectionAsync(fixture.ViewModel, () =>
+            fixture.ViewModel.PendingPermissionRequest?.MessageId.ToString() == "second");
+        var firstAnswer = first.RespondCommand.ExecuteAsync(first.Options[0]);
+        Task? secondAnswer = null;
+        Task? retry = null;
+        try
+        {
+            // Act: prepared is enough to show the next question, but does not confirm delivery.
+            await AwaitPermissionUiSignalAsync(dispatcher, secondVisible);
+            Assert.False(firstAnswer.IsCompleted);
+            Assert.Empty(peer.Responses);
+            var second = fixture.ViewModel.PendingPermissionRequest!;
+            var restored = WaitForPermissionProjectionAsync(fixture.ViewModel,
+                () => ReferenceEquals(first, fixture.ViewModel.PendingPermissionRequest));
+            peer.FailNextResponse = true;
+            secondAnswer = second.RespondCommand.ExecuteAsync(second.Options[0]);
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+            await AwaitPermissionUiSignalAsync(dispatcher, restored);
+
+            // Assert: both original commands are retryable after the same failed physical write.
+            Assert.True(first.RespondCommand.CanExecute(first.Options[0]));
+            Assert.True(second.RespondCommand.CanExecute(second.Options[0]));
+            Assert.Empty(peer.Responses);
+            retry = first.RespondCommand.ExecuteAsync(first.Options[0]);
+            await AwaitPermissionUiSignalAsync(dispatcher, retry);
+            await dispatcher.RunUntilIdleAsync();
+            var array = Assert.Single(peer.Responses);
+            Assert.Equal(2, array.GetArrayLength());
+            Assert.Equal("first", array[0].GetProperty("id").GetString());
+            Assert.Equal("second", array[1].GetProperty("id").GetString());
+            Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+            Assert.Null(first.UnsubscribeRequestChanges);
+            Assert.Null(second.UnsubscribeRequestChanges);
+        }
+        finally
+        {
+            await peer.DisconnectClientAsync();
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            if (secondAnswer is not null) await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+            if (retry is not null) await AwaitPermissionUiSignalAsync(dispatcher, retry);
+        }
+    }
+
+    [Fact]
+    public async Task PermissionBatch_BindingChangesWhileFirstAnswerPrepared_CancelsWithoutBlockingOtherConversation()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await DraftPermissionUiPeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.RequestBatch("remote-1", "remote-2");
+        await dispatcher.RunUntilIdleAsync();
+        var first = fixture.ViewModel.PendingPermissionRequest!;
+        var prepared = WaitForPermissionProjectionAsync(fixture.ViewModel,
+            () => fixture.ViewModel.PendingPermissionRequest is null);
+        var firstAnswer = first.RespondCommand.ExecuteAsync(first.Options[0]);
+        Task? secondAnswer = null;
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, prepared);
+
+            // Act: the first slot is withdrawn while the second conversation still owns its input.
+            await fixture.UpdateStateAsync(state => state with
+            {
+                Bindings = state.Bindings!.SetItem("conv-1", new ConversationBindingSlice("conv-1", "replacement", "profile"))
+            });
+            await dispatcher.RunUntilIdleAsync();
+            Assert.True(peer.Requests.First().IsCancellationRequested);
+            Assert.False(firstAnswer.IsCompleted);
+            Assert.Empty(peer.Responses);
+            await SelectPermissionConversationAsync(fixture, "conv-2");
+            var second = fixture.ViewModel.PendingPermissionRequest!;
+            secondAnswer = second.RespondCommand.ExecuteAsync(second.Options[0]);
+            await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+
+            // Assert
+            var response = Assert.Single(peer.Responses);
+            Assert.Equal("cancelled", response[0].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+            Assert.Equal("selected", response[1].GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+            await SelectPermissionConversationAsync(fixture, "conv-1");
+            Assert.Null(fixture.ViewModel.PendingPermissionRequest);
+        }
+        finally
+        {
+            await peer.DisconnectClientAsync();
+            await AwaitPermissionUiSignalAsync(dispatcher, firstAnswer);
+            if (secondAnswer is not null) await AwaitPermissionUiSignalAsync(dispatcher, secondAnswer);
+        }
+    }
+
+    private static async Task WaitForPermissionProjectionAsync(ChatViewModel viewModel, Func<bool> predicate)
+    {
+        var changed = NewPermissionSignal();
+        PropertyChangedEventHandler observer = (_, args) =>
+        {
+            if (args.PropertyName == nameof(ChatViewModel.PendingPermissionRequest) && predicate()) changed.TrySetResult(true);
+        };
+        viewModel.PropertyChanged += observer;
+        try
+        {
+            if (predicate()) changed.TrySetResult(true);
+            await changed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            viewModel.PropertyChanged -= observer;
+        }
+    }
+
+    private static async Task WaitForPermissionStateAsync(PermissionRequestEventArgs request, Func<bool> predicate)
+    {
+        var changed = NewPermissionSignal();
+        EventHandler observer = (_, _) => { if (predicate()) changed.TrySetResult(true); };
+        request.Changed += observer;
+        try
+        {
+            if (predicate()) changed.TrySetResult(true);
+            await changed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            request.Changed -= observer;
+        }
+    }
+
+    private sealed class DraftPermissionUiPeer : IAcpTransport
+    {
+        private readonly AcpClient _client;
+        private bool _disposed;
+
+        private DraftPermissionUiPeer()
+        {
+            _client = new AcpClient(this, Mock.Of<IAcpClientLogger>());
+            _client.PermissionRequestReceived += (_, request) => Requests.Enqueue(request);
+            Service = new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>());
+        }
+
+        internal ChatService Service { get; }
+        internal ConcurrentQueue<PermissionRequestEventArgs> Requests { get; } = new();
+        internal ConcurrentQueue<JsonElement> Responses { get; } = new();
+        internal bool FailNextResponse { get; set; }
+        internal Func<JsonElement, CancellationToken, Task<bool>>? ResponseSend { get; set; }
+        internal TaskCompletionSource<bool> ServiceDisposed { get; } = NewPermissionSignal();
+        public bool IsConnected { get; private set; }
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        internal static async Task<DraftPermissionUiPeer> CreateAsync()
+        {
+            var peer = new DraftPermissionUiPeer();
+            try
+            {
+                await peer._client.InitializeDraftAsync(new InitializeParams(new ClientInfo("Draft permission UI test", "1"),
+                    new ClientCapabilities())
+                { ProtocolVersion = AcpProtocolVersion.V2 }, TestContext.Current.CancellationToken)
+                    .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+                return peer;
+            }
+            catch
+            {
+                peer.Dispose();
+                throw;
+            }
+        }
+
+        internal void RequestBatch(string firstSession, string secondSession)
+            => Receive("[" + Request("first", firstSession, "First permission", "Review first access") + ","
+                + Request("second", secondSession, "Second permission", "Review second access") + "]");
+
+        internal Task<bool> DisconnectClientAsync() => _client.DisconnectAsync();
+
+        internal void CancelPermission(string id)
+            => Receive("{\"jsonrpc\":\"2.0\",\"method\":\"$/cancel_request\",\"params\":{\"requestId\":\"" + id + "\"}}");
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var document = JsonDocument.Parse(message);
+            var root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("method", out var method))
+            {
+                if (method.GetString() == "initialize")
+                {
+                    var result = JsonSerializer.Serialize(new InitializeResponse(AcpProtocolVersion.V2,
+                        new AgentInfo("Peer", "1"), new AgentCapabilities()),
+                        AcpWireFormat.For(AcpProtocolVersion.V2).TypeInfo<InitializeResponse>());
+                    Receive("{\"jsonrpc\":\"2.0\",\"id\":" + root.GetProperty("id").GetRawText()
+                        + ",\"result\":" + result + "}");
+                }
+                return Task.FromResult(true);
+            }
+            if (FailNextResponse)
+            {
+                FailNextResponse = false;
+                return Task.FromResult(false);
+            }
+            if (ResponseSend is { } send) return CompleteResponseAsync(root.Clone(), send, cancellationToken);
+            Responses.Enqueue(root.Clone());
+            return Task.FromResult(true);
+        }
+
+        private async Task<bool> CompleteResponseAsync(JsonElement response,
+            Func<JsonElement, CancellationToken, Task<bool>> send, CancellationToken cancellationToken)
+        {
+            if (!await send(response, cancellationToken).ConfigureAwait(false)) return false;
+            Responses.Enqueue(response);
+            return true;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            Service.Dispose();
+            IsConnected = false;
+            ServiceDisposed.TrySetResult(true);
+        }
+
+        private static string Request(string id, string session, string title, string description)
+            => "{\"jsonrpc\":\"2.0\",\"id\":\"" + id + "\",\"method\":\"session/request_permission\",\"params\":{\"sessionId\":\""
+                + session + "\",\"title\":\"" + title + "\",\"description\":\"" + description
+                + "\",\"options\":[{\"optionId\":\"allow\",\"name\":\"Allow once\",\"kind\":\"allow_once\"}]}}";
+
+        private void Receive(string message) => MessageReceived?.Invoke(this, new(message));
+    }
+}


### PR DESCRIPTION
实现协商版本门控的JSON-RPC批量帧解析/分发：V1拒绝数组，隔离V2内部入口按调用/通知/响应分别处理；需要回应的条目组成完整数组，物理发送成功后提交pending。失败保留有主请求可重试的整批，自动拒绝/纯错误且无人可重试的批次终止并释放负载。

本次复审修复：原batch owner显式区分prepared与physical sending，纯prepared让出下一请求，真正发送保留当前卡；混合unknown取消项与有效请求在失败后重试也不能抢当前卡。无Chat时由原connection owner终止失败交互，旧service清理不伤新service。ParseError/InvalidRequest无ID回复保留接收token，含pre-handshake不回落新连接。

净增量已重放actualmaina0e6334f，当前head74e80503；保留新B requestNotSentObserver/Activity安全域、C beforeSend、C2额外ID与nativefocus门禁。只重放batch独有路径，旧分支/中间树已备份。公开V2仍关闭。

验证：SDK1176/1176、Presentation权限64/64、真实Linux stdio2/2零跳过；全format/analyzer构建零警告错误，实际1.0.0包基线与nupkg consumer46/旧transport/offlineprojection/permission通过。原泄漏回调反向9例红、去负载清理2例红、物理状态和当前卡各2例红；最新混合二次发送探针1/1红→64/64绿。新SHA完整CI正在运行，合并前核验。

Refs #149。完整生产配置/产品接线/第三方Agent仍后续验收，不因内部batch门禁通过而开启V2或关总单。

最终18项实际CI通过、1项条件跳过，已rebase合入main `027514f2aefd1b6147e499b4ad47cde58392a4fc`。
