### PR TITLE
feat(acp): complete versioned session configuration contracts

### DIFF
--- a/scripts/gates/acp-v2-projection-consumer.cs
+++ b/scripts/gates/acp-v2-projection-consumer.cs
@@ -24,6 +24,15 @@ var history = new List<JsonElement>
 };
 
 var snapshot = AcpSessionDraftExtensions.ReplaySession("recorded-session", history);
+var configured = AcpSessionDraftExtensions.ReplaySession("configured-session",
+[
+    Parse("""{"sessionUpdate":"config_option_update","configOptions":[{"configId":"enabled","name":"Enabled","type":"boolean","currentValue":true},{"configId":"future","name":"Future","type":"_budget","value":{"tokens":1e2}}]}""")
+]);
+Require(configured.HasConfigOptions && configured.ConfigOptions.Length == 2
+    && configured.ConfigOptions[0].CurrentBooleanValue == true
+    && configured.ConfigOptions[1].RawPayload!.Value.GetProperty("value").GetProperty("tokens").GetRawText() == "1e2",
+    "Configuration replay must retain boolean and unknown option payloads in Agent order.");
+Require(!snapshot.HasConfigOptions, "Unreported configuration must remain distinct from an authoritative empty list.");
 Require(snapshot.Messages.Length == 2, "Message ids must upsert instead of creating duplicates.");
 Require(snapshot.Messages[0].Kind == AcpMessageKind.User, "First-seen order must be retained.");
 Require(Text(snapshot.Messages[1]) == "replacement tail", "A whole message replaces chunks; later chunks append.");

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -465,7 +465,11 @@ namespace SalmonEgg.Acp.Client
                 "session/new",
                 ToElement<SessionNewParams>(@params));
 
-            var response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            var wire = _wire;
+            var response = await SendRequestAsync(request, cancellationToken, connectionToken,
+                responseObserver: wire.Version == AcpProtocolVersion.V2
+                    ? response => ReceiveDraftConfiguration(response, wire, connectionToken)
+                    : null).ConfigureAwait(false);
 
             if (response.IsError)
             {
@@ -606,9 +610,17 @@ namespace SalmonEgg.Acp.Client
             CancellationToken connectionToken,
             CancellationToken cancellationToken)
         {
-            if (ProtocolVersion != AcpProtocolVersion.V2 || !RequestsFullReplay(request))
+            var wire = _wire;
+            if (wire.Version != AcpProtocolVersion.V2)
             {
                 return await SendRequestAsync(request, cancellationToken, connectionToken).ConfigureAwait(false);
+            }
+
+            if (!RequestsFullReplay(request))
+            {
+                return await SendRequestAsync(request, cancellationToken, connectionToken,
+                    responseObserver: response => ReceiveDraftConfiguration(response, wire, connectionToken, @params.SessionId))
+                    .ConfigureAwait(false);
             }
 
             AcpSessionProjection? replay = null;
@@ -619,7 +631,17 @@ namespace SalmonEgg.Acp.Client
                 request,
                 cancellationToken,
                 connectionToken,
-                responseObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
+                responseObserver: response =>
+                {
+                    try
+                    {
+                        ReceiveDraftConfiguration(response, wire, connectionToken, @params.SessionId);
+                    }
+                    finally
+                    {
+                        _sessionWork.EndReplay(@params.SessionId, replay, connectionToken);
+                    }
+                },
                 requestNotSentObserver: _ => _sessionWork.EndReplay(@params.SessionId, replay, connectionToken),
                 beforeSend: () => replay = _sessionWork.BeginReplay(@params.SessionId, connectionToken)).ConfigureAwait(false);
         }
@@ -872,26 +894,66 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionSetConfigOptionResponse> SetSessionConfigOptionAsync(SessionSetConfigOptionParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            ArgumentNullException.ThrowIfNull(@params);
+            var connectionToken = GetConnectionToken();
+            var wire = _wire;
 
             var request = new JsonRpcRequest(
                 Interlocked.Increment(ref _nextMessageId),
                 "session/set_config_option",
-                ToElement<SessionSetConfigOptionParams>(@params));
+                JsonSerializer.SerializeToElement(@params, wire.TypeInfo<SessionSetConfigOptionParams>()));
 
-            var response = await SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            var response = await SendRequestAsync(request, cancellationToken, connectionToken,
+                responseObserver: wire.Version == AcpProtocolVersion.V2
+                    ? response => ReceiveDraftConfiguration(response, wire, connectionToken, @params.SessionId, isSetResponse: true)
+                    : null).ConfigureAwait(false);
 
             if (response.IsError)
             {
                 throw new AcpException(response.Error!.Code, response.Error.Message, response.Error.Data);
             }
 
-            var configResponse = FromElement<SessionSetConfigOptionResponse>(response.Result!.Value);
+            var configResponse = response.Result!.Value.Deserialize(wire.TypeInfo<SessionSetConfigOptionResponse>());
             if (configResponse == null)
             {
                 throw new AcpException(JsonRpcErrorCode.ParseError, "Failed to parse session/set_config_option response");
             }
 
             return configResponse;
+        }
+
+        private void ReceiveDraftConfiguration(
+            JsonRpcResponse response,
+            AcpWireFormat wire,
+            CancellationToken connectionToken,
+            string? sessionId = null,
+            bool isSetResponse = false)
+        {
+            if (response.IsError) return;
+            if (response.Result is not { ValueKind: JsonValueKind.Object } result)
+            {
+                throw new JsonException("ACP v2 session configuration responses must be objects.");
+            }
+
+            // Apply in response dispatch, before another frame can replace this full list. The
+            // caller may cancel or its continuation may run after later notifications. None of
+            // those scheduling facts can replace receive order as the configuration authority.
+            IReadOnlyList<ConfigOption> configOptions;
+            if (isSetResponse)
+            {
+                configOptions = result.Deserialize(wire.TypeInfo<SessionSetConfigOptionResponse>())!.ConfigOptions ?? [];
+            }
+            else if (sessionId is not null)
+            {
+                configOptions = result.Deserialize(wire.TypeInfo<SessionResumeResponse>())!.ConfigOptions ?? [];
+            }
+            else
+            {
+                var created = result.Deserialize(wire.TypeInfo<SessionNewResponse>())!;
+                sessionId = created.SessionId;
+                configOptions = created.ConfigOptions ?? [];
+            }
+            _sessionWork.ReceiveConfigOptions(sessionId!, configOptions, connectionToken, registerSession: !isSetResponse);
         }
 
         /// <summary>
@@ -2381,7 +2443,17 @@ namespace SalmonEgg.Acp.Client
             {
                 return;
             }
