### PR TITLE
fix(acp): keep interaction consent on its originating connection

### DIFF
--- a/scripts/gates/wasm-smoke-lib/acp-test-server.mjs
+++ b/scripts/gates/wasm-smoke-lib/acp-test-server.mjs
@@ -12,6 +12,7 @@ export async function startAcpWebSocketServer(options = {}) {
   let deferNextSessionNewResponse = options.deferSessionNewResponse === true;
   let deferredSessionNew;
   let sessionPromptRequest;
+  let deferredPrompt;
   let clientRequestSequence = 0;
   let resolveInitialize;
   let resolveSessionNew;
@@ -145,6 +146,12 @@ export async function startAcpWebSocketServer(options = {}) {
         if (message.method === "session/prompt") {
           sessionPromptRequest = message;
           resolveSessionPrompt(message);
+          if (deferredPrompt) {
+            deferredPrompt.socket = socket;
+            deferredPrompt.request = message;
+            deferredPrompt.resolve(message);
+            continue;
+          }
           writeSessionUpdate(socket, sessionId, {
             sessionUpdate: "agent_message_chunk",
             content: {
@@ -159,6 +166,15 @@ export async function startAcpWebSocketServer(options = {}) {
               stopReason: "end_turn",
               userMessageId: message.params?.messageId ?? null
             }
+          });
+        }
+
+        if (message.method === "session/cancel" && deferredPrompt?.request
+          && deferredPrompt.socket === socket) {
+          deferredPrompt.cancellations.push(message);
+          writeJsonRpc(socket, {
+            jsonrpc: "2.0", id: deferredPrompt.request.id,
+            result: { stopReason: "cancelled" }
           });
         }
       }
@@ -181,6 +197,18 @@ export async function startAcpWebSocketServer(options = {}) {
   return {
     url: `ws://127.0.0.1:${port}/acp`,
     sessionId,
+    deferNextPrompt: () => {
+      if (deferredPrompt) throw new Error("A deferred prompt is already active.");
+      let resolve;
+      const received = new Promise(settle => { resolve = settle; });
+      const pending = { resolve, request: null, socket: null, cancellations: [] };
+      deferredPrompt = pending;
+      return {
+        waitForRequest: () => waitWithTimeout(received, "Timed out waiting for the held prompt.", 30_000),
+        cancellations: () => [...pending.cancellations],
+        release: () => { if (deferredPrompt === pending) deferredPrompt = undefined; }
+      };
+    },
     completeSessionNew: () => {
       if (!deferredSessionNew) {
         throw new Error("No deferred session/new request remains to complete.");

--- a/scripts/gates/wasm-smoke-lib/elicitation-form-flow.mjs
+++ b/scripts/gates/wasm-smoke-lib/elicitation-form-flow.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  clickVisibleControl,
   collectVisibleInteractiveDebug,
   typeIntoVisibleTextField,
   waitForControlEnabledState,
@@ -27,7 +28,8 @@ export async function verifyRemainingFormInputs(page, server) {
   requests.push(await verifyMultiSelectForm(page, server, suffix));
   requests.push(await verifyTitledMultiSelectForm(page, server, suffix));
   requests.push(await verifyDeclinedForm(page, server, suffix));
-  console.log("WASM form inputs: integer/number validation, bounded and titled multi-select, native Decline, typed replies and dismissal");
+  requests.push(...await verifySessionCancelledForm(page, server, suffix));
+  console.log("WASM form inputs: integer/number validation, bounded and titled multi-select, native Decline, session cancellation, next form, typed replies and dismissal");
   return requests;
 }
 
@@ -145,6 +147,47 @@ async function verifyDeclinedForm(page, server, suffix) {
   await activateFormAction(page, form, "Decline");
   await verifyResponseAndDismissal(page, form, { action: "decline" });
   return form.request;
+}
+
+async function verifySessionCancelledForm(page, server, suffix) {
+  const pending = server.deferNextPrompt();
+  const input = { automationIds: ["InputBox"], labels: [] };
+  const send = { automationIds: ["ChatInputArea.Send"], labels: [] };
+  const stop = { automationIds: ["ChatInputArea.Cancel"], labels: [] };
+  const prompt = `WASM prompt held for form cancellation ${suffix}`;
+  try {
+    await typeIntoVisibleTextField(page, input, prompt, "prompt before cancellation form", formTimeoutMs);
+    await waitForControlEnabledState(page, send, true, "held prompt ready to send");
+    await clickVisibleControl(page, send);
+    const request = await pending.waitForRequest();
+    assert.equal(request.params.sessionId, server.sessionId);
+    assert.ok(request.params.prompt.some(block => block.type === "text" && block.text === prompt),
+      "This round's input must reach the peer before cancellation is exercised.");
+
+    const form = await openForm(page, server, `WASM session-cancelled form ${suffix}`, {
+      input: { type: "string", title: `Cancelled form field ${suffix}` }
+    });
+    await waitForControlEnabledState(page, stop, true, "Stop remains available during the form");
+    await clickVisibleControl(page, stop);
+    await verifyResponseAndDismissal(page, form, { action: "cancel" });
+    assert.equal(pending.cancellations().length, 1, "Stop must send one session/cancel notification.");
+    assert.equal(pending.cancellations()[0].params.sessionId, server.sessionId);
+    pending.release();
+
+    const next = await openForm(page, server, `WASM form after session cancellation ${suffix}`, {
+      input: { type: "string", title: `Next form field ${suffix}` }
+    });
+    assert.equal(next.request.responses().length, 0, "The previous form must not auto-cancel this next request.");
+    await activateFormAction(page, next, "Cancel");
+    await verifyResponseAndDismissal(page, next, { action: "cancel" });
+    await waitForValue(page, () => {
+      const field = window.__salmoneggSmoke.semantic.resolveEditableField({ automationIds: ["InputBox"], labels: [] });
+      return field?.id && !field.disabled && !field.state.hidden;
+    }, null, "composer enabled after the cancelled form retires");
+    return [form.request, next.request];
+  } finally {
+    pending.release();
+  }
 }
 
 async function openForm(page, server, prompt, properties) {

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -1137,11 +1137,7 @@ namespace SalmonEgg.Acp.Client
             CancellationToken connectionCancellation;
             JsonRpcResponse responseMessage;
             var isPeerCancellation = false;
-            if (cancelForSession)
-            {
-                pending.ElicitationState!.RequestCancellation();
-                pending.ElicitationState.NotifyChanged();
-            }
+            Task<bool>? cancellationResponse = null;
 
             lock (_lock)
             {
@@ -1153,22 +1149,37 @@ namespace SalmonEgg.Acp.Client
                     return false;
                 }
 
-                if (pending.ElicitationState!.IsResponseInFlight
-                    || (pending.ElicitationState.IsCancellationRequested && response is not ElicitationCancelResponse))
-                {
-                    return false;
-                }
+                cancellationResponse = PrepareElicitationCancellation(pending, response, cancelForSession);
 
-                // Claim without removing: a failed send must remain retryable, while a second action
-                // cannot race the first one onto the wire. The callback owns this exact request object,
-                // so reusing its JSON-RPC id never lets an old form answer a later request.
-                pending.ElicitationState!.IsResponseInFlight = true;
-                pending.PreparedElicitationResponse = response;
-                pending.HasPreparedElicitationFailure = false;
-                connectionCancellation = _messageLoopCts?.Token ?? CancellationToken.None;
-                isPeerCancellation = response is ElicitationCancelResponse && pending.PreparedCancellationResponse?.IsError == true;
-                responseMessage = isPeerCancellation ? pending.PreparedCancellationResponse!
-                    : new JsonRpcResponse(pending.MessageId, ToElement<CreateElicitationResponse>(response));
+                if (cancellationResponse is not null)
+                {
+                    responseMessage = null!;
+                    connectionCancellation = pending.ConnectionToken;
+                }
+                else
+                {
+                    if (pending.ElicitationState!.IsResponseInFlight
+                        || (pending.ElicitationState.IsCancellationRequested && response is not ElicitationCancelResponse))
+                    {
+                        return false;
+                    }
+
+                    // Claim without removing: a failed send must remain retryable, while a second action
+                    // cannot race the first one onto the wire. The callback owns this exact request object,
+                    // so reusing its JSON-RPC id never lets an old form answer a later request.
+                    pending.ElicitationState!.IsResponseInFlight = true;
+                    pending.PreparedElicitationResponse = response;
+                    pending.HasPreparedElicitationFailure = false;
+                    connectionCancellation = _messageLoopCts?.Token ?? CancellationToken.None;
+                    isPeerCancellation = response is ElicitationCancelResponse && pending.PreparedCancellationResponse?.IsError == true;
+                    responseMessage = isPeerCancellation ? pending.PreparedCancellationResponse!
+                        : new JsonRpcResponse(pending.MessageId, ToElement<CreateElicitationResponse>(response));
+                }
+            }
+
+            if (cancellationResponse is not null)
+            {
+                return await cancellationResponse.ConfigureAwait(false);
             }
 
             var sent = false;
@@ -1186,6 +1197,54 @@ namespace SalmonEgg.Acp.Client
                 {
                     await SendPendingElicitationCancellationAsync(pending, connectionCancellation).ConfigureAwait(false);
                 }
+            }
+        }
+
+        // Called under the request lock; cancellation shares the existing pending/batch owner.
+        private Task<bool>? PrepareElicitationCancellation(
+            PendingInboundRequest pending, CreateElicitationResponse response, bool cancelForSession)
+        {
+            if (!cancelForSession && response is not ElicitationCancelResponse) return null;
+            pending.ElicitationState!.RequestCancellation();
+            Task<bool>? responseTask = null;
+            if (pending.MessageId is not null && _responseRoutes.TryGetValue(pending.MessageId, out var route)
+                && route.Batch is { } batch)
+            {
+                pending.PreparedCancellationResponse ??= new JsonRpcResponse(pending.MessageId, ToElement(response));
+                pending.PreparedElicitationResponse = response;
+                pending.ElicitationState.IsResponseInFlight = true;
+                responseTask = batch.SubmitCancellation(route.Index, pending.PreparedCancellationResponse);
+            }
+            else if (pending.ElicitationState.IsResponseInFlight)
+            {
+                // Session stop sends its notification without waiting for an already accepted write.
+                // Explicit cancellation callers wait for the result of the original request.
+                responseTask = cancelForSession ? Task.FromResult(false) : WaitForElicitationSettlementAsync(pending);
+            }
+            pending.ElicitationState.NotifyChanged();
+            return responseTask;
+        }
+
+        private static async Task<bool> WaitForElicitationSettlementAsync(PendingInboundRequest pending)
+        {
+            var state = pending.ElicitationState!;
+            var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            EventHandler? changed = null;
+            changed = (_, _) =>
+            {
+                if (state.CanCancel && state.IsResponseInFlight) return;
+                completed.TrySetResult(!state.CanCancel);
+            };
+            state.Changed += changed;
+            using var closed = state.ConnectionClosed.Register(() => completed.TrySetResult(false));
+            try
+            {
+                changed(null, EventArgs.Empty);
+                return await completed.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                state.Changed -= changed;
             }
         }
 

--- a/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatStore.cs
+++ b/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatStore.cs
@@ -27,6 +27,12 @@ public interface IChatStore
     /// before downstream reactive projections have observed it.
     /// </summary>
     ValueTask<ChatState> GetCurrentStateAsync();
+
+    /// <summary>
+    /// Returns the same committed state without yielding, or null before the store has established it.
+    /// Used by browser-gesture authorization, which cannot await without losing user activation.
+    /// </summary>
+    ChatState? ReadCommittedState() => null;
 }
 
 /// <summary>
@@ -81,6 +87,8 @@ public sealed class ChatStore : IChatStore
 
     public async ValueTask<ChatState> GetCurrentStateAsync()
         => Volatile.Read(ref _cachedState) ?? await State ?? ChatState.Empty;
+
+    public ChatState? ReadCommittedState() => Volatile.Read(ref _cachedState);
 
     private bool TryAdvanceProjectedGeneration(long generation)
     {

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpAuthoritativeConnectionResolver.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpAuthoritativeConnectionResolver.cs
@@ -18,6 +18,26 @@ internal sealed class AcpAuthoritativeConnectionResolver
         _connectionSessionRegistry = connectionSessionRegistry;
     }
 
+    public bool TryResolveSourceConnection(IChatService service, out AcpAuthoritativeConnectionSnapshot snapshot)
+    {
+        snapshot = default;
+        if (_connectionSessionRegistry is null
+            || !_connectionSessionRegistry.TryGetProfileId(service, out var profileId)
+            || !_connectionSessionRegistry.TryGetByProfile(profileId, out var session)
+            || !ReferenceEquals(session.Service, service)
+            || string.IsNullOrWhiteSpace(session.ConnectionInstanceId)
+            || !service.IsConnected)
+        {
+            return false;
+        }
+
+        snapshot = new(service, profileId, session.ConnectionInstanceId);
+        return true;
+    }
+
+    public bool IsSourceConnectionCurrent(AcpAuthoritativeConnectionSnapshot expected)
+        => TryResolveSourceConnection(expected.ChatService, out var current) && current == expected;
+
     public bool TryResolveReadyForegroundConnection(
         IChatService? foregroundChatService,
         ChatConnectionState connectionState,

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AuthoritativeRemoteSessionRouter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AuthoritativeRemoteSessionRouter.cs
@@ -10,6 +10,9 @@ public interface IAuthoritativeRemoteSessionRouter
     ValueTask<string?> ResolveConversationIdAsync(string remoteSessionId, CancellationToken cancellationToken = default);
 
     string? ResolveConversationId(ChatState state, string remoteSessionId);
+
+    string? ResolveConversationId(ChatState state, string remoteSessionId, string profileId)
+        => AuthoritativeRemoteSessionRouter.ResolveProfileConversationId(state, remoteSessionId, profileId);
 }
 
 public sealed class AuthoritativeRemoteSessionRouter : IAuthoritativeRemoteSessionRouter
@@ -49,5 +52,26 @@ public sealed class AuthoritativeRemoteSessionRouter : IAuthoritativeRemoteSessi
         }
 
         return null;
+    }
+
+    internal static string? ResolveProfileConversationId(ChatState state, string remoteSessionId, string profileId)
+    {
+        if (string.IsNullOrWhiteSpace(remoteSessionId) || string.IsNullOrWhiteSpace(profileId) || state.Bindings is null)
+        {
+            return null;
+        }
+
+        string? match = null;
+        foreach (var binding in state.Bindings)
+        {
+            if (string.Equals(binding.Value.RemoteSessionId, remoteSessionId, StringComparison.Ordinal)
+                && string.Equals(binding.Value.ProfileId, profileId, StringComparison.Ordinal))
+            {
+                if (match is not null) return null;
+                match = binding.Key;
+            }
+        }
+
+        return match;
     }
 }

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -1767,20 +1767,28 @@ public partial class ChatViewModel
     private void ProcessElicitationRequest(IChatService service, int foregroundGeneration, ElicitationRequestEventArgs request)
     {
         var requestingAgent = service.AgentInfo;
-        _ = ProcessElicitationRequestAsync(service, foregroundGeneration, request,
+        _ = ProcessElicitationRequestAsync(CaptureInteractionSource(service, foregroundGeneration), request,
             requestingAgent?.Title ?? requestingAgent?.Name ?? CurrentAgentDisplayText);
     }
 
     private async Task ProcessElicitationRequestAsync(
-        IChatService service, int foregroundGeneration, ElicitationRequestEventArgs request, string agentName)
+        InteractionRequestSource source, ElicitationRequestEventArgs request, string agentName)
     {
         try
         {
+            ConversationBindingSlice? binding = null;
             var projection = await _interactionEventBridge.BuildElicitationRequestAsync(
                 request,
                 (conversationId, request) => PostToUiAsync(() => RemovePendingElicitationRequestState(conversationId, request)),
                 Logger, PostToUiAsync, agentName,
-                unshown => CancelUndisplayedElicitationAsync(service, foregroundGeneration, unshown)).ConfigureAwait(false);
+                unshown => CancelUndisplayedElicitationAsync(source.Service, source.ForegroundGeneration, unshown),
+                async remoteSessionId =>
+                {
+                    var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(false);
+                    var conversationId = ResolveInteractionConversation(state, remoteSessionId, source);
+                    binding = state.ResolveBinding(conversationId);
+                    return conversationId;
+                }).ConfigureAwait(false);
             if (projection is null)
             {
                 return;
@@ -1791,12 +1799,12 @@ public partial class ChatViewModel
             {
                 // Routing and dispatcher work may finish after the foreground owner was replaced.
                 // A stale form must not occupy the new connection's only interaction slot.
-                if (_disposed || !request.State.CanRespond || !service.IsConnected
-                    || foregroundGeneration != Volatile.Read(ref _foregroundChatServiceGeneration))
+                if (binding is null || !request.State.CanRespond || !IsInteractionBindingCurrent(source, binding))
                 {
                     return;
                 }
 
+                AttachElicitationOwnership(projection.Value.ViewModel, source, binding, request);
                 displayed = _panelStateCoordinator.TryStoreElicitationRequest(projection.Value.ConversationId, projection.Value.ViewModel);
                 PendingElicitationRequest = _panelStateCoordinator.GetPendingElicitationRequest(CurrentSessionId);
             }).ConfigureAwait(true);
@@ -1805,12 +1813,12 @@ public partial class ChatViewModel
                 projection.Value.ViewModel.Dispose();
                 // This surface holds one form per conversation. Keep the visible request and cancel
                 // the unshown one instead of replacing an interaction the user still needs to answer.
-                await CancelUndisplayedElicitationAsync(service, foregroundGeneration, request).ConfigureAwait(false);
+                await CancelUndisplayedElicitationAsync(source.Service, source.ForegroundGeneration, request).ConfigureAwait(false);
             }
         }
         catch (Exception)
         {
-            await CancelUndisplayedElicitationAsync(service, foregroundGeneration, request).ConfigureAwait(false);
+            await CancelUndisplayedElicitationAsync(source.Service, source.ForegroundGeneration, request).ConfigureAwait(false);
         }
     }
 
