### PR TITLE
fix(acp): preserve replay ownership and recover draft content fields

### DIFF
--- a/scripts/gates/acp-v2-projection-consumer.cs
+++ b/scripts/gates/acp-v2-projection-consumer.cs
@@ -60,6 +60,27 @@ var recent = AcpSessionDraftExtensions.ReplaySession("bounded-history",
 Require(recent.UnprojectedUpdates.Length == AcpSessionSnapshot.MaxUnprojectedUpdates
     && recent.OmittedUnprojectedUpdateCount == 1 && snapshot.OmittedUnprojectedUpdateCount == 0,
     "Unprojected evidence must be bounded and omissions must remain visible on each snapshot.");
+
+var recovered = AcpSessionDraftExtensions.ReplaySession("content-recovery",
+[
+    Parse("""{"sessionUpdate":"agent_message","messageId":"a","content":[{"type":"text","text":"kept","annotations":false}]}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":" tail","_meta":false}}""")
+]);
+Require(Text(recovered.Messages.Single()) == "kept tail",
+    "Schema-defaultable annotations and metadata must not discard content or reject chunks.");
+Require(recovered.Messages[0].Content.All(static block => block.Annotations is null && block.Meta is null),
+    "Invalid optional content fields must default without becoming peer metadata.");
+var invalidTextRejected = false;
+try
+{
+    AcpSessionDraftExtensions.ReplaySession("invalid-content",
+    [Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":42}}""")]);
+}
+catch (JsonException)
+{
+    invalidTextRejected = true;
+}
+Require(invalidTextRejected, "Required text type errors must remain rejected.");
 Console.WriteLine("draft-projection-consumer-ok");
 
 static JsonElement Parse(string json)

--- a/scripts/gates/acp-v2-projection-consumer.cs
+++ b/scripts/gates/acp-v2-projection-consumer.cs
@@ -81,6 +81,32 @@ catch (JsonException)
     invalidTextRejected = true;
 }
 Require(invalidTextRejected, "Required text type errors must remain rejected.");
