### PR TITLE
fix(auth): localize credential connection failures by category

### DIFF
--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -644,7 +644,8 @@ public static class DependencyInjection
                 sp.GetRequiredService<IAcpConnectionSessionCleaner>(),
                 sp.GetRequiredService<IAcpConnectionPoolManager>(),
                 sp.GetRequiredService<IAcpConnectionDependencySnapshotProvider>(),
-                platformCapabilities: sp.GetRequiredService<IPlatformCapabilityService>());
+                platformCapabilities: sp.GetRequiredService<IPlatformCapabilityService>(),
+                localizer: sp.GetRequiredService<IStringLocalizer<CoreStrings>>());
         });
         services.AddSingleton(sp =>
         {

--- a/src/SalmonEgg.Domain/Models/CredentialBindingValidationError.cs
+++ b/src/SalmonEgg.Domain/Models/CredentialBindingValidationError.cs
@@ -14,4 +14,6 @@ public enum CredentialBindingValidationError
     InvalidHeaderEndpoint,
     InvalidHeaderName,
     InvalidHeaderScheme,
+    MissingCredential,
+    UnsupportedCredentialCharacters,
 }

--- a/src/SalmonEgg.Domain/Models/ResolvedCredentialBinding.cs
+++ b/src/SalmonEgg.Domain/Models/ResolvedCredentialBinding.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using SalmonEgg.Domain.Services;
 
 namespace SalmonEgg.Domain.Models;
 
@@ -33,19 +34,23 @@ public sealed class ResolvedCredentialBinding
 
 public sealed class CredentialBindingResolution
 {
-    private CredentialBindingResolution(ResolvedCredentialBinding? value, string? error)
+    private CredentialBindingResolution(ResolvedCredentialBinding? value, CredentialBindingValidationError? errorKind)
     {
         Value = value;
-        Error = error;
+        ErrorKind = errorKind;
     }
 
     public ResolvedCredentialBinding? Value { get; }
 
-    public string? Error { get; }
+    /// <summary>Stable failure category for a host's localized presentation.</summary>
+    public CredentialBindingValidationError? ErrorKind { get; }
+
+    /// <summary>English diagnostic for non-UI callers; never contains the credential value.</summary>
+    public string? Error => ErrorKind is { } error ? CredentialBindingPolicy.GetDiagnosticMessage(error) : null;
 
     public bool IsSuccess => Value is not null;
 
     internal static CredentialBindingResolution Success(ResolvedCredentialBinding value) => new(value, null);
 
-    internal static CredentialBindingResolution Failure(string error) => new(null, error);
+    internal static CredentialBindingResolution Failure(CredentialBindingValidationError error) => new(null, error);
 }

--- a/src/SalmonEgg.Domain/Services/CredentialBindingPolicy.cs
+++ b/src/SalmonEgg.Domain/Services/CredentialBindingPolicy.cs
@@ -68,6 +68,8 @@ public static class CredentialBindingPolicy
         CredentialBindingValidationError.InvalidHeaderEndpoint => "A header credential requires a matching HTTP or WebSocket endpoint without user information or a fragment.",
         CredentialBindingValidationError.InvalidHeaderName => "Choose an authentication header name, not a transport-controlled header.",
         CredentialBindingValidationError.InvalidHeaderScheme => "Use one HTTP token for the header scheme, or leave it empty for a raw value.",
+        CredentialBindingValidationError.MissingCredential => "The bound credential is not set. Set it in secure storage or remove the credential binding before connecting.",
+        CredentialBindingValidationError.UnsupportedCredentialCharacters => "The credential contains characters unsupported by its destination. Replace the stored credential.",
         _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
     };
 

--- a/src/SalmonEgg.Domain/Services/CredentialBindingResolver.cs
+++ b/src/SalmonEgg.Domain/Services/CredentialBindingResolver.cs
@@ -17,7 +17,7 @@ public static class CredentialBindingResolver
         ArgumentNullException.ThrowIfNull(configuration);
         if (CredentialBindingPolicy.GetValidationError(configuration) is { } error)
         {
-            return CredentialBindingResolution.Failure(CredentialBindingPolicy.GetDiagnosticMessage(error));
+            return CredentialBindingResolution.Failure(error);
         }
 
         var environment = new Dictionary<string, string>(configuration.StdioEnvironment, StringComparer.Ordinal);