-            pending.ResponseObserver?.Invoke(response);
+            try
+            {
+                pending.ResponseObserver?.Invoke(response);
+            }
+            catch (Exception error)
+            {
+                // The response owner has already claimed this id. Contract failures must fault
+                // its waiter rather than leave it waiting forever after correlation is removed.
+                pending.Completion.TrySetException(error);
+                return;
+            }
             if (!pending.Completion.TrySetResult(response))
             {
                 // Caller cancellation leaves correlation alive until the peer sends its terminal

--- a/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
@@ -23,6 +23,7 @@ internal sealed class AcpSessionProjection
     private readonly Queue<(JsonElement Payload, int ByteCount)> _unprojected = new();
     private int _unprojectedBytes;
     private long _omittedUnprojectedUpdateCount;
+    private ImmutableArray<JsonElement>? _configOptions;
 
     internal void Apply(SessionUpdate update, JsonElement payload)
     {
@@ -58,6 +59,9 @@ internal sealed class AcpSessionProjection
                 break;
             case StateSessionUpdate:
                 break;
+            case ConfigOptionUpdate configuration:
+                SetConfigOptions(configuration.ConfigOptions ?? []);
+                break;
             default:
                 RetainUnprojected(payload);
                 break;
@@ -72,7 +76,11 @@ internal sealed class AcpSessionProjection
             _terminalOrder.Select(static value => value.Snapshot()).ToImmutableArray(),
             _unprojected.Select(static entry => entry.Payload).ToImmutableArray(),
             _omittedUnprojectedUpdateCount,
-            state is null ? null : AcpSessionProjectionJson.Store<SessionWorkState>(state));
+            state is null ? null : AcpSessionProjectionJson.Store<SessionWorkState>(state),
+            _configOptions);
+
+    internal void SetConfigOptions(IReadOnlyList<ConfigOption> configOptions)
+        => _configOptions = configOptions.Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray();
 
     private void RetainUnprojected(JsonElement payload)
     {

--- a/src/SalmonEgg.Acp/Client/AcpSessionSnapshot.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionSnapshot.cs
@@ -35,6 +35,7 @@ public sealed class AcpSessionSnapshot
     public const int MaxUnprojectedUtf8Bytes = 256 * 1024;
 
     private readonly JsonElement? _workState;
+    private readonly ImmutableArray<JsonElement>? _configOptions;
 
     internal AcpSessionSnapshot(
         string sessionId,
@@ -43,7 +44,8 @@ public sealed class AcpSessionSnapshot
         ImmutableArray<AcpTerminalSnapshot> terminals,
         ImmutableArray<JsonElement> unprojectedUpdates,
         long omittedUnprojectedUpdateCount,
-        JsonElement? workState)
+        JsonElement? workState,
+        ImmutableArray<JsonElement>? configOptions)
     {
         SessionId = sessionId;
         Messages = messages;
@@ -52,6 +54,7 @@ public sealed class AcpSessionSnapshot
         UnprojectedUpdates = unprojectedUpdates;
         OmittedUnprojectedUpdateCount = omittedUnprojectedUpdateCount;
         _workState = workState;
+        _configOptions = configOptions;
     }
 
     /// <summary>The session whose history was projected.</summary>
@@ -78,6 +81,17 @@ public sealed class AcpSessionSnapshot
 
     /// <summary>The latest reported work state, detached from the client's work controller.</summary>
     public SessionWorkState? WorkState => AcpSessionProjectionJson.Read<SessionWorkState>(_workState);
+
+    /// <summary>Whether the Agent has supplied an authoritative configuration list, including an empty list.</summary>
+    public bool HasConfigOptions => _configOptions.HasValue;
+
+    /// <summary>
+    /// The latest full configuration list in Agent priority order. Known and unknown option types
+    /// are retained. Each access returns detached wire DTOs; hosts edit only types they understand.
+    /// </summary>
+    public ImmutableArray<ConfigOption> ConfigOptions => _configOptions is { } options
+        ? AcpSessionProjectionJson.ReadArray<ConfigOption>(options)
+        : [];
 }
 
 /// <summary>The current content of one Agent-identified message.</summary>

--- a/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
@@ -245,6 +245,25 @@ internal sealed class AcpSessionWorkController
         }
     }
 
+    internal void ReceiveConfigOptions(
+        string sessionId,
+        IReadOnlyList<ConfigOption> configOptions,
+        CancellationToken connectionToken,
+        bool registerSession)
+    {
+        lock (_gate)
+        {
+            if (!IsCurrent(connectionToken) || (!registerSession && _closedSessions.Contains(sessionId)))
+            {
+                return;
+            }
+            if (registerSession) _closedSessions.Remove(sessionId);
+            var session = GetOrCreateSession(sessionId);
+            session.Projection ??= new AcpSessionProjection();
+            session.Projection.SetConfigOptions(configOptions);
+        }
+    }
+
     internal AcpSessionProjection BeginReplay(string sessionId, CancellationToken connectionToken)
     {
         lock (_gate)

--- a/src/SalmonEgg.Acp/Protocol/ConfigOptionTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/ConfigOptionTypes.cs
@@ -39,7 +39,9 @@ public sealed record ConfigOption : AcpProtocolObject
     [JsonIgnore]
     public List<ConfigOptionGroup> OptionGroups { get; init; } = new();
 
-    internal JsonElement? RawPayload { get; init; }
+    /// <summary>The received option payload, including custom types and uninterpreted extension fields.</summary>
+    [JsonIgnore]
+    public JsonElement? RawPayload { get; internal init; }
 }
 
 [JsonConverter(typeof(ConfigOptionValueJsonConverter))]
@@ -121,7 +123,7 @@ internal sealed class ConfigOptionJsonConverter : JsonConverter<ConfigOption>
             CurrentBooleanValue = currentBoolean,
             Options = selectOptions,
             OptionGroups = optionGroups,
-            Meta = AcpMetaJson.Read(root),
+            Meta = ReadMetadata(root, options),
             RawPayload = root.Clone()
         };
     }
@@ -196,7 +198,7 @@ internal sealed class ConfigOptionJsonConverter : JsonConverter<ConfigOption>
             {
                 try
                 {
-                    groupOptions.Add(ReadOption(item));
+                    groupOptions.Add(ReadOption(item, options));
                 }
                 catch (JsonException)
                 {
@@ -210,7 +212,7 @@ internal sealed class ConfigOptionJsonConverter : JsonConverter<ConfigOption>
             Group = ReadRequiredString(element, GroupPropertyName(options)),
             Name = ReadRequiredString(element, "name"),
             Options = groupOptions,
-            Meta = AcpMetaJson.Read(element),
+            Meta = ReadMetadata(element, options),
             RawPayload = element.Clone()
         };
     }
@@ -260,18 +262,18 @@ internal sealed class ConfigOptionJsonConverter : JsonConverter<ConfigOption>
             }
             else
             {
-                options.Add(ReadOption(item));
+                options.Add(ReadOption(item, serializerOptions));
             }
         }
     }
 
-    internal static ConfigOptionValue ReadOption(JsonElement element)
+    internal static ConfigOptionValue ReadOption(JsonElement element, JsonSerializerOptions options)
         => new()
         {
             Value = ReadRequiredString(element, "value"),
             Name = ReadRequiredString(element, "name"),
             Description = ReadOptionalString(element, "description"),
-            Meta = AcpMetaJson.Read(element),
+            Meta = ReadMetadata(element, options),
             RawPayload = element.Clone()
         };
 
@@ -312,7 +314,12 @@ internal sealed class ConfigOptionJsonConverter : JsonConverter<ConfigOption>
             : null;
     }
 