+
+var media = AcpSessionDraftExtensions.ReplaySession("media-recovery",
+[
+    Parse("""{"sessionUpdate":"agent_message","messageId":"m","content":[{"type":"image","data":"YQ==","mimeType":"image/png","uri":false}]}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"resource_link","uri":"file:///kept","name":"kept","title":false,"description":17,"mimeType":{},"size":"large"}}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"resource","resource":{"uri":"file:///kept","text":"resource text","mimeType":false}}}"""),
+    Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"resource","resource":{"uri":"file:///kept","blob":"YQ==","mimeType":false}}}""")
+]).Messages.Single().Content;
+Require(media.Length == 4 && media[0] is ImageContentBlock { Data: "YQ==", MimeType: "image/png", Uri: null },
+    "Invalid optional image URI must not discard valid media.");
+Require(media[1] is ResourceLinkContentBlock { Uri: "file:///kept", Name: "kept", Title: null, Description: null, MimeType: null, Size: null },
+    "Optional resource-link fields must default independently of its required identity.");
+Require(media[2] is ResourceContentBlock { Resource: { Text: "resource text", MimeType: null } }
+    && media[3] is ResourceContentBlock { Resource: { Blob: "YQ==", MimeType: null } },
+    "Optional embedded-resource media types must not discard either valid union branch.");
+var invalidResourceRejected = false;
+try
+{
+    AcpSessionDraftExtensions.ReplaySession("invalid-resource",
+    [Parse("""{"sessionUpdate":"agent_message_chunk","messageId":"m","content":{"type":"resource","resource":{"uri":"file:///kept","text":17,"blob":false}}}""")]);
+}
+catch (JsonException)
+{
+    invalidResourceRejected = true;
+}
+Require(invalidResourceRejected, "An embedded resource must satisfy a required text or blob branch.");
 Console.WriteLine("draft-projection-consumer-ok");
 
 static JsonElement Parse(string json)

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -612,26 +612,16 @@ namespace SalmonEgg.Acp.Client
             }
 
             AcpSessionProjection? replay = null;
-            try
-            {
-                return await SendRequestAsync(
-                    request,
-                    cancellationToken,
-                    connectionToken,
-                    responseObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
-                    beforeSend: () => replay = _sessionWork.BeginReplay(@params.SessionId, connectionToken)).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && replay is not null)
-            {
-                // Cancelling the wait cannot retract streamed replay. Its response or disconnect
-                // releases the claim; another full replay must not interleave uncorrelated updates.
-                throw;
-            }
-            catch
-            {
-                _sessionWork.EndReplay(@params.SessionId, replay, connectionToken);
-                throw;
-            }
+            // A cancelled wait or failed write cannot retract replay the peer may already be
+            // streaming. The request owner alone distinguishes an unsent request from one awaiting
+            // its terminal response; the replay claim must have that same lifetime.
+            return await SendRequestAsync(
+                request,
+                cancellationToken,
+                connectionToken,
+                responseObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
+                requestNotSentObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
+                beforeSend: () => replay = _sessionWork.BeginReplay(@params.SessionId, connectionToken)).ConfigureAwait(false);
         }
 
         private static bool RequestsFullReplay(JsonRpcRequest request)

--- a/src/SalmonEgg.Acp/Content/ContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ContentBlock.cs
@@ -138,7 +138,7 @@ namespace SalmonEgg.Acp.Content
             {
                 Data = ReadRequiredContentString(root, "data", options)!,
                 MimeType = ReadRequiredContentString(root, "mimeType", options)!,
-                Uri = ReadString(root, "uri"),
+                Uri = ReadOptionalContentString(root, "uri", options),
                 Annotations = ReadAnnotations(root, options),
                 Meta = ReadMetadata(root, options)
             };
@@ -163,10 +163,10 @@ namespace SalmonEgg.Acp.Content
             {
                 Uri = ReadRequiredContentString(root, "uri", options)!,
                 Name = ReadRequiredContentString(root, "name", options),
-                MimeType = ReadString(root, "mimeType"),
-                Title = ReadString(root, "title"),
-                Description = ReadString(root, "description"),
-                Size = ReadInt64(root, "size"),
+                MimeType = ReadOptionalContentString(root, "mimeType", options),
+                Title = ReadOptionalContentString(root, "title", options),
+                Description = ReadOptionalContentString(root, "description", options),
+                Size = ReadOptionalContentSize(root, options),
                 RawIcons = root.TryGetProperty("icons", out var icons) ? icons.Clone() : null,
                 Annotations = ReadAnnotations(root, options),
                 Meta = ReadMetadata(root, options)
@@ -214,12 +214,46 @@ namespace SalmonEgg.Acp.Content
                 throw new JsonException("Embedded resource payload must be a JSON object.");
             }
 
+            if (AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2)
+            {
+                return ReadDraftEmbeddedResource(element, options);
+            }
+
             return new EmbeddedResource
             {
                 Uri = ReadRequiredContentString(element, "uri", options)!,
                 MimeType = ReadString(element, "mimeType")!,
                 Text = ReadString(element, "text"),
                 Blob = ReadString(element, "blob"),
+                Meta = ReadMetadata(element, options)
+            };
+        }
+
+        private static EmbeddedResource ReadDraftEmbeddedResource(JsonElement element, JsonSerializerOptions options)
+        {
+            // The pinned v2 resource union is untagged: try text before blob, as the upstream
+            // reader does. The other branch's fields cannot invalidate an otherwise valid branch.
+            string? text = null;
+            string? blob = null;
+            if (element.TryGetProperty("text", out var rawText) && rawText.ValueKind == JsonValueKind.String)
+            {
+                text = rawText.GetString();
+            }
+            else if (element.TryGetProperty("blob", out var rawBlob) && rawBlob.ValueKind == JsonValueKind.String)
+            {
+                blob = rawBlob.GetString();
+            }
+            else
+            {
+                throw new JsonException("ACP v2 embedded resource requires string 'text' or 'blob'.");
+            }
+
+            return new EmbeddedResource
+            {
+                Uri = ReadRequiredContentString(element, "uri", options)!,
+                MimeType = ReadOptionalContentString(element, "mimeType", options)!,
+                Text = text,
+                Blob = blob,
                 Meta = ReadMetadata(element, options)
             };
         }
@@ -260,6 +294,20 @@ namespace SalmonEgg.Acp.Content
             => AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
                 ? AcpMetaJson.ReadOrDefault(root)
                 : AcpMetaJson.Read(root);
+
+        // Only the v2 fields marked x-deserialize-default-on-error call these readers. Required
+        // strings keep the strict reader, and unversioned/v1 contracts keep their existing behavior.
+        private static string? ReadOptionalContentString(JsonElement root, string propertyName, JsonSerializerOptions options)
+            => AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
+                ? root.TryGetProperty(propertyName, out var field) && field.ValueKind == JsonValueKind.String
+                    ? field.GetString() : null
+                : ReadString(root, propertyName);
+
+        private static long? ReadOptionalContentSize(JsonElement root, JsonSerializerOptions options)
+            => AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
+                ? root.TryGetProperty("size", out var field) && field.ValueKind == JsonValueKind.Number && field.TryGetInt64(out var size)
+                    ? size : null
+                : ReadInt64(root, "size");
 
         private static string? ReadRequiredContentString(JsonElement root, string propertyName, JsonSerializerOptions options)
         {

--- a/src/SalmonEgg.Acp/Content/ContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ContentBlock.cs
@@ -87,12 +87,12 @@ namespace SalmonEgg.Acp.Content
 
             return discriminator switch
             {
-                "text" => ReadText(root),
-                "image" => ReadImage(root),
-                "audio" => ReadAudio(root),
-                "resource_link" => ReadResourceLink(root),
-                "resource" => ReadResource(root),
-                _ => ReadUnknown(root, discriminator)
+                "text" => ReadText(root, options),
+                "image" => ReadImage(root, options),
+                "audio" => ReadAudio(root, options),
+                "resource_link" => ReadResourceLink(root, options),
+                "resource" => ReadResource(root, options),
+                _ => ReadUnknown(root, discriminator, options)
             };
         }
 
@@ -121,60 +121,60 @@ namespace SalmonEgg.Acp.Content
             }
         }
 
-        private static TextContentBlock ReadText(JsonElement root)
+        private static TextContentBlock ReadText(JsonElement root, JsonSerializerOptions options)
         {
             var block = new TextContentBlock
             {
-                Text = ReadString(root, "text")!,
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root)
+                Text = ReadRequiredContentString(root, "text", options)!,
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options)
             };
             return block;
         }
 
-        private static ImageContentBlock ReadImage(JsonElement root)
+        private static ImageContentBlock ReadImage(JsonElement root, JsonSerializerOptions options)
         {
             var block = new ImageContentBlock
             {
-                Data = ReadString(root, "data")!,
-                MimeType = ReadString(root, "mimeType")!,
+                Data = ReadRequiredContentString(root, "data", options)!,
+                MimeType = ReadRequiredContentString(root, "mimeType", options)!,
                 Uri = ReadString(root, "uri"),
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root)
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options)
             };
             return block;
         }
 
-        private static AudioContentBlock ReadAudio(JsonElement root)
+        private static AudioContentBlock ReadAudio(JsonElement root, JsonSerializerOptions options)
         {
             var block = new AudioContentBlock
             {
-                Data = ReadString(root, "data")!,
-                MimeType = ReadString(root, "mimeType")!,
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root)
+                Data = ReadRequiredContentString(root, "data", options)!,
+                MimeType = ReadRequiredContentString(root, "mimeType", options)!,
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options)
             };
             return block;
         }
 
-        internal static ResourceLinkContentBlock ReadResourceLink(JsonElement root)
+        internal static ResourceLinkContentBlock ReadResourceLink(JsonElement root, JsonSerializerOptions options)
         {
             var block = new ResourceLinkContentBlock
             {
-                Uri = ReadString(root, "uri")!,
-                Name = ReadString(root, "name"),
+                Uri = ReadRequiredContentString(root, "uri", options)!,
+                Name = ReadRequiredContentString(root, "name", options),
                 MimeType = ReadString(root, "mimeType"),
                 Title = ReadString(root, "title"),
                 Description = ReadString(root, "description"),
                 Size = ReadInt64(root, "size"),
                 RawIcons = root.TryGetProperty("icons", out var icons) ? icons.Clone() : null,
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root)
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options)
             };
             return block;
         }
 
-        private static ResourceContentBlock ReadResource(JsonElement root)
+        private static ResourceContentBlock ReadResource(JsonElement root, JsonSerializerOptions options)
         {
             if (!root.TryGetProperty("resource", out var resourceElement)
                 || resourceElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
@@ -184,14 +184,14 @@ namespace SalmonEgg.Acp.Content
 
             var block = new ResourceContentBlock
             {
-                Resource = ReadEmbeddedResource(resourceElement),
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root)
+                Resource = ReadEmbeddedResource(resourceElement, options),
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options)
             };
             return block;
         }
 
-        private static ContentBlock ReadUnknown(JsonElement root, string discriminator)
+        private static ContentBlock ReadUnknown(JsonElement root, string discriminator, JsonSerializerOptions options)
         {
             // Unknown discriminators take the passthrough path: the spec requires a receiver to preserve the raw
             // payload of content types it does not recognize, leaving the decision to accept or reject them to the
@@ -201,13 +201,13 @@ namespace SalmonEgg.Acp.Content
             return new ContentBlock
             {
                 UnknownTypeDiscriminator = discriminator,
-                Annotations = ReadAnnotations(root),
-                Meta = AcpMetaJson.Read(root),
+                Annotations = ReadAnnotations(root, options),
+                Meta = ReadMetadata(root, options),
                 RawPayload = root.Clone()
             };
         }
 
-        private static EmbeddedResource ReadEmbeddedResource(JsonElement element)
+        private static EmbeddedResource ReadEmbeddedResource(JsonElement element, JsonSerializerOptions options)
         {
             if (element.ValueKind != JsonValueKind.Object)
             {
@@ -216,20 +216,28 @@ namespace SalmonEgg.Acp.Content
 
             return new EmbeddedResource
             {
-                Uri = ReadString(element, "uri")!,
+                Uri = ReadRequiredContentString(element, "uri", options)!,
                 MimeType = ReadString(element, "mimeType")!,
                 Text = ReadString(element, "text"),
                 Blob = ReadString(element, "blob"),
-                Meta = AcpMetaJson.Read(element)
+                Meta = ReadMetadata(element, options)
             };
         }
 
-        private static Annotations? ReadAnnotations(JsonElement root)
+        private static Annotations? ReadAnnotations(JsonElement root, JsonSerializerOptions options)
         {
             if (!root.TryGetProperty("annotations", out var annotationsElement)
                 || annotationsElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
             {
                 return null;
+            }
+
+            if (AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2)
+            {
+                // The v2 content contract at 5ebaf0aceb04a4ba6574cd63fa6355352dc6d931 defaults each optional field before the
+                // containing content list decides whether an item is invalid. The generated
+                // annotation contract also preserves valid siblings when one hint is malformed.
+                return DefaultableObjectJsonConverter<Annotations>.ReadValue(annotationsElement, options);
             }
 
             if (annotationsElement.ValueKind != JsonValueKind.Object)
@@ -246,6 +254,21 @@ namespace SalmonEgg.Acp.Content
             };
 
             return annotations;
+        }
+
+        private static Dictionary<string, object?>? ReadMetadata(JsonElement root, JsonSerializerOptions options)
+            => AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
+                ? AcpMetaJson.ReadOrDefault(root)
+                : AcpMetaJson.Read(root);
+
+        private static string? ReadRequiredContentString(JsonElement root, string propertyName, JsonSerializerOptions options)
+        {
+            var value = ReadString(root, propertyName);
+            if (value is null && AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2)
+            {
+                throw new JsonException($"ACP v2 content requires string '{propertyName}'.");
+            }
+            return value;
         }
 
         private static List<string>? ReadStringList(JsonElement root, string propertyName)

--- a/src/SalmonEgg.Acp/Content/ResourceLinkContentBlock.cs
+++ b/src/SalmonEgg.Acp/Content/ResourceLinkContentBlock.cs
@@ -99,7 +99,7 @@ namespace SalmonEgg.Acp.Content
         public override ResourceLinkContentBlock? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             using var document = JsonDocument.ParseValue(ref reader);
-            return ContentBlockJsonConverter.ReadResourceLink(document.RootElement);
+            return ContentBlockJsonConverter.ReadResourceLink(document.RootElement, options);
         }
 
         public override void Write(Utf8JsonWriter writer, ResourceLinkContentBlock value, JsonSerializerOptions options)

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -128,9 +128,11 @@ The [pinned v2 schema](https://github.com/agentclientprotocol/agent-client-proto
 explicitly allows default-on-error for optional patch fields and skip-invalid-items for message,
 tool-content, and location arrays. Those recoveries apply only to the v2 contracts that declare
 them. Required identities and chunks remain strict, unknown string discriminators survive, and
-content annotations and metadata recover their own optional fields before an enclosing list may
-discard an invalid content item. Valid text survives malformed hints; required text type errors
-remain invalid. V1 optional-field type validation is unchanged. The actual nupkg consumer gate replays mixed
+content annotations, metadata, optional image URIs, and optional resource-link/resource fields
+recover independently before an enclosing list may discard an invalid content item. Valid payloads
+survive malformed hints; required field type errors remain invalid. Embedded resources follow the
+schema's untagged union, selecting a valid text branch before a valid blob branch and rejecting a
+payload that satisfies neither. V1 optional-field type validation is unchanged. The actual nupkg consumer gate replays mixed
 history and asserts replacement, append, clear, terminal bytes, and snapshot isolation.
 
 `AcpPermissionDraftExtensions.ReadRequest(parameters)` parses recorded v2 permission params;

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -112,7 +112,8 @@ copies because wire DTO collections are mutable; editing a returned
 DTO cannot alter an existing snapshot or client state. A full `replayFrom: { type: "start" }` begins
 a fresh projection, while resume without replay retains prior history. Overlapping full replays
 are rejected because session updates carry no request id that could separate them; cancelling the
-local wait retains this claim until the peer responds or the connection ends.
+local wait or receiving an unknown write outcome retains this claim until the peer responds or the
+connection ends. Only a request that never started transport I/O releases the claim immediately.
 
 A snapshot is a current view, not a lossless event archive. `UnprojectedUpdates` retains recent
 unhandled updates verbatim within `MaxUnprojectedUpdates` (64 entries) and
@@ -127,7 +128,9 @@ The [pinned v2 schema](https://github.com/agentclientprotocol/agent-client-proto
 explicitly allows default-on-error for optional patch fields and skip-invalid-items for message,
 tool-content, and location arrays. Those recoveries apply only to the v2 contracts that declare
 them. Required identities and chunks remain strict, unknown string discriminators survive, and
-v1 optional-field type validation is unchanged. The actual nupkg consumer gate replays mixed
+content annotations and metadata recover their own optional fields before an enclosing list may
+discard an invalid content item. Valid text survives malformed hints; required text type errors
+remain invalid. V1 optional-field type validation is unchanged. The actual nupkg consumer gate replays mixed
 history and asserts replacement, append, clear, terminal bytes, and snapshot isolation.
 
 `AcpPermissionDraftExtensions.ReadRequest(parameters)` parses recorded v2 permission params;

--- a/src/SalmonEgg.Acp/Serialization/SessionProjectionWireContract.cs
+++ b/src/SalmonEgg.Acp/Serialization/SessionProjectionWireContract.cs
@@ -8,13 +8,20 @@ using SalmonEgg.Acp.Tool;
 
 namespace SalmonEgg.Acp.Serialization;
 
-// The v2 schema explicitly grants recovery to patch fields, not to the ids or streamed items.
+// The v2 schema grants recovery to optional metadata and patch fields, never required chunk content or ids.
 // Keep this on the negotiated resolver so v1 and unversioned serializers retain their contracts.
 internal static class SessionProjectionWireContract
 {
     internal static void Apply(JsonTypeInfo info)
     {
-        if (typeof(WholeMessageUpdate).IsAssignableFrom(info.Type))
+        if (info.Type == typeof(Annotations))
+        {
+            Property(info, "audience").CustomConverter = new DefaultableListJsonConverter<string>();
+            Property(info, "priority").CustomConverter = new DefaultableNullableJsonConverter<double>();
+            Property(info, "lastModified").CustomConverter = new DefaultableStringJsonConverter();
+            DefaultMetadata(info);
+        }
+        else if (typeof(WholeMessageUpdate).IsAssignableFrom(info.Type))
         {
             Property(info, "content").CustomConverter = new DefaultableListJsonConverter<ContentBlock>();
             DefaultMetadata(info);

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionContentRecoveryTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionContentRecoveryTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Acp.Tool;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpSessionContentRecoveryTests
+{
+    public static TheoryData<string, string> ContentCases => new()
+    {
+        { "text", "\"text\":\"kept\"" },
+        { "image", "\"data\":\"YQ==\",\"mimeType\":\"image/png\"" },
+        { "audio", "\"data\":\"YQ==\",\"mimeType\":\"audio/wav\"" },
+        { "resource_link", "\"name\":\"kept\",\"uri\":\"file:///kept\"" },
+        { "resource", "\"resource\":{\"uri\":\"file:///kept\",\"text\":\"kept\"}" }
+    };
+
+    [Theory]
+    [MemberData(nameof(ContentCases))]
+    public void ReplaySession_InvalidContentAnnotationsAndMetadata_PreservesWholeAndChunkContent(string type, string fields)
+    {
+        // Arrange
+        var content = "{\"type\":\"" + type + "\"," + fields + ",\"annotations\":false,\"_meta\":false}";
+        var whole = AcpSessionDraftExtensions.ReplaySession("session", [Update(content, chunk: false)]);
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("session", [Update(content, chunk: false), Update(content, chunk: true)]);
+
+        // Assert
+        var message = Assert.Single(snapshot.Messages);
+        Assert.Single(whole.Messages[0].Content);
+        Assert.Equal(2, message.Content.Length);
+        foreach (var block in message.Content)
+        {
+            Assert.Equal(type, block.Type);
+            Assert.Null(block.Annotations);
+            Assert.Null(block.Meta);
+            AssertPayloadPreserved(block);
+        }
+    }
+
+    [Fact]
+    public void ReplaySession_InvalidAnnotationFields_DefaultsOnlyTheInvalidFields()
+    {
+        // Arrange
+        var content = """{"type":"text","text":"kept","annotations":{"audience":["user",17,"assistant"],"priority":false,"lastModified":"2026-09-11T00:00:00Z","_meta":false},"_meta":{"source":"agent"}}""";
+
+        // Act
+        var message = Assert.Single(AcpSessionDraftExtensions.ReplaySession("session", [Update(content, chunk: true)]).Messages);
+
+        // Assert
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(message.Content));
+        Assert.Equal("kept", text.Text);
+        Assert.Equal(["user", "assistant"], text.Annotations!.Audience);
+        Assert.Null(text.Annotations.Priority);
+        Assert.Equal("2026-09-11T00:00:00Z", text.Annotations.LastModified);
+        Assert.Null(text.Annotations.Meta);
+        Assert.Equal("agent", Assert.IsType<JsonElement>(text.Meta!["source"]).GetString());
+    }
+
+    [Fact]
+    public void ReplaySession_InvalidAnnotationCollectionAndTimestamp_PreservesValidPriority()
+    {
+        // Arrange
+        var content = """{"type":"text","text":"kept","annotations":{"audience":false,"priority":0.5,"lastModified":17,"_meta":{"source":"annotations"}}}""";
+
+        // Act
+        var message = Assert.Single(AcpSessionDraftExtensions.ReplaySession("session", [Update(content, chunk: false)]).Messages);
+
+        // Assert
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(message.Content));
+        Assert.Null(text.Annotations!.Audience);
+        Assert.Equal(0.5, text.Annotations.Priority);
+        Assert.Null(text.Annotations.LastModified);
+        Assert.Equal("annotations", Assert.IsType<JsonElement>(text.Annotations.Meta!["source"]).GetString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",\"text\":null")]
+    [InlineData(",\"text\":42")]
+    public void ReplaySession_InvalidRequiredText_SkipsOnlyInvalidWholeItemsAndRejectsChunks(string field)
+    {
+        // Arrange
+        var invalid = "{\"type\":\"text\"" + field + ",\"annotations\":{}}";
+        var whole = Json("{\"sessionUpdate\":\"agent_message\",\"messageId\":\"m\",\"content\":["
+            + invalid + ",{\"type\":\"text\",\"text\":\"valid sibling\"}]}");
+
+        // Act / Assert
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("session", [whole]);
+        Assert.Equal("valid sibling", Assert.IsType<TextContentBlock>(Assert.Single(snapshot.Messages[0].Content)).Text);
+        Assert.Throws<JsonException>(() => AcpSessionDraftExtensions.ReplaySession("session", [Update(invalid, chunk: true)]));
+    }
+
+    [Theory]
+    [InlineData("_vendor")]
+    [InlineData("future_kind")]
+    public void ReplaySession_UnknownContentWithUnrecognizedMetadata_PreservesRawPayload(string type)
+    {
+        // Arrange
+        var content = "{\"type\":\"" + type + "\",\"annotations\":false,\"_meta\":17,\"payload\":{\"number\":1.20e+02}}";
+
+        // Act
+        var block = Assert.Single(AcpSessionDraftExtensions.ReplaySession("session", [Update(content, chunk: true)]).Messages[0].Content);
+        var replay = JsonSerializer.Serialize(block, Wire.V2<ContentBlock>());
+
+        // Assert
+        Assert.Equal(type, block.Type);
+        Assert.Equal(content, replay);
+    }
+
+    [Fact]
+    public void ReplaySession_ToolAndEmbeddedResourceMetadata_RecoversAtTheContentBoundary()
+    {
+        // Arrange
+        var resource = """{"type":"resource","resource":{"uri":"file:///kept","text":"kept","_meta":false}}""";
+        var tool = Json("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"tool","content":{"type":"content","content":{"type":"text","text":"tool text","annotations":false,"_meta":false}}}""");
+
+        // Act
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("session", [Update(resource, chunk: true), tool]);
+
+        // Assert
+        var embedded = Assert.IsType<ResourceContentBlock>(Assert.Single(snapshot.Messages[0].Content)).Resource;
+        Assert.Equal("kept", embedded.Text);
+        Assert.Null(embedded.Meta);
+        var toolText = Assert.IsType<TextContentBlock>(Assert.IsType<ContentToolCallContent>(Assert.Single(snapshot.ToolCalls[0].Content)).Content);
+        Assert.Equal("tool text", toolText.Text);
+        Assert.Null(toolText.Annotations);
+        Assert.Null(toolText.Meta);
+    }
+
+    [Fact]
+    public void ResourceLink_DirectDraftReader_UsesTheSameContentRecovery()
+    {
+        // Arrange
+        const string content = """{"type":"resource_link","uri":"file:///kept","name":"kept","annotations":false,"_meta":false}""";
+
+        // Act
+        var link = JsonSerializer.Deserialize(content, Wire.V2<ResourceLinkContentBlock>());
+
+        // Assert
+        Assert.Equal("kept", link!.Name);
+        Assert.Equal("file:///kept", link.Uri);
+        Assert.Null(link.Annotations);
+        Assert.Null(link.Meta);
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(content, Wire.V1<ResourceLinkContentBlock>()));
+    }
+
+    [Theory]
+    [InlineData("\"annotations\":false")]
+    [InlineData("\"_meta\":false")]
+    [InlineData("\"annotations\":{\"priority\":false}")]
+    [InlineData("\"annotations\":{\"audience\":[\"user\",17]}")]
+    public void StableContentReader_InvalidOptionalFields_RetainsItsExistingStrictContract(string field)
+    {
+        // Arrange
+        var content = "{\"type\":\"text\",\"text\":\"kept\"," + field + "}";
+
+        // Act / Assert
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(content, AcpJsonContext.Default.ContentBlock));
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(content, Wire.V1<ContentBlock>()));
+    }
+
+    private static void AssertPayloadPreserved(ContentBlock block)
+    {
+        switch (block)
+        {
+            case TextContentBlock text:
+                Assert.Equal("kept", text.Text);
+                break;
+            case ImageContentBlock image:
+                Assert.Equal("YQ==", image.Data);
+                Assert.Equal("image/png", image.MimeType);
+                break;
+            case AudioContentBlock audio:
+                Assert.Equal("YQ==", audio.Data);
+                Assert.Equal("audio/wav", audio.MimeType);
+                break;
+            case ResourceLinkContentBlock link:
+                Assert.Equal("kept", link.Name);
+                Assert.Equal("file:///kept", link.Uri);
+                break;
+            case ResourceContentBlock resource:
+                Assert.Equal("kept", resource.Resource.Text);
+                Assert.Equal("file:///kept", resource.Resource.Uri);
+                break;
+            default:
+                Assert.Fail("Expected a known content type.");
+                break;
+        }
+    }
+
+    private static JsonElement Update(string content, bool chunk)
+        => Json("{\"sessionUpdate\":\"" + (chunk ? "agent_message_chunk" : "agent_message")
+            + "\",\"messageId\":\"m\",\"content\":" + (chunk ? content : "[" + content + "]") + "}");
+
+    private static JsonElement Json(string text)
+    {
+        using var document = JsonDocument.Parse(text);
+        return document.RootElement.Clone();
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionContentRecoveryTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionContentRecoveryTests.cs
@@ -149,6 +149,124 @@ public sealed class AcpSessionContentRecoveryTests
     }
 
     [Theory]
