### PR TITLE
fix(acp): preserve setup prerequisites and runtime path editing

### DIFF
--- a/.github/workflows/gui-smoke-gates.yml
+++ b/.github/workflows/gui-smoke-gates.yml
@@ -71,6 +71,20 @@ jobs:
       - name: Run Skia Desktop GUI smoke
         run: ./scripts/gates/run-skia-desktop-gui-smoke-gates.sh Debug
 
+      - name: Verify ACP setup path editing with native keyboard input
+        timeout-minutes: 3
+        run: |
+          python3 scripts/gates/skia-acp-setup-path-smoke.py \
+            --no-build --artifacts "${RUNNER_TEMP}/acp-setup-path-smoke"
+
+      - name: Upload ACP setup path evidence
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: acp-setup-path-smoke
+          path: ${{ runner.temp }}/acp-setup-path-smoke
+          if-no-files-found: ignore
+
       # This checks the native launcher only. Native URL capability stays disabled until the
       # product's GUI consent-to-browser path has its own platform gate as well.
       - name: Run Linux external browser isolation probe

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -275,6 +275,14 @@ scripts/gates/run-skia-desktop-gui-smoke-gates.sh Debug
 
 Linux Skia Desktop 当前使用 Uno X11 host。该 host-window smoke 不声明 AT-SPI 或完整控件语义树覆盖；本机 `dbus-run-session` + Xvfb + `org.a11y.Bus` 探测显示 SalmonEgg 进程未注册到 AT-SPI bus，强制 `GTK_MODULES=atk-bridge` 也不会产生语义 provider。NumberBox 的 DEBUG probe 不是通用语义自动化替代品：它只为已知模板回归走 authoritative 页面导航，使用生产控件已有的 `AutomationId` 定位真实 NumberBox，并读取已实现视觉树的原生状态。若后续 Uno/Skia host 暴露稳定 AT-SPI provider，应新增独立 Linux semantic GUI gate；在此之前禁止用 X11 window 属性、截图内容、隐藏测试 UI 或返回预设结果的 test hook 冒充语义自动化。
 
+ACP 向导路径编辑门禁同样使用本次 Debug Skia 产物、独立 Xvfb 和临时 AppData：
+
+```bash
+python3 scripts/gates/skia-acp-setup-path-smoke.py --artifacts /tmp/acp-setup-path-smoke
+```
+
+目录须为空或尚未存在。脚本默认构建当前工作树；仅在同一工作树刚完成 Debug Desktop 构建后使用 `--no-build`，CI 会复用上一 Skia 步骤的产物。门禁经正式设置入口和原生按钮进入向导，要求真实探测确认 Qwen 未安装（本机已安装时可用 `--agent goose` 选择另一确实缺失的目录项），再用 XTest 逐字符输入、清空及重新输入，逐次断言控件仍可见、焦点仍属于该输入框且绑定值一致。它记录产物路径、DLL 哈希、提交与工作树状态、PID 和每次采样；结束时回收自身进程组。此验证限 Linux Skia，不代替 Windows WinUI/MSIX 或 WASM 验收。修改编辑区可见性后，须临时恢复缺失状态控制的旧可见性并确认首字采样失败，再恢复修复重跑。
+
 该 gate 与 Windows FlaUI / WASM Playwright gate 分工不同：
 
 - Windows WinUI 3 / MSIX GUI 行为：`scripts/gates/run-gui-smoke-gates.ps1`，使用 FlaUI/UIA3；

--- a/SalmonEgg/SalmonEgg/MainPage.xaml.cs
+++ b/SalmonEgg/SalmonEgg/MainPage.xaml.cs
@@ -778,6 +778,9 @@ public sealed partial class MainPage : Page, INavigationIntentConsumer, IGamepad
         // Diagnostics-only NumberBox theme probe. Navigation, focus cycling, and realized-template
         // sampling remain owned by the independent probe; the page only exposes the live shell root.
         NumberBoxThemeProbeDriver.TryStart(App.ServiceProvider, this);
+
+        // The opt-in setup probe owns navigation and sampling; the shell only supplies its live root.
+        AcpSetupRuntimePathProbeDriver.TryStart(App.ServiceProvider, this);
     }
 
     private void OnMainPageGettingFocus(object? sender, GettingFocusEventArgs e)