@@ -1892,39 +1900,39 @@ public partial class ChatViewModel
 
     private void ProcessPermissionRequest(IChatService service, int foregroundGeneration, PermissionRequestEventArgs request)
     {
-        _ = ProcessPermissionRequestAsync(service, foregroundGeneration, request);
+        _ = ProcessPermissionRequestAsync(CaptureInteractionSource(service, foregroundGeneration), request);
     }
 
-    private async Task ProcessPermissionRequestAsync(IChatService service, int foregroundGeneration, PermissionRequestEventArgs request)
+    private async Task ProcessPermissionRequestAsync(InteractionRequestSource source, PermissionRequestEventArgs request)
     {
         try
         {
             var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(false);
-            var conversationId = _authoritativeRemoteSessionRouter.ResolveConversationId(state, request.SessionId);
+            var conversationId = ResolveInteractionConversation(state, request.SessionId, source);
             var binding = state.ResolveBinding(conversationId);
             await PostToUiAsync(async () =>
             {
-                if (!IsPermissionSourceCurrent(service, foregroundGeneration) || !request.CanRespond)
+                if (!IsInteractionSourceActive(source) || !request.CanRespond)
                 {
                     return;
                 }
 
-                if (string.IsNullOrWhiteSpace(conversationId) || binding is null)
+                if (string.IsNullOrWhiteSpace(conversationId) || binding is null || !IsInteractionConnectionCurrent(source))
                 {
-                    await CancelUndisplayedPermissionAsync(service, foregroundGeneration, request).ConfigureAwait(true);
+                    await CancelUndisplayedPermissionAsync(source, request).ConfigureAwait(true);
                     return;
                 }
 
                 var currentState = await _chatStore.GetCurrentStateAsync().ConfigureAwait(true);
-                if (!IsPermissionSourceCurrent(service, foregroundGeneration) || !request.CanRespond)
+                if (!IsInteractionSourceActive(source) || !request.CanRespond)
                 {
                     return;
                 }
 
-                var viewModel = CreateOwnedPermissionRequest(service, foregroundGeneration, request, conversationId, binding);
+                var viewModel = CreateOwnedPermissionRequest(source, request, conversationId, binding);
                 _panelStateCoordinator.StorePermissionRequest(conversationId, viewModel);
-                SubscribePermissionRequestChanges(service, foregroundGeneration, request, conversationId, viewModel);
-                RefreshPermissionRequestProjection(service, foregroundGeneration, request, conversationId, viewModel);
+                SubscribePermissionRequestChanges(source, request, conversationId, viewModel);
+                RefreshPermissionRequestProjection(source, request, conversationId, viewModel);
                 ReconcilePermissionBindings(currentState.Bindings);
                 SyncPermissionRequestProjection();
             }).ConfigureAwait(false);
@@ -1932,34 +1940,33 @@ public partial class ChatViewModel
         catch (Exception error)
         {
             Logger.LogError("Error processing permission request. ExceptionType={ExceptionType}", error.GetType().FullName);
-            if (IsPermissionSourceCurrent(service, foregroundGeneration))
+            if (IsInteractionSourceActive(source))
             {
-                await CancelUndisplayedPermissionAsync(service, foregroundGeneration, request).ConfigureAwait(false);
+                await CancelUndisplayedPermissionAsync(source, request).ConfigureAwait(false);
             }
         }
     }
 
     private PermissionRequestViewModel CreateOwnedPermissionRequest(
-        IChatService service, int foregroundGeneration, PermissionRequestEventArgs request,
+        InteractionRequestSource source, PermissionRequestEventArgs request,
         string? conversationId, ConversationBindingSlice? binding)
     {
         PermissionRequestViewModel? viewModel = null;
         viewModel = _interactionEventBridge.CreatePermissionRequestViewModel(
             request,
-            async (_, outcome, optionId) =>
+            (_, outcome, optionId) =>
             {
                 var bindingCurrent = conversationId is not null && binding is not null
-                    && await IsPermissionBindingCurrentAsync(conversationId, binding).ConfigureAwait(false);
-                if (!IsPermissionSourceCurrent(service, foregroundGeneration) || !request.CanRespond)
+                    && IsInteractionBindingCurrent(source, binding);
+                if (!IsInteractionSourceActive(source) || !request.CanRespond)
                 {
-                    return false;
+                    return Task.FromResult(false);
                 }
 
                 // A binding change withdraws the old choice, but the original request still
                 // requires an answer. Its callback keeps that cancellation on its own client.
                 var canSelect = bindingCurrent && viewModel?.IsCancellationOnly != true;
-                return await request.TryRespondAsync(canSelect ? outcome : "cancelled",
-                    canSelect ? optionId : null).ConfigureAwait(false);
+                return request.TryRespondAsync(canSelect ? outcome : "cancelled", canSelect ? optionId : null);
             },
             () => PostToUiAsync(() => RemovePermissionRequestProjection(conversationId, viewModel!)));
         viewModel.ToolCallId = TryResolvePermissionToolCallId(request.ToolCall);
@@ -1968,7 +1975,8 @@ public partial class ChatViewModel
             ? ResolveLocalizerText("Permission_DefaultTitle", "Permission required") : viewModel.RequestTitle;
         viewModel.Binding = binding;
         viewModel.Description = request.Description ?? string.Empty;
-        viewModel.IsRequestAvailable = () => IsPermissionSourceCurrent(service, foregroundGeneration) && request.CanRespond;
+        viewModel.IsRequestAvailable = () => IsInteractionSourceActive(source) && request.CanRespond;
+        viewModel.IsBindingCurrent = () => binding is not null && IsInteractionBindingCurrent(source, binding);
         viewModel.IsResponsePrepared = () => request.IsResponsePrepared;
         viewModel.IsResponseSending = () => request.IsResponseSending;
         viewModel.IsRequestCancellationRequested = () => request.IsCancellationRequested;
@@ -1976,17 +1984,17 @@ public partial class ChatViewModel
     }
 
     private void SubscribePermissionRequestChanges(
-        IChatService service, int foregroundGeneration, PermissionRequestEventArgs request,
+        InteractionRequestSource source, PermissionRequestEventArgs request,
         string? conversationId, PermissionRequestViewModel viewModel)
     {
         EventHandler changed = (_, _) => _ = ProcessPermissionRequestChangedAsync(
-            service, foregroundGeneration, request, conversationId, viewModel);
+            source, request, conversationId, viewModel);
         request.Changed += changed;
         viewModel.UnsubscribeRequestChanges = () => request.Changed -= changed;
     }
 
     private async Task ProcessPermissionRequestChangedAsync(
-        IChatService service, int foregroundGeneration, PermissionRequestEventArgs request,
+        InteractionRequestSource source, PermissionRequestEventArgs request,
         string? conversationId, PermissionRequestViewModel viewModel)
     {
         try
@@ -1998,7 +2006,7 @@ public partial class ChatViewModel
                 // A captured SDK callback can outlive unsubscription, a binding change or replacement.
                 // Only the exact projection still held by this conversation may change its surface.
                 if (_disposed || !_panelStateCoordinator.ContainsPermissionRequest(conversationId, viewModel)) return;
-                RefreshPermissionRequestProjection(service, foregroundGeneration, request, conversationId, viewModel);
+                RefreshPermissionRequestProjection(source, request, conversationId, viewModel);
                 ReconcilePermissionBindings(state.Bindings);
                 SyncPermissionRequestProjection();
             }).ConfigureAwait(false);