+    [InlineData("false")]
+    [InlineData("17")]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    public void ReplaySession_InvalidOptionalMediaFields_PreservesImageAndResourcePayloads(string invalid)
+    {
+        // Arrange
+        var image = "{\"type\":\"image\",\"data\":\"YQ==\",\"mimeType\":\"image/png\",\"uri\":" + invalid + "}";
+        var link = "{\"type\":\"resource_link\",\"uri\":\"file:///kept\",\"name\":\"kept\",\"title\":" + invalid
+            + ",\"description\":" + invalid + ",\"mimeType\":" + invalid + ",\"size\":false}";
+        var textResource = "{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\",\"text\":\"kept\",\"mimeType\":" + invalid + "}}";
+        var blobResource = "{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\",\"blob\":\"YQ==\",\"mimeType\":" + invalid + "}}";
+
+        // Act
+        var blocks = AcpSessionDraftExtensions.ReplaySession("session",
+            [Update(image, false), Update(link, true), Update(textResource, true), Update(blobResource, true)]).Messages[0].Content;
+
+        // Assert
+        Assert.Equal(4, blocks.Length);
+        var recoveredImage = Assert.IsType<ImageContentBlock>(blocks[0]);
+        Assert.Equal("YQ==", recoveredImage.Data);
+        Assert.Equal("image/png", recoveredImage.MimeType);
+        Assert.Null(recoveredImage.Uri);
+        var recoveredLink = Assert.IsType<ResourceLinkContentBlock>(blocks[1]);
+        Assert.Equal("file:///kept", recoveredLink.Uri);
+        Assert.Equal("kept", recoveredLink.Name);
+        Assert.Null(recoveredLink.Title);
+        Assert.Null(recoveredLink.Description);
+        Assert.Null(recoveredLink.MimeType);
+        Assert.Null(recoveredLink.Size);
+        Assert.Equal("kept", Assert.IsType<ResourceContentBlock>(blocks[2]).Resource.Text);
+        Assert.Equal("YQ==", Assert.IsType<ResourceContentBlock>(blocks[3]).Resource.Blob);
+        Assert.Null(Assert.IsType<ResourceContentBlock>(blocks[2]).Resource.MimeType);
+        Assert.Null(Assert.IsType<ResourceContentBlock>(blocks[3]).Resource.MimeType);
+        foreach (var content in new[] { image, link, textResource, blobResource })
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(content, Wire.V1<ContentBlock>()));
+        }
+    }
+
+    [Theory]
+    [InlineData("false")]
+    [InlineData("\"large\"")]
+    [InlineData("1.25")]
+    [InlineData("9223372036854775808")]
+    public void ResourceLink_InvalidOptionalSize_DefaultsWithoutDiscardingValidFields(string size)
+    {
+        // Arrange
+        var content = "{\"type\":\"resource_link\",\"uri\":\"file:///kept\",\"name\":\"kept\",\"title\":\"title\",\"size\":" + size + "}";
+
+        // Act
+        var link = JsonSerializer.Deserialize(content, Wire.V2<ResourceLinkContentBlock>())!;
+
+        // Assert
+        Assert.Equal("title", link.Title);
+        Assert.Null(link.Size);
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(content, Wire.V1<ResourceLinkContentBlock>()));
+    }
+
+    [Theory]
+    [InlineData("{\"type\":\"image\",\"mimeType\":\"image/png\"}")]
+    [InlineData("{\"type\":\"image\",\"data\":42,\"mimeType\":\"image/png\"}")]
+    [InlineData("{\"type\":\"audio\",\"data\":\"YQ==\",\"mimeType\":false}")]
+    [InlineData("{\"type\":\"resource_link\",\"name\":\"name\",\"uri\":false}")]
+    [InlineData("{\"type\":\"resource_link\",\"uri\":\"file:///kept\",\"name\":false}")]
+    [InlineData("{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\"}}")]
+    [InlineData("{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\",\"text\":null,\"blob\":null}}")]
+    [InlineData("{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\",\"text\":17,\"blob\":false}}")]
+    public void ReplaySession_InvalidRequiredMediaFields_RejectsChunksAndSkipsInvalidWholeItems(string content)
+    {
+        // Arrange / Act / Assert
+        Assert.Throws<JsonException>(() => AcpSessionDraftExtensions.ReplaySession("session", [Update(content, true)]));
+        Assert.Empty(AcpSessionDraftExtensions.ReplaySession("session", [Update(content, false)]).Messages[0].Content);
+    }
+
+    [Theory]
+    [InlineData("\"text\":\"kept\",\"blob\":17", "kept", null)]
+    [InlineData("\"text\":17,\"blob\":\"YQ==\"", null, "YQ==")]
+    [InlineData("\"text\":\"kept\",\"blob\":\"YQ==\"", "kept", null)]
+    [InlineData("\"text\":\"\"", "", null)]
+    [InlineData("\"blob\":\"\"", null, "")]
+    public void ReplaySession_EmbeddedResourceUnion_UsesTheFirstValidSchemaBranch(string fields, string? text, string? blob)
+    {
+        // Arrange
+        var content = "{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///kept\"," + fields + ",\"mimeType\":false}}";
+
+        // Act
+        var resource = Assert.IsType<ResourceContentBlock>(AcpSessionDraftExtensions.ReplaySession("session", [Update(content, true)]).Messages[0].Content[0]).Resource;
+
+        // Assert
+        Assert.Equal(text, resource.Text);
+        Assert.Equal(blob, resource.Blob);
+        Assert.Null(resource.MimeType);
+    }
+
+    [Fact]
+    public void ResourceLink_OptionalFieldRecovery_PreservesArbitraryValidSiblings()
+        => FsCheckPropertyRunner.Run(this, nameof(OptionalFieldRecoveryProperty));
+
+    private void OptionalFieldRecoveryProperty(string? title, long size, byte seed)
+    {
+        // Arrange
+        var invalid = new[] { "false", "17", "{}", "[]", "null" }[seed % 5];
+        var fields = "{\"type\":\"resource_link\",\"uri\":\"file:///kept\",\"name\":\"kept\",\"title\":"
+            + JsonSerializer.Serialize(title, AcpJsonContext.Default.String) + ",\"description\":" + invalid
+            + ",\"size\":" + size.ToString(System.Globalization.CultureInfo.InvariantCulture) + "}";
+
+        // Act
+        var link = Assert.IsType<ResourceLinkContentBlock>(AcpSessionDraftExtensions.ReplaySession("session", [Update(fields, false)]).Messages[0].Content[0]);
+
+        // Assert
+        Assert.Equal(title, link.Title);
+        Assert.Equal(size, link.Size);
+        Assert.Null(link.Description);
+        Assert.Equal("file:///kept", link.Uri);
+    }
+
+    [Theory]
     [InlineData("\"annotations\":false")]
     [InlineData("\"_meta\":false")]
     [InlineData("\"annotations\":{\"priority\":false}")]

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionProjectionTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionProjectionTests.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Acp.Content;
 using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Observability;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Acp.Serialization;
 using SalmonEgg.Acp.Tool;
