### PR TITLE
fix(acp): retain HTTP response routing until delivery succeeds

### DIFF
--- a/scripts/gates/run-acp-cancellation-transport-gates.sh
+++ b/scripts/gates/run-acp-cancellation-transport-gates.sh
@@ -23,8 +23,9 @@ timeout --signal=TERM --kill-after=10s 180s "$dotnet_bin" test \
   --filter-class SalmonEgg.Infrastructure.Tests.Transport.StdioCancelRequestFullStackTests \
   --filter-class SalmonEgg.Infrastructure.Tests.Transport.WebSocketCancelRequestFullStackTests \
   --filter-class SalmonEgg.Infrastructure.Tests.Transport.StreamableHttpCancelRequestFullStackTests \
+  --filter-class SalmonEgg.Infrastructure.Tests.Transport.StreamableHttpPermissionRetryFullStackTests \
   --filter-class SalmonEgg.Infrastructure.Tests.Transport.NetworkCancellationErrorOwnershipTests \
-  --minimum-expected-tests 6 \
+  --minimum-expected-tests 8 \
   --output Detailed > "$log_file" 2>&1 || {
     cat "$log_file"
     exit 1
@@ -41,7 +42,7 @@ import sys
 text = pathlib.Path(sys.argv[1]).read_text()
 passed = re.findall(r'^\s+succeeded:\s+(\d+)\s*$', text, re.M)
 skipped = re.findall(r'^\s+skipped:\s+(\d+)\s*$', text, re.M)
-if not passed or int(passed[-1]) < 6 or not skipped or int(skipped[-1]) != 0:
+if not passed or int(passed[-1]) < 8 or not skipped or int(skipped[-1]) != 0:
     raise SystemExit('Cancellation transport gate did not execute every real transport case without skips.')
-print('[gate] Real stdio, WebSocket, HTTP/2 + SSE, and error-ownership contracts passed with no skipped cases.')
+print('[gate] Real stdio, WebSocket, HTTP/2 + SSE cancellation and permission retries passed with no skipped cases.')
 PY

--- a/src/SalmonEgg.Infrastructure/Network/StreamableHttpTransport.cs
+++ b/src/SalmonEgg.Infrastructure/Network/StreamableHttpTransport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
+using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Domain.Models;
 
 namespace SalmonEgg.Infrastructure.Network
@@ -46,11 +48,11 @@ namespace SalmonEgg.Infrastructure.Network
 
         // 出站请求 id → (method, params.sessionId):用于在响应回流时识别
         // session/new(会话 id 在 result)与 session/load(会话 id 在请求参数)以开启会话级流。
-        private readonly ConcurrentDictionary<string, PendingRequest> _pendingRequests = new();
+        private readonly ConcurrentDictionary<AcpRequestId, PendingRequest> _pendingRequests = new();
 
-        // 会话级流上收到的服务端请求 id → sessionId:client 回发的 JSON-RPC 响应
-        // (如权限响应)按草案须带 Acp-Session-Id,而响应体本身不携带 sessionId。
-        private readonly ConcurrentDictionary<string, string> _inboundRequestSessions = new();
+        // 服务端请求 id → 所属流:权限回复须带 Acp-Session-Id,连接级请求则不带;
+        // 响应体本身不携带 sessionId,所以路由必须保留到 POST 成功。
+        private readonly ConcurrentDictionary<AcpRequestId, InboundRequestRoute> _inboundRequestSessions = new();
 
         private readonly ConcurrentDictionary<string, Lazy<Task>> _sessionStreams = new();
 
@@ -298,10 +300,16 @@ namespace SalmonEgg.Infrastructure.Network
                     "Streamable HTTP transport has no connection id yet; initialize must complete first.");
             }
 