-    private static void WriteUnknownFields(Utf8JsonWriter writer, JsonElement? rawPayload, params string[] knownPropertyNames)
+    private static Dictionary<string, object?>? ReadMetadata(JsonElement element, JsonSerializerOptions options)
+        => AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2
+            ? AcpMetaJson.ReadOrDefault(element)
+            : AcpMetaJson.Read(element);
+
+    internal static void WriteUnknownFields(Utf8JsonWriter writer, JsonElement? rawPayload, params string[] knownPropertyNames)
     {
         if (rawPayload is not { } payload)
         {
@@ -380,7 +387,7 @@ internal sealed class ConfigOptionValueJsonConverter : JsonConverter<ConfigOptio
     public override ConfigOptionValue? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
     {
         using var document = JsonDocument.ParseValue(ref reader);
-        return ConfigOptionJsonConverter.ReadOption(document.RootElement);
+        return ConfigOptionJsonConverter.ReadOption(document.RootElement, options);
     }
 
     public override void Write(Utf8JsonWriter writer, ConfigOptionValue value, JsonSerializerOptions options)

--- a/src/SalmonEgg.Acp/Protocol/OtherSessionTypes.cs
+++ b/src/SalmonEgg.Acp/Protocol/OtherSessionTypes.cs
@@ -545,6 +545,8 @@ namespace SalmonEgg.Acp.Protocol
         [JsonIgnore]
         public bool? BooleanValue { get; init; }
 
+        internal JsonElement? RawPayload { get; init; }
+
         /// <summary>
         /// Creates a new SessionSetConfigOptionParams instance.
         /// </summary>
@@ -587,16 +589,19 @@ namespace SalmonEgg.Acp.Protocol
 
             using var document = JsonDocument.ParseValue(ref reader);
             var root = document.RootElement;
-            if (!root.TryGetProperty("value", out var value))
+            if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("value", out var value))
             {
                 throw new JsonException("ACP session/set_config_option requires value.");
             }
 
+            var isV2 = AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2;
+            var valueType = isV2 ? ReadRequiredString(root, "type")
+                : root.TryGetProperty("type", out var type) && type.ValueKind == JsonValueKind.String
+                    ? type.GetString()
+                    : null;
             string? stringValue = null;
             bool? booleanValue = null;
-            if (root.TryGetProperty("type", out var type)
-                && type.ValueKind == JsonValueKind.String
-                && string.Equals(type.GetString(), "boolean", System.StringComparison.Ordinal))
+            if (string.Equals(valueType, "boolean", System.StringComparison.Ordinal))
             {
                 if (value.ValueKind is not JsonValueKind.True and not JsonValueKind.False)
                 {
@@ -605,13 +610,13 @@ namespace SalmonEgg.Acp.Protocol
 
                 booleanValue = value.GetBoolean();
             }
-            else if (value.ValueKind == JsonValueKind.String)
+            else if (!isV2 || valueType == "id")
             {
-                stringValue = value.GetString() ?? string.Empty;
-            }
-            else
-            {
-                throw new JsonException("ACP session config value must be a string value ID or declared boolean.");
+                if (value.ValueKind != JsonValueKind.String)
+                {
+                    throw new JsonException("ACP session config value ID must be a string.");
+                }
+                stringValue = value.GetString();
             }
 
             return new SessionSetConfigOptionParams
@@ -620,7 +625,8 @@ namespace SalmonEgg.Acp.Protocol
                 ConfigId = ReadRequiredString(root, "configId"),
                 Value = stringValue,
                 BooleanValue = booleanValue,
-                Meta = AcpMetaJson.Read(root)
+                Meta = isV2 ? AcpMetaJson.ReadOrDefault(root) : AcpMetaJson.Read(root),
+                RawPayload = isV2 ? root.Clone() : null
             };
         }
 
@@ -629,10 +635,21 @@ namespace SalmonEgg.Acp.Protocol
             SessionSetConfigOptionParams value,
             JsonSerializerOptions options)
         {
+            var isV2 = AcpWireFormat.NegotiatedVersion(options) == AcpProtocolVersion.V2;
             writer.WriteStartObject();
             writer.WriteString("sessionId", value.SessionId);
             writer.WriteString("configId", value.ConfigId);
-            if (value.BooleanValue.HasValue)
+            if (value.RawPayload is { } raw && raw.GetProperty("type").GetString() is not "id" and not "boolean")
+            {
+                if (!isV2)
+                {
+                    throw new JsonException("Custom config value payloads require ACP v2.");
+                }
+                writer.WriteString("type", raw.GetProperty("type").GetString());
+                writer.WritePropertyName("value");
+                raw.GetProperty("value").WriteTo(writer);
+            }
+            else if (value.BooleanValue.HasValue)
             {
                 if (value.Value != null)
                 {
@@ -644,6 +661,7 @@ namespace SalmonEgg.Acp.Protocol
             }
             else if (value.Value != null)
             {
+                if (isV2) writer.WriteString("type", "id");
                 writer.WriteString("value", value.Value);
             }
             else
@@ -652,6 +670,8 @@ namespace SalmonEgg.Acp.Protocol
             }
 
             AcpMetaJson.Write(writer, value.Meta);
+            ConfigOptionJsonConverter.WriteUnknownFields(writer, value.RawPayload,
+                "sessionId", "configId", "type", "value", "_meta");
             writer.WriteEndObject();
         }
 

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -43,7 +43,7 @@ hosts must enable optional capabilities only after implementing their interactio
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | The SDK owns consent-response availability, connection lifetime, and completion in `ElicitationRequestEventArgs.State`. URL mode stays off in SDK defaults; SalmonEgg enables it on WASM and Linux desktop through its platform capability service. Linux uses the existing system opener after explicit consent. | The Linux product gate exercises its real card, stdio peer, native pointer input and isolated external browser. Other native platforms and independent real-Agent interoperability remain open in [#154](https://github.com/salmonloop/salmon-egg/issues/154). [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
-| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, message/tool/terminal projections, permission request handling, and version-gated JSON-RPC batches are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Configuration workflows, application UI integration, and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, configuration lifecycle, message/tool/terminal projections, permission request handling, and version-gated JSON-RPC batches are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Application UI integration and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
 
 Internal v2 batch validation follows the upstream schema at
 `5ebaf0aceb04a4ba6574cd63fa6355352dc6d931` and JSON-RPC 2.0 section 6.
@@ -114,6 +114,20 @@ a fresh projection, while resume without replay retains prior history. Overlappi
 are rejected because session updates carry no request id that could separate them; cancelling the
 local wait or receiving an unknown write outcome retains this claim until the peer responds or the
 connection ends. Only a request that never started transport I/O releases the claim immediately.
+
+Configuration follows the same session and connection owner. `session/new`, `session/resume`,
+`session/set_config_option` responses and `config_option_update` replace the complete list in wire
+receive order, including replies received after the caller abandons its wait. A later notification
+cannot be overwritten by an earlier response's delayed continuation. `HasConfigOptions` distinguishes
+an unreported list from an authoritative empty list; `ConfigOptions` returns detached DTOs in Agent
+priority order. Offline replay uses the same rules. The configuration contract is checked against
+[schema revision f1293d8e](https://github.com/agentclientprotocol/agent-client-protocol/blob/f1293d8e43d09a6745ff8fe717f9acd8299591b7/schema/v2/schema.json).
+Known option types are `select` and `boolean`; unknown types preserve their complete payload through
+`ConfigOption.RawPayload` and round-trip serialization. Unknown value types also round-trip raw
+`session/set_config_option` data. V2 value IDs carry `type: "id"`; V1 retains its default string
+variant with no discriminator. Configuration metadata recovers only at schema-authorized V2 fields.
+The application configuration projection retains boolean values and unknown payloads through its
+existing workspace path; only supported option types produce editable rows.
 
 A snapshot is a current view, not a lossless event archive. `UnprojectedUpdates` retains recent
 unhandled updates verbatim within `MaxUnprojectedUpdates` (64 entries) and

--- a/src/SalmonEgg.Domain/Models/Conversation/ConversationDocument.cs
+++ b/src/SalmonEgg.Domain/Models/Conversation/ConversationDocument.cs
@@ -83,6 +83,11 @@ namespace SalmonEgg.Domain.Models.Conversation
 
         public string? SelectedValue { get; set; }
 
+        public bool? BooleanValue { get; set; }
+
+        /// <summary>Original configuration payload retained when its option type is unknown.</summary>
+        public string? RawProtocolJson { get; set; }
+
         public List<ConversationConfigOptionChoiceSnapshot> Options { get; set; } = new();
     }
 

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionUpdateProjector.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionUpdateProjector.cs
@@ -68,13 +68,13 @@ public sealed class AcpSessionUpdateProjector : IAcpSessionUpdateProjector
     {
         var projectedOptions = configOptions?
             .Where(static option => option is not null)
-            .Where(static option => IsSupportedConfigOptionType(option.Type))
             .Select(MapConfigOption)
             .ToArray() ?? Array.Empty<AcpConfigOptionSnapshot>();
 
         var modeOption = projectedOptions.FirstOrDefault(option =>
-            string.Equals(option.Category, "mode", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(option.Id, "mode", StringComparison.OrdinalIgnoreCase));
+            string.Equals(option.ValueType, "select", StringComparison.Ordinal)
+            && (string.Equals(option.Category, "mode", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(option.Id, "mode", StringComparison.OrdinalIgnoreCase)));
 
         var availableModes = modeOption?.Options?
             .Select(static option => new AcpModeOption(option.Value, option.Name, option.Description ?? string.Empty))
@@ -84,7 +84,7 @@ public sealed class AcpSessionUpdateProjector : IAcpSessionUpdateProjector
             AvailableModes: availableModes,
             SelectedModeId: modeOption?.SelectedValue,
             ConfigOptions: projectedOptions,
-            ShowConfigOptionsPanel: projectedOptions.Length > 0);
+            ShowConfigOptionsPanel: projectedOptions.Any(static option => IsSupportedConfigOptionType(option.ValueType)));
     }
 
     private static AcpSessionUpdateDelta BuildSessionProjection(
@@ -117,7 +117,7 @@ public sealed class AcpSessionUpdateProjector : IAcpSessionUpdateProjector
     }
 
     private static bool IsSupportedConfigOptionType(string? valueType)