@@ -684,6 +686,74 @@ public sealed class AcpSessionProjectionTests
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ResumeSessionAsync_UnknownWriteOutcome_RetainsReplayUntilPeerResponse(bool throwOnWrite)
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.HoldResume = true;
+        peer.ResumeWrite = () => throwOnWrite
+            ? Task.FromException<bool>(new IOException("The replay write outcome is unknown."))
+            : Task.FromResult(false);
+        var request = new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start);
+
+        // Act
+        var failure = await Record.ExceptionAsync(() => peer.Client.ResumeSessionAsync(request, TestToken));
+        peer.Update("one", Message("agent_message_chunk", "m", "first replay"));
+        var overlapping = await Record.ExceptionAsync(() => peer.Client.ResumeSessionAsync(request, TestToken));
+
+        // Assert
+        if (throwOnWrite) Assert.IsType<IOException>(failure);
+        else Assert.IsType<InvalidOperationException>(failure);
+        Assert.IsType<InvalidOperationException>(overlapping);
+        Assert.Single(peer.Sent, static frame => frame.Method == "session/resume");
+        Assert.Equal(["first replay"], Texts(Assert.Single(peer.Client.GetSessionSnapshot("one")!.Messages)));
+
+        peer.ReplyResume();
+        peer.ResumeWrite = null;
+        peer.HoldResume = false;
+        peer.OnResume = _ => peer.Update("one", Message("agent_message_chunk", "m", "next replay"));
+        await peer.Client.ResumeSessionAsync(request, TestToken);
+        Assert.Equal(2, peer.Sent.Count(static frame => frame.Method == "session/resume"));
+        Assert.Equal(["next replay"], Texts(Assert.Single(peer.Client.GetSessionSnapshot("one")!.Messages)));
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_PreparationFailure_DoesNotClearHistoryOrClaimReplay()
+    {
+        // Arrange
+        using var peer = await ProjectionPeer.CreateAsync();
+        peer.Update("one", Whole("agent_message", "m", "kept"));
+        using var trace = new Activity("replay-preparation-failure").Start();
+        var failure = new InvalidOperationException("The tracing subscriber rejected this request.");
+        var request = new SessionResumeParams("one", "/workspace", [], replayFrom: SessionReplayFrom.Start);
+
+        // Act
+        using (var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == AcpActivitySources.ClientName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+            {
+                if (options.Parent.TraceId == trace.TraceId && options.Name == "acp.request session/resume") throw failure;
+                return ActivitySamplingResult.None;
+            }
+        })
+        {
+            ActivitySource.AddActivityListener(listener);
+            Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                peer.Client.ResumeSessionAsync(request, TestToken)));
+        }
+
+        // Assert
+        Assert.DoesNotContain(peer.Sent, static frame => frame.Method == "session/resume");
+        Assert.Equal(["kept"], Texts(Assert.Single(peer.Client.GetSessionSnapshot("one")!.Messages)));
+        await peer.Client.ResumeSessionAsync(request, TestToken);
+        Assert.Single(peer.Sent, static frame => frame.Method == "session/resume");
+        Assert.Empty(peer.Client.GetSessionSnapshot("one")!.Messages);
+    }
+
+    [Theory]
     [InlineData("close")]
     [InlineData("delete")]
     public async Task SessionRemoval_LateUpdate_DoesNotResurrectProjection(string operation)