--- a/SalmonEgg/SalmonEgg/Presentation/Diagnostics/AcpSetupRuntimePathProbeDriver.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Diagnostics/AcpSetupRuntimePathProbeDriver.cs
@@ -1,0 +1,233 @@
+using System;
+using Microsoft.UI.Xaml;
+
+#if DEBUG && __UNO_SKIA__
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using SalmonEgg.Presentation.Models.Settings;
+using SalmonEgg.Presentation.ViewModels.Navigation;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+using SalmonEgg.Presentation.Views.Settings;
+using Windows.Foundation;
+#endif
+
+namespace SalmonEgg.Presentation.Diagnostics;
+
+/// <summary>
+/// Exercises the real setup editor without assigning its text or restoring focus after a keystroke.
+/// The external X11 gate supplies keyboard input; this opt-in driver only records native input facts.
+/// </summary>
+internal static class AcpSetupRuntimePathProbeDriver
+{
+    public static void TryStart(IServiceProvider services, DependencyObject shellRoot)
+    {
+#if DEBUG && __UNO_SKIA__
+        if (Environment.GetEnvironmentVariable("SALMONEGG_ACP_SETUP_PATH_PROBE") != "1"
+            || Interlocked.Exchange(ref _started, 1) != 0)
+        {
+            return;
+        }
+
+        var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("AcpSetupRuntimePathProbe");
+        _ = RunAsync(services.GetRequiredService<MainNavigationViewModel>(), shellRoot, logger);
+#endif
+    }
+
+#if DEBUG && __UNO_SKIA__
+    private static int _started;
+    private const string FinalInput = "/tmp/acp-path-probe-next";
+
+    // Keep navigation, event attachment and sampling in one scope so the same finally always
+    // detaches the native input handler, including a failed assertion or a navigation timeout.
+    private static async Task RunAsync(
+        MainNavigationViewModel navigation,
+        DependencyObject shellRoot,
+        ILogger logger)
+    {
+        TextBox? input = null;
+        TextChangedEventHandler? handler = null;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        var token = timeout.Token;
+        try
+        {
+            if (!await navigation.ActivateSettingsAsync(SettingsSectionCatalog.AgentAcpKey).ConfigureAwait(true))
+            {
+                throw new InvalidOperationException("ACP settings navigation failed.");
+            }
+
+            var setup = await WaitForAsync(
+                () => Find<Button>(shellRoot, element =>
+                    AutomationProperties.GetAutomationId(element) == "Acp.Profiles.SetupWizard"), token).ConfigureAwait(true);
+            Invoke(setup);
+            var page = await WaitForAsync(
+                () => Find<AcpSetupWizardPage>(shellRoot, element => element.IsLoaded), token).ConfigureAwait(true);
+            var wizard = page.ViewModel;
+            var agentId = Environment.GetEnvironmentVariable("SALMONEGG_ACP_SETUP_PATH_AGENT") ?? "qwen-code";
+            var row = wizard.Agents.Single(candidate => candidate.AgentId == agentId);
+            wizard.SelectedAgent = row;
+            await wizard.GoNextCommand.ExecuteAsync(null).WaitAsync(token).ConfigureAwait(true);
+            if (!row.IsMissing || !wizard.IsOnAgentSelection || wizard.IsBusy)
+            {
+                throw new InvalidOperationException("The real runtime probe did not establish a missing agent.");
+            }
+
+            logger.LogInformation(
+                "AcpSetupPathProbe missing pid={ProcessId} agent={AgentId} command={Command} availability={Availability}",
+                Environment.ProcessId, row.AgentId, row.ProbeCommand, row.Availability);
+            var list = (ListView)page.FindName("AcpSetupAgentsList");
+            list.ScrollIntoView(row);
+            var container = await WaitForAsync(
+                () => list.ContainerFromItem(row) as ListViewItem, token).ConfigureAwait(true);
+            var expander = await WaitForAsync(
+                () => Find<Expander>(container, element => element.Name == "AgentProbeDiagnosticsExpander"), token).ConfigureAwait(true);
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(expander);
+            if (peer?.GetPattern(PatternInterface.ExpandCollapse) is not IExpandCollapseProvider expansion)
+            {
+                throw new InvalidOperationException("The native path disclosure has no expand provider.");
+            }
+
+            expansion.Expand();
+            input = await WaitForAsync(
+                () => Find<TextBox>(container, element =>
+                    AutomationProperties.GetAutomationId(element) == "AcpSetup.Agents.CustomCommand"), token).ConfigureAwait(true);
+            var verify = await WaitForAsync(
+                () => Find<Button>(container, element =>
+                    AutomationProperties.GetAutomationId(element) == "AcpSetup.Agents.VerifyCustomCommand"), token).ConfigureAwait(true);
+            input.StartBringIntoView();
+            await WaitForAsync(() => IsVisible(input) ? input : null, token).ConfigureAwait(true);
+            if (!input.Focus(FocusState.Keyboard))
+            {
+                throw new InvalidOperationException("The path input did not accept initial keyboard focus.");
+            }
+
+            var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var samples = 0;
+            var targetInput = input;
+            handler = (_, _) =>
+            {
+                // Binding and layout must finish before observing the edit's effects. This callback never
+                // restores the input, selection, or focus, so hiding the editor remains a failing sample.
+                _ = page.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+                {
+                    if (finished.Task.IsCompleted)
+                    {
+                        return;
+                    }
+
+                    page.UpdateLayout();
+                    var visible = IsVisible(targetInput);
+                    var focusOwner = targetInput.XamlRoot is null
+                        ? null
+                        : FocusManager.GetFocusedElement(targetInput.XamlRoot);
+                    var ownsFocus = ReferenceEquals(focusOwner, targetInput);
+                    var bindingMatches = targetInput.Text == row.CustomCommand;
+                    samples++;
+                    logger.LogInformation(
+                        "AcpSetupPathProbe sample={Sample} visible={Visible} focused={Focused} binding={Binding} verifyVisible={VerifyVisible} owner={Owner} text64={Text64}",
+                        samples, visible, ownsFocus, bindingMatches, IsVisible(verify),
+                        row.AgentId, Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(targetInput.Text)));
+                    if (!visible || !ownsFocus || !bindingMatches || !IsVisible(verify))
+                    {
+                        finished.TrySetException(new InvalidOperationException("The native path editor disappeared or lost its input owner."));
+                    }
+                    else if (targetInput.Text == FinalInput)
+                    {
+                        finished.TrySetResult();
+                    }
+                });
+            };
+            input.TextChanged += handler;
+            var bounds = input.TransformToVisual(null).TransformBounds(new Rect(0, 0, input.ActualWidth, input.ActualHeight));
+            logger.LogInformation(
+                "AcpSetupPathProbe ready pid={ProcessId} agent={AgentId} x={X} y={Y} width={Width} height={Height} scale={Scale}",
+                Environment.ProcessId, row.AgentId, bounds.X, bounds.Y, bounds.Width, bounds.Height, input.XamlRoot!.RasterizationScale);
+            await finished.Task.WaitAsync(token).ConfigureAwait(true);
+            logger.LogInformation("AcpSetupPathProbe complete passed={Passed} samples={Samples}", true, samples);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "AcpSetupPathProbe complete passed={Passed}", false);
+        }
+        finally
+        {
+            if (input is not null && handler is not null)
+            {
+                input.TextChanged -= handler;
+            }
+        }
+    }
+
+    private static void Invoke(Button button)
+    {
+        var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+        if (!button.IsEnabled || peer?.GetPattern(PatternInterface.Invoke) is not IInvokeProvider invocation)
+        {
+            throw new InvalidOperationException("The native setup button cannot be invoked.");
+        }
+
+        invocation.Invoke();
+    }
+
+    private static bool IsVisible(FrameworkElement element)
+    {
+        if (element.XamlRoot is null || element.ActualWidth <= 0 || element.ActualHeight <= 0)
+        {
+            return false;
+        }
+
+        for (DependencyObject? current = element; current is not null; current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is UIElement { Visibility: not Visibility.Visible } or UIElement { Opacity: <= 0 })
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static async Task<T> WaitForAsync<T>(Func<T?> find, CancellationToken cancellationToken)
+        where T : class
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (find() is { } value)
+            {
+                return value;
+            }
+
+            await Task.Delay(50, cancellationToken).ConfigureAwait(true);
+        }
+    }
+
+    private static T? Find<T>(DependencyObject root, Func<T, bool> matches)
+        where T : class, DependencyObject
+    {
+        if (root is T candidate && matches(candidate))
+        {
+            return candidate;
+        }
+
+        for (var index = 0; index < VisualTreeHelper.GetChildrenCount(root); index++)
+        {
+            if (Find(VisualTreeHelper.GetChild(root, index), matches) is { } found)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+#endif
+}

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Settings/AcpSetupWizardPage.xaml
@@ -193,39 +193,43 @@
                                                            Style="{StaticResource CaptionTextBlockStyle}"
                                                            TextWrapping="Wrap"
                                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-
-                                                <Expander x:Name="AgentProbeDiagnosticsExpander"
-                                                          IsExpanded="False"
-                                                          HorizontalAlignment="Stretch"
-                                                          HorizontalContentAlignment="Stretch">
-                                                    <Expander.Header>
-                                                        <TextBlock x:Uid="AcpSetup_WhyNotFound"/>
-                                                    </Expander.Header>
-                                                    <StackPanel Spacing="8">
-                                                        <TextBlock x:Uid="AcpSetup_PathHint"
-                                                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                                                   TextWrapping="Wrap"
-                                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                                        <TextBlock Text="{x:Bind ProbeDetail, Mode=OneWay}"
-                                                                   Visibility="{x:Bind HasProbeDetail, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                                                   FontFamily="Consolas"
-                                                                   TextWrapping="Wrap"
-                                                                   IsTextSelectionEnabled="True"
-                                                                   Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
-                                                        <TextBox x:Uid="AcpSetup_CustomCommand"
-                                                                 Text="{x:Bind CustomCommand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                                 AutomationProperties.AutomationId="AcpSetup.Agents.CustomCommand"/>
-                                                        <Button x:Name="VerifyCustomCommandButton"
-                                                                x:Uid="AcpSetup_VerifyCustomCommand"
-                                                                Tag="{x:Bind}"
-                                                                Click="OnVerifyAgentRowClick"
-                                                                IsEnabled="{x:Bind HasCustomCommand, Mode=OneWay}"
-                                                                AutomationProperties.AutomationId="AcpSetup.Agents.VerifyCustomCommand"
-                                                                HorizontalAlignment="Left"/>
-                                                    </StackPanel>
-                                                </Expander>
                                             </StackPanel>
+
+                                            <!-- Editing invalidates the probe, so the path input must not
+                                                 share the missing-only install surface's visibility. -->
+                                            <Expander x:Name="AgentProbeDiagnosticsExpander"
+                                                      IsExpanded="False"
+                                                      Visibility="{x:Bind IsRuntimePathEditorVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                      AutomationProperties.AutomationId="AcpSetup.Agents.PathDetails"
+                                                      HorizontalAlignment="Stretch"
+                                                      HorizontalContentAlignment="Stretch">
+                                                <Expander.Header>
+                                                    <TextBlock x:Uid="AcpSetup_RuntimePathDetails"/>
+                                                </Expander.Header>
+                                                <StackPanel Spacing="8">
+                                                    <TextBlock x:Uid="AcpSetup_PathHint"
+                                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                                               TextWrapping="Wrap"
+                                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                                    <TextBlock Text="{x:Bind ProbeDetail, Mode=OneWay}"
+                                                               Visibility="{x:Bind HasProbeDetail, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                                               FontFamily="Consolas"
+                                                               TextWrapping="Wrap"
+                                                               IsTextSelectionEnabled="True"
+                                                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
+                                                    <TextBox x:Uid="AcpSetup_CustomCommand"
+                                                             Text="{x:Bind CustomCommand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                             AutomationProperties.AutomationId="AcpSetup.Agents.CustomCommand"/>
+                                                    <Button x:Name="VerifyCustomCommandButton"
+                                                            x:Uid="AcpSetup_VerifyCustomCommand"
+                                                            Tag="{x:Bind}"
+                                                            Click="OnVerifyAgentRowClick"
+                                                            IsEnabled="{x:Bind HasCustomCommand, Mode=OneWay}"
+                                                            AutomationProperties.AutomationId="AcpSetup.Agents.VerifyCustomCommand"
+                                                            HorizontalAlignment="Left"/>
+                                                </StackPanel>
+                                            </Expander>
                                         </StackPanel>
                                     </DataTemplate>
                                 </ListView.ItemTemplate>

--- a/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en-US/Resources.resw
@@ -957,6 +957,9 @@
   <data name="AcpSetup_WhyNotFound.Text" xml:space="preserve">
     <value>Why was nothing found?</value>
   </data>
+  <data name="AcpSetup_RuntimePathDetails.Text" xml:space="preserve">
+    <value>Program path and detection details</value>
+  </data>
   <data name="AcpSetup_CustomCommand.Header" xml:space="preserve">
     <value>Full path to the command</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/en/Resources.resw
@@ -1482,6 +1482,9 @@
   <data name="AcpSetup_WhyNotFound.Text" xml:space="preserve">
     <value>Why was nothing found?</value>
   </data>
+  <data name="AcpSetup_RuntimePathDetails.Text" xml:space="preserve">
+    <value>Program path and detection details</value>
+  </data>
   <data name="AcpSetup_CustomCommand.Header" xml:space="preserve">
     <value>Full path to the command</value>
   </data>

--- a/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
+++ b/SalmonEgg/SalmonEgg/Strings/zh-Hans/Resources.resw
@@ -882,6 +882,9 @@
   <data name="AcpSetup_WhyNotFound.Text" xml:space="preserve">
     <value>为什么没检测到？</value>
   </data>
+  <data name="AcpSetup_RuntimePathDetails.Text" xml:space="preserve">
+    <value>程序路径与检测详情</value>
+  </data>
   <data name="AcpSetup_CustomCommand.Header" xml:space="preserve">
     <value>自定义命令的完整路径</value>
   </data>

--- a/scripts/gates/skia-acp-setup-path-smoke.py
+++ b/scripts/gates/skia-acp-setup-path-smoke.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Verify the setup path editor with real XTest keys against this tree's Debug Skia build."""
+
+import argparse
+import base64
+import ctypes
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+
+FIRST_INPUT = "/tmp/acp-path-probe"
+FINAL_INPUT = "/tmp/acp-path-probe-next"
+
+
+def stop_process(process):
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+    except ProcessLookupError:
+        process.wait(timeout=5)
+
+
+def build(args, repo, output):
+    if args.no_build:
+        return
+    command = [
+        args.dotnet, "build", str(repo / "SalmonEgg/SalmonEgg/SalmonEgg.csproj"),
+        "-c", "Debug", "-f", "net10.0-desktop", "-v", "minimal", "-m:1",
+        "-p:SalmonEggTargetFrameworks=net10.0-desktop",
+        "-p:SalmonEggAllTargetFrameworks=net10.0-desktop", "-p:UseSharedCompilation=false",
+    ]
+    env = dict(os.environ, DOTNET_PROCESSOR_COUNT="2", DOTNET_CLI_USE_MSBUILD_SERVER="0",
+               MSBUILDDISABLENODEREUSE="1")
+    with (output / "build.log").open("w") as log:
+        process = subprocess.Popen(command, cwd=repo, env=env, stdout=log,
+                                   stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            if process.wait(timeout=600) != 0:
+                raise RuntimeError("Debug Desktop build failed; see build.log")
+        finally:
+            stop_process(process)
+
+
+def read_events(stdout, app):
+    text = stdout.read_text(errors="replace") if stdout.exists() else ""
+    if "AcpSetupPathProbe complete passed=False" in text:
+        raise RuntimeError("Native path editor assertion failed; see stdout.log")
+    if app.poll() is not None:
+        raise RuntimeError(f"App exited during the probe: {app.returncode}")
+    return text
+
+
+def await_event(stdout, app, predicate, deadline, description):
+    while time.monotonic() < deadline:
+        text = read_events(stdout, app)
+        result = predicate(text)
+        if result:
+            return result
+        time.sleep(0.025)
+    raise RuntimeError(f"Timed out waiting for {description}")
+
+
+def run(args):
+    repo = Path(args.repo).resolve()
+    output = Path(args.artifacts).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    appdata = output / "appdata"
+    appdata.mkdir(exist_ok=False)
+    build(args, repo, output)
+    app_path = repo / "SalmonEgg/SalmonEgg/bin/Debug/net10.0-desktop/SalmonEgg"
+    assembly = app_path.with_suffix(".dll")
+    if not app_path.is_file() or not assembly.is_file():
+        raise RuntimeError("This tree has no Debug Desktop executable and assembly")
+    provenance = {
+        "repo": str(repo), "head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip(),
+        "working_tree": subprocess.check_output(["git", "status", "--short"], cwd=repo, text=True),
+        "app": str(app_path), "assembly_sha256": hashlib.sha256(assembly.read_bytes()).hexdigest(),
+        "built_by_gate": not args.no_build, "agent": args.agent,
+    }
+    (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+    helper = repo / "scripts/gates/skia-desktop-x11-window-probe.py"
+    spec = importlib.util.spec_from_file_location("x11_probe", helper)
+    x11_probe = importlib.util.module_from_spec(spec)
+    sys.dont_write_bytecode = True
+    spec.loader.exec_module(x11_probe)
+    x11 = x11_probe.configure_x11()
+    xtst = x11_probe.configure_xtst()
+    xvfb = app = display = None
+    read_fd, write_fd = os.pipe()
+    try:
+        with (output / "xvfb.log").open("w") as xvfb_log:
+            xvfb = subprocess.Popen(
+                ["Xvfb", "-displayfd", str(write_fd), "-screen", "0", "1920x1080x24", "-nolisten", "tcp"],
+                pass_fds=(write_fd,), stdout=xvfb_log, stderr=subprocess.STDOUT, start_new_session=True)
+        os.close(write_fd)
+        write_fd = None
+        if not select.select([read_fd], [], [], 10)[0]:
+            raise RuntimeError("Xvfb did not allocate a display")
+        display_name = ":" + os.read(read_fd, 32).decode().strip()
+        os.close(read_fd)
+        read_fd = None
+        display = x11.XOpenDisplay(display_name.encode())
+        if not display:
+            raise RuntimeError("Cannot connect to the isolated Xvfb display")
+        env = dict(os.environ, DISPLAY=display_name, SALMONEGG_GUI="1", SALMONEGG_APPDATA_ROOT=str(appdata),
+                   SALMONEGG_ACP_SETUP_PATH_PROBE="1", SALMONEGG_ACP_SETUP_PATH_AGENT=args.agent,
+                   DOTNET_PROCESSOR_COUNT="2")
+        stdout_path = output / "stdout.log"
+        with stdout_path.open("w") as stdout:
+            app = subprocess.Popen([str(app_path)], cwd=app_path.parent, env=env, stdout=stdout,
+                                   stderr=subprocess.STDOUT, start_new_session=True)
+        provenance.update(pid=app.pid, display=display_name)
+        (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+        deadline = time.monotonic() + 100
+        ready = await_event(stdout_path, app,
+                            lambda text: re.search(r"AcpSetupPathProbe ready pid=(\d+)[^\n]*", text),
+                            deadline, "the real missing-runtime editor")
+        if int(ready[1]) != app.pid:
+            raise RuntimeError("Ready marker belongs to a different process")
+        windows = x11_probe.get_viewable_windows(x11, display, x11.XDefaultRootWindow(display), app.pid, 200, 200)
+        own_windows = [candidate for candidate in windows if candidate[4] == app.pid]
+        if not own_windows:
+            # Uno's X11 host may omit _NET_WM_PID. This fresh display has only the app we launched;
+            # accept its sole named window, never a different explicit PID or an ambiguous display.
+            named = [value for value in windows if "SalmonEgg" in value[3] or "Salmon Egg" in value[3]]
+            if len(named) == 1 and named[0][4] is None and all(value[4] in (None, app.pid) for value in windows):
+                own_windows = named
+            else:
+                details = [{"window": value[1], "title": value[3], "pid": value[4]} for value in windows]
+                raise RuntimeError(f"No unique application window on the isolated display: {details}")
+        window = own_windows[0][1]
+        provenance.update(window=window, window_pid=own_windows[0][4],
+                          window_identity="pid-property" if own_windows[0][4] == app.pid else "isolated-display")
+        (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+        x11.XSetInputFocus(display, window, x11_probe.REVERT_TO_PARENT, x11_probe.CURRENT_TIME)
+        x11.XSync(display, 0)
+
+        def key(keysym, pressed):
+            code = x11.XKeysymToKeycode(display, keysym)
+            if not code or not xtst.XTestFakeKeyEvent(display, code, int(pressed), 0):
+                raise RuntimeError(f"XTest rejected keysym {keysym}")
+
+        def press(keysym):
+            key(keysym, True)
+            key(keysym, False)
+            x11.XSync(display, 0)
+
+        sample_count = 0
+
+        def expect_text(expected):
+            nonlocal sample_count
+            encoded = base64.b64encode(expected.encode()).decode()
+
+            def match(text):
+                for found in re.finditer(r"AcpSetupPathProbe sample=(\d+)([^\n]*)", text):
+                    details = found[2]
+                    if int(found[1]) <= sample_count or not re.search(r"\btext64=" + re.escape(encoded) + r"(?:\s|$)", details):
+                        continue
+                    if any(f"{field}=True" not in details for field in ["visible", "focused", "binding", "verifyVisible"]):
+                        raise RuntimeError(f"Invalid native input sample: {found[0]}")
+                    return int(found[1])
+                return None
+
+            sample_count = await_event(stdout_path, app, match, min(deadline, time.monotonic() + 5),
+                                       f"native text {expected!r}")
+
+        def type_text(value):
+            for length, character in enumerate(value, start=1):
+                press(ord(character))
+                expect_text(value[:length])
+
+        type_text(FIRST_INPUT)
+        key(0xFFE3, True)  # Control_L
+        press(ord("a"))
+        key(0xFFE3, False)
+        press(0xFF08)  # BackSpace
+        expect_text("")
+        type_text(FINAL_INPUT)
+        complete = await_event(stdout_path, app,
+                               lambda text: re.search(r"AcpSetupPathProbe complete passed=True samples=(\d+)", text),
+                               deadline, "native completion")
+        expected_samples = len(FIRST_INPUT) + 1 + len(FINAL_INPUT)
+        if int(complete[1]) < expected_samples or sample_count < expected_samples:
+            raise RuntimeError("Too few unique native input samples")
+        result = {"passed": True, "samples": sample_count, "expected_samples": expected_samples,
+                  "ready": ready[0], "pid": app.pid}
+        (output / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+        print(json.dumps(result))
+    finally:
+        if display:
+            x11.XCloseDisplay(display)
+        stop_process(app)
+        stop_process(xvfb)
+        for fd in (read_fd, write_fd):
+            if fd is not None:
+                os.close(fd)
+
+
+def main():
+    def interrupt(signum, _frame):
+        raise InterruptedError(f"Interrupted by signal {signum}")
+
+    signal.signal(signal.SIGTERM, interrupt)
+    signal.signal(signal.SIGINT, interrupt)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--artifacts", required=True, help="Fresh directory for this build and run's evidence")
+    parser.add_argument("--dotnet", default=shutil.which("dotnet") or "dotnet")
+    parser.add_argument("--no-build", action="store_true", help="Use a Debug Desktop build just produced in this same tree")
+    parser.add_argument("--agent", default="qwen-code", help="Real catalog agent whose runtime is absent on this machine")
+    args = parser.parse_args()
+    try:
+        run(args)
+    except Exception as exception:
+        print(f"ACP setup path smoke failed: {exception}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpAgentSetupState.cs
@@ -61,5 +61,24 @@ public sealed class AcpSetupDraft
     public AcpCommandOverrides CommandOverrides { get; init; } = AcpCommandOverrides.Empty;
 
     public AcpLaunchPlan BuildLaunchPlan()
-        => AcpLaunchPlanBuilder.Build(Adapter.LaunchTemplate, ParameterValues, CommandOverrides);
+    {
+        var plan = AcpLaunchPlanBuilder.Build(Adapter.LaunchTemplate, ParameterValues, CommandOverrides);
+        var environmentVariable = Adapter.RuntimeCommandEnvironmentVariable;
+        if (string.IsNullOrWhiteSpace(environmentVariable)
+            || !CommandOverrides.TryGetOverride(Agent.Runtime.ProbeCommand, out var runtimeCommand))
+        {
+            return plan;
+        }
+
+        var environment = new Dictionary<string, string>(plan.Environment, StringComparer.Ordinal)
+        {
+            [environmentVariable] = runtimeCommand
+        };
+        return new AcpLaunchPlan
+        {
+            Command = plan.Command,
+            Arguments = plan.Arguments,
+            Environment = environment
+        };
+    }
 }

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupParameterValidator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupParameterValidator.cs
@@ -11,9 +11,8 @@ public readonly record struct AcpSetupParameterViolation(string ParameterKey, st
 
 /// <summary>
 /// Validates wizard parameter values before a launch plan is tested or saved. Deliberately limited to
-/// checks that are certainly wrong regardless of agent: missing required values and values outside a
-/// declared closed set. Anything agent-specific is left to the connectivity test, which reports real
-/// failures instead of guesses.
+/// checks established by the launch contract: required values, closed sets, and unsupported runtime
+/// entry points. Other agent-specific behavior is left to the connectivity test.
 /// </summary>
 public static class AcpSetupParameterValidator
 {
@@ -28,6 +27,23 @@ public static class AcpSetupParameterValidator
     /// Localization key reported when a value falls outside the parameter's declared closed set.
     /// </summary>
     public const string ValueNotAllowedKey = "AcpSetup_Validation_ValueNotAllowed";
+
+    public const string RuntimeBatchLauncherNotSupportedKey = "AcpSetup_Validation_RuntimeBatchLauncherNotSupported";
+
+    public static IReadOnlyList<AcpSetupParameterViolation> Validate(AcpSetupDraft draft)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        var violations = new List<AcpSetupParameterViolation>(Validate(draft.Adapter.LaunchTemplate, draft.ParameterValues));
+        if (!draft.Adapter.SupportsWindowsRuntimeBatchLauncher
+            && !string.IsNullOrWhiteSpace(draft.Adapter.RuntimeCommandEnvironmentVariable)
+            && draft.CommandOverrides.TryGetOverride(draft.Agent.Runtime.ProbeCommand, out var path)
+            && IsWindowsBatchLauncher(path))
+        {
+            violations.Add(new AcpSetupParameterViolation(draft.Agent.Runtime.ProbeCommand, RuntimeBatchLauncherNotSupportedKey));
+        }
+
+        return violations;
+    }
 
     public static IReadOnlyList<AcpSetupParameterViolation> Validate(
         AcpLaunchTemplate template,
@@ -76,5 +92,21 @@ public static class AcpSetupParameterValidator
         }
 
         return false;
+    }
+
+    private static bool IsWindowsBatchLauncher(string path)
+    {
+        // Detect Windows drive, backslash and UNC syntax without consulting the host platform.
+        // POSIX permits .cmd executable names and multiple leading slashes; those remain probeable.
+        var uncShareSeparator = path.StartsWith("//", StringComparison.Ordinal)
+            ? path.IndexOf('/', 2)
+            : -1;
+        var windowsPath = (path.Length > 2 && char.IsAsciiLetter(path[0]) && path[1] == ':'
+                && path[2] is '\\' or '/')
+            || path.Contains('\\')
+            || (uncShareSeparator > 2 && uncShareSeparator + 1 < path.Length
+                && path[uncShareSeparator + 1] != '/');
+        return windowsPath && (path.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".bat", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
+++ b/src/SalmonEgg.Application/Services/AcpSetup/AcpSetupWizardOrchestrator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using SalmonEgg.Application.Common;
 using SalmonEgg.Domain.Models;
 using SalmonEgg.Domain.Models.AcpSetup;
 using SalmonEgg.Domain.Services;
@@ -221,9 +222,7 @@ public sealed class AcpSetupWizardOrchestrator
     {
         ArgumentNullException.ThrowIfNull(draft);
 
-        var violations = AcpSetupParameterValidator.Validate(
-            draft.Adapter.LaunchTemplate,
-            draft.ParameterValues);
+        var violations = AcpSetupParameterValidator.Validate(draft);
         if (violations.Count > 0)
         {
             return AcpSetupTestResult.Failure(
@@ -240,18 +239,25 @@ public sealed class AcpSetupWizardOrchestrator
     /// <summary>
     /// Persists the draft as a new stdio connection profile and returns it. The caller is expected to have
     /// tested the draft first; this method does not re-test, so a caller that skips testing saves an
-    /// unverified configuration deliberately rather than by accident.
+    /// unverified configuration deliberately rather than by accident. Known launch-contract failures
+    /// still return the validator's remediation key without writing a configuration.
     /// </summary>
-    public async Task<ServerConfiguration> SaveDraftAsync(
+    public async Task<Result<ServerConfiguration>> SaveDraftAsync(
         AcpSetupDraft draft,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(draft);
         cancellationToken.ThrowIfCancellationRequested();
 
+        var violations = AcpSetupParameterValidator.Validate(draft);
+        if (violations.Count > 0)
+        {
+            return Result<ServerConfiguration>.Failure(violations[0].MessageKey);
+        }
+
         var configuration = CreateConfiguration(draft);
         await _configurationService.SaveConfigurationAsync(configuration).ConfigureAwait(false);
-        return configuration;
+        return Result<ServerConfiguration>.Success(configuration);
     }
 
     internal static ServerConfiguration CreateConfiguration(AcpSetupDraft draft)

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpAgentDescriptor.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpAgentDescriptor.cs
@@ -49,4 +49,22 @@ public sealed class AcpAdapterDescriptor
     public required AcpComponentDescriptor Component { get; init; }
 
     public required AcpLaunchTemplate LaunchTemplate { get; init; }
+
+    /// <summary>
+    /// The adapter distribution supplies its own agent runtime, so a separate runtime installation is
+    /// optional. This differs from a built-in adapter, where the agent executable itself speaks ACP.
+    /// </summary>
+    public bool IncludesRuntime { get; init; }
+
+    /// <summary>
+    /// The adapter's documented environment variable for selecting a separately installed runtime.
+    /// Empty when the adapter has no such contract; an absent runtime override preserves its default.
+    /// </summary>
+    public string RuntimeCommandEnvironmentVariable { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the adapter invokes an overridden runtime through a Windows shell. Direct-process
+    /// adapters cannot consume a Windows batch launcher even when the wizard can probe that launcher.
+    /// </summary>
+    public bool SupportsWindowsRuntimeBatchLauncher { get; init; } = true;
 }

--- a/src/SalmonEgg.Domain/Models/AcpSetup/AcpCommandOverrides.cs
+++ b/src/SalmonEgg.Domain/Models/AcpSetup/AcpCommandOverrides.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SalmonEgg.Domain.Models.AcpSetup;
 
@@ -63,7 +64,15 @@ public sealed class AcpCommandOverrides
     /// when they supplied none.
     /// </summary>
     public string Resolve(string command)
-        => string.IsNullOrWhiteSpace(command)
-            ? command
-            : _overrides.TryGetValue(command, out var path) ? path : command;
+        => TryGetOverride(command, out var path) ? path : command;
+
+    /// <summary>
+    /// Distinguishes an explicit path from the unchanged catalog command, so an adapter can keep using
+    /// its bundled runtime when no separate runtime was selected.
+    /// </summary>
+    public bool TryGetOverride(string command, [NotNullWhen(true)] out string? path)
+    {
+        path = null;
+        return !string.IsNullOrWhiteSpace(command) && _overrides.TryGetValue(command, out path);
+    }
 }

--- a/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
+++ b/src/SalmonEgg.Infrastructure/AcpSetup/AcpAgentCatalogEntries.cs
@@ -48,6 +48,9 @@ internal static class AcpAgentCatalogEntries
         string adapterProbeCommand,
         string adapterPackageId,
         Uri adapterDocumentation,
+        bool includesRuntime,
+        string runtimeCommandEnvironmentVariable,
+        bool supportsWindowsRuntimeBatchLauncher,
         IReadOnlyList<AcpSetupParameterDefinition> parameters)
         => new()
         {
@@ -70,6 +73,9 @@ internal static class AcpAgentCatalogEntries
             {
                 new AcpAdapterDescriptor
                 {
+                    IncludesRuntime = includesRuntime,
+                    RuntimeCommandEnvironmentVariable = runtimeCommandEnvironmentVariable,
+                    SupportsWindowsRuntimeBatchLauncher = supportsWindowsRuntimeBatchLauncher,
                     Component = new AcpComponentDescriptor
                     {
                         Id = adapterId,
@@ -169,6 +175,13 @@ internal static class AcpAgentCatalogEntries
             adapterProbeCommand: "claude-agent-acp",
             adapterPackageId: "@agentclientprotocol/claude-agent-acp",
             adapterDocumentation: new Uri("https://github.com/agentclientprotocol/claude-agent-acp"),
+            // The adapter SDK bundles Claude Code; an explicit executable overrides that runtime.
+            // https://github.com/agentclientprotocol/claude-agent-acp/blob/v0.76.0/src/acp-agent.ts#L1441-L1478
+            includesRuntime: true,
+            runtimeCommandEnvironmentVariable: "CLAUDE_CODE_EXECUTABLE",
+            // v0.76.0 uses execFile for auth and its SDK spawns the selected runtime without a shell.
+            // https://github.com/agentclientprotocol/claude-agent-acp/blob/v0.76.0/src/acp-agent.ts#L2369-L2372
+            supportsWindowsRuntimeBatchLauncher: false,
             parameters: Array.Empty<AcpSetupParameterDefinition>());
 
     private static AcpAgentDescriptor CreateCodex()
@@ -184,6 +197,11 @@ internal static class AcpAgentCatalogEntries
             adapterProbeCommand: "codex-acp",
             adapterPackageId: "@agentclientprotocol/codex-acp",
             adapterDocumentation: new Uri("https://github.com/agentclientprotocol/codex-acp"),
+            // The adapter includes Codex and accepts CODEX_PATH for a selected installation.
+            // https://github.com/agentclientprotocol/codex-acp/blob/v1.11.0/README.md#L38-L42
+            includesRuntime: true,
+            runtimeCommandEnvironmentVariable: "CODEX_PATH",
+            supportsWindowsRuntimeBatchLauncher: true,
             parameters: Array.Empty<AcpSetupParameterDefinition>());
 
     private static AcpAgentDescriptor CreateGeminiCli()

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -582,6 +582,9 @@ Create the corresponding Markdown file in:
   <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
     <value>Value not allowed. Pick one from the list.</value>
   </data>
+  <data name="AcpSetup_Validation_RuntimeBatchLauncherNotSupported" xml:space="preserve">
+    <value>This adapter cannot use a Windows batch file as its agent runtime. Choose the native executable (such as claude.exe), or clear the custom runtime path to use the adapter's bundled runtime.</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>Failed to delete the agent profile. Please try again later.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -582,6 +582,9 @@ Create the corresponding Markdown file in:
   <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
     <value>Value not allowed. Pick one from the list.</value>
   </data>
+  <data name="AcpSetup_Validation_RuntimeBatchLauncherNotSupported" xml:space="preserve">
+    <value>This adapter cannot use a Windows batch file as its agent runtime. Choose the native executable (such as claude.exe), or clear the custom runtime path to use the adapter's bundled runtime.</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>Failed to delete the agent profile. Please try again later.</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -584,6 +584,9 @@
   <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
     <value>取值不在允许范围内，请从列表中选择。</value>
   </data>
+  <data name="AcpSetup_Validation_RuntimeBatchLauncherNotSupported" xml:space="preserve">
+    <value>此适配器不能使用 Windows 批处理文件作为 Agent 运行时。请选择原生可执行程序（例如 claude.exe），或清空自定义运行时路径以使用适配器自带的运行时。</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>删除 Agent 配置失败，请稍后重试。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -584,6 +584,9 @@
   <data name="AcpSetup_Validation_ValueNotAllowed" xml:space="preserve">
     <value>取值不在允许范围内，请从列表中选择。</value>
   </data>
+  <data name="AcpSetup_Validation_RuntimeBatchLauncherNotSupported" xml:space="preserve">
+    <value>此适配器不能使用 Windows 批处理文件作为 Agent 运行时。请选择原生可执行程序（例如 claude.exe），或清空自定义运行时路径以使用适配器自带的运行时。</value>
+  </data>
   <data name="AcpProfiles_DeleteFailed" xml:space="preserve">
     <value>删除 Agent 配置失败，请稍后重试。</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupAgentRowViewModel.cs
@@ -55,6 +55,7 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsMissing))]
     [NotifyPropertyChangedFor(nameof(IsUndetermined))]
     [NotifyPropertyChangedFor(nameof(IsChecking))]
+    [NotifyPropertyChangedFor(nameof(IsRuntimePathEditorVisible))]
     [NotifyPropertyChangedFor(nameof(Version))]
     [NotifyPropertyChangedFor(nameof(HasVersion))]
     [NotifyPropertyChangedFor(nameof(ProbeDetail))]
@@ -93,6 +94,13 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     public bool IsUndetermined => Runtime.Availability == AcpComponentAvailability.Undetermined;
 
     public bool IsChecking => Runtime.Availability == AcpComponentAvailability.Checking;
+
+    /// <summary>
+    /// Keeps the path editor available while an edit invalidates its previous probe, including when the
+    /// user clears the path to try again. Probe availability must not remove the focused input mid-edit.
+    /// </summary>
+    public bool IsRuntimePathEditorVisible
+        => IsMissing || HasCustomCommand || (IsUndetermined && CommandRevision > 0);
 
     public string Version => Runtime.Version ?? string.Empty;
 
@@ -255,9 +263,20 @@ public sealed partial class AcpSetupAgentRowViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasCustomCommand))]
     [NotifyPropertyChangedFor(nameof(SelectedCandidate))]
+    [NotifyPropertyChangedFor(nameof(IsRuntimePathEditorVisible))]
     private string _customCommand = string.Empty;
 
     public bool HasCustomCommand => !string.IsNullOrWhiteSpace(CustomCommand);
+
+    internal long CommandRevision { get; private set; }
+
+    partial void OnCustomCommandChanged(string value)
+    {
+        // A path edited away and back is still a new request. Its previous probe cannot approve it.
+        CommandRevision++;
+        RuntimeToolchain = null;
+        Runtime = AcpComponentProbeResult.Undetermined(Agent.Runtime.Id);
+    }
 
     /// <summary>
     /// Raised when the user asks this row to be installed; the owning wizard subscribes because it

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Settings/AcpSetup/AcpSetupWizardViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -32,12 +33,34 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 {
     private const int MaxInstallOutputLines = 200;
 
+    /// <summary>
+    /// The selected row's properties that the wizard's own gates read.
+    /// </summary>
+    /// <remarks>
+    /// The gates live on the wizard but decide on facts the row holds, and the generated
+    /// <c>NotifyCanExecuteChangedFor</c> only reaches fields declared beside the command — it cannot see
+    /// across objects. This subscription is therefore the sole route by which a row's answer reaches the
+    /// buttons, and a fact the gates read but this list omits leaves them showing the verdict they were
+    /// last told. Naming them in one place is what keeps the next gate that reads a row fact from having
+    /// to rediscover that.
+    /// </remarks>
+    private static readonly string[] GateBearingRowProperties =
+    [
+        nameof(AcpSetupAgentRowViewModel.IsMissing),
+        nameof(AcpSetupAgentRowViewModel.IsChecking),
+        nameof(AcpSetupAgentRowViewModel.HasCustomCommand)
+    ];
+
     private readonly AcpSetupWizardOrchestrator _orchestrator;
     private readonly IUiDispatcher _uiDispatcher;
     private readonly IStringLocalizer<CoreStrings>? _localizer;
     private readonly ILogger<AcpSetupWizardViewModel> _logger;
     private readonly TimeProvider _timeProvider;
     private bool _suppressAdapterSelectionProbe;
+    private bool _adapterProbeRequested;
+    private long _selectionRevision;
+    private long _adapterRevision;
+    private long _draftRevision;
 
     public AcpSetupWizardViewModel(
         AcpSetupWizardOrchestrator orchestrator,
@@ -58,6 +81,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             row.InstallRequested += InstallAgentRow;
             row.InstallToolchainRequested += InstallAgentToolchain;
             row.VerifyRequested += VerifyAgentRow;
+            row.PropertyChanged += OnAgentRowPropertyChanged;
             Agents.Add(row);
         }
     }
@@ -127,6 +151,15 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(StepPositionText))]
     private AcpSetupAgentRowViewModel? _selectedAgent;
 
+    partial void OnSelectedAgentChanged(AcpSetupAgentRowViewModel? value)
+    {
+        _selectionRevision++;
+        _adapterProbeRequested = false;
+        SelectedAdapter = null;
+        Adapters.Clear();
+        InvalidateVerification();
+    }
+
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GoNextCommand))]
     [NotifyCanExecuteChangedFor(nameof(InstallAdapterCommand))]
@@ -150,17 +183,21 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// </summary>
     partial void OnSelectedAdapterChanged(AcpAdapterDescriptor? value)
     {
+        _adapterRevision++;
         AdapterProbe = null;
         AdapterToolchain = null;
-        TestResult = null;
-        Verification = ProfileVerification.Unknown;
+        InvalidateVerification();
         Parameters.Clear();
         LaunchCommandPreview = string.Empty;
         AdapterCustomCommand = string.Empty;
 
         if (!_suppressAdapterSelectionProbe && value is not null && IsOnComponentSetup)
         {
-            _ = DetectAdapterCommand.ExecuteAsync(null);
+            _adapterProbeRequested = true;
+            if (!IsBusy)
+            {
+                _ = DetectAdapterCommand.ExecuteAsync(null);
+            }
         }
     }
 
@@ -224,8 +261,10 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     partial void OnAdapterCustomCommandChanged(string value)
     {
-        TestResult = null;
-        Verification = ProfileVerification.Unknown;
+        _adapterRevision++;
+        AdapterProbe = null;
+        AdapterToolchain = null;
+        InvalidateVerification();
         RefreshLaunchCommandPreview();
     }
 
@@ -456,15 +495,34 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanRunOperation))]
     private async Task DetectAgentsAsync(CancellationToken cancellationToken)
     {
+        var revisions = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (var row in Agents)
+        {
+            revisions[row.AgentId] = row.CommandRevision;
+        }
+
+        var overrides = CollectCommandOverrides();
         await RunOperationAsync(
             async token =>
             {
                 _orchestrator.InvalidateSearchPaths();
-                MarkAgentsChecking();
-                var states = await _orchestrator
-                    .DetectAgentsAsync(CollectCommandOverrides(), token)
-                    .ConfigureAwait(false);
-                await _uiDispatcher.EnqueueAsync(() => ApplyRuntimeProbes(states)).ConfigureAwait(false);
+                await _uiDispatcher.EnqueueAsync(MarkAgentsChecking).ConfigureAwait(false);
+                try
+                {
+                    var states = await _orchestrator
+                        .DetectAgentsAsync(overrides, token).ConfigureAwait(false);
+                    await _uiDispatcher.EnqueueAsync(() =>
+                    {
+                        if (!token.IsCancellationRequested)
+                        {
+                            ApplyRuntimeProbes(states, revisions);
+                        }
+                    }).ConfigureAwait(false);
+                }
+                finally
+                {
+                    await _uiDispatcher.EnqueueAsync(ResetCheckingAgents).ConfigureAwait(false);
+                }
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -483,15 +541,26 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             return;
         }
 
+        var revision = row.CommandRevision;
+        var overrides = CollectCommandOverrides();
         _ = RunOperationAsync(
             async token =>
             {
+                _orchestrator.InvalidateSearchPaths();
                 var probe = await _orchestrator
-                    .DetectComponentAsync(row.Agent.Runtime, CollectCommandOverrides(), token)
+                    .DetectComponentAsync(row.Agent.Runtime, overrides, token)
                     .ConfigureAwait(false);
+                var toolchain = await _orchestrator
+                    .DetectToolchainAsync(row.Agent.Runtime, overrides, token).ConfigureAwait(false);
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
+                        if (token.IsCancellationRequested || row.CommandRevision != revision)
+                        {
+                            return;
+                        }
+
+                        row.RuntimeToolchain = toolchain;
                         row.Runtime = probe;
                         OnPropertyChanged(nameof(StepPositionText));
                     })
@@ -505,11 +574,14 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     {
         var agent = SelectedAgent;
         var adapter = SelectedAdapter;
-        if (adapter is null)
+        if (adapter is null || IsBusy)
         {
             return;
         }
 
+        _adapterProbeRequested = false;
+        var context = CaptureAdapterOperation(adapter);
+        var overrides = CollectCommandOverrides();
         await RunOperationAsync(
             async token =>
             {
@@ -517,31 +589,28 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 // toolchain-missing surface offers, so it must look at the machine rather than at the
                 // search that was current when the wizard first said the toolchain was absent.
                 _orchestrator.InvalidateSearchPaths();
-                await ProbeAdapterAsync(agent, adapter, CollectCommandOverrides(), token).ConfigureAwait(false);
+                await ProbeAdapterAsync(context, overrides, token).ConfigureAwait(false);
             },
             cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ProbeAdapterAsync(
-        AcpSetupAgentRowViewModel? agent,
-        AcpAdapterDescriptor adapter,
+        AdapterOperation context,
         AcpCommandOverrides overrides,
         CancellationToken cancellationToken)
     {
         var probe = await _orchestrator
-            .DetectComponentAsync(adapter.Component, overrides, cancellationToken)
+            .DetectComponentAsync(context.Adapter.Component, overrides, cancellationToken)
             .ConfigureAwait(false);
         var toolchain = await _orchestrator
-            .DetectToolchainAsync(adapter.Component, overrides, cancellationToken)
+            .DetectToolchainAsync(context.Adapter.Component, overrides, cancellationToken)
             .ConfigureAwait(false);
 
         await _uiDispatcher.EnqueueAsync(() =>
         {
             // Native selection can change during a process probe. A late result belongs to the
             // captured agent and adapter, and must never approve their replacements.
-            if (!cancellationToken.IsCancellationRequested
-                && ReferenceEquals(SelectedAgent, agent)
-                && ReferenceEquals(SelectedAdapter, adapter))
+            if (IsCurrentAdapterOperation(context, cancellationToken))
             {
                 AdapterProbe = probe;
                 AdapterToolchain = toolchain;
@@ -582,10 +651,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         // it, rather than showing the previous log until the first line of this one arrives.
         ResetInstallOutput();
 
+        var revision = row.CommandRevision;
+        var overrides = CollectCommandOverrides();
         _ = RunOperationAsync(
             async token =>
             {
-                var overrides = CollectCommandOverrides();
                 var (install, probe) = await _orchestrator
                     .InstallComponentAsync(row.Agent.Runtime, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
@@ -600,6 +670,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
+                        if (token.IsCancellationRequested || row.CommandRevision != revision)
+                        {
+                            return;
+                        }
+
                         row.Runtime = probe;
                         row.RuntimeToolchain = toolchain;
                         OnPropertyChanged(nameof(StepPositionText));
@@ -622,16 +697,22 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         }
 
         ResetInstallOutput();
+        var revision = row.CommandRevision;
+        var overrides = CollectCommandOverrides();
         _ = RunOperationAsync(
             async token =>
             {
-                var overrides = CollectCommandOverrides();
                 var (install, toolchain) = await _orchestrator
                     .InstallToolchainAsync(row.Agent.Runtime, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
 
                 await _uiDispatcher.EnqueueAsync(() =>
                 {
+                    if (token.IsCancellationRequested || row.CommandRevision != revision)
+                    {
+                        return;
+                    }
+
                     row.RuntimeToolchain = toolchain;
                     ReportToolchainInstallFailure(install);
                 }).ConfigureAwait(false);
@@ -643,16 +724,17 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     private async Task InstallToolchainAsync(CancellationToken cancellationToken)
     {
         var adapter = SelectedAdapter;
-        if (adapter is null)
+        if (adapter is null || !CanInstallToolchain())
         {
             return;
         }
 
         ResetInstallOutput();
+        var context = CaptureAdapterOperation(adapter);
+        var overrides = CollectCommandOverrides();
         await RunOperationAsync(
             async token =>
             {
-                var overrides = CollectCommandOverrides();
                 var (install, toolchain) = await _orchestrator
                     .InstallToolchainAsync(adapter.Component, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
@@ -661,7 +743,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 {
                     // A ComboBox change can land while the downloader is running; never apply an old
                     // adapter's result to the newly selected one.
-                    if (ReferenceEquals(SelectedAdapter, adapter))
+                    if (IsCurrentAdapterOperation(context, token))
                     {
                         AdapterToolchain = toolchain;
                         ReportToolchainInstallFailure(install);
@@ -678,7 +760,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     private async Task InstallAdapterAsync(CancellationToken cancellationToken)
     {
         var adapter = SelectedAdapter;
-        if (adapter is null)
+        if (adapter is null || !CanInstallAdapter())
         {
             return;
         }
@@ -686,10 +768,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         // Same reason as the row install: one shared surface, so each install starts from its own log.
         ResetInstallOutput();
 
+        var context = CaptureAdapterOperation(adapter);
+        var overrides = CollectCommandOverrides();
         await RunOperationAsync(
             async token =>
             {
-                var overrides = CollectCommandOverrides();
                 var (install, probe) = await _orchestrator
                     .InstallComponentAsync(adapter.Component, AppendInstallOutput, overrides, token)
                     .ConfigureAwait(false);
@@ -700,7 +783,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
-                        if (ReferenceEquals(SelectedAdapter, adapter))
+                        if (IsCurrentAdapterOperation(context, token))
                         {
                             AdapterProbe = probe;
                             AdapterToolchain = toolchain;
@@ -732,6 +815,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanTest))]
     private async Task TestAsync(CancellationToken cancellationToken)
     {
+        if (!CanTest())
+        {
+            return;
+        }
+
         var draft = BuildDraft();
         if (draft is null)
         {
@@ -743,6 +831,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         // the draft.
         TestResult = null;
         Verification = ProfileVerification.Unknown;
+        var revision = _draftRevision;
 
         await RunOperationAsync(
             async token =>
@@ -751,6 +840,11 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 await _uiDispatcher
                     .EnqueueAsync(() =>
                     {
+                        if (token.IsCancellationRequested || _draftRevision != revision)
+                        {
+                            return;
+                        }
+
                         TestResult = result;
                         Verification = result.IsSuccess
                             ? ProfileVerification.Verified(_timeProvider.GetUtcNow())
@@ -762,7 +856,10 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             cancellationToken).ConfigureAwait(false);
     }
 
-    private bool CanTest() => !IsBusy && SelectedAdapter is not null;
+    // Reads the same runtime prerequisite as the two step gates. Resolving an adapter is not the same as
+    // being able to launch it: a handshake against a runtime the user has not installed yet can only fail,
+    // and it would report that absence as a connectivity fault.
+    private bool CanTest() => !IsBusy && SelectedAdapter is not null && !IsRuntimeInstallRequired;
 
     /// <summary>
     /// Deliberately accepts an untested draft and moves to naming it. This is distinct from automatic step
@@ -810,7 +907,19 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             async token =>
             {
                 var saved = await _orchestrator.SaveDraftAsync(draft, token).ConfigureAwait(false);
-                await _uiDispatcher.EnqueueAsync(() => SavedProfile = saved).ConfigureAwait(false);
+                await _uiDispatcher.EnqueueAsync(() =>
+                {
+                    if (saved.IsSuccess)
+                    {
+                        SavedProfile = saved.Value;
+                        return;
+                    }
+
+                    TestResult = AcpSetupTestResult.Failure(AcpSetupTestStage.Validation, null, saved.Error);
+                    Verification = ProfileVerification.Unknown;
+                    ApplyValidationMessages(TestResult);
+                    Step = AcpSetupWizardStep.Test;
+                }).ConfigureAwait(false);
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -863,7 +972,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
     private bool CanGoNext() => !IsBusy && Step switch
     {
-        AcpSetupWizardStep.AgentSelection => SelectedAgent is { IsMissing: false, IsChecking: false },
+        AcpSetupWizardStep.AgentSelection => SelectedAgent is { IsChecking: false } && !IsRuntimeInstallRequired,
         AcpSetupWizardStep.ComponentSetup => CanAdvanceFromComponentSetup(),
         AcpSetupWizardStep.Parameters => true,
         AcpSetupWizardStep.Test => IsTestSuccessful,
@@ -880,6 +989,10 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
         var overrides = CollectCommandOverrides();
         var command = overrides.Resolve(row.ProbeCommand);
+        // Captured before the probe starts, because re-selecting this same row is a new request for the
+        // same object: identity would still match while the intent behind this walk has been replaced.
+        var selectionRevision = _selectionRevision;
+        var commandRevision = row.CommandRevision;
         await RunOperationAsync(async token =>
         {
             // Entering the wizard does not run the optional catalog sweep. Check the selected
@@ -891,6 +1004,7 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 .DetectToolchainAsync(row.Agent.Runtime, overrides, token).ConfigureAwait(false);
 
             AcpAdapterDescriptor? adapter = null;
+            AdapterOperation? context = null;
             await _uiDispatcher.EnqueueAsync(() =>
             {
                 if (!IsCurrentSelection())
@@ -901,24 +1015,31 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
                 row.RuntimeToolchain = toolchain;
                 row.Runtime = runtime;
                 OnPropertyChanged(nameof(StepPositionText));
-                if (row.IsMissing)
+
+                // PrepareComponentSetup resolves the adapter, and whether an absent runtime blocks the walk
+                // is a fact about that adapter. Preparing first is what lets the gate below see it.
+                PrepareComponentSetup();
+                if (IsRuntimeInstallRequired)
                 {
                     return;
                 }
 
-                PrepareComponentSetup();
                 adapter = SelectedAdapter;
+                if (adapter is not null)
+                {
+                    context = CaptureAdapterOperation(adapter);
+                }
             }).ConfigureAwait(false);
 
-            if (adapter is null)
+            if (adapter is null || context is null)
             {
                 return;
             }
 
-            await ProbeAdapterAsync(row, adapter, overrides, token).ConfigureAwait(false);
+            await ProbeAdapterAsync(context.Value, overrides, token).ConfigureAwait(false);
             await _uiDispatcher.EnqueueAsync(() =>
             {
-                if (!IsCurrentSelection() || !ReferenceEquals(SelectedAdapter, adapter))
+                if (!IsCurrentSelection() || !IsCurrentAdapterOperation(context.Value, token))
                 {
                     return;
                 }
@@ -936,6 +1057,8 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             bool IsCurrentSelection()
                 => !token.IsCancellationRequested
                     && ReferenceEquals(SelectedAgent, row)
+                    && _selectionRevision == selectionRevision
+                    && row.CommandRevision == commandRevision
                     && string.Equals(command, CollectCommandOverrides().Resolve(row.ProbeCommand), StringComparison.Ordinal);
         }, cancellationToken).ConfigureAwait(false);
     }
@@ -946,9 +1069,18 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// </summary>
     private bool CanAdvanceFromComponentSetup()
         => SelectedAdapter is not null
-            && SelectedAgent?.IsMissing != true
+            && !IsRuntimeInstallRequired
             && AdapterProbe is not null
             && !IsAdapterMissing;
+
+    /// <summary>
+    /// A missing standalone runtime is optional when the adapter supplies it, unless the user chose a
+    /// custom runtime path. Before component setup, the recommended adapter owns the same decision.
+    /// </summary>
+    private bool IsRuntimeInstallRequired
+        => SelectedAgent is { IsMissing: true } row
+            && (row.HasCustomCommand
+                || (SelectedAdapter ?? row.Agent.ResolveRecommendedAdapter())?.IncludesRuntime != true);
 
     private void AdvancePastComponentSetup()
     {
@@ -1269,19 +1401,42 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Shows every row as being looked at. Callers marshal to the UI thread themselves, so the sweep can
+    /// guarantee the checking state is visible before detection starts and retired after it ends.
+    /// </summary>
     private void MarkAgentsChecking()
     {
-        _uiDispatcher.Enqueue(() =>
+        foreach (var row in Agents)
         {
-            foreach (var row in Agents)
+            row.Runtime = new AcpComponentProbeResult
             {
-                row.Runtime = new AcpComponentProbeResult
-                {
-                    ComponentId = row.Agent.Runtime.Id,
-                    Availability = AcpComponentAvailability.Checking
-                };
+                ComponentId = row.Agent.Runtime.Id,
+                Availability = AcpComponentAvailability.Checking
+            };
+        }
+    }
+
+    /// <summary>
+    /// Retires the checking state from any row still wearing it.
+    /// </summary>
+    /// <remarks>
+    /// Runs whether the sweep completed, failed, or was cancelled. Checking is a transient display state
+    /// that also blocks the walk (<c>IsChecking</c> gates Next), so a sweep that ends without answering a
+    /// row must hand it back as undetermined — a question nobody is asking any more — rather than leaving
+    /// the user looking at a spinner they cannot cancel out of.
+    /// </remarks>
+    private void ResetCheckingAgents()
+    {
+        foreach (var row in Agents)
+        {
+            if (row.IsChecking)
+            {
+                row.Runtime = AcpComponentProbeResult.Undetermined(row.Agent.Runtime.Id);
             }
-        });
+        }
+
+        OnPropertyChanged(nameof(StepPositionText));
     }
 
     /// <remarks>
@@ -1289,7 +1444,9 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
     /// the component probe is what raises the flags the view reads — so writing it last means the view
     /// never renders a "missing" row against a toolchain answer from the previous sweep.
     /// </remarks>
-    private void ApplyRuntimeProbes(IReadOnlyList<AcpAgentDetectionState> states)
+    private void ApplyRuntimeProbes(
+        IReadOnlyList<AcpAgentDetectionState> states,
+        IReadOnlyDictionary<string, long> requestedRevisions)
     {
         var byAgentId = new Dictionary<string, AcpAgentDetectionState>(StringComparer.Ordinal);
         foreach (var state in states)
@@ -1299,11 +1456,21 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
 
         foreach (var row in Agents)
         {
-            if (byAgentId.TryGetValue(row.AgentId, out var state))
+            if (!byAgentId.TryGetValue(row.AgentId, out var state))
             {
-                row.RuntimeToolchain = state.RuntimeToolchain;
-                row.Runtime = state.Runtime;
+                continue;
             }
+
+            // The sweep probed the paths as they stood when it started. A row whose path the user edited
+            // since then was asked a different question, so this answer cannot speak for it.
+            if (!requestedRevisions.TryGetValue(row.AgentId, out var requested)
+                || row.CommandRevision != requested)
+            {
+                continue;
+            }
+
+            row.RuntimeToolchain = state.RuntimeToolchain;
+            row.Runtime = state.Runtime;
         }
 
         OnPropertyChanged(nameof(StepPositionText));
@@ -1437,6 +1604,104 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
         ErrorMessage = install.ErrorDetail ?? Localize(InstallFailedKey, "Installation failed.");
     }
 
+    // ── Operation identity ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Discards any verdict attached to the draft as it stood, and retires the operations that were
+    /// working towards one.
+    /// </summary>
+    /// <remarks>
+    /// One entry point, called from every edit that changes what would be launched — agent, adapter, and
+    /// adapter path. The revision it bumps is what a completing test compares against: without it, a test
+    /// that started before an edit could land its pass afterwards and let a draft nobody tested be saved
+    /// as verified.
+    /// </remarks>
+    private void InvalidateVerification()
+    {
+        _draftRevision++;
+        TestResult = null;
+        Verification = ProfileVerification.Unknown;
+    }
+
+    /// <summary>
+    /// Identifies one adapter operation by the selection that started it.
+    /// </summary>
+    /// <remarks>
+    /// Reference equality on the descriptors is not sufficient. Re-selecting the same adapter, or editing
+    /// its path away and back, restores the same objects while asking a new question — so the counters
+    /// are what distinguish "still the same request" from "looks like it".
+    /// </remarks>
+    private readonly record struct AdapterOperation(
+        AcpSetupAgentRowViewModel? Agent,
+        AcpAdapterDescriptor Adapter,
+        long SelectionRevision,
+        long AdapterRevision);
+
+    private AdapterOperation CaptureAdapterOperation(AcpAdapterDescriptor adapter)
+        => new(SelectedAgent, adapter, _selectionRevision, _adapterRevision);
+
+    /// <summary>
+    /// Whether a completed adapter operation still speaks for the current selection.
+    /// </summary>
+    private bool IsCurrentAdapterOperation(AdapterOperation context, CancellationToken cancellationToken)
+        => !cancellationToken.IsCancellationRequested
+            && ReferenceEquals(SelectedAgent, context.Agent)
+            && ReferenceEquals(SelectedAdapter, context.Adapter)
+            && _selectionRevision == context.SelectionRevision
+            && _adapterRevision == context.AdapterRevision;
+
+    /// <summary>
+    /// Reacts to a row editing its own runtime path, and re-asks the gates that read its state.
+    /// </summary>
+    /// <remarks>
+    /// The row owns its path and revision; the wizard owns the draft's verdict and the deferred adapter
+    /// probe. A path edit therefore has to reach here: the runtime it names is part of what a saved
+    /// profile launches, so a verdict obtained against the previous path is no longer proof of anything.
+    /// <para>
+    /// Invalidating that verdict is not itself a signal to the gates. It writes values that are already
+    /// cleared on the path the user is most likely to take — supplying a path for a runtime just reported
+    /// absent — and an unchanged value raises nothing, so the notification has to be explicit.
+    /// </para>
+    /// </remarks>
+    private void OnAgentRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (!ReferenceEquals(sender, SelectedAgent))
+        {
+            return;
+        }
+
+        if (string.Equals(e.PropertyName, nameof(AcpSetupAgentRowViewModel.CustomCommand), StringComparison.Ordinal))
+        {
+            InvalidateVerification();
+            RefreshLaunchCommandPreview();
+        }
+
+        if (Array.IndexOf(GateBearingRowProperties, e.PropertyName) >= 0)
+        {
+            GoNextCommand.NotifyCanExecuteChanged();
+            TestCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    /// <summary>
+    /// Runs an adapter probe that a selection change asked for while an operation held the wizard busy.
+    /// </summary>
+    /// <remarks>
+    /// The selection handler cannot start one itself: <see cref="RunOperationAsync"/> admits a single
+    /// operation, so a probe started under the busy flag would return immediately and leave the new
+    /// adapter permanently unprobed — which reads to the user as a Next button that never enables.
+    /// Deferring to here means the request survives the operation that displaced it.
+    /// </remarks>
+    private void RunDeferredAdapterProbe()
+    {
+        if (!_adapterProbeRequested || IsBusy || SelectedAdapter is null || !IsOnComponentSetup)
+        {
+            return;
+        }
+
+        _ = DetectAdapterCommand.ExecuteAsync(null);
+    }
+
     private bool CanRunOperation() => !IsBusy;
 
     /// <summary>
@@ -1515,7 +1780,13 @@ public sealed partial class AcpSetupWizardViewModel : ObservableObject
             // pointing at a disposed source, where Cancel throws ObjectDisposedException inside a command
             // handler.
             _operationCancellation = null;
-            await _uiDispatcher.EnqueueAsync(() => IsBusy = false).ConfigureAwait(false);
+            await _uiDispatcher
+                .EnqueueAsync(() =>
+                {
+                    IsBusy = false;
+                    RunDeferredAdapterProbe();
+                })
+                .ConfigureAwait(false);
             cancellation.Dispose();
         }
     }

--- a/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAdapterRuntimeLaunchTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/AcpSetup/AcpAdapterRuntimeLaunchTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Domain.Services.AcpSetup;
+using SalmonEgg.Infrastructure.AcpSetup;
+
+namespace SalmonEgg.Infrastructure.Tests.AcpSetup;
+
+public sealed class AcpAdapterRuntimeLaunchTests
+{
+    [Theory]
+    [InlineData("claude-code", "claude", "CLAUDE_CODE_EXECUTABLE")]
+    [InlineData("codex", "codex", "CODEX_PATH")]
+    public void BuildLaunchPlan_WithRuntimeOverride_PassesPathToAdapter(
+        string agentId,
+        string runtimeCommand,
+        string environmentVariable)
+    {
+        // Arrange
+        var runtimePath = "/custom agent/bin/" + runtimeCommand;
+        var draft = CreateDraft(
+            agentId,
+            AcpCommandOverrides.Create(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [runtimeCommand] = runtimePath
+            }));
+
+        // Act
+        var plan = draft.BuildLaunchPlan();
+
+        // Assert
+        Assert.Equal(draft.Adapter.Component.ProbeCommand, plan.Command);
+        Assert.True(plan.Environment.TryGetValue(environmentVariable, out var executable));
+        Assert.Equal(runtimePath, executable);
+    }
+
+    [Theory]
+    [InlineData("claude-code", "CLAUDE_CODE_EXECUTABLE")]
+    [InlineData("codex", "CODEX_PATH")]
+    public void BuildLaunchPlan_WithoutRuntimeOverride_PreservesAdapterRuntimeSelection(
+        string agentId,
+        string environmentVariable)
+    {
+        // Arrange
+        var draft = CreateDraft(agentId, AcpCommandOverrides.Empty);
+
+        // Act
+        var plan = draft.BuildLaunchPlan();
+
+        // Assert
+        Assert.Equal(draft.Adapter.Component.ProbeCommand, plan.Command);
+        Assert.False(plan.Environment.ContainsKey(environmentVariable));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Users\Agent\claude.cmd")]
+    [InlineData(@"C:\Users\Agent\claude.BAT")]
+    [InlineData("C:/Agent Tools/claude.CMD")]
+    [InlineData(@"\\server\tools\claude.cmd")]
+    [InlineData("//server/tools/claude.bat")]
+    [InlineData(@".\claude.cmd")]
+    public async Task TestDraft_ClaudeWindowsBatchRuntime_ReturnsValidationBeforeLaunching(string runtimePath)
+    {
+        // Arrange
+        var draft = CreateRuntimeDraft("claude-code", runtimePath);
+        var tester = new Mock<IAcpSetupConnectivityTester>(MockBehavior.Strict);
+        var orchestrator = CreateOrchestrator(tester.Object, Mock.Of<IConfigurationService>());
+
+        // Act
+        var result = await orchestrator.TestDraftAsync(draft, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AcpSetupTestStage.Validation, result.Stage);
+        Assert.Equal(AcpSetupParameterValidator.RuntimeBatchLauncherNotSupportedKey, result.RemediationKey);
+        Assert.Null(result.ErrorDetail);
+        Assert.Equal(runtimePath, draft.CommandOverrides.Resolve("claude"));
+        tester.Verify(value => value.TestAsync(It.IsAny<AcpLaunchPlan>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("claude-code", @"C:\Program Files\Claude\claude.exe")]
+    [InlineData("claude-code", "/opt/agent/claude")]
+    [InlineData("claude-code", "/opt/agent/claude.cmd")]
+    [InlineData("claude-code", "///opt/agent/claude.cmd")]
+    [InlineData("claude-code", "/opt/agent/cli.js")]
+    [InlineData("claude-code", @"C:\agent\cli.js")]
+    [InlineData("codex", @"C:\Users\Agent\codex.cmd")]
+    [InlineData("codex", @"C:\Users\Agent\codex.bat")]
+    public async Task TestDraft_NoKnownBatchRestriction_DelegatesUnchangedPlan(string agentId, string runtimePath)
+    {
+        // Arrange
+        var draft = CreateRuntimeDraft(agentId, runtimePath);
+        AcpLaunchPlan? testedPlan = null;
+        var tester = new Mock<IAcpSetupConnectivityTester>();
+        tester.Setup(value => value.TestAsync(It.IsAny<AcpLaunchPlan>(), It.IsAny<CancellationToken>()))
+            .Callback<AcpLaunchPlan, CancellationToken>((plan, _) => testedPlan = plan)
+            .ReturnsAsync(AcpSetupTestResult.Success(1, agentId));
+        var orchestrator = CreateOrchestrator(tester.Object, Mock.Of<IConfigurationService>());
+
+        // Act
+        var result = await orchestrator.TestDraftAsync(draft, TestContext.Current.CancellationToken);
+
+        // Assert: allowing the existing tester is not a claim that a particular executable works.
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(testedPlan);
+        Assert.Equal(runtimePath, testedPlan.Environment[draft.Adapter.RuntimeCommandEnvironmentVariable]);
+        tester.Verify(value => value.TestAsync(It.IsAny<AcpLaunchPlan>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SaveDraft_ClaudeWindowsBatchRuntime_CannotSaveAnInvalidVerdict(bool claimedVerified)
+    {
+        // Arrange
+        var verification = claimedVerified ? ProfileVerification.Verified(DateTimeOffset.UtcNow) : ProfileVerification.Unverified;
+        var draft = CreateRuntimeDraft("claude-code", @"C:\Agent\claude.cmd", verification);
+        var configuration = new Mock<IConfigurationService>(MockBehavior.Strict);
+        var tester = new Mock<IAcpSetupConnectivityTester>(MockBehavior.Strict);
+        var orchestrator = CreateOrchestrator(tester.Object, configuration.Object);
+
+        // Act
+        var result = await orchestrator.SaveDraftAsync(draft, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AcpSetupParameterValidator.RuntimeBatchLauncherNotSupportedKey, result.Error);
+        configuration.Verify(value => value.SaveConfigurationAsync(It.IsAny<ServerConfiguration>()), Times.Never);
+        tester.Verify(value => value.TestAsync(It.IsAny<AcpLaunchPlan>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Agent\claude.exe")]
+    [InlineData(null)]
+    public async Task SaveDraft_ValidUnverifiedRuntime_PreservesExplicitChoice(string? runtimePath)
+    {
+        // Arrange
+        var draft = CreateRuntimeDraft("claude-code", runtimePath, ProfileVerification.Unverified);
+        ServerConfiguration? saved = null;
+        var configuration = new Mock<IConfigurationService>();
+        configuration.Setup(value => value.SaveConfigurationAsync(It.IsAny<ServerConfiguration>()))
+            .Callback<ServerConfiguration>(value => saved = value).Returns(Task.CompletedTask);
+        var tester = new Mock<IAcpSetupConnectivityTester>(MockBehavior.Strict);
+        var orchestrator = CreateOrchestrator(tester.Object, configuration.Object);
+
+        // Act
+        var result = await orchestrator.SaveDraftAsync(draft, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Same(saved, result.Value);
+        Assert.Equal(ProfileVerification.Unverified, result.Value.Verification);
+        Assert.Equal(runtimePath is not null, result.Value.StdioEnvironment.ContainsKey("CLAUDE_CODE_EXECUTABLE"));
+        if (runtimePath is not null) Assert.Equal(runtimePath, result.Value.StdioEnvironment["CLAUDE_CODE_EXECUTABLE"]);
+        tester.Verify(value => value.TestAsync(It.IsAny<AcpLaunchPlan>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static AcpSetupWizardOrchestrator CreateOrchestrator(
+        IAcpSetupConnectivityTester tester, IConfigurationService configuration)
+        => new(new AcpAgentCatalog(), new StubAcpExecutableProbe(), Mock.Of<IAcpComponentInstaller>(), tester, configuration);
+
+    private static AcpSetupDraft CreateRuntimeDraft(
+        string agentId, string? runtimePath, ProfileVerification verification = default)
+    {
+        var agent = new AcpAgentCatalog().FindAgent(agentId)!;
+        return new AcpSetupDraft
+        {
+            Agent = agent,
+            Adapter = agent.ResolveRecommendedAdapter()!,
+            ParameterValues = new Dictionary<string, string>(StringComparer.Ordinal),
+            ProfileName = agent.DisplayName,
+            Verification = verification,
+            CommandOverrides = runtimePath is null ? AcpCommandOverrides.Empty
+                : AcpCommandOverrides.Create(new Dictionary<string, string> { [agent.Runtime.ProbeCommand] = runtimePath })
+        };
+    }
+
+    private static AcpSetupDraft CreateDraft(string agentId, AcpCommandOverrides overrides)
+    {
+        var agent = new AcpAgentCatalog().FindAgent(agentId)!;
+        return new AcpSetupDraft
+        {
+            Agent = agent,
+            Adapter = agent.ResolveRecommendedAdapter()!,
+            ParameterValues = new Dictionary<string, string>(StringComparer.Ordinal),
+            ProfileName = agent.DisplayName,
+            CommandOverrides = overrides
+        };
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupPrerequisiteFlowTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupPrerequisiteFlowTests.cs
@@ -289,6 +289,255 @@ public sealed class AcpSetupPrerequisiteFlowTests
         Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
     }
 
+    [Fact]
+    public async Task DetectAdapter_PathEditedDuringProbe_DoesNotApproveTheUntestedPath()
+    {
+        // Arrange
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/test/bin/test-agent");
+        var wizard = CreateWizard(
+            probe,
+            agents: [AcpSetupWizardFixtures.Agent(adapters: AcpSetupWizardFixtures.ExecutableAdapter())]);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        Assert.True(wizard.IsAdapterMissing);
+        var pending = new TaskCompletionSource<IReadOnlyList<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        probe.ResolveCandidatesAsync = (_, token) => pending.Task.WaitAsync(token);
+        wizard.AdapterCustomCommand = "/old/adapter";
+
+        // Act
+        var detection = wizard.DetectAdapterCommand.ExecuteAsync(null);
+        Assert.True(wizard.IsBusy);
+        wizard.AdapterCustomCommand = "/new/missing-adapter";
+        pending.SetResult(new[] { "/old/adapter" });
+        await detection.WaitAsync(TestContext.Current.CancellationToken);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(wizard.IsBusy);
+        Assert.Equal("/new/missing-adapter", wizard.AdapterCustomCommand);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DetectAgents_CancelledSweep_RestoresARetryableSelection()
+    {
+        // Arrange
+        var pending = new TaskCompletionSource<IReadOnlyList<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probe = new StubExecutableProbe { ResolveCandidatesAsync = (_, token) => pending.Task.WaitAsync(token) };
+        var wizard = CreateWizard(
+            probe,
+            agents: [AcpSetupWizardFixtures.Agent(adapters: AcpSetupWizardFixtures.BuiltInAdapter())]);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        // Act
+        var detection = wizard.DetectAgentsCommand.ExecuteAsync(null);
+        Assert.True(wizard.SelectedAgent.IsChecking);
+        wizard.CancelOperationCommand.Execute(null);
+        await detection.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(wizard.IsBusy);
+        Assert.False(wizard.HasErrorMessage);
+        Assert.False(wizard.SelectedAgent.IsChecking);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task GoNext_AgentChangedAwayAndBackDuringProbe_DoesNotConsumeTheOldNextIntent()
+    {
+        // Arrange
+        var pending = new TaskCompletionSource<IReadOnlyList<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probe = new StubExecutableProbe { ResolveCandidatesAsync = (_, token) => pending.Task.WaitAsync(token) };
+        var wizard = AcpSetupWizardFixtures.CreateWizard(
+            new StubAgentCatalog(AcpSetupWizardFixtures.Agent("first"), AcpSetupWizardFixtures.Agent("second")),
+            probe, new StubComponentInstaller(),
+            new StubConnectivityTester(StubConnectivityTester.SuccessfulHandshake()),
+            new RecordingConfigurationService());
+        wizard.SelectedAgent = wizard.Agents[0];
+
+        // Act
+        var next = wizard.GoNextCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = wizard.Agents[1];
+        wizard.SelectedAgent = wizard.Agents[0];
+        pending.SetResult(new[] { "/old/agent" });
+        await next.WaitAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(wizard.IsBusy);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+    }
+
+    /// <summary>
+    /// An adapter that ships its own copy of the agent must not be blocked on a separate runtime install.
+    /// </summary>
+    /// <remarks>
+    /// The catalog records this for Claude Code and Codex, whose adapter distributions bundle the agent.
+    /// Demanding the standalone CLI first tells the user to install something the adapter already carries,
+    /// which is the same class of wrong answer as letting an absent runtime through: the gate is asserting
+    /// a prerequisite it has not established.
+    /// </remarks>
+    [Fact]
+    public async Task GoNext_AdapterSuppliesItsOwnRuntime_DoesNotRequireASeparateRuntimeInstall()
+    {
+        // Arrange
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.AdapterCommand, "/test/bin/test-agent-acp");
+        var adapter = AcpSetupWizardFixtures.ExecutableAdapter(includesRuntime: true);
+        var wizard = CreateWizard(probe, agents: [AcpSetupWizardFixtures.Agent(adapters: adapter)]);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+
+        // Act
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(wizard.SelectedAgent.IsMissing);
+        Assert.NotEqual(AcpSetupWizardStep.AgentSelection, wizard.Step);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GoNext_BundledRuntimeMissingAfterDetection_UsesTheRecommendedAdapter(bool selectBeforeDetection)
+    {
+        // Arrange
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.AdapterCommand, "/test/bin/test-agent-acp");
+        var adapter = AcpSetupWizardFixtures.ExecutableAdapter(includesRuntime: true);
+        var wizard = CreateWizard(probe, agents: [AcpSetupWizardFixtures.Agent(adapters: adapter)]);
+        var row = Assert.Single(wizard.Agents);
+        if (selectBeforeDetection)
+        {
+            wizard.SelectedAgent = row;
+        }
+
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        wizard.SelectedAgent = row;
+        Assert.True(row.IsMissing);
+
+        // Act / Assert: detecting first must not make an otherwise usable adapter unreachable.
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        Assert.True(wizard.IsAdapterInstalled);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+    }
+
+    [Fact]
+    public async Task GoNext_BundledAdapterWithMissingCustomRuntime_RemainsOnSelection()
+    {
+        // Arrange
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.AdapterCommand, "/test/bin/test-agent-acp");
+        var adapter = AcpSetupWizardFixtures.ExecutableAdapter(includesRuntime: true);
+        var wizard = CreateWizard(probe, agents: [AcpSetupWizardFixtures.Agent(adapters: adapter)]);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var row = Assert.Single(wizard.Agents);
+        wizard.SelectedAgent = row;
+        row.CustomCommand = "/custom/missing-agent";
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        Assert.True(row.IsMissing);
+        Assert.Contains(row.CustomCommand, probe.ProbedCommands);
+        probe.ProbedCommands.Clear();
+
+        // Act
+        await wizard.GoNextCommand.ExecuteAsync(null);
+
+        // Assert: a bundled default must not override the user's explicit runtime choice.
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        Assert.Null(wizard.AdapterProbe);
+        Assert.Empty(probe.ProbedCommands);
+    }
+
+    /// <summary>
+    /// Supplying a path for a runtime the wizard reported absent must put the walk back within reach.
+    /// </summary>
+    /// <remarks>
+    /// CanExecute is only re-read when something raises the change notification, so a gate reading a fact
+    /// nobody announces keeps showing the verdict it was last told. The custom-path box shares the
+    /// selection step with Next and writes on every keystroke, outside any operation whose completion
+    /// would re-notify — so a Next left grey here has nothing to correct it, and the user faces a path the
+    /// wizard would accept beside a button saying it would not. Asserting through CanExecuteChanged rather
+    /// than a bare CanExecute call is the difference that matters: reading the property directly recomputes
+    /// it and would pass no matter what the view had been told.
+    /// </remarks>
+    [Fact]
+    public async Task GoNext_CustomPathSuppliedForAMissingRuntime_ReOffersTheWalk()
+    {
+        // Arrange: nothing on PATH, so the probe positively reports the runtime absent and Next is withheld.
+        var wizard = CreateWizard(
+            new StubExecutableProbe(),
+            agents: [AcpSetupWizardFixtures.Agent(adapters: AcpSetupWizardFixtures.BuiltInAdapter())]);
+        var row = Assert.Single(wizard.Agents);
+        wizard.SelectedAgent = row;
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        Assert.True(row.IsMissing);
+        Assert.False(wizard.GoNextCommand.CanExecute(null));
+
+        var offerChanged = false;
+        wizard.GoNextCommand.CanExecuteChanged += (_, _) => offerChanged = true;
+
+        // Act: exactly what the bound text box writes as the user types.
+        row.CustomCommand = "/custom/bin/" + AcpSetupWizardFixtures.RuntimeCommand;
+
+        // Assert
+        Assert.False(row.IsMissing);
+        Assert.True(offerChanged);
+        Assert.True(wizard.GoNextCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// An adapter chosen while an operation holds the wizard busy must still be probed.
+    /// </summary>
+    /// <remarks>
+    /// The adapter list is not disabled during an operation, so the user can re-choose while one runs.
+    /// Only one operation is admitted at a time, so the probe the selection asks for cannot start then —
+    /// and a request dropped on that floor leaves the new adapter permanently unprobed, which the user
+    /// reads as a Next button that never enables.
+    /// </remarks>
+    [Fact]
+    public async Task SelectAdapter_ChosenWhileBusy_IsStillProbed()
+    {
+        // Arrange: reach the adapter step, then hold the wizard busy on a probe that has not answered.
+        var first = AcpSetupWizardFixtures.ExecutableAdapter("adapter.first");
+        var second = AcpSetupWizardFixtures.ExecutableAdapter("adapter.second");
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(AcpSetupWizardFixtures.RuntimeCommand, "/test/bin/test-agent");
+        var wizard = CreateWizard(probe, agents: [AcpSetupWizardFixtures.Agent(adapters: [first, second])]);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+
+        var pending = new TaskCompletionSource<IReadOnlyList<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        probe.ResolveCandidatesAsync = (_, token) => pending.Task.WaitAsync(token);
+        var detection = wizard.DetectAdapterCommand.ExecuteAsync(null);
+        Assert.True(wizard.IsBusy);
+
+        // Act: choose the other adapter while busy, then let the displaced operation finish.
+        wizard.SelectedAdapter = second;
+        probe.ResolveCandidatesAsync = null;
+        probe.ProbedCommands.Clear();
+        pending.SetResult([]);
+        await detection.WaitAsync(TestContext.Current.CancellationToken);
+        if (wizard.DetectAdapterCommand.ExecutionTask is { } deferred)
+        {
+            await deferred.WaitAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Assert
+        Assert.False(wizard.IsBusy);
+        Assert.Same(second, wizard.SelectedAdapter);
+        Assert.Contains(AcpSetupWizardFixtures.AdapterCommand, probe.ProbedCommands);
+        Assert.NotNull(wizard.AdapterProbe);
+    }
+
     private static AcpSetupWizardViewModel CreateWizard(
         StubExecutableProbe probe,
         StubComponentInstaller? installer = null,

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupRuntimeEntryValidationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupRuntimeEntryValidationTests.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+using System.Resources;
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+public sealed class AcpSetupRuntimeEntryValidationTests
+{
+    private const string NativeExecutableMessage = "此适配器不能使用 Windows 批处理文件作为 Agent 运行时。请选择原生可执行程序（例如 claude.exe），或清空自定义运行时路径以使用适配器自带的运行时。";
+
+    [Fact]
+    public async Task Test_InvalidWindowsRuntime_ClearsVerificationWithoutStartingConnectivityTest()
+    {
+        // Arrange
+        var (wizard, tester, _) = await CreateWizardAsync();
+        wizard.Verification = ProfileVerification.Verified(DateTimeOffset.UtcNow);
+
+        // Act
+        await wizard.TestCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Equal(0, tester.TestCount);
+        Assert.Equal(ProfileVerification.Unknown, wizard.Verification);
+        Assert.Equal(AcpSetupTestStage.Validation, wizard.TestResult?.Stage);
+        Assert.Equal(NativeExecutableMessage, wizard.TestRemediationText);
+        Assert.Equal(@"C:\Agent\claude.cmd", wizard.SelectedAgent?.CustomCommand);
+    }
+
+    [Fact]
+    public async Task Save_InvalidWindowsRuntime_ReportsValidationAndClearsClaimedVerification()
+    {
+        // Arrange
+        var (wizard, tester, configuration) = await CreateWizardAsync();
+        wizard.SkipTestCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.Save, wizard.Step);
+        wizard.Verification = ProfileVerification.Verified(DateTimeOffset.UtcNow);
+
+        // Act
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Empty(configuration.Saved);
+        Assert.Null(wizard.SavedProfile);
+        Assert.Equal(0, tester.TestCount);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        Assert.Equal(ProfileVerification.Unknown, wizard.Verification);
+        Assert.Equal(AcpSetupTestStage.Validation, wizard.TestResult?.Stage);
+        Assert.Equal(NativeExecutableMessage, wizard.TestRemediationText);
+        Assert.False(wizard.SaveCommand.CanExecute(null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("zh-Hans")]
+    [InlineData("en")]
+    [InlineData("en-US")]
+    public void RuntimeEntryValidation_Remediation_UsesPackagedLanguageResource(string language)
+    {
+        // Arrange
+        var resources = new ResourceManager(typeof(CoreStrings));
+
+        // Act
+        var message = resources.GetString(AcpSetupParameterValidator.RuntimeBatchLauncherNotSupportedKey,
+            CultureInfo.GetCultureInfo(language));
+
+        // Assert
+        Assert.Equal(language.StartsWith("en", StringComparison.Ordinal)
+            ? "This adapter cannot use a Windows batch file as its agent runtime. Choose the native executable (such as claude.exe), or clear the custom runtime path to use the adapter's bundled runtime."
+            : NativeExecutableMessage, message);
+    }
+
+    private static async Task<(AcpSetupWizardViewModel Wizard, StubConnectivityTester Tester, RecordingConfigurationService Configuration)> CreateWizardAsync()
+    {
+        var adapter = new AcpAdapterDescriptor
+        {
+            Component = new AcpComponentDescriptor
+            {
+                Id = "adapter",
+                DisplayName = "Adapter",
+                Distribution = AcpDistributionKind.Binary,
+                DetectionMode = AcpComponentDetectionMode.ExecutableOnPath,
+                ProbeCommand = "adapter"
+            },
+            LaunchTemplate = new AcpLaunchTemplate { Command = "adapter" },
+            IncludesRuntime = true,
+            RuntimeCommandEnvironmentVariable = "CLAUDE_CODE_EXECUTABLE",
+            SupportsWindowsRuntimeBatchLauncher = false
+        };
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(@"C:\Agent\claude.cmd", @"C:\Agent\claude.cmd");
+        probe.SetExecutable("adapter", @"C:\Agent\adapter.cmd");
+        var tester = new StubConnectivityTester(StubConnectivityTester.SuccessfulHandshake());
+        var configuration = new RecordingConfigurationService();
+        var localizer = new MockResourceLocalizer();
+        var wizard = AcpSetupWizardFixtures.CreateWizard(
+            new StubAgentCatalog(AcpSetupWizardFixtures.Agent(adapters: adapter)), probe,
+            new StubComponentInstaller(), tester, configuration, localizer: localizer);
+        wizard.SelectedAgent = Assert.Single(wizard.Agents);
+        wizard.SelectedAgent.CustomCommand = @"C:\Agent\claude.cmd";
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        return (wizard, tester, configuration);
+    }
+
+    private sealed class MockResourceLocalizer : IStringLocalizer<CoreStrings>
+    {
+        private static readonly ResourceManager Resources = new(typeof(CoreStrings));
+
+        public LocalizedString this[string name] => new(name,
+            Resources.GetString(name, CultureInfo.GetCultureInfo("zh-Hans")) ?? name);
+
+        public LocalizedString this[string name, params object[] arguments] => this[name];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupRuntimePathEditorTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupRuntimePathEditorTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+public sealed class AcpSetupRuntimePathEditorTests
+{
+    [Fact]
+    public void CustomCommand_TypedAndCleared_KeepsEditorAvailableWithoutAnOldProbeVerdict()
+    {
+        // Arrange
+        var row = new AcpSetupAgentRowViewModel(AcpSetupWizardFixtures.Agent());
+        Assert.False(row.IsRuntimePathEditorVisible);
+        var changed = new List<string?>();
+        row.PropertyChanged += (_, args) => changed.Add(args.PropertyName);
+        row.Runtime = AcpComponentProbeResult.Missing(row.Agent.Runtime.Id);
+        Assert.True(row.IsRuntimePathEditorVisible);
+        Assert.Contains(nameof(row.IsRuntimePathEditorVisible), changed);
+
+        // Act / Assert: every keystroke and clearing the input leave the same editor reachable.
+        foreach (var text in new[] { "/", "/c", "/custom", "/custom/bin/agent", string.Empty, " ", "/replacement" })
+        {
+            changed.Clear();
+            row.CustomCommand = text;
+
+            Assert.True(row.IsUndetermined);
+            Assert.False(row.IsMissing);
+            Assert.True(row.IsRuntimePathEditorVisible);
+            Assert.Contains(nameof(row.IsRuntimePathEditorVisible), changed);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Runtime_CustomPathProbeCompletes_KeepsTheSelectedPathEditable(bool found)
+    {
+        // Arrange
+        var row = new AcpSetupAgentRowViewModel(AcpSetupWizardFixtures.Agent());
+        row.Runtime = AcpComponentProbeResult.Missing(row.Agent.Runtime.Id);
+        row.CustomCommand = "/custom/bin/agent";
+
+        // Act
+        row.Runtime = found
+            ? AcpComponentProbeResult.Installed(row.Agent.Runtime.Id, row.CustomCommand, version: null)
+            : AcpComponentProbeResult.Missing(row.Agent.Runtime.Id);
+
+        // Assert
+        Assert.Equal(found, row.IsInstalled);
+        Assert.Equal(!found, row.IsMissing);
+        Assert.True(row.IsRuntimePathEditorVisible);
+        Assert.Equal("/custom/bin/agent", row.CustomCommand);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Runtime_DefaultPathProbeCompletesAfterClearing_UsesTheNewVerdict(bool found)
+    {
+        // Arrange
+        var row = new AcpSetupAgentRowViewModel(AcpSetupWizardFixtures.Agent());
+        row.CustomCommand = "/custom/bin/agent";
+        row.CustomCommand = string.Empty;
+        Assert.True(row.IsRuntimePathEditorVisible);
+        var notified = false;
+        row.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(row.IsRuntimePathEditorVisible))
+            {
+                notified = true;
+            }
+        };
+
+        // Act
+        row.Runtime = found
+            ? AcpComponentProbeResult.Installed(row.Agent.Runtime.Id, "/default/bin/agent", version: null)
+            : AcpComponentProbeResult.Missing(row.Agent.Runtime.Id);
+
+        // Assert
+        Assert.True(notified);
+        Assert.Equal(!found, row.IsRuntimePathEditorVisible);
+        Assert.False(row.HasCustomCommand);
+    }
+
+    [Fact]
+    public void SelectedCandidate_ChangedBeforeProbeCompletes_PreservesCandidatesAndUsesTheChosenPath()
+    {
+        // Arrange
+        var row = new AcpSetupAgentRowViewModel(AcpSetupWizardFixtures.Agent());
+        string[] candidates = ["/first/bin/agent", "/second/bin/agent"];
+        row.Runtime = AcpComponentProbeResult.Installed(
+            row.Agent.Runtime.Id, candidates[0], version: null, candidates: candidates);
+        var requestedPaths = new List<string>();
+        row.VerifyRequested += selected => requestedPaths.Add(selected.CustomCommand);
+
+        // Act
+        row.SelectedCandidate = candidates[1];
+
+        // Assert
+        Assert.True(row.IsUndetermined);
+        Assert.True(row.IsRuntimePathEditorVisible);
+        Assert.True(row.HasMultipleCandidates);
+        Assert.Equal(candidates, row.Candidates);
+        Assert.Equal(candidates[1], row.SelectedCandidate);
+        Assert.Equal(candidates[1], Assert.Single(requestedPaths));
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupSaveValidationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupSaveValidationTests.cs
@@ -1,0 +1,85 @@
+using System.Threading.Tasks;
+using SalmonEgg.Application.Services.AcpSetup;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Models.AcpSetup;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+using SalmonEgg.Presentation.ViewModels.Settings.AcpSetup;
+
+namespace SalmonEgg.Presentation.Core.Tests.Settings.AcpSetup;
+
+public sealed class AcpSetupSaveValidationTests
+{
+    [Fact]
+    public async Task SkipThenSave_UnsupportedRuntimeLauncher_ShowsLocalizedRemediationAndAllowsCorrection()
+    {
+        // Arrange: the launcher exists, but this adapter starts runtimes without a Windows shell.
+        const string unsupportedRuntime = @"C:\Tools\test-agent.cmd";
+        const string supportedRuntime = @"C:\Tools\test-agent.exe";
+        const string remediation = "请选择原生可执行文件，或清空路径以使用适配器自带的运行时。";
+        var probe = new StubExecutableProbe();
+        probe.SetExecutable(unsupportedRuntime, unsupportedRuntime);
+        probe.SetExecutable(supportedRuntime, supportedRuntime);
+        probe.SetExecutable(AcpSetupWizardFixtures.AdapterCommand, "/test/bin/test-agent-acp");
+        probe.SetExecutable("/test/bin/test-agent-acp", "/test/bin/test-agent-acp");
+        var executableAdapter = AcpSetupWizardFixtures.ExecutableAdapter();
+        var adapter = new AcpAdapterDescriptor
+        {
+            Component = executableAdapter.Component,
+            LaunchTemplate = executableAdapter.LaunchTemplate,
+            IncludesRuntime = true,
+            RuntimeCommandEnvironmentVariable = "TEST_AGENT_RUNTIME",
+            SupportsWindowsRuntimeBatchLauncher = false
+        };
+        var tester = new StubConnectivityTester(StubConnectivityTester.SuccessfulHandshake());
+        var configuration = new RecordingConfigurationService();
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", AcpSetupParameterValidator.RuntimeBatchLauncherNotSupportedKey, remediation);
+        var wizard = AcpSetupWizardFixtures.CreateWizard(
+            new StubAgentCatalog(AcpSetupWizardFixtures.Agent(adapters: adapter)),
+            probe, new StubComponentInstaller(), tester, configuration, localizer);
+        await wizard.DetectAgentsCommand.ExecuteAsync(null);
+        var row = Assert.Single(wizard.Agents);
+        wizard.SelectedAgent = row;
+        row.CustomCommand = unsupportedRuntime;
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        Assert.True(wizard.SkipTestCommand.CanExecute(null));
+        wizard.SkipTestCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.Save, wizard.Step);
+        Assert.True(wizard.SaveCommand.CanExecute(null));
+
+        // Act
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        // Assert: skipping connectivity testing does not bypass an established launch constraint.
+        Assert.Empty(configuration.Saved);
+        Assert.Null(wizard.SavedProfile);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        Assert.Equal(ProfileVerificationState.Unknown, wizard.Verification.State);
+        Assert.Equal(AcpSetupTestStage.Validation, wizard.TestResult?.Stage);
+        Assert.Equal(remediation, wizard.TestRemediationText);
+        Assert.False(wizard.HasErrorMessage);
+        Assert.False(wizard.SaveCommand.CanExecute(null));
+        Assert.Equal(0, tester.TestCount);
+
+        // The user can return to the path field, correct it, and explicitly save an unverified profile.
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.ComponentSetup, wizard.Step);
+        wizard.GoBackCommand.Execute(null);
+        Assert.Equal(AcpSetupWizardStep.AgentSelection, wizard.Step);
+        row.CustomCommand = supportedRuntime;
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        await wizard.GoNextCommand.ExecuteAsync(null);
+        Assert.Equal(AcpSetupWizardStep.Test, wizard.Step);
+        wizard.SkipTestCommand.Execute(null);
+        await wizard.SaveCommand.ExecuteAsync(null);
+
+        var saved = Assert.Single(configuration.Saved);
+        Assert.Same(saved, wizard.SavedProfile);
+        Assert.Equal(ProfileVerificationState.Unverified, saved.Verification.State);
+        Assert.Equal(supportedRuntime, saved.StdioEnvironment[adapter.RuntimeCommandEnvironmentVariable]);
+        Assert.Equal(0, tester.TestCount);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Settings/AcpSetup/AcpSetupWizardFixtures.cs
@@ -363,9 +363,11 @@ internal static class AcpSetupWizardFixtures
 
     public static AcpAdapterDescriptor ExecutableAdapter(
         string id = "adapter.executable",
+        bool includesRuntime = false,
         params AcpSetupParameterDefinition[] parameters)
         => new()
         {
+            IncludesRuntime = includesRuntime,
             Component = new AcpComponentDescriptor
             {
                 Id = id,


### PR DESCRIPTION
ACP 安装向导在重新选择 Agent、编辑程序路径或取消检测时，可能保留旧探测结论、把自带运行时的适配器挡在“下一步”，或让路径输入框在首字输入后消失。本 PR 让步骤门控和探测结果按当前选择与路径生效，保留编辑入口，并在忙碌期间换选适配器后补做当前选择的探测。

Claude/Codex npm 适配器使用目录声明的内置运行时能力；显式选择独立运行时时，同一个启动计划把路径传给适配器约定的环境变量。测试和保存共用校验：Claude 适配器无法启动的 Windows 批处理路径会显示本地化改正提示，不启动测试进程也不写配置；普通 POSIX 路径和 Codex 的已声明路径语义保持可用。

验证：完整 Presentation 3593/3593、Infrastructure 的 AcpSetup 160/160、Application 的 AcpSetup 28/28，全部零跳过。新增回归覆盖扫描前后选择、选择/路径往返、取消、忙时换选、保存失败后改正，以及逐字编辑。桌面 Debug 构建通过；新 Xvfb/XTest 门禁从正式设置入口进入真实缺失 Qwen 的向导，44 次实际键盘采样通过，门禁已接 CI。反向验证临时恢复旧可见性后，首字采样即失败；恢复源码并重编后再次 44/44 通过。最终提交 `75e40517` 的 16 项检查通过、1 项仓库条件检查跳过，包含新输入门禁、真实 WASM 全链、Windows MSIX 打包、Windows ConPTY 和各平台构建。

基线为 main `cab0a410`。官方行为依据固定在 Claude Agent ACP 0.76.0 与 Codex ACP 1.11.0 的源码注释；未执行真实第三方登录，也不把 Linux 输入门禁当作 Windows 安装包 GUI 验收。Refs #195。

门禁实现说明：Debug driver 保持单一方法作用域，以同一个 finally 覆盖导航超时、输入断言失败与事件解绑；因此按代码规范的明确例外保留超过 60 行的方法。它不会进入 Release 行为；采样期间不回写文本、不恢复焦点或展开状态。