-            var sessionId = ResolveOutboundSessionId(peek);
-            if (peek.Id is not null && !peek.IsResponse)
+            InboundRequestRoute? responseRoute = null;
+            if (peek.IsResponse && peek.Id is { } responseId)
             {
-                _pendingRequests[peek.Id] = new PendingRequest(peek.Method, peek.ParamsSessionId);
+                _inboundRequestSessions.TryGetValue(responseId, out responseRoute);
+            }
+
+            var sessionId = peek.IsResponse ? responseRoute?.SessionId : ResolveOutboundSessionId(peek);
+            if (peek.Id is { } requestId && !peek.IsResponse)
+            {
+                _pendingRequests[requestId] = new PendingRequest(peek.Method, peek.ParamsSessionId);
             }
 
             using var request = CreateJsonPost(message, includeConnectionId: true, sessionId);
@@ -310,25 +318,25 @@ namespace SalmonEgg.Infrastructure.Network
 
             // 草案:除 initialize 外一律 202,真实响应走 SSE 流。对 200 附带 JSON 正文的
             // 服务器保持宽松接收,把正文当作已送达的消息转发,不视为协议错误。
-            if (response.StatusCode != System.Net.HttpStatusCode.Accepted)
+            var body = response.StatusCode != System.Net.HttpStatusCode.Accepted
+                ? await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false)
+                : null;
+
+            // A failed POST leaves the request retryable. After success remove only the route
+            // captured for this response: the peer may already have reused the id on an SSE stream.
+            if (responseRoute is not null && peek.Id is { } completedId)
             {
-                var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-                if (!string.IsNullOrWhiteSpace(body))
-                {
-                    HandleInboundMessage(body, streamSessionId: null);
-                }
+                _inboundRequestSessions.TryRemove(new KeyValuePair<AcpRequestId, InboundRequestRoute>(completedId, responseRoute));
+            }
+
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                HandleInboundMessage(body, streamSessionId: null);
             }
         }
 
-        private string? ResolveOutboundSessionId(MessagePeek peek)
+        private static string? ResolveOutboundSessionId(MessagePeek peek)
         {
-            if (peek.IsResponse)
-            {
-                return peek.Id is not null && _inboundRequestSessions.TryRemove(peek.Id, out var sessionId)
-                    ? sessionId
-                    : null;
-            }
-
             // 草案明确列出的会话级 POST 是 session/prompt、session/cancel 与权限响应;
             // 其余带 sessionId 的方法(set_mode/close 等)的响应被声明在连接级流,
             // 故按连接级发送。草案定稿若扩大会话级清单,此判定须同步。
@@ -500,7 +508,7 @@ namespace SalmonEgg.Infrastructure.Network
         private void HandleInboundMessage(string message, string? streamSessionId)
         {
             var peek = MessagePeek.From(message);
-            if (peek.IsResponse && peek.Id is not null && _pendingRequests.TryRemove(peek.Id, out var pending))
+            if (peek.IsResponse && peek.Id is { } responseId && _pendingRequests.TryRemove(responseId, out var pending))
             {
                 // session/new 的会话 id 在 result;session/load 的会话 id 来自请求参数。
                 // 两者都要求随即开启会话级 SSE 流,否则该会话的更新与 prompt 响应永远收不到。
@@ -515,9 +523,9 @@ namespace SalmonEgg.Infrastructure.Network
                     EnsureSessionStream(establishedSessionId!);
                 }
             }
-            else if (!peek.IsResponse && peek.Method is not null && peek.Id is not null && streamSessionId is not null)
+            else if (!peek.IsResponse && peek.Method is not null && peek.Id is { } requestId)
             {
-                _inboundRequestSessions[peek.Id] = streamSessionId;
+                _inboundRequestSessions[requestId] = new InboundRequestRoute(streamSessionId);
             }
 
             // 多个 SSE 流与 POST 内联正文并发到达;串行化发布以维持下游依赖的到达序单线程契约。
@@ -591,6 +599,12 @@ namespace SalmonEgg.Infrastructure.Network
 
         private readonly record struct PendingRequest(string? Method, string? SessionId);
 
+        // Reference identity distinguishes successive requests even when both id and session match.
+        private sealed class InboundRequestRoute(string? sessionId)
+        {
+            public string? SessionId { get; } = sessionId;
+        }
+
         /// <summary>
         /// 只读窥探出/入站 JSON-RPC 消息的路由要素;负载本身原样透传,绝不改写。
         /// 非法 JSON 不在传输层拒绝(由协议层裁决),返回空要素按连接级处理。
@@ -599,7 +613,7 @@ namespace SalmonEgg.Infrastructure.Network
         {
             public string? Method { get; init; }
 
-            public string? Id { get; init; }
+            public AcpRequestId? Id { get; init; }
 
             public string? ParamsSessionId { get; init; }
 
@@ -624,11 +638,11 @@ namespace SalmonEgg.Infrastructure.Network
                         method = methodElement.GetString();
                     }
 
-                    string? id = null;
+                    AcpRequestId? id = null;
                     if (root.TryGetProperty("id", out var idElement)
-                        && idElement.ValueKind is JsonValueKind.String or JsonValueKind.Number)
+                        && AcpRequestId.TryFromEnvelopeId(idElement, out var requestId))
                     {
-                        id = idElement.ValueKind == JsonValueKind.String ? idElement.GetString() : idElement.GetRawText();
+                        id = requestId;
                     }
 
                     string? paramsSessionId = null;