@@ -33,13 +33,12 @@ public static class CredentialBindingResolver
             : configuration.Authentication?.ApiKey;
         if (string.IsNullOrEmpty(secret))
         {
-            return CredentialBindingResolution.Failure(
-                "The bound credential is not set. Set it in secure storage or remove the credential binding before connecting.");
+            return CredentialBindingResolution.Failure(CredentialBindingValidationError.MissingCredential);
         }
 
         if (secret.Contains('\0') || (binding.Target == CredentialTarget.Header && secret.Any(character => character < ' ' || character > '~')))
         {
-            return CredentialBindingResolution.Failure("The credential contains characters unsupported by its destination. Replace the stored credential.");
+            return CredentialBindingResolution.Failure(CredentialBindingValidationError.UnsupportedCredentialCharacters);
         }
 
         if (binding.Target == CredentialTarget.Environment)

--- a/src/SalmonEgg.Presentation.Core/Localization/CredentialBindingErrorMessageFormatter.cs
+++ b/src/SalmonEgg.Presentation.Core/Localization/CredentialBindingErrorMessageFormatter.cs
@@ -20,6 +20,8 @@ public static class CredentialBindingErrorMessageFormatter
             CredentialBindingValidationError.InvalidHeaderEndpoint => "CredentialBinding_InvalidHeaderEndpoint",
             CredentialBindingValidationError.InvalidHeaderName => "CredentialBinding_InvalidHeaderName",
             CredentialBindingValidationError.InvalidHeaderScheme => "CredentialBinding_InvalidHeaderScheme",
+            CredentialBindingValidationError.MissingCredential => "CredentialBinding_MissingCredential",
+            CredentialBindingValidationError.UnsupportedCredentialCharacters => "CredentialBinding_UnsupportedCredentialCharacters",
             _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
         };
         return localizer[resourceKey];

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1438,6 +1438,12 @@ Create the corresponding Markdown file in:
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>Use one HTTP token for the header scheme, or leave it empty for a raw value.</value>
   </data>
+  <data name="CredentialBinding_MissingCredential" xml:space="preserve">
+    <value>The bound credential is not set. Set it in secure storage or remove the credential binding before connecting.</value>
+  </data>
+  <data name="CredentialBinding_UnsupportedCredentialCharacters" xml:space="preserve">
+    <value>The credential contains characters unsupported by its destination. Replace the stored credential.</value>
+  </data>
   <data name="ChatAuth_TerminalTitle" xml:space="preserve">
     <value>Sign in to agent</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1438,6 +1438,12 @@ Create the corresponding Markdown file in:
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>Use one HTTP token for the header scheme, or leave it empty for a raw value.</value>
   </data>
+  <data name="CredentialBinding_MissingCredential" xml:space="preserve">
+    <value>The bound credential is not set. Set it in secure storage or remove the credential binding before connecting.</value>
+  </data>
+  <data name="CredentialBinding_UnsupportedCredentialCharacters" xml:space="preserve">
+    <value>The credential contains characters unsupported by its destination. Replace the stored credential.</value>
+  </data>
   <data name="ChatAuth_TerminalTitle" xml:space="preserve">
     <value>Sign in to agent</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1444,6 +1444,12 @@
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>请求头方案只能填写一个 HTTP 标记；如需直接发送凭据原值，请留空。</value>
   </data>
+  <data name="CredentialBinding_MissingCredential" xml:space="preserve">
+    <value>尚未设置已绑定的凭据。请先保存 Token 或 API Key，或移除凭据绑定后再连接。</value>
+  </data>
+  <data name="CredentialBinding_UnsupportedCredentialCharacters" xml:space="preserve">
+    <value>凭据包含目标不支持的字符。请替换已保存的凭据后再连接。</value>
+  </data>
   <data name="ChatAuth_TerminalTitle" xml:space="preserve">
     <value>登录智能体</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1444,6 +1444,12 @@
   <data name="CredentialBinding_InvalidHeaderScheme" xml:space="preserve">
     <value>请求头方案只能填写一个 HTTP 标记；如需直接发送凭据原值，请留空。</value>
   </data>
+  <data name="CredentialBinding_MissingCredential" xml:space="preserve">
+    <value>尚未设置已绑定的凭据。请先保存 Token 或 API Key，或移除凭据绑定后再连接。</value>
+  </data>
+  <data name="CredentialBinding_UnsupportedCredentialCharacters" xml:space="preserve">
+    <value>凭据包含目标不支持的字符。请替换已保存的凭据后再连接。</value>
+  </data>
   <data name="ChatAuth_TerminalTitle" xml:space="preserve">
     <value>登录智能体</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 using SalmonEgg.Application.Services.Chat;
@@ -12,6 +13,8 @@ using SalmonEgg.Acp.Mcp;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Localization;
+using SalmonEgg.Presentation.Core.Resources;
 
 namespace SalmonEgg.Presentation.Core.Services.Chat;
 