@@ -946,6 +1016,7 @@ public sealed class AcpSessionProjectionTests
         internal List<JsonRpcRequest> Sent { get; } = [];
         internal Action<JsonRpcRequest>? OnResume { get; set; }
         internal Func<Task>? BeforeResumeWrite { get; set; }
+        internal Func<Task<bool>>? ResumeWrite { get; set; }
         internal bool HoldResume { get; set; }
 
         public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
@@ -1012,6 +1083,7 @@ public sealed class AcpSessionProjectionTests
             {
                 _resume = request;
                 OnResume?.Invoke(request);
+                if (ResumeWrite is not null) return ResumeWrite();
                 if (!HoldResume) ReplyResume();
             }
             else


### PR DESCRIPTION
Two SDK defects could corrupt draft session replay: an uncertain transport write released its replay claim while the peer could still be streaming history, and malformed optional content hints could discard valid text/media or reject a chunk. Keep replay ownership on the existing request lifecycle and apply the pinned V2 schema's field-level recovery before an enclosing list decides whether an item is invalid.

The content reader preserves valid sibling fields, keeps required fields strict, and follows the embedded-resource text/blob union. Stable V1 and unversioned decoding retain their existing behavior; production live V2 remains disabled.

Validation: 1,257 SDK tests passed with no skips; formatting and Release analyzer builds passed with zero warnings/errors. Actual local nupkg consumers passed, including public offline projection, required-field rejection, all 46 draft compilation diagnostics, and the precompiled legacy transport consumer. Replay and content regression tests failed before their fixes; optional-field property testing checks arbitrary valid siblings. CI rebuilds and tests the final PR commit and package.

Related to #149.
