### PR TITLE
fix(msix): resolve Git Bash for local packaging

### DIFF
--- a/.github/workflows/platform-build-gates.yml
+++ b/.github/workflows/platform-build-gates.yml
@@ -202,6 +202,10 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Verify local MSIX Git Bash resolution
+        shell: pwsh
+        run: ./scripts/gates/run-msix-git-bash-resolution-gate.ps1
+
       - name: Restore WinUI app for isolated MSIX build
         shell: pwsh
         run: |

--- a/.tools/msix-tooling.ps1
+++ b/.tools/msix-tooling.ps1
@@ -1,0 +1,26 @@
+# The bundled CLI is published by scripts/release/publish-cli-binary.sh, the same script the release
+# workflow runs, so the local MSIX needs a POSIX shell. Only Git for Windows Bash is compatible with
+# the native Windows paths passed by the packaging script; bash.exe on PATH may be the WSL launcher.
+function Get-BashPath {
+    $gitOnPath = Get-Command git.exe -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($gitOnPath) {
+        $gitRoot = Split-Path -Parent (Split-Path -Parent $gitOnPath.Source)
+        $gitBash = Join-Path $gitRoot 'bin\bash.exe'
+        if (Test-Path -LiteralPath $gitBash -PathType Leaf) {
+            return $gitBash
+        }
+    }
+
+    $candidates = @(
+        (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+        (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe')
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            return $candidate
+        }
+    }
+
+    throw "Git for Windows bash.exe not found. The MSIX package embeds the salmon-egg CLI, published by scripts/release/publish-cli-binary.sh; install Git for Windows so this script can run it."
+}

--- a/.tools/run-winui3-msix.ps1
+++ b/.tools/run-winui3-msix.ps1
@@ -6,6 +6,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'msix-tooling.ps1')
 
 # Improve UTF-8 output when invoked from Windows PowerShell / cmd.
 try {
@@ -89,28 +90,6 @@ function Get-MSBuildPath {
     }
 
     return $msbuild
-}
-
-# The bundled CLI is published by scripts/release/publish-cli-binary.sh, the same script the release
-# workflow runs, so this local package embeds the same binary users get. That means this script needs a
-# POSIX shell; Git for Windows provides one, and the repository's other gates already assume it.
-function Get-BashPath {
-    $onPath = Get-Command bash -ErrorAction SilentlyContinue
-    if ($onPath) {
-        return $onPath.Source
-    }
-
-    $candidates = @(
-        (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
-        (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe')
-    )
-    foreach ($candidate in $candidates) {
-        if ($candidate -and (Test-Path -LiteralPath $candidate)) {
-            return $candidate
-        }
-    }
-
-    throw "bash.exe not found. The MSIX package embeds the salmon-egg CLI, published by scripts/release/publish-cli-binary.sh; install Git for Windows so this script can run it."
 }
 
 function Get-CertificateFromStore {
@@ -778,16 +757,24 @@ foreach ($referenceProject in $referenceProjects) {
 # than as a missing package file several minutes into MakeAppx.
 $bundledCliLogPath = Join-Path $msixLogDir "$logStamp-bundled-cli.log"
 $publishCliScript = Join-Path $repoRoot 'scripts\release\publish-cli-binary.sh'
-Invoke-LoggedProcess `
-    -FilePath (Get-BashPath) `
-    -Arguments @(
-        $publishCliScript,
-        '--rid', 'win-x64',
-        '--configuration', $Configuration
-    ) `
-    -LogPath $bundledCliLogPath `
-    -StepName 'Publishing the bundled salmon-egg CLI' `
-    -DisplayCommand "bash publish-cli-binary.sh --rid win-x64 --configuration $Configuration"
+$previousNuGetAudit = [Environment]::GetEnvironmentVariable('NuGetAudit', [EnvironmentVariableTarget]::Process)
+try {
+    # Match the local MSIX restore above. A transient vulnerability-feed failure must not turn the
+    # CLI's nested restore into NU1900-as-error after the package graph has already restored.
+    $env:NuGetAudit = 'false'
+    Invoke-LoggedProcess `
+        -FilePath (Get-BashPath) `
+        -Arguments @(
+            $publishCliScript,
+            '--rid', 'win-x64',
+            '--configuration', $Configuration
+        ) `
+        -LogPath $bundledCliLogPath `
+        -StepName 'Publishing the bundled salmon-egg CLI' `
+        -DisplayCommand "bash publish-cli-binary.sh --rid win-x64 --configuration $Configuration"
+} finally {
+    [Environment]::SetEnvironmentVariable('NuGetAudit', $previousNuGetAudit, [EnvironmentVariableTarget]::Process)
+}
 
 $bundledCli = Join-Path $repoRoot 'artifacts\cli-bin\win-x64\salmon-egg.exe'
 if (-not (Test-Path -LiteralPath $bundledCli)) {

--- a/scripts/gates/run-msix-git-bash-resolution-gate.ps1
+++ b/scripts/gates/run-msix-git-bash-resolution-gate.ps1
@@ -1,0 +1,53 @@
+#requires -Version 7.0
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$runScriptPath = Join-Path $repoRoot '.tools\run-winui3-msix.ps1'
+$runScript = Get-Content -LiteralPath $runScriptPath -Raw
+if ($runScript -notmatch "(?m)^\. \(Join-Path \`$PSScriptRoot 'msix-tooling\.ps1'\)\s*\r?$") {
+    throw "The MSIX runner does not load its tooling helper."
+}
+
+. (Join-Path $repoRoot '.tools\msix-tooling.ps1')
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("salmonegg-msix-bash-" + [guid]::NewGuid().ToString('n'))
+$originalPath = $env:PATH
+$originalProgramFiles = $env:ProgramFiles
+$originalProgramFilesX86 = ${env:ProgramFiles(x86)}
+
+try {
+    $fakeWindowsDirectory = Join-Path $testRoot 'Windows\System32'
+    $fakeGitRoot = Join-Path $testRoot 'Custom Git'
+    $fakeGitCommandDirectory = Join-Path $fakeGitRoot 'cmd'
+    $fakeGitBinDirectory = Join-Path $fakeGitRoot 'bin'
+    $fakeWslBash = Join-Path $fakeWindowsDirectory 'bash.exe'
+    $fakeGit = Join-Path $fakeGitCommandDirectory 'git.exe'
+    $fakeGitBash = Join-Path $fakeGitBinDirectory 'bash.exe'
+
+    New-Item -ItemType Directory -Force -Path $fakeWindowsDirectory, $fakeGitCommandDirectory, $fakeGitBinDirectory | Out-Null
+    New-Item -ItemType File -Force -Path $fakeWslBash, $fakeGit, $fakeGitBash | Out-Null
+
+    # Reproduce the local failure shape: the WSL launcher is the first bash on PATH, while Git for
+    # Windows is installed elsewhere and exposes git.exe through its cmd directory.
+    $env:PATH = "$fakeWindowsDirectory;$fakeGitCommandDirectory"
+    $env:ProgramFiles = Join-Path $testRoot 'No default Program Files'
+    ${env:ProgramFiles(x86)} = Join-Path $testRoot 'No default Program Files x86'
+
+    $resolved = Get-BashPath
+    if (-not [string]::Equals($resolved, $fakeGitBash, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Expected Git for Windows bash '$fakeGitBash', got '$resolved'."
+    }
+
+    if ([string]::Equals($resolved, $fakeWslBash, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'The MSIX runner selected the WSL bash launcher.'
+    }
+
+    Write-Host '[msix-bash] passed: Git for Windows bash wins when the WSL launcher is first on PATH'
+} finally {
+    $env:PATH = $originalPath
+    $env:ProgramFiles = $originalProgramFiles
+    ${env:ProgramFiles(x86)} = $originalProgramFilesX86
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

- resolve Bash from the Git for Windows installation instead of accepting the WSL launcher found first on PATH
- keep the bundled CLI's nested restore aligned with the local MSIX restore by disabling non-deterministic NuGet vulnerability-feed auditing for that local step
- add a Windows gate that reproduces WSL-first PATH resolution and verifies the production helper is wired into the runner

## Root cause

The CLI-in-MSIX change made un.bat msix invoke scripts/release/publish-cli-binary.sh. On Windows, Get-Command bash selected C:\Windows\System32\bash.exe (the WSL launcher) before Git Bash. WSL received a native Windows script path and reported C:Users...publish-cli-binary.sh: No such file or directory, so packaging stopped before a new MSIX could be produced or installed. After fixing that path, the CLI's nested restore exposed a second local-only failure: an SSL error from the NuGet vulnerability feed became NU1900-as-error even though the owning MSIX restore already disables audit.

This was not caused by an installed package being stale; the failure happened before package installation. The fixed run removed 1.4.3, installed the newly built 1.5.2.0 package, and launched it successfully.

## Verification

- scripts/gates/run-msix-git-bash-resolution-gate.ps1
- un.bat msix (Debug): publish, sign, uninstall 1.4.3, install 1.5.2.0, launch succeeded
- scripts/gates/run-msix-package-contract-gate.ps1 -Package <built-msix>
- installed salmon-egg --version through %LOCALAPPDATA%\Microsoft\WindowsApps: succeeded
- scripts/gates/run-core-gates.ps1 -Configuration Release -SkipSolutionRestore: Release app build had 0 warnings / 0 errors; 207 contract tests passed
- PowerShell 7 and Windows PowerShell 5.1 both resolve C:\Program Files\Git\bin\bash.exe

## Known environment limitation

dotnet test --solution SalmonEgg.sln --configuration Release --timeout 20m --output Normal -p:NuGetAudit=false reached the existing test/build graph but returned UNOWA0001 for 
et10.0-browserwasm: this host's installed wasm-tools manifest is not recognized by the pinned SDK. The Windows MSIX path and scoped Release contract gates above pass.