--- a/tests/SalmonEgg.Infrastructure.Tests/Network/StreamableHttpTransportTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Network/StreamableHttpTransportTests.cs
@@ -158,6 +158,203 @@ public sealed class StreamableHttpTransportTests : IDisposable
         Assert.Equal("sess-9", permissionPost.SessionId);
     }
 
+    [Theory]
+    [InlineData("77", "\"77\"")]
+    [InlineData("\"77\"", "77")]
+    [InlineData("null", "\"null\"")]
+    public async Task PermissionResponses_WithDistinctIdTypes_KeepTheirSessionRoutes(string firstId, string secondId)
+    {
+        // Arrange: ids that look alike in diagnostics still name different JSON-RPC requests.
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await OpenSessionAsync("second", 3);
+        await EmitPermissionAsync("first", firstId);
+        await EmitPermissionAsync("second", secondId);
+
+        // Act
+        await _transport.SendAsync(PermissionResponse(firstId), TestContext.Current.CancellationToken);
+        await _transport.SendAsync(PermissionResponse(secondId), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("first", _server.Posts.Single(post => post.Body == PermissionResponse(firstId)).SessionId);
+        Assert.Equal("second", _server.Posts.Single(post => post.Body == PermissionResponse(secondId)).SessionId);
+    }
+
+    [Theory]
+    [InlineData("first")]
+    [InlineData("second")]
+    [InlineData(null)]
+    public async Task PermissionResponse_WhenPeerReusesIdDuringPostCompletion_PreservesTheNewRoute(string? nextSession)
+    {
+        // Arrange: SSE can deliver the next request before the previous POST completion is observed.
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await OpenSessionAsync("second", 3);
+        await EmitPermissionAsync("first", "77");
+        var posted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var accepted = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        const string connectionResponse = "{\"jsonrpc\":\"2.0\",\"id\":77,\"result\":{}}";
+        _server.PostResponse = (post, ct) =>
+        {
+            if (post.Body == connectionResponse) return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted));
+            posted.TrySetResult();
+            return accepted.Task.WaitAsync(ct);
+        };
+
+        // Act
+        var previousResponse = _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+        await posted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        if (nextSession is not null)
+        {
+            await EmitPermissionAsync(nextSession, "77", "next");
+        }
+        else
+        {
+            const string connectionRequest = "{\"jsonrpc\":\"2.0\",\"id\":77,\"method\":\"_ping\",\"params\":{}}";
+            await _server.EmitOnConnectionStreamAsync(connectionRequest);
+            await WaitForAsync(() => _received.Contains(connectionRequest));
+            await _transport.SendAsync(connectionResponse, TestContext.Current.CancellationToken);
+            Assert.Null(_server.Posts.Single(post => post.Body == connectionResponse).SessionId);
+        }
+        accepted.SetResult(new HttpResponseMessage(HttpStatusCode.Accepted));
+        await previousResponse;
+        _server.PostResponse = null;
+        await _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+
+        // Assert: this also covers reuse on the same session, where comparing only the strings fails.
+        var replies = _server.Posts.Where(post => post.Body == PermissionResponse("77")).ToArray();
+        Assert.Equal(2, replies.Length);
+        Assert.Equal("first", replies[0].SessionId);
+        Assert.Equal(nextSession, replies[1].SessionId);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PermissionResponse_WhenPostThrowsOrIsCancelled_RetainsRouteForRetry(bool cancel)
+    {
+        // Arrange
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await EmitPermissionAsync("first", "77");
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        _server.PostResponse = async (_, ct) =>
+        {
+            if (cancel)
+            {
+                cancellation.Cancel();
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            }
+            throw new HttpRequestException("Temporary write failure.");
+        };
+
+        // Act
+        if (cancel)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _transport.SendAsync(PermissionResponse("77"), cancellation.Token));
+        }
+        else
+        {
+            await Assert.ThrowsAsync<HttpRequestException>(() => _transport.SendAsync(PermissionResponse("77"), cancellation.Token));
+        }
+        _server.PostResponse = null;
+        await _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var replies = _server.Posts.Where(post => post.Body == PermissionResponse("77")).ToArray();
+        Assert.Equal(2, replies.Length);
+        Assert.All(replies, post => Assert.Equal("first", post.SessionId));
+    }
+
+    [Fact]
+    public async Task PermissionResponse_AfterSuccessfulPost_DoesNotLeakRouteIntoConnectionRequest()
+    {
+        // Arrange
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await EmitPermissionAsync("first", "77");
+        await _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+
+        // Act: a later connection-level request legitimately reuses the now-completed id.
+        const string connectionRequest = "{\"jsonrpc\":\"2.0\",\"id\":77,\"method\":\"_ping\",\"params\":{}}";
+        await _server.EmitOnConnectionStreamAsync(connectionRequest);
+        await WaitForAsync(() => _received.Contains(connectionRequest));
+        const string response = "{\"jsonrpc\":\"2.0\",\"id\":77,\"result\":{}}";
+        await _transport.SendAsync(response, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(_server.Posts.Single(post => post.Body == response).SessionId);
+    }
+
+    [Fact]
+    public async Task PermissionResponse_WithInlineConnectionRequest_ReentrantReplyUsesTheNewScope()
+    {
+        // Arrange: the peer's successful POST body can contain its next request.
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await EmitPermissionAsync("first", "77");
+        const string connectionRequest = "{\"jsonrpc\":\"2.0\",\"id\":77,\"method\":\"_ping\",\"params\":{}}";
+        const string connectionResponse = "{\"jsonrpc\":\"2.0\",\"id\":77,\"result\":{}}";
+        var replied = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = _transport.Messages.Subscribe(message =>
+        {
+            if (message == connectionRequest)
+            {
+                replied.SetResult(_transport.SendAsync(connectionResponse, TestContext.Current.CancellationToken));
+            }
+        });
+        _server.PostResponse = (post, _) => Task.FromResult(post.Body == connectionResponse
+            ? new HttpResponseMessage(HttpStatusCode.Accepted)
+            : new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(connectionRequest, Encoding.UTF8, "application/json")
+            });
+
+        // Act
+        await _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+        var reply = await replied.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await reply;
+
+        // Assert
+        Assert.Null(_server.Posts.Single(post => post.Body == connectionResponse).SessionId);
+    }
+
+    [Fact]
+    public async Task PermissionResponse_WhenOldPostCompletesAfterReconnect_PreservesTheNewConnectionRoute()
+    {
+        // Arrange: a server can finish an accepted POST after the original connection closes.
+        await InitializeAsync();
+        await OpenSessionAsync("first", 2);
+        await EmitPermissionAsync("first", "77");
+        var posted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var accepted = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _server.PostResponse = (_, _) =>
+        {
+            posted.SetResult();
+            return accepted.Task;
+        };
+        var oldResponse = _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+        await posted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Act: the new connection receives another request with the same id and session spelling.
+        await _transport.DisconnectAsync();
+        _server.PostResponse = null;
+        _server.RestartStreams();
+        await _transport.ConnectAsync(Endpoint, TestContext.Current.CancellationToken);
+        await _transport.SendAsync("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}", TestContext.Current.CancellationToken);
+        await WaitForAsync(() => _server.ConnectionStreamRequests.Count == 2);
+        await OpenSessionAsync("first", 3);
+        await EmitPermissionAsync("first", "77", "new-connection");
+        accepted.SetResult(new HttpResponseMessage(HttpStatusCode.Accepted));
+        await oldResponse;
+        await _transport.SendAsync(PermissionResponse("77"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var replies = _server.Posts.Where(post => post.Body == PermissionResponse("77")).ToArray();
+        Assert.Equal(2, replies.Length);
+        Assert.All(replies, post => Assert.Equal("first", post.SessionId));
+    }
+
     [Fact]
     public async Task Disconnect_SendsDeleteWithConnectionId()
     {
@@ -206,6 +403,23 @@ public sealed class StreamableHttpTransportTests : IDisposable
         await WaitForAsync(() => _server.ConnectionStreamRequests.Count == 1);
     }
 
+    private async Task OpenSessionAsync(string sessionId, int requestId)
+    {
+        await _transport.SendAsync($$$$"""{"jsonrpc":"2.0","id":{{{{requestId}}}},"method":"session/new","params":{}}""", TestContext.Current.CancellationToken);
+        await _server.EmitOnConnectionStreamAsync($$$$"""{"jsonrpc":"2.0","id":{{{{requestId}}}},"result":{"sessionId":"{{{{sessionId}}}}"}}""");
+        await WaitForAsync(() => _server.SessionStreamRequests.Any(request => request.SessionId == sessionId));
+    }
+
+    private async Task EmitPermissionAsync(string sessionId, string id, string toolCallId = "tool")
+    {
+        var message = $$$$"""{"jsonrpc":"2.0","id":{{{{id}}}},"method":"session/request_permission","params":{"sessionId":"{{{{sessionId}}}}","toolCall":{"toolCallId":"{{{{toolCallId}}}}"}}}""";
+        await _server.EmitOnSessionStreamAsync(sessionId, message);
+        await WaitForAsync(() => _received.Contains(message));
+    }
+
+    private static string PermissionResponse(string id)
+        => $$$$"""{"jsonrpc":"2.0","id":{{{{id}}}},"result":{"outcome":{"outcome":"cancelled"}}}""";
+
     private static async Task WaitForAsync(Func<bool> condition, int timeoutSeconds = 5)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(timeoutSeconds);
@@ -232,7 +446,7 @@ public sealed class StreamableHttpTransportTests : IDisposable
     private sealed class FakeAcpServerHandler : HttpMessageHandler
     {
         private readonly ConcurrentDictionary<string, Pipe> _sessionPipes = new();
-        private readonly Pipe _connectionPipe = new();
+        private Pipe _connectionPipe = new();
 
         public bool OmitConnectionIdOnInitialize { get; set; }
 
@@ -241,6 +455,8 @@ public sealed class StreamableHttpTransportTests : IDisposable
         public bool HangDeleteRequests { get; set; }
 
         public bool HangInitializeRequests { get; set; }
+
+        public Func<PostRequest, CancellationToken, Task<HttpResponseMessage>>? PostResponse { get; set; }
 
         public ConcurrentQueue<PostRequest> Posts { get; } = new();
 
@@ -255,6 +471,13 @@ public sealed class StreamableHttpTransportTests : IDisposable
 
         public Task EmitOnSessionStreamAsync(string sessionId, string message)
             => WriteSseAsync(_sessionPipes.GetOrAdd(sessionId, _ => new Pipe()), message);
+
+        public void RestartStreams()
+        {
+            _connectionPipe = new Pipe();
+            _sessionPipes.Clear();
+            SessionStreamRequests.Clear();
+        }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -303,8 +526,11 @@ public sealed class StreamableHttpTransportTests : IDisposable
                     return response;
                 }
 
-                Posts.Enqueue(new PostRequest(body, connectionId, sessionId));
-                return new HttpResponseMessage(HttpStatusCode.Accepted);
+                var post = new PostRequest(body, connectionId, sessionId);
+                Posts.Enqueue(post);
+                return PostResponse is { } respond
+                    ? await respond(post, cancellationToken)
+                    : new HttpResponseMessage(HttpStatusCode.Accepted);
             }
 
             var accept = string.Join(",", request.Headers.Accept.Select(header => header.ToString()));

--- a/tests/SalmonEgg.Infrastructure.Tests/Transport/StreamableHttpPermissionRetryFullStackTests.cs
+++ b/tests/SalmonEgg.Infrastructure.Tests/Transport/StreamableHttpPermissionRetryFullStackTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Logging;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Network;
+using Serilog;
+
+namespace SalmonEgg.Infrastructure.Tests.Transport;
+
+public sealed class StreamableHttpPermissionRetryFullStackTests
+{
+    [Theory]
+    [InlineData("selected", "allow")]
+    [InlineData("cancelled", null)]
+    public async Task PermissionResponse_AfterTemporaryHttpFailure_RetriesOnTheOriginalSession(string outcome, string? optionId)
+    {
+        // Arrange: use real HTTP/2 POSTs and a session SSE stream through both production adapters.
+        await using var peer = await PermissionHttpPeer.StartAsync();
+        using var transport = new StreamableHttpTransport(Log.Logger);
+        using var network = new NetworkTransportAdapter(transport, peer.Url);
+        using var client = new AcpClient(new DomainAcpTransportAdapter(network));
+        var received = new TaskCompletionSource<PermissionRequestEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.PermissionRequestReceived += (_, request) => received.TrySetResult(request);
+        var token = TestContext.Current.CancellationToken;
+        await client.InitializeAsync(new InitializeParams(new ClientInfo("permission-retry", "1"), new ClientCapabilities()), token);
+        await client.CreateSessionAsync(new SessionNewParams(Path.GetFullPath(Path.GetTempPath()), null), token);
+        await peer.SessionReady.Task.WaitAsync(TimeSpan.FromSeconds(5), token);
+        await peer.SendPermissionAsync(token);
+        var request = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), token);
+
+        // Act: the server rejects the first attempt without ending the connection.
+        Assert.False(await request.TryRespondAsync(outcome, optionId).WaitAsync(TimeSpan.FromSeconds(5), token));
+        Assert.True(request.CanRespond);
+        var retried = await request.TryRespondAsync(outcome, optionId).WaitAsync(TimeSpan.FromSeconds(5), token);
+
+        // Assert: the same request and session reach the peer, for both a choice and a cancellation.
+        Assert.True(retried);
+        Assert.False(request.CanRespond);
+        Assert.True(client.IsConnected);
+        Assert.Equal(new[] { PermissionHttpPeer.SessionId, PermissionHttpPeer.SessionId }, peer.ResponseSessions);
+        Assert.All(peer.ResponseProtocols, protocol => Assert.Equal("HTTP/2", protocol));
+        var response = Assert.Single(peer.AcceptedResponses);
+        Assert.Equal(73, response.GetProperty("id").GetInt32());
+        Assert.Equal(outcome, response.GetProperty("result").GetProperty("outcome").GetProperty("outcome").GetString());
+        await client.DisconnectAsync().WaitAsync(TimeSpan.FromSeconds(5), token);
+    }
+
+    private sealed class PermissionHttpPeer : IAsyncDisposable
+    {
+        internal const string SessionId = "permission-session";
+        private const string ConnectionId = "permission-connection";
+        private readonly WebApplication _app;
+        private readonly Channel<string> _events = Channel.CreateUnbounded<string>();
+        private readonly CancellationTokenSource _stop = new();
+        private int _responseCount;
+
+        private PermissionHttpPeer(WebApplication app) => _app = app;
+
+        internal string Url => _app.Urls.Single() + "/acp";
+        internal TaskCompletionSource SessionReady { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal ConcurrentQueue<string> ResponseSessions { get; } = new();
+        internal ConcurrentQueue<string> ResponseProtocols { get; } = new();
+        internal ConcurrentQueue<JsonElement> AcceptedResponses { get; } = new();
+
+        internal static async Task<PermissionHttpPeer> StartAsync()
+        {
+            var builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, 0,
+                listener => listener.Protocols = HttpProtocols.Http2));
+            var peer = new PermissionHttpPeer(builder.Build());
+            peer._app.Run(peer.HandleAsync);
+            await peer._app.StartAsync(TestContext.Current.CancellationToken);
+            return peer;
+        }
+
+        internal ValueTask SendPermissionAsync(CancellationToken token)
+            => _events.Writer.WriteAsync("""
+                {"jsonrpc":"2.0","id":73,"method":"session/request_permission","params":{
+                "sessionId":"permission-session","toolCall":{"toolCallId":"tool"},
+                "options":[{"optionId":"allow","name":"Allow once","kind":"allow_once"}]}}
+                """.ReplaceLineEndings(string.Empty), token);
+
+        public async ValueTask DisposeAsync()
+        {
+            await _stop.CancelAsync();
+            _events.Writer.TryComplete();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await _app.StopAsync(timeout.Token);
+            await _app.DisposeAsync();
+            _stop.Dispose();
+        }
+
+        private async Task HandleAsync(HttpContext context)
+        {
+            using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(_stop.Token, context.RequestAborted);
+            try
+            {
+                if (HttpMethods.IsDelete(context.Request.Method))
+                {
+                    context.Response.StatusCode = StatusCodes.Status202Accepted;
+                    return;
+                }
+                if (HttpMethods.IsGet(context.Request.Method))
+                {
+                    await StreamAsync(context, lifetime.Token);
+                    return;
+                }
+
+                using var document = await JsonDocument.ParseAsync(context.Request.Body, cancellationToken: lifetime.Token);
+                var message = document.RootElement;
+                if (message.TryGetProperty("method", out var method))
+                {
+                    var id = message.GetProperty("id").GetRawText();
+                    var result = method.GetString() == "initialize"
+                        ? "{\"protocolVersion\":1,\"agentInfo\":{\"name\":\"peer\",\"version\":\"1\"},\"agentCapabilities\":{}}"
+                        : "{\"sessionId\":\"" + SessionId + "\"}";
+                    context.Response.Headers["Acp-Connection-Id"] = ConnectionId;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":" + result + "}", lifetime.Token);
+                    return;
+                }
+
+                var sessionId = context.Request.Headers["Acp-Session-Id"].ToString();
+                ResponseSessions.Enqueue(sessionId);
+                ResponseProtocols.Enqueue(context.Request.Protocol);
+                if (Interlocked.Increment(ref _responseCount) == 1)
+                {
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                }
+                else if (sessionId != SessionId)
+                {
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                }
+                else
+                {
+                    AcceptedResponses.Enqueue(message.Clone());
+                    context.Response.StatusCode = StatusCodes.Status202Accepted;
+                }
+            }
+            catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+            {
+            }
+        }
+
+        private async Task StreamAsync(HttpContext context, CancellationToken token)
+        {
+            context.Response.ContentType = "text/event-stream";
+            await context.Response.WriteAsync(": ready\n\n", token);
+            await context.Response.Body.FlushAsync(token);
+            if (context.Request.Headers["Acp-Session-Id"] != SessionId)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return;
+            }
+
+            SessionReady.TrySetResult();
+            await foreach (var message in _events.Reader.ReadAllAsync(token))
+            {
+                await context.Response.WriteAsync("data: " + message + "\n\n", token);
+                await context.Response.Body.FlushAsync(token);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Permission responses over Streamable HTTP lost their `Acp-Session-Id` after a failed POST, so retrying either a choice or a cancellation could never reach the original session. Keep the route until delivery succeeds, then remove only that request's captured route. Reuse the SDK's typed JSON-RPC IDs and retain the new scope when a peer reuses an ID or replies inline during POST completion.

Validation: 24 targeted transport cases passed, including failure/cancellation, number/string/null IDs, same/different-session reuse, immediate connection-level replies, and a late POST completion after reconnect. The full Infrastructure suite passed 894 cases with 7 expected environment/platform skips. The Linux gate separately executed all 8 real stdio, WebSocket, HTTP/2 + SSE cancellation/permission cases with zero skips. Both new real permission retry cases failed before the fix and pass afterward. Changed-file format verification passed. Platform checks run on this PR's final commit.

The transport continues to follow the repository's adopted Streamable HTTP/WebSocket RFD; this change does not enable draft ACP V2 in production.

Related to #148.