@@ -34,6 +37,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
     private readonly ILogger<AcpChatCoordinator> _logger;
     private readonly int _sessionUpdateBufferLimit;
     private readonly IPlatformCapabilityService? _platformCapabilities;
+    private readonly IStringLocalizer<CoreStrings>? _localizer;
     private AcpChatServiceAdapter? _activeChatServiceAdapter;
     private readonly object _applyScopeLock = new();
     private readonly object _poolConnectionGateSync = new();
@@ -53,7 +57,8 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         IAcpConnectionPoolManager? connectionPoolManager = null,
         IAcpConnectionDependencySnapshotProvider? connectionDependencySnapshotProvider = null,
         int sessionUpdateBufferLimit = DefaultSessionUpdateBufferLimit,
-        IPlatformCapabilityService? platformCapabilities = null)
+        IPlatformCapabilityService? platformCapabilities = null,
+        IStringLocalizer<CoreStrings>? localizer = null)
     {
         _chatServiceFactory = chatServiceFactory ?? throw new ArgumentNullException(nameof(chatServiceFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -83,6 +88,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         _transportSupportPolicy = transportSupportPolicy ?? throw new ArgumentNullException(nameof(transportSupportPolicy));
         _sessionUpdateBufferLimit = sessionUpdateBufferLimit;
         _platformCapabilities = platformCapabilities;
+        _localizer = localizer;
     }
 
     public async Task<AcpTransportApplyResult> ConnectToProfileAsync(
@@ -1155,7 +1161,10 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             }
 
             await DisconnectProfileInPoolAsync(profile.Id, cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(result.Error);
+            var message = result.ErrorKind is { } error && _localizer is not null
+                ? CredentialBindingErrorMessageFormatter.Format(error, _localizer)
+                : result.Error;
+            throw new InvalidOperationException(message);
         }
 
         return result.Value!.HasHeader || result.Value.Environment.Count > 0 ? result.Value : null;

--- a/tests/SalmonEgg.Domain.Tests/Services/CredentialBindingResolverTests.cs
+++ b/tests/SalmonEgg.Domain.Tests/Services/CredentialBindingResolverTests.cs
@@ -16,6 +16,8 @@ public sealed class CredentialBindingResolverTests
         var resolved = CredentialBindingResolver.Resolve(profile);
 
         Assert.True(resolved.IsSuccess);
+        Assert.Null(resolved.ErrorKind);
+        Assert.Null(resolved.Error);
         Assert.DoesNotContain(Secret, resolved.Value!.Environment.Values);
         Assert.Null(resolved.Value.HeaderValue);
     }
@@ -74,6 +76,7 @@ public sealed class CredentialBindingResolverTests
         var resolved = CredentialBindingResolver.Resolve(profile);
 
         Assert.False(resolved.IsSuccess);
+        Assert.Equal(CredentialBindingValidationError.DestinationChanged, resolved.ErrorKind);
         Assert.Contains("Bind the credential again", resolved.Error);
         Assert.DoesNotContain(Secret, resolved.Error);
     }
@@ -109,6 +112,7 @@ public sealed class CredentialBindingResolverTests
 
         Assert.False(resolved.IsSuccess);
         Assert.Null(resolved.Value);
+        Assert.Equal(CredentialBindingValidationError.MissingCredential, resolved.ErrorKind);
         Assert.Contains("not set", resolved.Error);
     }
 
@@ -126,6 +130,8 @@ public sealed class CredentialBindingResolverTests
         var resolved = CredentialBindingResolver.Resolve(profile);
 
         Assert.False(resolved.IsSuccess);
+        Assert.Equal(scheme is null ? CredentialBindingValidationError.InvalidHeaderName
+            : CredentialBindingValidationError.InvalidHeaderScheme, resolved.ErrorKind);
         Assert.DoesNotContain(Secret, resolved.Error);
     }
 
@@ -139,6 +145,7 @@ public sealed class CredentialBindingResolverTests
         var resolved = CredentialBindingResolver.Resolve(profile);
 
         Assert.False(resolved.IsSuccess);