-        => string.Equals(valueType, "select", StringComparison.Ordinal);
+        => valueType is "select" or "boolean";
 
     private static IReadOnlyList<ConversationPlanEntrySnapshot> MapPlanEntries(IReadOnlyList<PlanEntry>? entries)
     {
@@ -195,7 +195,9 @@ public sealed class AcpSessionUpdateProjector : IAcpSessionUpdateProjector
             option.Category,
             option.Type,
             option.CurrentValue,
-            projectedOptions);
+            projectedOptions,
+            option.CurrentBooleanValue,
+            IsSupportedConfigOptionType(option.Type) ? null : option.RawPayload?.GetRawText());
     }
 }
 
@@ -226,7 +228,9 @@ public sealed partial record AcpConfigOptionSnapshot(
     string? Category,
     string? ValueType,
     string? SelectedValue,
-    IReadOnlyList<AcpConfigOptionChoice> Options);
+    IReadOnlyList<AcpConfigOptionChoice> Options,
+    bool? BooleanValue = null,
+    string? RawProtocolJson = null);
 
 public sealed record AcpSessionInfoSnapshot(
     string? Title,

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/ChatConversationWorkspace.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/ChatConversationWorkspace.cs
@@ -1373,6 +1373,8 @@ public sealed class ChatConversationWorkspace : ObservableObject, IConversationC
             Category = source.Category,
             ValueType = source.ValueType,
             SelectedValue = source.SelectedValue,
+            BooleanValue = source.BooleanValue,
+            RawProtocolJson = source.RawProtocolJson,
             Options = (source.Options ?? [])
                 .Select(CloneConfigOptionChoice)
                 .ToList()

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/WorkspaceWriter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/WorkspaceWriter.cs
@@ -869,6 +869,8 @@ public sealed class WorkspaceWriter : IWorkspaceWriter, IDisposable
             Category = snapshot.Category,
             ValueType = snapshot.ValueType,
             SelectedValue = snapshot.SelectedValue,
+            BooleanValue = snapshot.BooleanValue,
+            RawProtocolJson = snapshot.RawProtocolJson,
             Options = (snapshot.Options ?? [])
                 .Select(CloneConfigOptionChoiceSnapshot)
                 .ToList()

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/WorkspaceWriter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/WorkspaceWriter.cs
@@ -683,6 +683,8 @@ public sealed class WorkspaceWriter : IWorkspaceWriter, IDisposable
             && string.Equals(left.Category, right.Category, StringComparison.Ordinal)
             && string.Equals(left.ValueType, right.ValueType, StringComparison.Ordinal)
             && string.Equals(left.SelectedValue, right.SelectedValue, StringComparison.Ordinal)
+            && left.BooleanValue == right.BooleanValue
+            && string.Equals(left.RawProtocolJson, right.RawProtocolJson, StringComparison.Ordinal)
             && ConfigOptionChoiceSequencesEqual(left.Options ?? [], right.Options ?? []);
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -2921,6 +2921,8 @@ public partial class ChatViewModel
             Category = option.Category,
             ValueType = option.ValueType,
             SelectedValue = option.SelectedValue,
+            BooleanValue = option.BooleanValue,
+            RawProtocolJson = option.RawProtocolJson,
             Options = option.Options
                 .Select(static item => new ConversationConfigOptionChoiceSnapshot
                 {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.cs
@@ -207,8 +207,9 @@ public partial class ConfigOptionViewModel : ObservableObject
             Category = option.Category,
             ValueType = option.Type,
             IsRequired = true,
-            Value = option.CurrentValue,
-            TextValue = option.CurrentValue ?? string.Empty
+            Value = option.Type == "boolean" ? option.CurrentBooleanValue : option.CurrentValue,
+            TextValue = option.CurrentValue ?? string.Empty,
+            BoolValue = option.CurrentBooleanValue ?? false
         };
 
         if (option.Options is { Count: > 0 })

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/SessionOptions/ChatSessionOptionsPresenter.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/SessionOptions/ChatSessionOptionsPresenter.cs
@@ -28,6 +28,9 @@ public sealed class ChatSessionOptionsPresenter
             .ToList();
 
         var projectedConfigOptions = configOptions
+            // Unknown options remain in the authoritative store and persistence. Only variants
+            // with implemented editing semantics may create interactive controls.
+            .Where(static option => option.ValueType is null or "select" or "boolean")
             .Select(MapConfigOption)
             .ToList();
 
@@ -42,7 +45,7 @@ public sealed class ChatSessionOptionsPresenter
             projectedModes,
             resolvedSelectedModeId,
             projectedConfigOptions,
-            showConfigOptionsPanel,
+            showConfigOptionsPanel && projectedConfigOptions.Count > 0,
             modeConfigSelection.ModeConfigId,
             modelConfigSelection.ModelOptions,
             modelConfigSelection.ModelConfigId,
@@ -198,8 +201,9 @@ public sealed class ChatSessionOptionsPresenter
             Category = option.Category,
             ValueType = option.ValueType ?? "string",
             IsRequired = true,
-            Value = option.SelectedValue ?? string.Empty,
-            TextValue = option.SelectedValue ?? string.Empty
+            Value = option.ValueType == "boolean" ? option.BooleanValue : option.SelectedValue ?? string.Empty,
+            TextValue = option.SelectedValue ?? string.Empty,
+            BoolValue = option.BooleanValue ?? false
         };
 
         if (option.Options.Count > 0)

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionConfigurationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionConfigurationTests.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpSessionConfigurationTests
+{
+    private static CancellationToken TestToken => TestContext.Current.CancellationToken;
+    private const string InitialOptions = """[{"configId":"model","name":"Model","type":"select","currentValue":"fast","options":[{"value":"fast","name":"Fast"}]},{"configId":"reasoning","name":"Reasoning","type":"boolean","currentValue":false}]""";
+
+    [Fact]
+    public async Task CreateSession_ConfigurationIsCommittedBeforeAsyncStorageAndLaterUpdates()
+    {
+        var storage = new DelayedSessionStore();
+        using var peer = await ConfigurationPeer.CreateAsync(storage);
+        var created = peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        await storage.Entered.Task.WaitAsync(TestToken);
+
+        var initial = peer.Client.GetSessionSnapshot("one");
+        peer.Update(BooleanOptions(true));
+        storage.Release.TrySetResult();
+        await created;
+
+        Assert.NotNull(initial);
+        Assert.True(initial.HasConfigOptions);
+        Assert.Equal(["model", "reasoning"], initial.ConfigOptions.Select(static option => option.Id));
+        Assert.False(initial.ConfigOptions[1].CurrentBooleanValue);
+        Assert.True(Assert.Single(peer.Client.GetSessionSnapshot("one")!.ConfigOptions).CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task SetOption_ResponseAndNotificationFollowReceiveOrder()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        peer.OnSet = request =>
+        {
+            peer.Reply(request, OptionsResponse(BooleanOptions(true)));
+            peer.Update(BooleanOptions(false));
+        };
+
+        var result = await peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+
+        Assert.True(Assert.Single(result.ConfigOptions!).CurrentBooleanValue);
+        Assert.False(Assert.Single(peer.Client.GetSessionSnapshot("one")!.ConfigOptions).CurrentBooleanValue);
+        Assert.Empty(peer.Errors);
+    }
+
+    [Fact]
+    public async Task SetOption_ConcurrentRequests_ResponseOrderOwnsFullState()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        var first = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+        var firstRequest = peer.LastSet!;
+        var second = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", false), TestToken);
+
+        peer.Reply(peer.LastSet!, OptionsResponse(BooleanOptions(false)));
+        await second;
+        peer.Reply(firstRequest, OptionsResponse(BooleanOptions(true)));
+        await first;
+
+        Assert.True(Assert.Single(peer.Client.GetSessionSnapshot("one")!.ConfigOptions).CurrentBooleanValue);
+    }
+
+    [Theory]
+    [InlineData("id", "\"fast\"")]
+    [InlineData("boolean", "true")]
+    public async Task SetOption_UsesTypedWireAndFullAuthoritativeResponse(string type, string value)
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        peer.OnSet = request => peer.Reply(request, OptionsResponse(BooleanOptions(true)));
+        var request = type == "id"
+            ? new SessionSetConfigOptionParams("one", "model", "fast")
+            : new SessionSetConfigOptionParams("one", "reasoning", true);
+
+        await peer.Client.SetSessionConfigOptionAsync(request, TestToken);
+
+        Assert.Equal(type, peer.LastSet!.Params!.Value.GetProperty("type").GetString());
+        Assert.Equal(value, peer.LastSet.Params.Value.GetProperty("value").GetRawText());
+        Assert.Equal("reasoning", Assert.Single(peer.Client.GetSessionSnapshot("one")!.ConfigOptions).Id);
+    }
+
+    [Fact]
+    public async Task SetOption_AbandonedAwait_StillCommitsThePeersFinalResponse()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        using var caller = new CancellationTokenSource();
+        var pending = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), caller.Token);
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+
+        peer.Reply(peer.LastSet!, OptionsResponse(BooleanOptions(true)));
+
+        Assert.True(Assert.Single(peer.Client.GetSessionSnapshot("one")!.ConfigOptions).CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task SetOption_PeerError_DoesNotOptimisticallyChangeConfiguration()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        var pending = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+        peer.Error(peer.LastSet!, JsonRpcErrorCode.InvalidParams);
+
+        await Assert.ThrowsAsync<AcpException>(() => pending);
+
+        Assert.False(peer.Client.GetSessionSnapshot("one")!.ConfigOptions[1].CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task SetOption_InvalidResponse_FaultsTheRequestAndPreservesLastState()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        peer.OnSet = request => peer.Reply(request, "{}");
+
+        var failure = await Record.ExceptionAsync(async () => await peer.Client.SetSessionConfigOptionAsync(
+            new("one", "reasoning", true), TestToken).WaitAsync(TimeSpan.FromSeconds(5), TestToken));
+
+        Assert.IsType<JsonException>(failure);
+        Assert.False(peer.Client.GetSessionSnapshot("one")!.ConfigOptions[1].CurrentBooleanValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ResumeSession_MissingOptionalList_IsAnAuthoritativeEmptyList(bool replay)
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+
+        await peer.Client.ResumeSessionAsync(new SessionResumeParams("one", "/workspace", [],
+            replayFrom: replay ? SessionReplayFrom.Start : null), TestToken);
+
+        var snapshot = peer.Client.GetSessionSnapshot("one")!;
+        Assert.True(snapshot.HasConfigOptions);
+        Assert.Empty(snapshot.ConfigOptions);
+    }
+
+    [Fact]
+    public async Task ClosedSession_IgnoresLateConfigurationResponse()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        var pending = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+        await peer.Client.CloseSessionAsync(new("one"), TestToken);
+
+        peer.Reply(peer.LastSet!, OptionsResponse(BooleanOptions(true)));
+        await pending;
+
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+    }
+
+    [Fact]
+    public async Task ReconnectedSession_DoesNotReceiveOldConfigurationResponse()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        var pending = peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+        var deliverOld = peer.CaptureDelivery();
+        var oldResponse = peer.Response(peer.LastSet!, OptionsResponse(BooleanOptions(true)));
+        await peer.Client.DisconnectAsync();
+        await Assert.ThrowsAnyAsync<Exception>(() => pending);
+        await peer.InitializeAsync();
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+
+        deliverOld(oldResponse);
+
+        Assert.False(peer.Client.GetSessionSnapshot("one")!.ConfigOptions[1].CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task V1_SetOption_KeepsStableWireAndDoesNotExposeDraftState()
+    {
+        using var peer = await ConfigurationPeer.CreateAsync(version: AcpProtocolVersion.V1);
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        peer.OnSet = request => peer.Reply(request, "{\"configOptions\":[]}");
+
+        await peer.Client.SetSessionConfigOptionAsync(new("one", "model", "fast"), TestToken);
+
+        Assert.False(peer.LastSet!.Params!.Value.TryGetProperty("type", out _));
+        Assert.Null(peer.Client.GetSessionSnapshot("one"));
+    }
+
+    [Fact]
+    public void OfflineReplay_ConfigurationPreservesUnknownOptionsAndDetachedPriorityOrder()
+    {
+        const string options = """[{"configId":"custom","name":"Custom","type":"_budget","currentValue":{"tokens":1e2},"future":true},{"configId":"reasoning","name":"Reasoning","type":"boolean","currentValue":true},{"configId":"model","name":"Model","type":"select","currentValue":"fast","options":[{"groupId":"g","name":"Group","options":[{"value":"fast","name":"Fast","_meta":{"hint":"owned"}}]}]}]""";
+
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [Json(Update(options))]);
+        var copy = snapshot.ConfigOptions;
+        copy[2].OptionGroups[0].Options.Clear();
+
+        Assert.True(snapshot.HasConfigOptions);
+        Assert.Equal(["custom", "reasoning", "model"], snapshot.ConfigOptions.Select(static option => option.Id));
+        var raw = JsonSerializer.SerializeToElement(snapshot.ConfigOptions[0], AcpWireFormat.For(2).TypeInfo<ConfigOption>());
+        Assert.Equal("1e2", raw.GetProperty("currentValue").GetProperty("tokens").GetRawText());
+        Assert.True(raw.GetProperty("future").GetBoolean());
+        Assert.Single(snapshot.ConfigOptions[2].OptionGroups[0].Options);
+        Assert.Empty(snapshot.UnprojectedUpdates);
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("null")]
+    [InlineData("false")]
+    public void OfflineReplay_FullConfigurationReplacement_ClearsOldOptions(string replacement)
+    {
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", [Json(Update(InitialOptions)), Json(Update(replacement))]);
+
+        Assert.True(snapshot.HasConfigOptions);
+        Assert.Empty(snapshot.ConfigOptions);
+    }
+
+    [Fact]
+    public void OfflineReplay_NoConfigUpdate_DoesNotInventAuthoritativeState()
+    {
+        var snapshot = AcpSessionDraftExtensions.ReplaySession("one", []);
+
+        Assert.False(snapshot.HasConfigOptions);
+        Assert.Empty(snapshot.ConfigOptions);
+    }
+
+    private static string BooleanOptions(bool value)
+        => "[{\"configId\":\"reasoning\",\"name\":\"Reasoning\",\"type\":\"boolean\",\"currentValue\":"
+            + (value ? "true" : "false") + "}]";
+
+    private static string OptionsResponse(string options) => "{\"configOptions\":" + options + "}";
+    private static string Update(string options) => "{\"sessionUpdate\":\"config_option_update\",\"configOptions\":" + options + "}";
+    private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private sealed class DelayedSessionStore : IAcpClientSessionStore
+    {
+        private readonly InMemoryAcpClientSessionStore _inner = new();
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool ContainsSession(string sessionId) => _inner.ContainsSession(sessionId);
+        public bool RemoveSession(string sessionId) => _inner.RemoveSession(sessionId);
+        public bool UpdateCurrentMode(string sessionId, string modeId) => _inner.UpdateCurrentMode(sessionId, modeId);
+        public Task<bool> CancelSessionAsync(string sessionId) => _inner.CancelSessionAsync(sessionId);
+        public async Task CreateSessionAsync(string sessionId, string cwd)
+        {
+            Entered.TrySetResult();
+            await Release.Task.WaitAsync(TestToken);
+            await _inner.CreateSessionAsync(sessionId, cwd);
+        }
+    }
+
+    private sealed class ConfigurationPeer : IAcpTransport, IDisposable
+    {
+        private readonly int _version;
+        private readonly MessageParser _parser = new();
+        internal AcpClient Client { get; }
+        internal List<string> Errors { get; } = [];
+        internal JsonRpcRequest? LastSet { get; private set; }
+        internal Action<JsonRpcRequest>? OnSet { get; set; }
+        public bool IsConnected { get; private set; } = true;
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        private ConfigurationPeer(IAcpClientSessionStore? store, int version)
+        {
+            _version = version;
+            Client = new AcpClient(this, sessionStore: store);
+            Client.ErrorOccurred += (_, error) => Errors.Add(error);
+        }
+
+        internal static async Task<ConfigurationPeer> CreateAsync(IAcpClientSessionStore? store = null, int version = AcpProtocolVersion.V2)
+        {
+            var peer = new ConfigurationPeer(store, version);
+            await peer.InitializeAsync();
+            return peer;
+        }
+
+        internal static async Task<ConfigurationPeer> CreateWithSessionAsync()
+        {
+            var peer = await CreateAsync();
+            await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+            return peer;
+        }
+
+        internal Task<InitializeResponse> InitializeAsync()
+        {
+            var request = new InitializeParams(new ClientInfo("config-test", "1"), new ClientCapabilities()) { ProtocolVersion = _version };
+            return _version == AcpProtocolVersion.V2
+                ? Client.InitializeDraftAsync(request, TestToken)
+                : Client.InitializeAsync(request, TestToken);
+        }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendMessageAsync(string json, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_parser.ParseMessage(json) is not JsonRpcRequest request) return Task.FromResult(true);
+            switch (request.Method)
+            {
+                case "initialize":
+                    var initialize = new InitializeResponse(_version, new AgentInfo("config-peer", "1"), new AgentCapabilities
+                    {
+                        SessionCapabilities = new SessionCapabilities { Resume = new SessionResumeCapabilities(), Close = new SessionCloseCapabilities() }
+                    });
+                    Reply(request, JsonSerializer.Serialize(initialize, AcpWireFormat.For(_version).TypeInfo<InitializeResponse>()));
+                    break;
+                case "session/new":
+                    Reply(request, _version == AcpProtocolVersion.V2
+                        ? "{\"sessionId\":\"one\",\"configOptions\":" + InitialOptions + "}"
+                        : "{\"sessionId\":\"one\"}");
+                    break;
+                case "session/resume":
+                case "session/close":
+                    Reply(request, "{}");
+                    break;
+                case "session/set_config_option":
+                    LastSet = request;
+                    OnSet?.Invoke(request);
+                    break;
+            }
+            return Task.FromResult(true);
+        }
+
+        internal void Update(string options) => Deliver("{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"one\",\"update\":" + AcpSessionConfigurationTests.Update(options) + "}}");
+        internal void Reply(JsonRpcRequest request, string result) => Deliver(Response(request, result));
+        internal string Response(JsonRpcRequest request, string result) => "{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"result\":" + result + "}";
+        internal void Error(JsonRpcRequest request, int code) => Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + request.Id + ",\"error\":{\"code\":" + code + ",\"message\":\"rejected\"}}");
+        private void Deliver(string json) => MessageReceived?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+        internal Action<string> CaptureDelivery()
+        {
+            var handlers = MessageReceived;
+            return json => handlers?.Invoke(this, new AcpTransportMessageReceivedEventArgs(json));
+        }
+
+        public void Dispose() => Client.Dispose();
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Protocol/SessionConfigWireContractTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Protocol/SessionConfigWireContractTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Tests.Protocol;
+
+public sealed class SessionConfigWireContractTests
+{
+    [Fact]
+    public void SetOption_StringValue_UsesTheNegotiatedDiscriminator()
+    {
+        var request = new SessionSetConfigOptionParams("s", "model", "fast");
+
+        var v1 = JsonSerializer.SerializeToElement(request, AcpJsonContext.Default.SessionSetConfigOptionParams);
+        var v2 = JsonSerializer.SerializeToElement(request, Wire.V2<SessionSetConfigOptionParams>());
+
+        Assert.False(v1.TryGetProperty("type", out _));
+        Assert.Equal("id", v2.GetProperty("type").GetString());
+        Assert.Equal("fast", v2.GetProperty("value").GetString());
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("false")]
+    [InlineData("17")]
+    [InlineData("\"text\"")]
+    [InlineData("[1,2]")]
+    [InlineData("{\"amount\":1e2,\"unit\":\"tokens\"}")]
+    public void SetOption_UnknownV2Type_PreservesRawValueAndExtensions(string value)
+    {
+        var json = "{\"sessionId\":\"s\",\"configId\":\"budget\",\"type\":\"_budget\",\"value\":"
+            + value + ",\"future\":{\"nested\":true},\"_meta\":{\"trace\":\"t\"}}";
+
+        var request = JsonSerializer.Deserialize(json, Wire.V2<SessionSetConfigOptionParams>());
+        Assert.NotNull(request);
+        var result = JsonSerializer.SerializeToElement(request, Wire.V2<SessionSetConfigOptionParams>());
+
+        Assert.Equal("_budget", result.GetProperty("type").GetString());
+        Assert.Equal(value, result.GetProperty("value").GetRawText());
+        Assert.True(result.GetProperty("future").GetProperty("nested").GetBoolean());
+        Assert.Equal("t", result.GetProperty("_meta").GetProperty("trace").GetString());
+    }
+
+    [Theory]
+    [InlineData("{\"value\":\"fast\"}")]
+    [InlineData("{\"type\":null,\"value\":\"fast\"}")]
+    [InlineData("{\"type\":false,\"value\":\"fast\"}")]
+    [InlineData("{\"type\":\"id\",\"value\":true}")]
+    [InlineData("{\"type\":\"boolean\",\"value\":\"true\"}")]
+    [InlineData("{\"type\":\"_future\"}")]
+    public void SetOption_V2RequiredDiscriminatorAndKnownValueTypes_RemainStrict(string fields)
+    {
+        var json = "{\"sessionId\":\"s\",\"configId\":\"c\"," + fields[1..];
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, Wire.V2<SessionSetConfigOptionParams>()));
+    }
+
+    [Fact]
+    public void SetOption_V2KnownType_PreservesUnknownFields()
+    {
+        const string json = """{"sessionId":"s","configId":"mode","type":"id","value":"plan","future":1e2}""";
+
+        var request = JsonSerializer.Deserialize(json, Wire.V2<SessionSetConfigOptionParams>());
+        Assert.NotNull(request);
+        var result = JsonSerializer.SerializeToElement(request, Wire.V2<SessionSetConfigOptionParams>());
+
+        Assert.Equal("id", result.GetProperty("type").GetString());
+        Assert.Equal("1e2", result.GetProperty("future").GetRawText());
+    }
+
+    [Theory]
+    [InlineData("{\"configId\":\"b\",\"name\":\"Enabled\",\"type\":\"boolean\",\"currentValue\":true,\"_meta\":false}")]
+    [InlineData("{\"configId\":\"s\",\"name\":\"Model\",\"type\":\"select\",\"currentValue\":\"fast\",\"options\":[{\"value\":\"fast\",\"name\":\"Fast\",\"_meta\":false}]}")]
+    [InlineData("{\"configId\":\"s\",\"name\":\"Model\",\"type\":\"select\",\"currentValue\":\"fast\",\"options\":[{\"groupId\":\"g\",\"name\":\"Group\",\"_meta\":false,\"options\":[{\"value\":\"fast\",\"name\":\"Fast\"}]}]}")]
+    public void ConfigOption_V2InvalidOptionalMetadata_DoesNotDropValidConfiguration(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, Wire.V2<ConfigOption>());
+
+        Assert.NotNull(result);
+        Assert.Null(result.Meta);
+        if (result.Type == "select")
+        {
+            var value = result.Options.Count > 0 ? Assert.Single(result.Options) : Assert.Single(Assert.Single(result.OptionGroups).Options);
+            Assert.Equal("fast", value.Value);
+            Assert.Null(value.Meta);
+        }
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpSessionUpdateProjectorTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpSessionUpdateProjectorTests.cs
@@ -86,7 +86,7 @@ public class AcpSessionUpdateProjectorTests
     }
 
     [Fact]