@@ -2010,10 +2018,10 @@ public partial class ChatViewModel
     }
 
     private void RefreshPermissionRequestProjection(
-        IChatService service, int foregroundGeneration, PermissionRequestEventArgs request,
+        InteractionRequestSource source, PermissionRequestEventArgs request,
         string? conversationId, PermissionRequestViewModel viewModel)
     {
-        if (!IsPermissionSourceCurrent(service, foregroundGeneration) || !request.CanRespond)
+        if (!IsInteractionSourceActive(source) || !request.CanRespond)
         {
             RemovePermissionRequestProjection(conversationId, viewModel);
         }
@@ -2025,15 +2033,6 @@ public partial class ChatViewModel
                     "This request was cancelled. Retry cancellation to dismiss it."), bindingChanged: false);
         }
     }
-
-    private bool IsPermissionSourceCurrent(IChatService service, int foregroundGeneration)
-        // A PoolOnly replacement can leave the original service live for its background conversation.
-        // Its request callback remains authoritative even while another service is in the foreground.
-        => !_disposed && foregroundGeneration == Volatile.Read(ref _foregroundChatServiceGeneration)
-            && service.IsConnected;
-
-    private async Task<bool> IsPermissionBindingCurrentAsync(string conversationId, ConversationBindingSlice binding)
-        => (await _chatStore.GetCurrentStateAsync().ConfigureAwait(false)).ResolveBinding(conversationId) == binding;
 
     private void ReconcilePermissionBindings(IImmutableDictionary<string, ConversationBindingSlice>? bindings)
     {
@@ -2051,7 +2050,7 @@ public partial class ChatViewModel
         try
         {
             if (request.Binding is null || !request.IsAvailable || request.OnRespond is null
-                || await IsPermissionBindingCurrentAsync(conversationId, request.Binding).ConfigureAwait(true))
+                || request.IsBindingCurrent?.Invoke() == true)
             {
                 return;
             }
@@ -2076,7 +2075,7 @@ public partial class ChatViewModel
     }
 
     private async Task CancelUndisplayedPermissionAsync(
-        IChatService service, int foregroundGeneration, PermissionRequestEventArgs request)
+        InteractionRequestSource source, PermissionRequestEventArgs request)
     {
         try
         {
@@ -2089,10 +2088,10 @@ public partial class ChatViewModel
 
         await PostToUiAsync(async () =>
         {
-            if (!IsPermissionSourceCurrent(service, foregroundGeneration) || !request.CanRespond) return;
+            if (!IsInteractionSourceActive(source) || !request.CanRespond) return;
             if (string.IsNullOrWhiteSpace(CurrentSessionId) || !IsChatShellVisibleForRemoteUi)
             {
-                await _acpConnectionCommands.DisconnectAfterInteractionFailureAsync(service, this,
+                await _acpConnectionCommands.DisconnectAfterInteractionFailureAsync(source.Service, this,
                     ResolveLocalizerText("Permission_CancellationFailedDisconnected",
                         "Could not cancel an undisplayed permission request. The connection was closed. Reconnect to the agent."))
                     .ConfigureAwait(true);
@@ -2100,14 +2099,14 @@ public partial class ChatViewModel
             }
             // No conversation owns this request, so retain only its cancellation on the existing
             // interaction owner. A later selection or reused id cannot turn it into permission.
-            var viewModel = CreateOwnedPermissionRequest(service, foregroundGeneration, request, null, null);
+            var viewModel = CreateOwnedPermissionRequest(source, request, null, null);
             viewModel.ShowCancellationRetry(
                 ResolveLocalizerText("Permission_RetryCancellation", "Retry cancellation"),
                 ResolveLocalizerText("Permission_Cancelled",
                     "This request was cancelled. Retry cancellation to dismiss it."), bindingChanged: false);
             _panelStateCoordinator.StoreUnboundPermissionCancellation(viewModel);
-            SubscribePermissionRequestChanges(service, foregroundGeneration, request, null, viewModel);
-            RefreshPermissionRequestProjection(service, foregroundGeneration, request, null, viewModel);
+            SubscribePermissionRequestChanges(source, request, null, viewModel);
+            RefreshPermissionRequestProjection(source, request, null, viewModel);
             SyncPermissionRequestProjection();
         }).ConfigureAwait(false);
     }

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.InteractionOwnership.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.InteractionOwnership.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.ViewModels.Chat.Elicitation;
+using SalmonEgg.Presentation.ViewModels.Chat.Interactions;
+
+namespace SalmonEgg.Presentation.ViewModels.Chat;
+
+public partial class ChatViewModel
+{
+    private sealed record InteractionRequestSource(
+        IChatService Service, int ForegroundGeneration, AcpAuthoritativeConnectionSnapshot? Connection);
+
+    private InteractionRequestSource CaptureInteractionSource(IChatService service, int foregroundGeneration)
+        => new(service, foregroundGeneration,
+            _authoritativeConnectionResolver.TryResolveSourceConnection(service, out var connection) ? connection : null);
+
+    private bool IsInteractionSourceActive(InteractionRequestSource source)
+        => !_disposed && source.ForegroundGeneration == Volatile.Read(ref _foregroundChatServiceGeneration)
+            && source.Service.IsConnected;
+
+    private bool IsInteractionConnectionCurrent(InteractionRequestSource source)
+        => IsInteractionSourceActive(source) && source.Connection is { } connection
+            && _authoritativeConnectionResolver.IsSourceConnectionCurrent(connection);
+
+    private string? ResolveInteractionConversation(ChatState state, string? remoteSessionId, InteractionRequestSource source)
+        => source.Connection?.ProfileId is { } profileId && !string.IsNullOrWhiteSpace(remoteSessionId)
+            ? _authoritativeRemoteSessionRouter.ResolveConversationId(state, remoteSessionId, profileId)
+            : null;
+
+    private bool IsInteractionBindingCurrent(InteractionRequestSource source, ConversationBindingSlice binding)
+        => IsInteractionConnectionCurrent(source)
+            && string.Equals(source.Connection?.ProfileId, binding.ProfileId, StringComparison.Ordinal)
+            && _chatStore.ReadCommittedState()?.ResolveBinding(binding.ConversationId) == binding;
+
+    private void ReconcileElicitationBindings()
+    {
+        foreach (var request in _panelStateCoordinator.GetElicitationRequests())
+        {
+            request.ReconcileBinding();
+        }
+    }
+
+    private void AttachElicitationOwnership(
+        ElicitationRequestViewModel viewModel, InteractionRequestSource source,
+        ConversationBindingSlice binding, ElicitationRequestEventArgs request)
+    {
+        viewModel.BindToConversation(
+            () => IsInteractionBindingCurrent(source, binding),
+            () => CancelBoundElicitationAsync(viewModel, source, binding, request));
+    }
+
+    private async Task<bool> CancelBoundElicitationAsync(
+        ElicitationRequestViewModel viewModel, InteractionRequestSource source,
+        ConversationBindingSlice binding, ElicitationRequestEventArgs request)
+    {
+        var sent = await ChatInteractionEventBridge.CancelUndisplayedElicitationAsync(request, Logger).ConfigureAwait(false);
+        if (sent) return true;
+        await PostToUiAsync(async () =>
+        {
+            if (!IsInteractionSourceActive(source) || !request.State.CanCancel) return;
+            if (IsChatShellVisibleForRemoteUi
+                && ReferenceEquals(_panelStateCoordinator.GetPendingElicitationRequest(binding.ConversationId), viewModel)) return;
+            await _acpConnectionCommands.DisconnectAfterInteractionFailureAsync(source.Service, this,
+                ResolveLocalizerText("Elicitation_CancellationFailedDisconnected",
+                    "Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent."))
+                .ConfigureAwait(true);
+        }).ConfigureAwait(false);
+        return false;
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -1855,6 +1855,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         {
             ApplySessionIdentityProjection(projection, out sessionChanged);
             ReconcilePermissionBindings(projection.Bindings);
+            ReconcileElicitationBindings();
             ApplyPromptAndProfileProjection(projection, sessionChanged);
             ApplyTranscriptAndPlanProjection(projection, sessionChanged);
             ApplyConversationStatusProjection(projection);

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/ElicitationInteractionViewModels.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/ElicitationInteractionViewModels.cs
@@ -27,6 +27,10 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
     private Func<Action, Task>? _dispatchAsync;
     private CancellationTokenRegistration _connectionClosedRegistration;
     private Func<Task>? _dismiss;
+    private Func<bool>? _isBindingCurrent;
+    private Func<Task<bool>>? _cancelInvalidBinding;
+    private bool _bindingWithdrawn;
+    private bool _dismissRequested;
     private bool _urlDispatched;
     private bool _disposed;
 
@@ -87,11 +91,53 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
     public bool ShowReopen => IsAwaitingCompletion && !IsCompleted;
 
     public bool CanReopen => ShowReopen && !_disposed && !IsSubmitting && _urlTarget is not null
-        && _uriLauncher.IsSupported && !(_requestState?.ConnectionClosed.IsCancellationRequested ?? false);
+        && _uriLauncher.IsSupported && IsBindingCurrent && !(_requestState?.ConnectionClosed.IsCancellationRequested ?? false);
 
-    public bool CanRespond => !_disposed && !IsSubmitting && (_requestState?.CanRespond ?? true);
+    public bool CanRespond => !_disposed && !IsSubmitting && IsBindingCurrent && (_requestState?.CanRespond ?? true);
 
     public bool CanCancel => !_disposed && !IsSubmitting && (_requestState?.CanCancel ?? true);
+
+    private bool IsBindingCurrent => !_bindingWithdrawn && (_isBindingCurrent?.Invoke() ?? true);
+
+    internal void BindToConversation(Func<bool> isBindingCurrent, Func<Task<bool>> cancelInvalidBinding)
+    {
+        _isBindingCurrent = isBindingCurrent;
+        _cancelInvalidBinding = cancelInvalidBinding;
+    }
+
+    internal void ReconcileBinding()
+    {
+        if (_disposed || _bindingWithdrawn || IsBindingCurrent) return;
+        _bindingWithdrawn = true;
+        FullUrl = string.Empty;
+        _urlTarget = null;
+        OnPropertyChanged(nameof(FullUrl));
+        OnPropertyChanged(nameof(UrlHost));
+        RefreshCommands();
+        _ = CancelInvalidBindingAsync();
+    }
+
+    private async Task CancelInvalidBindingAsync()
+    {
+        try
+        {
+            if (_requestState?.CanCancel == true && _cancelInvalidBinding is not null)
+            {
+                if (!await _cancelInvalidBinding().ConfigureAwait(true))
+                {
+                    SetLocalizedError("Elicitation_ResponseFailed", "The response could not be sent. Please try again.");
+                }
+            }
+            else if (_dismiss is not null)
+            {
+                await DismissOnceAsync().ConfigureAwait(true);
+            }
+        }
+        catch
+        {
+            SetLocalizedError("Elicitation_RequestExpired", "This request has expired. Reconnect to continue.");
+        }
+    }
 
     public string SubmitText => IsUrl
         ? (_urlDispatched ? Localize("Elicitation_RetryResponse", "Retry response") : Localize("Elicitation_OpenBrowser", "Open in browser"))
@@ -199,9 +245,24 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
     [RelayCommand]
     private async Task DismissAsync()
     {
-        if (_dismiss is not null && IsAwaitingCompletion)
+        if (IsAwaitingCompletion)
+        {
+            await DismissOnceAsync().ConfigureAwait(true);
+        }
+    }
+
+    private async Task DismissOnceAsync()
+    {
+        if (_dismissRequested || _dismiss is null) return;
+        _dismissRequested = true;
+        try
         {
             await _dismiss().ConfigureAwait(true);
+        }
+        catch
+        {
+            _dismissRequested = false;
+            throw;
         }
     }
 
@@ -254,6 +315,8 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
         OnAccept = null;
         OnDecline = null;
         OnCancel = null;
+        _isBindingCurrent = null;
+        _cancelInvalidBinding = null;
         foreach (var field in Fields)
         {
             field.Changed -= OnFieldChanged;
@@ -333,7 +396,7 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
                 _urlDispatched = true;
             }
 
-            if (_disposed || !(_requestState?.CanRespond ?? true))
+            if (_disposed || !IsBindingCurrent || !(_requestState?.CanRespond ?? true))
             {
                 return;
             }
@@ -402,9 +465,10 @@ public sealed partial class ElicitationRequestViewModel : ObservableObject, IDis
                 {
                     // Session cancellation also answers through the SDK, without a card command.
                     // Only a committed terminal response retires this exact projection.
-                    if (IsUrl && _requestState?.ResponseAction is ElicitationActions.Cancel or ElicitationActions.Decline)
+                    if (!connectionClosed && !(_requestState?.ConnectionClosed.IsCancellationRequested ?? false)
+                        && _requestState is { CanCancel: false } && (!IsAwaitingCompletion || _bindingWithdrawn))
                     {
-                        dismissTask = _dismiss?.Invoke();
+                        dismissTask = DismissOnceAsync();
                         return;
                     }
 
@@ -1034,24 +1098,13 @@ public static class ElicitationInteractionViewModelFactory
         var hasUnsupportedRequiredFields = required.Except(fields.Select(static field => field.Name), StringComparer.Ordinal).Any();
         var viewModel = new ElicitationRequestViewModel(args.MessageId, args.SessionId, args.Request.Message,
             fields, localizer, hasUnsupportedRequiredFields);
-        viewModel.OnAccept = async content => await RespondAndClearAsync(() => args.Accept(content), () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
-        viewModel.OnDecline = async () => await RespondAndClearAsync(args.Decline, () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
-        viewModel.OnCancel = async () => await RespondAndClearAsync(args.Cancel, () => clearPendingRequestAsync(viewModel)).ConfigureAwait(true);
+        viewModel.OnAccept = args.Accept;
+        viewModel.OnDecline = args.Decline;
+        viewModel.OnCancel = args.Cancel;
         viewModel.AttachRequest(args, UnsupportedExternalUriLauncher.Instance,
             dispatchAsync ?? (action => { action(); return Task.CompletedTask; }),
             () => clearPendingRequestAsync(viewModel), agentName);
         return viewModel;
-    }
-
-    private static async Task<bool> RespondAndClearAsync(Func<Task<bool>> respond, Func<Task> clear)
-    {
-        if (!await respond().ConfigureAwait(true))
-        {
-            return false;
-        }
-
-        await clear().ConfigureAwait(true);
-        return true;
     }
 
     private static ElicitationFieldViewModel? CreateField(

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Interactions/ChatInteractionEventBridge.cs
@@ -86,7 +86,8 @@ public sealed class ChatInteractionEventBridge
         ILogger logger,
         Func<Action, Task>? dispatchAsync = null,
         string agentName = "",
-        Func<ElicitationRequestEventArgs, Task>? cancelUndisplayedAsync = null)
+        Func<ElicitationRequestEventArgs, Task>? cancelUndisplayedAsync = null,
+        Func<string, ValueTask<string?>>? resolveConversationAsync = null)
     {
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(clearPendingRequestAsync);
@@ -99,12 +100,14 @@ public sealed class ChatInteractionEventBridge
             return null;
         }
 
+        // The application supplies its captured connection-scoped resolver. The default is retained
+        // for hosts that own only a single connection and use this bridge independently of ChatViewModel.
         string? conversationId;
         try
         {
-            conversationId = await _authoritativeRemoteSessionRouter
-                .ResolveConversationIdAsync(args.SessionId)
-                .ConfigureAwait(false);
+            conversationId = resolveConversationAsync is null
+                ? await _authoritativeRemoteSessionRouter.ResolveConversationIdAsync(args.SessionId).ConfigureAwait(false)
+                : await resolveConversationAsync(args.SessionId).ConfigureAwait(false);
         }
         catch (Exception)
         {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/Panels/ChatConversationPanelStateCoordinator.cs
@@ -95,6 +95,9 @@ public sealed class ChatConversationPanelStateCoordinator
         return _pendingElicitationRequestsByConversation.TryAdd(conversationId, request);
     }
 
+    internal IReadOnlyList<ElicitationRequestViewModel> GetElicitationRequests()
+        => _pendingElicitationRequestsByConversation.Values.ToArray();
+
     public bool RemoveElicitationRequest(string conversationId, ElicitationRequestViewModel request)
     {
         // A response can finish after disconnect and another form's arrival, even with the same id.
@@ -208,7 +211,8 @@ public sealed class ChatConversationPanelStateCoordinator
             var currentBinding = bindings?.GetValueOrDefault(conversationId);
             foreach (var request in requests)
             {
-                if (request.Binding is not null && request.Binding != currentBinding && request.IsAvailable)
+                if (request.Binding is not null && request.IsAvailable
+                    && (request.Binding != currentBinding || request.IsBindingCurrent?.Invoke() == false))
                 {
                     obsolete.Add((conversationId, request));
                 }

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/PermissionRequestViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/PermissionRequestViewModel.cs
@@ -29,6 +29,7 @@ public partial class PermissionRequestViewModel : ObservableObject
     internal Task? BindingCancellationTask { get; set; }
     internal bool BindingCancellationAttempted { get; set; }
     internal Func<bool>? IsRequestAvailable { get; set; }
+    internal Func<bool>? IsBindingCurrent { get; set; }
     internal Func<bool>? IsResponsePrepared { get; set; }
     internal Func<bool>? IsResponseSending { get; set; }
     internal Func<bool>? IsRequestCancellationRequested { get; set; }

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientBatchTests.cs
@@ -1333,6 +1333,60 @@ public sealed class AcpClientBatchTests
             + "\"sessionId\":\"session\",\"mode\":\"url\",\"elicitationId\":\"" + elicitationId
             + "\",\"url\":\"https://agent.example/authorize\",\"message\":\"Authorize\"}}";
 
+    [Fact]
+    public async Task Batch_ExplicitFormCancellation_ReplacesPreparedAcceptBeforeSiblingResponds()
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync();
+        var forms = new List<ElicitationRequestEventArgs>();
+        peer.Client.ElicitationRequestReceived += (_, request) => forms.Add(request);
+        peer.Deliver("[" + Form("1") + "," + Form("2") + "]");
+        var accepting = forms[0].Accept(null);
+
+        // Act
+        var cancelling = forms[0].Cancel();
+        var sibling = forms[1].Decline();
+
+        // Assert
+        Assert.True(await cancelling.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await accepting.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.True(await sibling.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal("cancel", response[0].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal("decline", response[1].GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal("cancel", forms[0].State.ResponseAction);
+        Assert.False(forms[0].State.CanCancel);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Elicitation_ExplicitCancelWhileAcceptWrites_WaitsForTheActualTerminalResponse(bool acceptSucceeds)
+    {
+        // Arrange
+        using var peer = await BatchPeer.CreateAsync(AcpProtocolVersion.V1);
+        ElicitationRequestEventArgs? form = null;
+        peer.Client.ElicitationRequestReceived += (_, request) => form = request;
+        peer.Deliver(Form("1"));
+        var write = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.NextResponseWrite = write.Task;
+        var accepting = form!.Accept(null);
+
+        // Act
+        var cancelling = form.Cancel();
+        Assert.False(cancelling.IsCompleted);
+        Assert.Empty(peer.Responses);
+        Assert.False(form.State.CanRespond);
+        write.TrySetResult(acceptSucceeds);
+
+        // Assert
+        Assert.True(await cancelling.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        Assert.Equal(acceptSucceeds, await accepting.WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+        var response = Assert.Single(peer.Responses);
+        Assert.Equal(acceptSucceeds ? "accept" : "cancel", response.GetProperty("result").GetProperty("action").GetString());
+        Assert.Equal(acceptSucceeds ? "accept" : "cancel", form.State.ResponseAction);
+    }
+
     private sealed class BatchPeer : IAcpTransport
     {
         private readonly int _version;

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpClientElicitationTests.cs
@@ -810,10 +810,11 @@ public sealed class AcpClientElicitationTests
             .Returns(sendResult.Task);
         var request = ReceiveRequest(client, parser, 312, UrlParamsJson);
         var accepted = request.Accept(null);
+        var cancelled = request.Cancel();
 
         try
         {
-            Assert.False(await request.Cancel());
+            Assert.False(cancelled.IsCompleted);
             Assert.Single(sentMessages);
         }
         finally
@@ -822,9 +823,41 @@ public sealed class AcpClientElicitationTests
         }
 
         Assert.True(await accepted);
+        Assert.True(await cancelled.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         var response = await WaitForResponseAsync(parser, sentMessages, 312);
         Assert.Equal("""{"action":"accept"}""", response.Result!.Value.GetRawText());
         Assert.Empty(sentMessages);
+    }
+
+    [Fact]
+    public async Task ElicitationResponse_DisconnectSettlesExplicitCancellation_WhenTransportIgnoresCancellation()
+    {
+        // Arrange
+        var parser = new MessageParser();
+        using var client = await CreateInitializedClientAsync(UrlCapabilities());
+        var physicalWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _transportMock.Setup(transport => transport.SendMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(physicalWrite.Task);
+        var request = ReceiveRequest(client, parser, 313, UrlParamsJson);
+        var accepted = request.Accept(null);
+        var cancelled = request.Cancel();
+        Assert.False(cancelled.IsCompleted);
+
+        // Act
+        try
+        {
+            await client.DisconnectAsync().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            // Assert: disposing the connection cannot be held by the uncooperative physical write.
+            Assert.False(await cancelled.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+            Assert.False(request.State.CanRespond);
+            Assert.Null(request.State.ResponseAction);
+        }
+        finally
+        {
+            physicalWrite.TrySetResult(false);
+            await accepted.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
     }
 
     [Fact]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelElicitationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelElicitationTests.cs
@@ -12,7 +12,7 @@ public partial class ChatViewModelTests
     public async Task ElicitationRequestReceived_WhenOwnerChangesBeforeUiDispatch_DoesNotOccupyNewFormSlot()
     {
         var syncContext = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(syncContext);
+        await using var fixture = CreateInteractionViewModel(syncContext);
         var viewModel = fixture.ViewModel;
         var previousService = CreateConnectedChatService();
         await syncContext.RunUntilCompletedAsync(viewModel.ReplaceChatServiceAsync(
@@ -69,7 +69,7 @@ public partial class ChatViewModelTests
     public async Task ElicitationRequestReceived_WhenDisposedBeforeUiDispatch_DoesNotRepopulateForm()
     {
         var syncContext = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(syncContext);
+        await using var fixture = CreateInteractionViewModel(syncContext);
         var service = CreateConnectedChatService();
         await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(
             RegisterInteractionMock(fixture, service.Object, "profile-1"), TestContext.Current.CancellationToken));
@@ -100,7 +100,7 @@ public partial class ChatViewModelTests
     public async Task ElicitationRequestReceived_WhenPoolServiceChangesBeforeUiDispatch_PreservesForm()
     {
         var syncContext = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(syncContext);
+        await using var fixture = CreateInteractionViewModel(syncContext);
         var service = CreateConnectedChatService();
         await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(
             RegisterInteractionMock(fixture, service.Object, "profile-1"), TestContext.Current.CancellationToken));
@@ -135,7 +135,7 @@ public partial class ChatViewModelTests
     [InlineData(true)]
     public async Task ElicitationRequestReceived_WhenFormAlreadyHeld_CancelsNewRequest(bool firstResponseInFlight)
     {
-        await using var fixture = CreateViewModel();
+        await using var fixture = CreateInteractionViewModel();
         var viewModel = fixture.ViewModel;
         var chatService = CreateConnectedChatService();
         viewModel.ReplaceChatService(RegisterInteractionMock(fixture, chatService.Object, "profile-1"));

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelElicitationTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelElicitationTests.cs
@@ -15,7 +15,8 @@ public partial class ChatViewModelTests
         await using var fixture = CreateViewModel(syncContext);
         var viewModel = fixture.ViewModel;
         var previousService = CreateConnectedChatService();
-        await syncContext.RunUntilCompletedAsync(viewModel.ReplaceChatServiceAsync(previousService.Object, TestContext.Current.CancellationToken));
+        await syncContext.RunUntilCompletedAsync(viewModel.ReplaceChatServiceAsync(
+            RegisterInteractionMock(fixture, previousService.Object, "profile-1"), TestContext.Current.CancellationToken));
         await fixture.UpdateStateAsync(state => state with
         {
             HydratedConversationId = "conv-1",
@@ -39,7 +40,7 @@ public partial class ChatViewModelTests
         try
         {
             SynchronizationContext.SetSynchronizationContext(syncContext);
-            viewModel.ReplaceChatService(currentService.Object);
+            viewModel.ReplaceChatService(RegisterInteractionMock(fixture, currentService.Object, "profile-1"));
         }
         finally
         {
@@ -70,7 +71,8 @@ public partial class ChatViewModelTests
         var syncContext = new QueueingSynchronizationContext();
         await using var fixture = CreateViewModel(syncContext);
         var service = CreateConnectedChatService();
-        await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(service.Object, TestContext.Current.CancellationToken));
+        await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(
+            RegisterInteractionMock(fixture, service.Object, "profile-1"), TestContext.Current.CancellationToken));
         await fixture.UpdateStateAsync(state => state with
         {
             HydratedConversationId = "conv-1",
@@ -100,7 +102,8 @@ public partial class ChatViewModelTests
         var syncContext = new QueueingSynchronizationContext();
         await using var fixture = CreateViewModel(syncContext);
         var service = CreateConnectedChatService();
-        await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(service.Object, TestContext.Current.CancellationToken));
+        await syncContext.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(
+            RegisterInteractionMock(fixture, service.Object, "profile-1"), TestContext.Current.CancellationToken));
         await fixture.UpdateStateAsync(state => state with
         {
             HydratedConversationId = "conv-1",
@@ -110,7 +113,8 @@ public partial class ChatViewModelTests
         await syncContext.RunUntilIdleAsync();
         var cancelled = 0;
         var replacement = ((IAcpChatCoordinatorSink)fixture.ViewModel).ReplaceChatServiceAsync(
-            CreateConnectedChatService().Object, ServiceReplaceIntent.PoolOnly, TestContext.Current.CancellationToken);
+            RegisterInteractionMock(fixture, CreateConnectedChatService().Object, "profile-other"),
+            ServiceReplaceIntent.PoolOnly, TestContext.Current.CancellationToken);
         service.Raise(chat => chat.ElicitationRequestReceived += null,
             new ElicitationRequestEventArgs("form-1", new FormElicitationRequest
             {
@@ -134,7 +138,7 @@ public partial class ChatViewModelTests
         await using var fixture = CreateViewModel();
         var viewModel = fixture.ViewModel;
         var chatService = CreateConnectedChatService();
-        viewModel.ReplaceChatService(chatService.Object);
+        viewModel.ReplaceChatService(RegisterInteractionMock(fixture, chatService.Object, "profile-1"));
         var initialState = (await fixture.GetStateAsync()) with
         {
             HydratedConversationId = "conv-1",

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationBindingRaces.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationBindingRaces.cs
@@ -1,0 +1,221 @@
+using Moq;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Models.Navigation;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Elicitation_AcceptedUrlAuthorityChanges_CannotReopenOrSendAnotherResponse(bool connectionChanged)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(value => value.IsSupported).Returns(true);
+        launcher.Setup(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExternalUriOpenResult.Dispatched);
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher, launcher.Object);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("accepted", "url", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var card = fixture.ViewModel.PendingElicitationRequest!;
+        await AwaitWithSynchronizationContextAsync(dispatcher, card.SubmitCommand.ExecuteAsync(null));
+        Assert.True(card.CanReopen);
+
+        // Act
+        if (connectionChanged)
+        {
+            RegisterInteractionService(fixture, peer.Service, connectionId: "new-instance");
+        }
+        else
+        {
+            Assert.Equal(BindingUpdateStatus.Success, (await fixture.ViewModel.ConversationBindingCommands
+                .UpdateBindingAsync("conv-1", "replacement-remote", "profile")).Status);
+        }
+        await card.ReopenCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(card.CanReopen);
+        launcher.Verify(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal("accept", Assert.Single(peer.Responses).GetProperty("result").GetProperty("action").GetString());
+        await fixture.ApplyCurrentStoreProjectionAsync();
+        await dispatcher.RunUntilIdleAsync();
+        Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+    }
+
+    [Fact]
+    public async Task Elicitation_BindingCommitsBeforeUiProjection_CannotOpenUrlOrAccept()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(value => value.IsSupported).Returns(true);
+        launcher.Setup(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExternalUriOpenResult.Dispatched);
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher, launcher.Object);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("url", "url", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var card = fixture.ViewModel.PendingElicitationRequest!;
+        Assert.True(card.CanSubmit);
+
+        // Act: commit authoritative state without draining the UI dispatcher's older projection.
+        var result = await fixture.ViewModel.ConversationBindingCommands
+            .UpdateBindingAsync("conv-1", "replacement-remote", "profile");
+        Assert.Equal(BindingUpdateStatus.Success, result.Status);
+        await card.SubmitCommand.ExecuteAsync(null);
+
+        // Assert: this synchronous guard runs before browser dispatch, preserving the click boundary.
+        launcher.Verify(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.DoesNotContain(peer.Responses, response => response.GetProperty("result").GetProperty("action").GetString() == "accept");
+        await dispatcher.RunUntilIdleAsync();
+        Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+    }
+
+    [Theory]
+    [InlineData("form", true)]
+    [InlineData("form", false)]
+    [InlineData("url", true)]
+    [InlineData("url", false)]
+    public async Task Elicitation_BindingChangesWhileResponseWrites_KeepsDeliveryWithOriginalRequest(string mode, bool acceptSucceeds)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var launcher = new Mock<IExternalUriLauncher>();
+        launcher.SetupGet(value => value.IsSupported).Returns(true);
+        launcher.Setup(value => value.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExternalUriOpenResult.Dispatched);
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher, launcher.Object);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("form", mode, "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var card = fixture.ViewModel.PendingElicitationRequest!;
+        var started = NewPermissionSignal();
+        var release = NewPermissionSignal();
+        peer.ResponseSend = (response, token) =>
+        {
+            if (response.GetProperty("result").GetProperty("action").GetString() != "accept") return Task.FromResult(true);
+            started.TrySetResult(true);
+            return release.Task.WaitAsync(token);
+        };
+        var responseTask = card.SubmitCommand.ExecuteAsync(null);
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, started.Task);
+
+            // Act
+            var result = await fixture.ViewModel.ConversationBindingCommands
+                .UpdateBindingAsync("conv-1", "replacement-remote", "profile");
+            Assert.Equal(BindingUpdateStatus.Success, result.Status);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert: invalidation withdraws actions but does not tear down a live physical write.
+            Assert.Same(card, fixture.ViewModel.PendingElicitationRequest);
+            Assert.False(card.CanRespond);
+            Assert.True(peer.IsConnected);
+            Assert.Empty(peer.Responses);
+            release.TrySetResult(acceptSucceeds);
+            await AwaitPermissionUiSignalAsync(dispatcher, responseTask);
+            await dispatcher.RunUntilIdleAsync();
+            Assert.True(peer.IsConnected);
+            Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+            Assert.Equal(acceptSucceeds ? "accept" : "cancel",
+                Assert.Single(peer.Responses).GetProperty("result").GetProperty("action").GetString());
+        }
+        finally
+        {
+            release.TrySetResult(acceptSucceeds);
+            await AwaitPermissionUiSignalAsync(dispatcher, responseTask);
+        }
+    }
+
+    [Fact]
+    public async Task Elicitation_BindingCancellationFailsAfterPoolSwitch_ClosesOnlyOriginalService()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var shell = new ShellNavigationRuntimeStateStore { CurrentShellContent = ShellNavigationContent.Chat };
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher, shellNavigationRuntimeState: shell);
+        using var oldPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        using var newPeer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
+        RegisterInteractionService(fixture, newPeer.Service, "another-profile");
+        oldPeer.Elicit("old", "form", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var started = NewPermissionSignal();
+        var release = NewPermissionSignal();
+        oldPeer.ResponseSend = (_, token) => { started.TrySetResult(true); return release.Task.WaitAsync(token); };
+        var changed = await fixture.ViewModel.ConversationBindingCommands
+            .UpdateBindingAsync("conv-1", "replacement-remote", "another-profile");
+        Assert.Equal(BindingUpdateStatus.Success, changed.Status);
+        try
+        {
+            await AwaitPermissionUiSignalAsync(dispatcher, started.Task);
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.ViewModel.ReplaceChatServiceWithIntentAsync(newPeer.Service, ServiceReplaceIntent.PoolOnly,
+                    TestContext.Current.CancellationToken));
+            shell.CurrentShellContent = ShellNavigationContent.Settings;
+
+            // Act
+            release.TrySetResult(false);
+            await AwaitPermissionUiSignalAsync(dispatcher, oldPeer.ServiceDisposed.Task);
+            await dispatcher.RunUntilIdleAsync();
+
+            // Assert
+            Assert.False(oldPeer.IsConnected);
+            Assert.True(newPeer.IsConnected);
+            Assert.Same(newPeer.Service, fixture.ViewModel.CurrentChatService);
+            Assert.Empty(newPeer.Responses);
+            Assert.Null((await fixture.ConnectionStore.GetCurrentStateAsync()).Error);
+        }
+        finally
+        {
+            release.TrySetResult(false);
+            await dispatcher.RunUntilIdleAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Elicitation_BindingCancellationWriteFails_RetainsOnlyCancellationForRetry()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        var shell = new ShellNavigationRuntimeStateStore { CurrentShellContent = ShellNavigationContent.Chat };
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher, shellNavigationRuntimeState: shell);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("old", "form", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var original = fixture.ViewModel.PendingElicitationRequest!;
+        var attempts = 0;
+        peer.ResponseSend = (_, _) => { attempts++; return Task.FromResult(false); };
+
+        // Act
+        var result = await fixture.ViewModel.ConversationBindingCommands
+            .UpdateBindingAsync("conv-1", "replacement-remote", "profile");
+        Assert.Equal(BindingUpdateStatus.Success, result.Status);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        Assert.True(peer.IsConnected);
+        Assert.Same(original, fixture.ViewModel.PendingElicitationRequest);
+        Assert.False(original.CanRespond);
+        Assert.True(original.CanCancel);
+        Assert.True(original.HasError);
+        await fixture.ApplyCurrentStoreProjectionAsync();
+        await dispatcher.RunUntilIdleAsync();
+        Assert.Equal(1, attempts);
+        peer.ResponseSend = (_, _) => Task.FromResult(true);
+        await AwaitWithSynchronizationContextAsync(dispatcher, original.CancelCommand.ExecuteAsync(null));
+        Assert.Equal("cancel", Assert.Single(peer.Responses).GetProperty("result").GetProperty("action").GetString());
+        Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
@@ -7,6 +7,7 @@ using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Mvux.Chat;
 using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
 using SalmonEgg.Presentation.Core.Services.Chat;
 using SalmonEgg.Presentation.Core.Tests.Localization;
 
@@ -292,7 +293,9 @@ public partial class ChatViewModelTests
     private static ClientCapabilities UrlElicitationCapabilities()
         => ClientCapabilityDefaults.Create() with { Elicitation = new() { Form = new(), Url = new() } };
 
-    private static ViewModelFixture CreateElicitationDeliveryFixture(QueueingSynchronizationContext dispatcher)
+    private static ViewModelFixture CreateElicitationDeliveryFixture(
+        QueueingSynchronizationContext dispatcher, IExternalUriLauncher? externalUriLauncher = null,
+        IShellNavigationRuntimeState? shellNavigationRuntimeState = null)
     {
         var localizer = new MutableTestCoreStringLocalizer();
         localizer.Set("zh-Hans", "Elicitation_CancellationFailedDisconnected", ElicitationDisconnectedMessage);
@@ -300,6 +303,8 @@ public partial class ChatViewModelTests
             NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
             Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
         return CreateViewModel(dispatcher, acpConnectionCommands: commands, localizer: localizer,
+            externalUriLauncher: externalUriLauncher,
+            shellNavigationRuntimeState: shellNavigationRuntimeState,
             acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
                 NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
                 Mock.Of<IAcpRemoteSessionRecoveryContextResolver>()));

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationDelivery.cs
@@ -302,7 +302,7 @@ public partial class ChatViewModelTests
         var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
             NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
             Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
-        return CreateViewModel(dispatcher, acpConnectionCommands: commands, localizer: localizer,
+        return CreateInteractionViewModel(dispatcher, acpConnectionCommands: commands, localizer: localizer,
             externalUriLauncher: externalUriLauncher,
             shellNavigationRuntimeState: shellNavigationRuntimeState,
             acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationTerminalState.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.ElicitationTerminalState.cs
@@ -1,0 +1,42 @@
+using SalmonEgg.Acp.Protocol;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData("form")]
+    [InlineData("url")]
+    public async Task Elicitation_SessionCancellation_RetiresTheFinishedCard(string mode)
+    {
+        // Arrange: the production SDK, ChatService and ChatViewModel hold the visible request.
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("first", mode, "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var previous = fixture.ViewModel.PendingElicitationRequest;
+        Assert.NotNull(previous);
+
+        // Act: cancellation originates outside the card's own CancelCommand.
+        await AwaitWithSynchronizationContextAsync(dispatcher,
+            peer.Service.CancelSessionAsync(new SessionCancelParams("remote-1")));
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert: the SDK has delivered the terminal response; the UI must release this exact slot.
+        Assert.Single(peer.Responses);
+        Assert.False(Assert.Single(peer.Elicitations).State.CanCancel);
+        Assert.True(peer.IsConnected);
+        var cancelledCard = fixture.ViewModel.PendingElicitationRequest;
+        peer.Elicit("second", "form", "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        TestContext.Current.TestOutputHelper!.WriteLine(
+            $"Mode={mode}; CancelledCardStillVisible={cancelledCard is not null}; "
+            + $"CurrentCard={fixture.ViewModel.PendingElicitationRequest?.MessageId}; "
+            + $"WireReplies={string.Join(";", peer.Responses.Select(response => response.GetRawText()))}");
+        Assert.Null(cancelledCard);
+        Assert.Equal("second", fixture.ViewModel.PendingElicitationRequest?.MessageId.ToString());
+        Assert.Single(peer.Responses);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionFixture.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionFixture.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    // Interaction ownership requires a registered connection. Other chat tests intentionally exercise
+    // the host's no-registry path, so the shared CreateViewModel must not install an empty registry.
+    private static ViewModelFixture CreateInteractionViewModel(
+        SynchronizationContext? syncContext = null,
+        IAcpConnectionCommands? acpConnectionCommands = null,
+        IShellNavigationRuntimeState? shellNavigationRuntimeState = null,
+        IStringLocalizer<CoreStrings>? localizer = null,
+        IAppLanguageService? languageService = null,
+        Func<IChatConnectionStore, IAcpConnectionCoordinator>? acpConnectionCoordinatorFactory = null,
+        IExternalUriLauncher? externalUriLauncher = null)
+        => CreateViewModel(
+            syncContext,
+            acpConnectionCommands: acpConnectionCommands,
+            shellNavigationRuntimeState: shellNavigationRuntimeState,
+            localizer: localizer,
+            languageService: languageService,
+            acpConnectionCoordinatorFactory: acpConnectionCoordinatorFactory,
+            externalUriLauncher: externalUriLauncher,
+            connectionSessionRegistry: new InMemoryAcpConnectionSessionRegistry());
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionSourceOwnership.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionSourceOwnership.cs
@@ -40,7 +40,7 @@ public partial class ChatViewModelTests
         // Arrange: the first real service publishes before a profile switch; routing waits while
         // the production BindingCoordinator gives a second profile its identically named session.
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var previousPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AwaitWithSynchronizationContextAsync(dispatcher,

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionSourceOwnership.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.InteractionSourceOwnership.cs
@@ -1,0 +1,113 @@
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData("form")]
+    [InlineData("url")]
+    public async Task Elicitation_BindingReplaced_WithdrawsTheOriginalRequest(string mode)
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateElicitationDeliveryFixture(dispatcher);
+        using var peer = await PermissionUiPeer.CreateAsync(UrlElicitationCapabilities());
+        await AttachPermissionPeerAsync(fixture, dispatcher, peer);
+        peer.Elicit("old-form", mode, "bound-session");
+        await dispatcher.RunUntilIdleAsync();
+        var original = fixture.ViewModel.PendingElicitationRequest;
+        Assert.NotNull(original);
+
+        // Act: same local conversation now represents a different authoritative remote session.
+        var changed = await fixture.ViewModel.ConversationBindingCommands
+            .UpdateBindingAsync("conv-1", "replacement-remote", "profile");
+        Assert.Equal(BindingUpdateStatus.Success, changed.Status);
+        Assert.Equal("replacement-remote", (await fixture.ChatStore.GetCurrentStateAsync())
+            .ResolveBinding("conv-1")?.RemoteSessionId);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert: the stale question must not remain actionable on the replacement session.
+        Assert.False(original.CanRespond);
+        Assert.Null(fixture.ViewModel.PendingElicitationRequest);
+        Assert.Equal("cancel", Assert.Single(peer.Responses).GetProperty("result").GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public async Task Permission_EqualRemoteIdsAcrossProfiles_DoNotGrantConsentToAnotherProfile()
+    {
+        // Arrange: the first real service publishes before a profile switch; routing waits while
+        // the production BindingCoordinator gives a second profile its identically named session.
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateViewModel(dispatcher);
+        using var previousPeer = await PermissionUiPeer.CreateAsync();
+        using var currentPeer = await PermissionUiPeer.CreateAsync();
+        await AwaitWithSynchronizationContextAsync(dispatcher,
+            fixture.Workspace.RestoreAsync(TestContext.Current.CancellationToken));
+        await AttachPermissionPeerAsync(fixture, dispatcher, previousPeer);
+        RegisterInteractionService(fixture, previousPeer.Service, "profile-a");
+        RegisterInteractionService(fixture, currentPeer.Service, "profile-b");
+        var first = await fixture.ViewModel.ConversationBindingCommands
+            .UpdateBindingAsync("conv-1", "shared-remote", "profile-a");
+        Assert.Equal(BindingUpdateStatus.Success, first.Status);
+        await dispatcher.RunUntilIdleAsync();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.ChatStore.ReadState = async () =>
+        {
+            fixture.ChatStore.ReadState = null;
+            started.TrySetResult();
+            await release.Task.WaitAsync(TestContext.Current.CancellationToken);
+            return fixture.ChatStore.LatestState;
+        };
+        previousPeer.Request("profile-a-permission", "shared-remote", "old-tool");
+        await started.Task.WaitAsync(TestContext.Current.CancellationToken);
+        try
+        {
+            var second = await fixture.ViewModel.ConversationBindingCommands
+                .UpdateBindingAsync("conv-2", "shared-remote", "profile-b");
+            TestContext.Current.TestOutputHelper!.WriteLine($"SecondBindingStatus={second.Status}; Error={second.ErrorMessage}");
+            Assert.Equal(BindingUpdateStatus.Success, second.Status);
+            var newState = await fixture.ChatStore.GetCurrentStateAsync();
+            Assert.Null(newState.ResolveBinding("conv-1"));
+            Assert.Equal("profile-b", newState.ResolveBinding("conv-2")?.ProfileId);
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.ViewModel.ReplaceChatServiceWithIntentAsync(currentPeer.Service,
+                    ServiceReplaceIntent.PoolOnly, TestContext.Current.CancellationToken));
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.DispatchConnectionAsync(new SetSelectedProfileIntentAction("profile-b")).AsTask());
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.DispatchConnectionAsync(new SetForegroundTransportProfileAction("profile-b")).AsTask());
+            await SelectPermissionConversationAsync(fixture, "conv-2");
+
+            // Act: only now can the old request choose its destination from the new bindings.
+            release.TrySetResult();
+            await dispatcher.RunUntilIdleAsync();
+            var projectedOnOtherProfile = fixture.ViewModel.PendingPermissionRequest;
+            TestContext.Current.TestOutputHelper!.WriteLine(
+                $"CurrentConversation={fixture.ViewModel.CurrentSessionId}; ForegroundProfile={fixture.ViewModel.ForegroundTransportProfileId}; "
+                + $"VisibleRequest={projectedOnOtherProfile?.MessageId}; RequestBindingProfile={projectedOnOtherProfile?.Binding?.ProfileId}");
+            if (projectedOnOtherProfile is not null)
+            {
+                await AwaitWithSynchronizationContextAsync(dispatcher,
+                    projectedOnOtherProfile.RespondCommand.ExecuteAsync(projectedOnOtherProfile.Options[0]));
+            }
+            TestContext.Current.TestOutputHelper!.WriteLine(
+                $"OldPeerReplies={string.Join(";", previousPeer.Responses.Select(response => response.GetRawText()))}; "
+                + $"NewPeerReplyCount={currentPeer.Responses.Count}");
+
+            // Assert: the current profile's interaction cannot grant consent to the previous peer.
+            Assert.DoesNotContain(previousPeer.Responses, response => response.TryGetProperty("result", out var result)
+                && result.TryGetProperty("outcome", out var outcome)
+                && outcome.GetProperty("outcome").GetString() == "selected");
+            Assert.Empty(currentPeer.Responses);
+        }
+        finally
+        {
+            fixture.ChatStore.ReadState = null;
+            release.TrySetResult();
+            await dispatcher.RunUntilIdleAsync();
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
@@ -12,6 +12,7 @@ using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Mvux.Chat;
 using SalmonEgg.Presentation.Core.Services;
 using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Threading;
 using SalmonEgg.Presentation.Models.Navigation;
 using SalmonEgg.Presentation.ViewModels.Chat;
 
@@ -393,10 +394,12 @@ public partial class ChatViewModelTests
         {
             _client = new AcpClient(this, Mock.Of<IAcpClientLogger>());
             _client.PermissionRequestReceived += (_, request) => Requests.Enqueue(request);
-            Service = new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>());
+            Service = new AcpChatServiceAdapter(
+                new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>()),
+                new AcpEventAdapter(_ => { }, new ImmediateUiDispatcher()));
         }
 
-        internal ChatService Service { get; }
+        internal AcpChatServiceAdapter Service { get; }
         internal ConcurrentQueue<PermissionRequestEventArgs> Requests { get; } = new();
         internal ConcurrentQueue<JsonElement> Responses { get; } = new();
         internal bool FailNextResponse { get; set; }

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionBatch.cs
@@ -27,7 +27,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var stablePeer = await PermissionUiPeer.CreateAsync();
         using var peer = await DraftPermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
@@ -92,7 +92,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var stablePeer = await PermissionUiPeer.CreateAsync();
         using var peer = await DraftPermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
@@ -151,7 +151,7 @@ public partial class ChatViewModelTests
         var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
             NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
             Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
-        await using var fixture = CreateViewModel(dispatcher, acpConnectionCommands: commands,
+        await using var fixture = CreateInteractionViewModel(dispatcher, acpConnectionCommands: commands,
             shellNavigationRuntimeState: shell,
             acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
                 NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
@@ -181,7 +181,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var stablePeer = await PermissionUiPeer.CreateAsync();
         using var peer = await DraftPermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
@@ -247,7 +247,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var stablePeer = await PermissionUiPeer.CreateAsync();
         using var peer = await DraftPermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
@@ -305,7 +305,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var stablePeer = await PermissionUiPeer.CreateAsync();
         using var peer = await DraftPermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionDelivery.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionDelivery.cs
@@ -30,7 +30,7 @@ public partial class ChatViewModelTests
         var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
             NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
             Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
-        await using var fixture = CreateViewModel(dispatcher, acpConnectionCommands: commands,
+        await using var fixture = CreateInteractionViewModel(dispatcher, acpConnectionCommands: commands,
             shellNavigationRuntimeState: shell, localizer: localizer,
             acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
                 NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
@@ -67,7 +67,7 @@ public partial class ChatViewModelTests
         var commands = new AcpChatCoordinator(Mock.Of<IAcpChatServiceFactory>(),
             NullLogger<AcpChatCoordinator>.Instance, Mock.Of<ITransportSupportPolicy>(),
             Mock.Of<IAcpMcpServerProvider>(), Mock.Of<IAcpSessionCommandOrchestrator>());
-        await using var fixture = CreateViewModel(dispatcher, acpConnectionCommands: commands,
+        await using var fixture = CreateInteractionViewModel(dispatcher, acpConnectionCommands: commands,
             shellNavigationRuntimeState: shell,
             acpConnectionCoordinatorFactory: store => new AcpConnectionCoordinator(store,
                 NullLogger<AcpConnectionCoordinator>.Instance, Mock.Of<IAcpMcpServerResolver>(),
@@ -116,7 +116,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("first", "remote-1", "first-tool");
@@ -176,7 +176,7 @@ public partial class ChatViewModelTests
         var localizer = new MutableTestCoreStringLocalizer();
         localizer.Set("zh-Hans", "Permission_RetryCancellation", "重试取消");
         localizer.Set("zh-Hans", "Permission_Cancelled", "此请求已取消，请重试取消。");
-        await using var fixture = CreateViewModel(dispatcher, localizer: localizer);
+        await using var fixture = CreateInteractionViewModel(dispatcher, localizer: localizer);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         var attempts = 0;
@@ -227,7 +227,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.ResponseSend = (_, _) => Task.FromResult(false);
@@ -259,7 +259,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         var attempts = 0;
@@ -292,7 +292,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
@@ -325,7 +325,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionNotifications.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionNotifications.cs
@@ -17,7 +17,7 @@ public partial class ChatViewModelTests
         var dispatcher = new QueueingSynchronizationContext();
         var localizer = new MutableTestCoreStringLocalizer();
         localizer.Set("zh-Hans", "Permission_Cancelled", "此请求已取消，请重试取消。");
-        await using var fixture = CreateViewModel(dispatcher, localizer: localizer);
+        await using var fixture = CreateInteractionViewModel(dispatcher, localizer: localizer);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -72,7 +72,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("first", "remote-1", "tool-one");
@@ -126,7 +126,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -160,7 +160,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
@@ -221,7 +221,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionNotifications.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionNotifications.cs
@@ -187,6 +187,7 @@ public partial class ChatViewModelTests
             Assert.True(dispatcher.PendingCount > 0);
 
             // Act: replace on the UI thread before pumping the already queued old notification.
+            RegisterInteractionService(fixture, currentPeer.Service);
             RunPermissionUiAction(dispatcher, () => fixture.ViewModel.ReplaceChatService(currentPeer.Service));
             Assert.Null(oldPrompt.UnsubscribeRequestChanges);
             currentPeer.Request("permission", "remote-1", "new-tool");

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
@@ -5,10 +5,12 @@ using Moq;
 using SalmonEgg.Acp.Client;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models;
 using SalmonEgg.Domain.Models.Conversation;
 using SalmonEgg.Domain.Services;
 using SalmonEgg.Presentation.Core.Mvux.Chat;
 using SalmonEgg.Presentation.Core.Tests.Localization;
+using SalmonEgg.Presentation.Core.Tests.Threading;
 using SalmonEgg.Presentation.Core.Services.Chat;
 using SalmonEgg.Presentation.ViewModels.Chat;
 
@@ -25,7 +27,11 @@ public partial class ChatViewModelTests
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
-        dispatcher.Enqueue(() => fixture.ViewModel.ReplaceChatService(currentPeer.Service));
+        dispatcher.Enqueue(() =>
+        {
+            RegisterInteractionService(fixture, currentPeer.Service);
+            fixture.ViewModel.ReplaceChatService(currentPeer.Service);
+        });
         oldPeer.Request("permission", "remote-1", "old-tool");
 
         // Act
@@ -52,6 +58,7 @@ public partial class ChatViewModelTests
         oldPeer.Request("permission", "remote-1", "old-tool");
         await dispatcher.RunUntilIdleAsync();
         var oldPrompt = Assert.IsType<PermissionRequestViewModel>(fixture.ViewModel.PendingPermissionRequest);
+        RegisterInteractionService(fixture, currentPeer.Service);
         await AwaitWithSynchronizationContextAsync(dispatcher,
             fixture.ViewModel.ReplaceChatServiceAsync(currentPeer.Service, TestContext.Current.CancellationToken));
         currentPeer.Request("permission", "remote-1", "current-tool");
@@ -93,6 +100,7 @@ public partial class ChatViewModelTests
         try
         {
             await AwaitWithSynchronizationContextAsync(dispatcher, started.Task);
+            RegisterInteractionService(fixture, currentPeer.Service);
             await AwaitWithSynchronizationContextAsync(dispatcher,
                 fixture.ViewModel.ReplaceChatServiceAsync(currentPeer.Service, TestContext.Current.CancellationToken));
             currentPeer.Request("permission", "remote-1", "current-tool");
@@ -500,6 +508,11 @@ public partial class ChatViewModelTests
         using var originalPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, originalPeer);
+        RegisterInteractionService(fixture, currentPeer.Service, "profile-other");
+        await fixture.UpdateStateAsync(state => state with
+        {
+            Bindings = state.Bindings!.SetItem("conv-2", new("conv-2", "remote-2", "profile-other"))
+        });
         originalPeer.Request("permission", "remote-1", "tool-one");
         await dispatcher.RunUntilIdleAsync();
         var original = fixture.ViewModel.PendingPermissionRequest!;
@@ -642,6 +655,7 @@ public partial class ChatViewModelTests
     private static async Task AttachPermissionPeerAsync(
         ViewModelFixture fixture, QueueingSynchronizationContext dispatcher, PermissionUiPeer peer, IChatService? service = null)
     {
+        RegisterInteractionService(fixture, (AcpChatServiceAdapter)(service ?? peer.Service));
         await AwaitWithSynchronizationContextAsync(dispatcher,
             fixture.ViewModel.ReplaceChatServiceAsync(service ?? peer.Service, TestContext.Current.CancellationToken));
         await fixture.UpdateStateAsync(state => state with
@@ -652,6 +666,23 @@ public partial class ChatViewModelTests
                 .Add("conv-2", new("conv-2", "remote-2", "profile"))
         });
         await dispatcher.RunUntilIdleAsync();
+    }
+
+    private static void RegisterInteractionService(
+        ViewModelFixture fixture, AcpChatServiceAdapter service, string profileId = "profile", string? connectionId = null)
+        => fixture.InteractionRegistry.Upsert(new(profileId, service,
+            new InitializeResponse(1, new AgentInfo("Peer", "1"), new AgentCapabilities()),
+            new AcpConnectionReuseKey(TransportType.WebSocket, "", "", ""), connectionId ?? Guid.NewGuid().ToString("N")));
+
+    private static AcpChatServiceAdapter RegisterInteractionMock(
+        ViewModelFixture fixture, IChatService service, string profileId)
+    {
+        AcpChatServiceAdapter? adapter = null;
+        var eventAdapter = new AcpEventAdapter(update => adapter!.PublishBufferedUpdate(update), new ImmediateUiDispatcher());
+        adapter = new AcpChatServiceAdapter(service, eventAdapter);
+        eventAdapter.ReleaseUnscopedBufferedUpdates(lowTrust: false);
+        RegisterInteractionService(fixture, adapter, profileId);
+        return adapter;
     }
 
     private static async Task SelectPermissionConversationAsync(ViewModelFixture fixture, string conversationId)
@@ -682,10 +713,12 @@ public partial class ChatViewModelTests
             _client = new AcpClient(this, Mock.Of<IAcpClientLogger>());
             _client.PermissionRequestReceived += (_, request) => Requests.Enqueue(request);
             _client.ElicitationRequestReceived += (_, request) => Elicitations.Enqueue(request);
-            Service = new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>());
+            Service = new AcpChatServiceAdapter(
+                new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>()),
+                new AcpEventAdapter(_ => { }, new ImmediateUiDispatcher()));
         }
 
-        public ChatService Service { get; }
+        public AcpChatServiceAdapter Service { get; }
         public ConcurrentQueue<PermissionRequestEventArgs> Requests { get; } = new();
         public ConcurrentQueue<ElicitationRequestEventArgs> Elicitations { get; } = new();
         public ConcurrentQueue<JsonElement> Responses { get; } = new();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.PermissionOwnership.cs
@@ -23,7 +23,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
@@ -51,7 +51,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
@@ -82,7 +82,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var oldPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, oldPeer);
@@ -128,7 +128,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         await AddPermissionToolCardAsync(fixture, "conv-1", "shared-tool-id");
@@ -176,7 +176,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "old-tool");
@@ -204,7 +204,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("first", "remote-1", "first-tool");
@@ -232,7 +232,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("obsolete", "remote-1", "old-tool");
@@ -268,7 +268,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("obsolete", "remote-1", "old-tool");
@@ -317,7 +317,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("obsolete", "remote-1", "old-tool");
@@ -392,7 +392,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("obsolete", "remote-1", "old-tool");
@@ -450,7 +450,7 @@ public partial class ChatViewModelTests
         localizer.Set("en-US", "Permission_BindingChanged", "This request is no longer valid.");
         var languageService = new Mock<IAppLanguageService>();
         languageService.SetupGet(service => service.CurrentLanguageTag).Returns("zh-Hans");
-        await using var fixture = CreateViewModel(dispatcher, localizer: localizer, languageService: languageService.Object);
+        await using var fixture = CreateInteractionViewModel(dispatcher, localizer: localizer, languageService: languageService.Object);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("obsolete", "remote-1", "old-tool");
@@ -483,7 +483,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         using var adapter = new AcpChatServiceAdapter(peer.Service, new AcpEventAdapter(_ => { }, dispatcher));
         await AttachPermissionPeerAsync(fixture, dispatcher, peer, adapter);
@@ -504,7 +504,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var originalPeer = await PermissionUiPeer.CreateAsync();
         using var currentPeer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, originalPeer);
@@ -539,7 +539,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -565,7 +565,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -587,7 +587,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -611,7 +611,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
 
@@ -630,7 +630,7 @@ public partial class ChatViewModelTests
     {
         // Arrange
         var dispatcher = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(dispatcher);
+        await using var fixture = CreateInteractionViewModel(dispatcher);
         using var peer = await PermissionUiPeer.CreateAsync();
         await AttachPermissionPeerAsync(fixture, dispatcher, peer);
         peer.Request("permission", "remote-1", "tool");
@@ -670,9 +670,12 @@ public partial class ChatViewModelTests
 
     private static void RegisterInteractionService(
         ViewModelFixture fixture, AcpChatServiceAdapter service, string profileId = "profile", string? connectionId = null)
-        => fixture.InteractionRegistry.Upsert(new(profileId, service,
+    {
+        Assert.NotNull(fixture.InteractionRegistry);
+        fixture.InteractionRegistry.Upsert(new(profileId, service,
             new InitializeResponse(1, new AgentInfo("Peer", "1"), new AgentCapabilities()),
             new AcpConnectionReuseKey(TransportType.WebSocket, "", "", ""), connectionId ?? Guid.NewGuid().ToString("N")));
+    }
 
     private static AcpChatServiceAdapter RegisterInteractionMock(
         ViewModelFixture fixture, IChatService service, string profileId)

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -91,7 +91,6 @@ public partial class ChatViewModelTests
         IExternalUriLauncher? externalUriLauncher = null)
     {
         var stateOwner = new object();
-        connectionSessionRegistry ??= new InMemoryAcpConnectionSessionRegistry();
         var connectionStateOwner = new object();
         var attentionStateOwner = new object();
         var state = State.Value(stateOwner, () => ChatState.Empty);
@@ -7243,7 +7242,7 @@ public partial class ChatViewModelTests
         public IChatConnectionStore ConnectionStore => _connectionStore;
         public RecordingChatStore ChatStore => _chatStore;
         public Mock<ILogger<ChatViewModel>> ViewModelLogger { get; }
-        public IAcpConnectionSessionRegistry InteractionRegistry { get; }
+        public IAcpConnectionSessionRegistry? InteractionRegistry { get; }
 
         public ViewModelFixture(
             ChatViewModel viewModel,
@@ -7264,7 +7263,7 @@ public partial class ChatViewModelTests
             object stateOwner,
             object connectionStateOwner,
             object attentionStateOwner,
-            IAcpConnectionSessionRegistry interactionRegistry)
+            IAcpConnectionSessionRegistry? interactionRegistry)
         {
             ViewModel = viewModel;
             _state = state;
@@ -8713,7 +8712,7 @@ public partial class ChatViewModelTests
         commands.Setup(x => x.CancelPromptAsync(It.IsAny<IAcpChatCoordinatorSink>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await using var fixture = CreateViewModel(syncContext, acpConnectionCommands: commands.Object);
+        await using var fixture = CreateInteractionViewModel(syncContext, acpConnectionCommands: commands.Object);
         var viewModel = fixture.ViewModel;
         var chatService = CreateConnectedChatService();
         var permissionResponses = new List<string>();
@@ -8755,7 +8754,7 @@ public partial class ChatViewModelTests
     public async Task CancelSessionCommand_WhenMatchingPermissionRequestIsPending_RespondsCancelled()
     {
         var syncContext = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(syncContext);
+        await using var fixture = CreateInteractionViewModel(syncContext);
         var chatService = CreateConnectedChatService();
         chatService.Setup(service => service.CancelSessionAsync(It.IsAny<SessionCancelParams>()))
             .Returns(Task.CompletedTask);
@@ -8814,7 +8813,7 @@ public partial class ChatViewModelTests
     public async Task PermissionRequestReceived_BeforeToolCallProjection_AttachesInlineActionsWhenToolCallAppears()
     {
         var syncContext = new QueueingSynchronizationContext();
-        await using var fixture = CreateViewModel(syncContext);
+        await using var fixture = CreateInteractionViewModel(syncContext);
         var chatService = CreateConnectedChatService();
         await AwaitWithSynchronizationContextAsync(syncContext, fixture.ViewModel.ReplaceChatServiceAsync(RegisterInteractionMock(fixture, chatService.Object, "profile-1"), TestContext.Current.CancellationToken));
 

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.cs
@@ -87,9 +87,11 @@ public partial class ChatViewModelTests
         IAiContentReportLauncher? aiContentReportLauncher = null,
         IShellLayoutMetricsSink? shellLayoutMetricsSink = null,
         bool enableWorkspacePersistence = false,
-        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null)
+        TerminalAuthenticationCoordinator? terminalAuthenticationCoordinator = null,
+        IExternalUriLauncher? externalUriLauncher = null)
     {
         var stateOwner = new object();
+        connectionSessionRegistry ??= new InMemoryAcpConnectionSessionRegistry();
         var connectionStateOwner = new object();
         var attentionStateOwner = new object();
         var state = State.Value(stateOwner, () => ChatState.Empty);
@@ -238,7 +240,8 @@ public partial class ChatViewModelTests
                 uiInteractionService: uiInteractionService,
                 aiContentReportLauncher: aiContentReportLauncher,
                 shellLayoutMetricsSink: shellLayoutMetricsSink,
-                terminalAuthenticationCoordinator: terminalAuthenticationCoordinator);
+                terminalAuthenticationCoordinator: terminalAuthenticationCoordinator,
+                externalUriLauncher: externalUriLauncher);
             conversationCatalogFacade.SetPanelCleanup(viewModel);
             return new ViewModelFixture(
                 viewModel,
@@ -258,7 +261,8 @@ public partial class ChatViewModelTests
                 vmLogger,
                 stateOwner,
                 connectionStateOwner,
-                attentionStateOwner);
+                attentionStateOwner,
+                connectionSessionRegistry);
         }
         finally
         {
@@ -7239,6 +7243,7 @@ public partial class ChatViewModelTests
         public IChatConnectionStore ConnectionStore => _connectionStore;
         public RecordingChatStore ChatStore => _chatStore;
         public Mock<ILogger<ChatViewModel>> ViewModelLogger { get; }
+        public IAcpConnectionSessionRegistry InteractionRegistry { get; }
 
         public ViewModelFixture(
             ChatViewModel viewModel,
@@ -7258,7 +7263,8 @@ public partial class ChatViewModelTests
             Mock<ILogger<ChatViewModel>> viewModelLogger,
             object stateOwner,
             object connectionStateOwner,
-            object attentionStateOwner)
+            object attentionStateOwner,
+            IAcpConnectionSessionRegistry interactionRegistry)
         {
             ViewModel = viewModel;
             _state = state;
@@ -7278,6 +7284,7 @@ public partial class ChatViewModelTests
             _stateOwner = stateOwner;
             _connectionStateOwner = connectionStateOwner;
             _attentionStateOwner = attentionStateOwner;
+            InteractionRegistry = interactionRegistry;
         }
 
         public Task<ChatState> GetStateAsync() => Task.FromResult(_chatStore.LatestState);
@@ -7612,6 +7619,8 @@ public partial class ChatViewModelTests
 
         public ValueTask<ChatState> GetCurrentStateAsync()
             => ReadState?.Invoke() ?? ValueTask.FromResult(LatestState);
+
+        public ChatState? ReadCommittedState() => LatestState;
     }
 
     [Fact]
@@ -8708,7 +8717,7 @@ public partial class ChatViewModelTests
         var viewModel = fixture.ViewModel;
         var chatService = CreateConnectedChatService();
         var permissionResponses = new List<string>();
-        await AwaitWithSynchronizationContextAsync(syncContext, viewModel.ReplaceChatServiceAsync(chatService.Object, TestContext.Current.CancellationToken));
+        await AwaitWithSynchronizationContextAsync(syncContext, viewModel.ReplaceChatServiceAsync(RegisterInteractionMock(fixture, chatService.Object, "profile-1"), TestContext.Current.CancellationToken));
 
         await fixture.UpdateStateAsync(state => state with
         {
@@ -8751,7 +8760,7 @@ public partial class ChatViewModelTests
         chatService.Setup(service => service.CancelSessionAsync(It.IsAny<SessionCancelParams>()))
             .Returns(Task.CompletedTask);
         var permissionResponses = new List<string>();
-        await AwaitWithSynchronizationContextAsync(syncContext, fixture.ViewModel.ReplaceChatServiceAsync(chatService.Object, TestContext.Current.CancellationToken));
+        await AwaitWithSynchronizationContextAsync(syncContext, fixture.ViewModel.ReplaceChatServiceAsync(RegisterInteractionMock(fixture, chatService.Object, "profile-a"), TestContext.Current.CancellationToken));
 
         await fixture.UpdateStateAsync(state => state with
         {
@@ -8807,7 +8816,7 @@ public partial class ChatViewModelTests
         var syncContext = new QueueingSynchronizationContext();
         await using var fixture = CreateViewModel(syncContext);
         var chatService = CreateConnectedChatService();
-        await AwaitWithSynchronizationContextAsync(syncContext, fixture.ViewModel.ReplaceChatServiceAsync(chatService.Object, TestContext.Current.CancellationToken));
+        await AwaitWithSynchronizationContextAsync(syncContext, fixture.ViewModel.ReplaceChatServiceAsync(RegisterInteractionMock(fixture, chatService.Object, "profile-1"), TestContext.Current.CancellationToken));
 
         await fixture.UpdateStateAsync(state => state with
         {

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/Mvux/ChatStoreTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/Mvux/ChatStoreTests.cs
@@ -13,6 +13,23 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat.Mvux;
 public class ChatStoreTests
 {
     [Fact]
+    public async Task ReadCommittedState_AfterBindingUpdate_ReturnsTheSameAuthoritativeSnapshot()
+    {
+        // Arrange
+        await using var state = State.Value(new object(), () => ChatState.Empty);
+        var store = new ChatStore(state);
+        Assert.Null(store.ReadCommittedState());
+
+        // Act
+        await store.Dispatch(new SetBindingSliceAction(new("conversation", "remote", "profile")));
+
+        // Assert
+        var asynchronous = await store.GetCurrentStateAsync();
+        Assert.Same(asynchronous, store.ReadCommittedState());
+        Assert.Equal("profile", store.ReadCommittedState()!.ResolveBinding("conversation")?.ProfileId);
+    }
+
+    [Fact]
     public async Task GivenStore_WhenDispatchAction_ThenStateIsUpdatedViaReducer()
     {
         // Arrange


### PR DESCRIPTION
Late permission requests could be routed to another agent's conversation when profiles reused a remote session ID. Resolve the originating service through the existing connection registry, retain its profile/connection identity, and check the authoritative conversation binding before presenting or answering permission, form, or URL requests. URL consent and reopen guards run synchronously so a valid browser gesture remains usable.

The SDK's committed terminal response now retires the exact form card, including session cancellation. A changed binding withdraws old choices; failed cancellation stays available for explicit retry while the owning card can be shown, and an undisplayable failure closes only its original service. Cancellation continues through the original pending/batch owner, including in-flight sends and disconnects.

Validation: complete Presentation regression 3,616/3,616 and SDK 1,261/1,261 passed with no skips; actual nupkg consumer gates passed. New behavior tests cover equal remote IDs across profiles, late callbacks, pool switches, authoritative binding changes before UI projection, accepted URL reopen, cancellation retry, and physical send/disconnect races. Interaction fixtures explicitly register their connections while the shared test fixture preserves its existing host setup. Independent Standards and Spec review passed.

A freshly built Release BrowserWasm product passed native form, Stop/session cancellation, next-form recovery, URL pointer consent/keyboard reopen and permission-queue flows. The GUI check was reverse-tested against a fresh build with only form-cancellation retirement disabled: it received the correct cancel response, then failed because the form/actions remained visible and the composer stayed disabled. The original source was restored byte-for-byte, rebuilt, and the entire GUI flow passed again; source and runtime assembly hashes distinguish the failing and restored products. Final platform CI is checked before merge. This does not enable live draft V2 or claim third-party agent/production bridge acceptance.

Related to #146, #148 and #154.