+        Assert.Equal(CredentialBindingValidationError.UnsupportedCredentialCharacters, resolved.ErrorKind);
         Assert.DoesNotContain(Secret, resolved.Error);
     }
 

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.CredentialLocalization.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatCoordinatorTests.CredentialLocalization.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public sealed partial class AcpChatCoordinatorTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CredentialConnection_ClearedCredentialAfterLanguageChange_LocalizesAndRetiresOriginalService(bool pooled)
+    {
+        // Arrange
+        var firstService = CreateChatService();
+        var factory = new Mock<IAcpChatServiceFactory>();
+        factory.Setup(value => value.CreateChatService(It.IsAny<ServerConfiguration>())).Returns(firstService.Object);
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("en-US", "CredentialBinding_MissingCredential", "Set the credential before reconnecting.");
+        const string expected = "请先设置凭据，再重新连接。";
+        localizer.Set("zh-Hans", "CredentialBinding_MissingCredential", expected);
+        localizer.SetLanguageTag("en-US");
+        var logger = new Mock<ILogger<AcpChatCoordinator>>();
+        var registry = new InMemoryAcpConnectionSessionRegistry();
+        var sut = new AcpChatCoordinator(factory.Object, logger.Object, CreateTransportSupportPolicy(),
+            EmptyMcpServerProvider, Mock.Of<IAcpSessionCommandOrchestrator>(), sessionRegistry: registry, localizer: localizer);
+        var sink = new FakeSink();
+        var profile = CreateBoundProfile("old-connection-private-canary");
+        await ConnectCredentialProfileAsync(sut, profile, sink, pooled);
+        var cleared = profile.Clone();
+        cleared.Authentication = null;
+
+        // Act: the singleton must resolve the language when reporting this attempt's failure.
+        localizer.SetLanguageTag("zh-Hans");
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ConnectCredentialProfileAsync(sut, cleared, sink, pooled));
+
+        // Assert
+        Assert.Equal(expected, failure.Message);
+        Assert.False(registry.TryGetByProfile(profile.Id, out _));
+        firstService.Verify(value => value.DisconnectAsync(), Times.Once);
+        firstService.Verify(value => value.Dispose(), Times.Once);
+        factory.Verify(value => value.CreateChatService(It.IsAny<ServerConfiguration>()), Times.Once);
+        if (!pooled) Assert.Null(sink.CurrentChatService);
+        var diagnostics = failure + string.Join("\n", logger.Invocations
+            .SelectMany(invocation => invocation.Arguments.Select(argument => argument?.ToString())));
+        Assert.DoesNotContain("old-connection-private-canary", diagnostics, StringComparison.Ordinal);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.CredentialConnectionLocalization.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.CredentialConnectionLocalization.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Resources;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SalmonEgg.Acp.Mcp;
+using SalmonEgg.Application.Services.Mcp;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    private const string ConnectionCredentialCanary = "credential-connection-private-canary";
+
+    [Theory]
+    [InlineData(CredentialBindingValidationError.MissingCredential, "尚未设置已绑定的凭据。请先保存 Token 或 API Key，或移除凭据绑定后再连接。")]
+    [InlineData(CredentialBindingValidationError.UnsupportedCredentialCharacters, "凭据包含目标不支持的字符。请替换已保存的凭据后再连接。")]
+    [InlineData(CredentialBindingValidationError.DestinationChanged, "配置目标已更改。请重新绑定凭据，确认允许将凭据发送到新目标。")]
+    [InlineData(CredentialBindingValidationError.ReservedEnvironmentName, "PATH 和 PATHEXT 由启动器管理。请选择 Agent 用于接收凭据的环境变量。")]
+    public async Task CredentialConnection_Failure_ProjectsChineseRemediationWithoutLaunching(
+        CredentialBindingValidationError error, string expected)
+    {
+        // Arrange: invoke the real connection owner from its public view-model command.
+        var capabilities = new Mock<IPlatformCapabilityService>();
+        capabilities.SetupGet(value => value.SupportsStdioTransport).Returns(true);
+        var factory = new Mock<IAcpChatServiceFactory>(MockBehavior.Strict);
+        var provider = new Mock<IAcpMcpServerProvider>();
+        provider.Setup(value => value.GetMcpServersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<McpServer>)Array.Empty<McpServer>());
+        var localizer = new ConnectionCredentialResourceLocalizer();
+        var logger = new Mock<ILogger<AcpChatCoordinator>>();
+        var coordinator = new AcpChatCoordinator(factory.Object, logger.Object,
+            new TransportSupportPolicy(capabilities.Object), provider.Object,
+            Mock.Of<IAcpSessionCommandOrchestrator>(), localizer: localizer);
+        await using var fixture = CreateViewModel(acpConnectionCommands: coordinator, localizer: localizer,
+            chatStateProjector: new ChatStateProjector(localizer));
+        var profile = CreateInvalidConnectionCredentialProfile(error);
+        fixture.Profiles.Profiles.Add(profile);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.ViewModel.ConnectToAcpProfileCommand.ExecuteAsync(profile));
+        var state = await fixture.GetConnectionStateAsync();
+        await WaitForConditionAsync(() => Task.FromResult(fixture.ViewModel.HasConnectionError));
+
+        // Assert
+        Assert.Equal(expected, failure.Message);
+        Assert.Equal(ConnectionPhase.Disconnected, state.Phase);
+        Assert.Equal(expected, state.Error);
+        Assert.Equal(expected, fixture.ViewModel.ConnectionErrorMessage);
+        Assert.Equal(localizer["ChatConnectionStatus_Disconnected"].Value, fixture.ViewModel.CurrentConnectionStatus);
+        factory.Verify(value => value.CreateChatService(It.IsAny<ServerConfiguration>()), Times.Never);
+        var diagnostics = failure + "\n" + string.Join("\n", logger.Invocations.Concat(fixture.ViewModelLogger.Invocations)
+            .SelectMany(invocation => invocation.Arguments.Select(argument => argument?.ToString())));
+        Assert.DoesNotContain(ConnectionCredentialCanary, diagnostics, StringComparison.Ordinal);
+    }
+
+    private static ServerConfiguration CreateInvalidConnectionCredentialProfile(CredentialBindingValidationError error)
+    {
+        var profile = new ServerConfiguration
+        {
+            Id = "localized-credential",
+            Name = "已绑定配置",
+            Transport = TransportType.Stdio,
+            StdioCommand = "agent",
+            Authentication = error == CredentialBindingValidationError.MissingCredential ? null
+                : new AuthenticationConfig
+                {
+                    Token = ConnectionCredentialCanary + (error == CredentialBindingValidationError.UnsupportedCredentialCharacters ? "\0" : "")
+                }
+        };
+        profile.CredentialBinding = CredentialBindingPolicy.Create(profile, CredentialSource.Token, CredentialTarget.Environment,
+            error == CredentialBindingValidationError.ReservedEnvironmentName ? "PATH" : "AGENT_TOKEN");
+        if (error == CredentialBindingValidationError.DestinationChanged) profile.StdioCommand = "different-agent";
+        return profile;
+    }
+
+    private sealed class ConnectionCredentialResourceLocalizer : IStringLocalizer<CoreStrings>
+    {
+        private static readonly ResourceManager Resources = new(typeof(CoreStrings));
+
+        public LocalizedString this[string name] => new(name,
+            Resources.GetString(name, CultureInfo.GetCultureInfo("zh-Hans")) ?? name);
+
+        public LocalizedString this[string name, params object[] arguments] => this[name];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Localization/CredentialBindingErrorMessageFormatterTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Localization/CredentialBindingErrorMessageFormatterTests.cs
@@ -20,6 +20,8 @@ public sealed class CredentialBindingErrorMessageFormatterTests
     [InlineData(CredentialBindingValidationError.InvalidHeaderEndpoint, "请求头凭据需要匹配的 HTTP 或 WebSocket 地址，且地址不能包含用户信息或片段标识。")]
     [InlineData(CredentialBindingValidationError.InvalidHeaderName, "请选择用于身份验证的请求头名称，不要使用传输层保留的请求头。")]
     [InlineData(CredentialBindingValidationError.InvalidHeaderScheme, "请求头方案只能填写一个 HTTP 标记；如需直接发送凭据原值，请留空。")]
+    [InlineData(CredentialBindingValidationError.MissingCredential, "尚未设置已绑定的凭据。请先保存 Token 或 API Key，或移除凭据绑定后再连接。")]
+    [InlineData(CredentialBindingValidationError.UnsupportedCredentialCharacters, "凭据包含目标不支持的字符。请替换已保存的凭据后再连接。")]
     public void Format_ChineseFailureCategory_UsesSpecificExplanation(CredentialBindingValidationError error, string expected)
     {
         // Arrange


### PR DESCRIPTION
When a bound credential was missing or unsuitable for its destination, connecting in the Chinese UI displayed the resolver's English diagnostic. Carry a typed failure category to the existing localized formatter so the connection state and error message use the current language and give a concrete next step. The CLI retains its existing English diagnostics.

Validation: 44 Domain cases, 8 connection cases (including 6 new cases), 15 formatter cases, 7 CLI cases, and 5 profile editor cases passed with no skips. The regressions exercise the public connection command, actual Chinese resources, refusal to launch with invalid credentials, secret-free diagnostics, and retirement of foreground/pooled connections after a credential is cleared. Desktop/WASM and other platform builds are checked by this PR's CI.

Related to #144.