-    public void ProjectSessionLoad_WhenConfigOptionsIncludeUnknownType_IgnoresSessionModesAndUnknownOptions()
+    public void ProjectSessionLoad_WhenConfigOptionsIncludeUnknownType_KeepsOptionsWithoutProjectingUnknownModes()
     {
         var projector = new AcpSessionUpdateProjector();
         var response = new SessionLoadResponse(
@@ -134,8 +134,10 @@ public class AcpSessionUpdateProjectorTests
             delta.AvailableModes!,
             mode => Assert.Contains(mode.ModeId, new[] { "config-mode", "config-alt" }));
         Assert.True(delta.ShowConfigOptionsPanel);
-        var configOption = Assert.Single(delta.ConfigOptions!);
+        Assert.Equal(2, delta.ConfigOptions!.Count);
+        var configOption = delta.ConfigOptions[0];
         Assert.Equal("mode", configOption.Id);
+        Assert.Equal("future-type", delta.ConfigOptions[1].ValueType);
     }
 
     [Fact]
@@ -350,7 +352,7 @@ public class AcpSessionUpdateProjectorTests
     }
 
     [Fact]
-    public void Project_ConfigOptionUpdate_IgnoresOptionsWithoutRecognizedType()
+    public void Project_ConfigOptionUpdate_RetainsUnknownOptionsWithoutCreatingSelectors()
     {
         var projector = new AcpSessionUpdateProjector();
         var update = new ConfigOptionUpdate
@@ -378,7 +380,7 @@ public class AcpSessionUpdateProjectorTests
 
         var delta = projector.Project(new SessionUpdateEventArgs("remote-1", update));
 
-        Assert.Empty(delta.ConfigOptions!);
+        Assert.Equal(2, delta.ConfigOptions!.Count);
         Assert.False(delta.ShowConfigOptionsPanel);
         Assert.Empty(delta.AvailableModes!);
         Assert.Null(delta.SelectedModeId);

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/SessionOptions/SessionConfigurationProjectionTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/SessionOptions/SessionConfigurationProjectionTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Domain.Models.Conversation;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.ViewModels.Chat.SessionOptions;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat.SessionOptions;
+
+public sealed class SessionConfigurationProjectionTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Project_BooleanConfig_RetainsTypedStateThroughTheProductPresenter(bool value)
+    {
+        var projector = new AcpSessionUpdateProjector();
+        var option = new ConfigOption
+        {
+            Id = "thinking",
+            Name = "Thinking",
+            Type = "boolean",
+            CurrentBooleanValue = value
+        };
+
+        var delta = projector.Project(new SessionUpdateEventArgs("s", new ConfigOptionUpdate { ConfigOptions = [option] }));
+        var configuration = Assert.Single(delta.ConfigOptions!);
+        var presented = new ChatSessionOptionsPresenter().Present([], null,
+            [new ConversationConfigOptionSnapshot
+            {
+                Id = configuration.Id,
+                Name = configuration.Name,
+                ValueType = configuration.ValueType,
+                SelectedValue = configuration.SelectedValue,
+                BooleanValue = configuration.BooleanValue
+            }], true);
+
+        var row = Assert.Single(presented.ConfigOptions);
+        Assert.True(row.IsBoolType);
+        Assert.Equal(value, row.BoolValue);
+        Assert.Equal(value, Assert.IsType<bool>(row.Value));
+        Assert.Null(configuration.SelectedValue);
+        Assert.True(delta.ShowConfigOptionsPanel);
+        Assert.True(presented.ShowConfigOptionsPanel);
+    }
+
+    [Fact]
+    public void Project_UnknownOption_RetainsRawPayloadAndPriorityWithoutInventingAnEditor()
+    {
+        const string json = """{"id":"budget","name":"Budget","type":"_budget","currentValue":{"tokens":1e2},"future":{"x":true}}""";
+        var unknown = JsonSerializer.Deserialize(json, AcpJsonContext.Default.ConfigOption)!;
+        var known = new ConfigOption { Id = "enabled", Name = "Enabled", Type = "boolean", CurrentBooleanValue = true };
+
+        var delta = new AcpSessionUpdateProjector().Project(new SessionUpdateEventArgs("s",
+            new ConfigOptionUpdate { ConfigOptions = [unknown, known] }));
+        var options = delta.ConfigOptions!;
+        var view = new ChatSessionOptionsPresenter().Present([], null,
+            options.Select(static option => new ConversationConfigOptionSnapshot
+            {
+                Id = option.Id,
+                ValueType = option.ValueType,
+                BooleanValue = option.BooleanValue,
+                RawProtocolJson = option.RawProtocolJson
+            }).ToArray(), true);
+
+        Assert.Equal(["budget", "enabled"], options.Select(static option => option.Id));
+        Assert.Equal(json, options[0].RawProtocolJson);
+        Assert.Equal("enabled", Assert.Single(view.ConfigOptions).Id);
+    }
+
+    [Fact]
+    public void Project_OnlyUnknownOption_DoesNotDisplayAnEmptyConfigurationPanel()
+    {
+        var option = new ConfigOption { Id = "future", Name = "Future", Type = "future" };
+
+        var delta = new AcpSessionUpdateProjector().ProjectSessionNew(new SessionNewResponse("s", configOptions: [option]));
+        var view = new ChatSessionOptionsPresenter().Present([], null,
+            [new ConversationConfigOptionSnapshot { Id = "future", ValueType = "future" }], true);
+
+        Assert.Single(delta.ConfigOptions!);
+        Assert.False(delta.ShowConfigOptionsPanel);
+        Assert.Empty(view.ConfigOptions);
+        Assert.False(view.ShowConfigOptionsPanel);
+    }
+
+    [Fact]
+    public void Present_ChangedBoolean_MustRefreshExistingRows()
+    {
+        var presenter = new ChatSessionOptionsPresenter();
+        var before = presenter.Present([], null,
+            [new ConversationConfigOptionSnapshot { Id = "enabled", ValueType = "boolean", BooleanValue = false }], true);
+        var after = presenter.Present([], null,
+            [new ConversationConfigOptionSnapshot { Id = "enabled", ValueType = "boolean", BooleanValue = true }], true);
+
+        Assert.False(presenter.ConfigOptionCollectionMatches(before.ConfigOptions, after.ConfigOptions));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateFromAcp_BooleanOption_KeepsItsValue(bool value)
+    {
+        var row = ConfigOptionViewModel.CreateFromAcp(new ConfigOption
+        {
+            Id = "toggle",
+            Name = "Toggle",
+            Type = "boolean",
+            CurrentBooleanValue = value
+        });
+
+        Assert.True(row.IsBoolType);
+        Assert.Equal(value, row.BoolValue);
+        Assert.Equal(value, row.Value);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
@@ -23,6 +23,49 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat;
 [Collection("NonParallel")]
 public sealed class WorkspaceWriterTests
 {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task FlushAsync_OnlyConfigValueChanges_PersistsTheSecondState(bool boolean)
+    {
+        var dispatcher = new ImmediateUiDispatcher();
+        var store = new CapturingConversationStore();
+        var preferences = CreatePreferences(dispatcher);
+        using var workspace = CreateWorkspace(store, new FakeSessionManager(), preferences, dispatcher);
+        using var writer = new WorkspaceWriter(workspace, dispatcher, TimeSpan.Zero);
+        await workspace.RestoreAsync(TestContext.Current.CancellationToken);
+        var first = new ConversationConfigOptionSnapshot
+        {
+            Id = "value", ValueType = boolean ? "boolean" : "_budget",
+            BooleanValue = boolean ? false : null,
+            RawProtocolJson = boolean ? null : "{\"value\":1}"
+        };
+        var second = new ConversationConfigOptionSnapshot
+        {
+            Id = first.Id, ValueType = first.ValueType,
+            BooleanValue = boolean ? true : null,
+            RawProtocolJson = boolean ? null : "{\"value\":2}"
+        };
+        var initial = new ChatState(HydratedConversationId: "config", ConfigOptions: ImmutableList.Create(first),
+            ShowConfigOptionsPanel: true, Generation: 1);
+        writer.Enqueue(initial, scheduleSave: false);
+        await writer.FlushAsync(TestContext.Current.CancellationToken);
+        await workspace.SaveAsync(TestContext.Current.CancellationToken);
+        var firstPersisted = workspace.GetConversationSnapshot("config")!;
+        var originalUpdatedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        workspace.UpsertConversationSnapshot(firstPersisted with { LastUpdatedAt = originalUpdatedAt },
+            ConversationWorkspaceSnapshotOrigin.RuntimeProjection);
+
+        writer.Enqueue(initial with { ConfigOptions = ImmutableList.Create(second), Generation = 2 }, scheduleSave: false);
+        await writer.FlushAsync(TestContext.Current.CancellationToken);
+        await workspace.SaveAsync(TestContext.Current.CancellationToken);
+
+        var option = Assert.Single(Assert.Single(store.LastSaved!.Conversations).ConfigOptions);
+        Assert.Equal(second.BooleanValue, option.BooleanValue);
+        Assert.Equal(second.RawProtocolJson, option.RawProtocolJson);
+        Assert.NotEqual(originalUpdatedAt, Assert.Single(store.LastSaved.Conversations).LastUpdatedAt);
+    }
+
     [Fact]
     public async Task FlushAsync_ConfigurationRoundTrip_PreservesBooleanAndUnknownRawValues()
     {
@@ -1141,11 +1184,16 @@ public sealed class WorkspaceWriterTests
 
     private sealed class CapturingConversationStore : IConversationStore
     {
+        public ConversationDocument? LastSaved { get; private set; }
+
         public Task<ConversationDocument> LoadAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(new ConversationDocument());
 
         public Task SaveAsync(ConversationDocument document, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        {
+            LastSaved = document;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeSessionManager : ISessionManager

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
@@ -24,6 +24,35 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat;
 public sealed class WorkspaceWriterTests
 {
     [Fact]
+    public async Task FlushAsync_ConfigurationRoundTrip_PreservesBooleanAndUnknownRawValues()
+    {
+        var dispatcher = new ImmediateUiDispatcher();
+        var store = new CapturingConversationStore();
+        var sessionManager = new FakeSessionManager();
+        var preferences = CreatePreferences(dispatcher);
+        using var workspace = CreateWorkspace(store, sessionManager, preferences, dispatcher);
+        using var writer = new WorkspaceWriter(workspace, dispatcher, TimeSpan.Zero);
+        const string raw = """{"configId":"budget","name":"Budget","type":"_budget","currentValue":{"tokens":1e2}}""";
+
+        writer.Enqueue(new ChatState(
+            HydratedConversationId: "session-config",
+            ConfigOptions: ImmutableList.Create(
+                new ConversationConfigOptionSnapshot { Id = "enabled", ValueType = "boolean", BooleanValue = true },
+                new ConversationConfigOptionSnapshot { Id = "budget", ValueType = "_budget", RawProtocolJson = raw }),
+            ShowConfigOptionsPanel: true,
+            Generation: 1), scheduleSave: false);
+        await writer.FlushAsync(TestContext.Current.CancellationToken);
+
+        var snapshot = workspace.GetConversationSnapshot("session-config");
+        Assert.NotNull(snapshot);
+        Assert.Equal(2, snapshot.ConfigOptions!.Count);
+        Assert.True(snapshot.ConfigOptions[0].BooleanValue);
+        Assert.Equal(raw, snapshot.ConfigOptions[1].RawProtocolJson);
+        snapshot.ConfigOptions[0].BooleanValue = false;
+        Assert.True(workspace.GetConversationSnapshot("session-config")!.ConfigOptions![0].BooleanValue);
+    }
+
+    [Fact]
     public async Task FlushAsync_HydratedConversation_DoesNotAdvanceLastUpdatedAt()
     {
         var dispatcher = new ImmediateUiDispatcher();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/WorkspaceWriterTests.cs
@@ -36,13 +36,15 @@ public sealed class WorkspaceWriterTests
         await workspace.RestoreAsync(TestContext.Current.CancellationToken);
         var first = new ConversationConfigOptionSnapshot
         {
-            Id = "value", ValueType = boolean ? "boolean" : "_budget",
+            Id = "value",
+            ValueType = boolean ? "boolean" : "_budget",
             BooleanValue = boolean ? false : null,
             RawProtocolJson = boolean ? null : "{\"value\":1}"
         };
         var second = new ConversationConfigOptionSnapshot
         {
-            Id = first.Id, ValueType = first.ValueType,
+            Id = first.Id,
+            ValueType = first.ValueType,
             BooleanValue = boolean ? true : null,
             RawProtocolJson = boolean ? null : "{\"value\":2}"
         };


### PR DESCRIPTION
会话配置的 V2 字符串设置请求缺少 type:id，未知设置值被当作字符串丢失原始数据；设置响应也没有进入 SDK 的权威配置快照。现在按协商版本读写 id/boolean/未知值，配置响应和通知在收包顺序中进入现有 session controller，取消等待或晚到回调不会覆盖新状态。

配置全量列表、boolean 值和未知 payload 已贯通既有产品 projector/presenter/workspace 克隆链；未知类型保留而不生成错误编辑器。V1 报文形态保持兼容，公开 live V2 仍关闭。通用会话设置 UI 和实验生命周期接线另行交付。

验证：SDK 1296/1296，配置 wire/lifecycle 35 项，产品 projector/presenter/workspace 55 项；SDK构建零警告错误；真实 nupkg 兼容基线、旧二进制、46 个草案类型消费和离线配置重放通过。新增边界在旧实现上14项失败，修后通过。独立复审另发现只改变布尔/raw值时更新时间未更新（值仍保存），已在原比较owner补两字段；固定旧时间戳的两例修前失败，完整 WorkspaceWriter 22/22通过。Refs #149。
