### PR TITLE
test(acp): verify independent agents and released WebSocket bridges

### DIFF
--- a/.github/workflows/ci-acp-sdk.yml
+++ b/.github/workflows/ci-acp-sdk.yml
@@ -11,6 +11,7 @@ on:
       - "src/SalmonEgg.Infrastructure.Desktop/Transport/**"
       - "src/SalmonEgg.Infrastructure/Client/DomainAcpClientAdapters.cs"
       - "scripts/gates/run-acp-batch-stdio-gate.sh"
+      - "scripts/gates/run-acp-official-v2-agent-gate.sh"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
       - "scripts/gates/acp-v2-*-consumer.cs"
@@ -30,6 +31,7 @@ on:
       - "src/SalmonEgg.Infrastructure.Desktop/Transport/**"
       - "src/SalmonEgg.Infrastructure/Client/DomainAcpClientAdapters.cs"
       - "scripts/gates/run-acp-batch-stdio-gate.sh"
+      - "scripts/gates/run-acp-official-v2-agent-gate.sh"
       - "scripts/gates/run-acp-sdk-gates.*"
       - "scripts/gates/run-acp-consumer-package-smoke.sh"
       - "scripts/gates/acp-v2-*-consumer.cs"
@@ -56,6 +58,32 @@ env:
   PACKAGE_OUTPUT: "artifacts/acp-sdk-pack"
 
 jobs:
+  upstream-v2-agent:
+    name: Official ACP V2 Agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Run the pinned upstream Agent against this SDK
+        run: bash scripts/gates/run-acp-official-v2-agent-gate.sh
+      - name: Upload upstream interoperability evidence
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: acp-official-v2-agent
+          path: |
+            artifacts/acp-official-v2-agent/agent-build.log
+            artifacts/acp-official-v2-agent/client.log
+            artifacts/acp-official-v2-agent/*.txt
+            artifacts/acp-official-v2-agent/*.sha256
+
   batch-stdio:
     name: ACP Batch Stdio (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -64,6 +64,12 @@ jobs:
         run: bash scripts/gates/run-acp-cancellation-transport-gates.sh Release
       - name: Verify bound credentials on real transports without skips
         run: bash scripts/gates/run-acp-credential-transport-gates.sh Release
+      - name: Verify a published ACP WebSocket bridge
+        shell: bash
+        run: |
+          python3 -m venv "$RUNNER_TEMP/acp-bridge-venv"
+          "$RUNNER_TEMP/acp-bridge-venv/bin/pip" install acpremote==1.9.0
+          python3 scripts/gates/run-acp-published-bridge-gate.py --bridge "$RUNNER_TEMP/acp-bridge-venv/bin/acpremote"
       - name: Upload transport evidence
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -72,6 +78,7 @@ jobs:
           path: |
             artifacts/acp-cancellation/
             artifacts/acp-credentials/
+            artifacts/acp-published-bridge/
 
   build-and-test:
     name: Build and Test

--- a/scripts/gates/fixtures/elicitation-mcp-peer.py
+++ b/scripts/gates/fixtures/elicitation-mcp-peer.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Local MCP tool used to verify a real ACP Agent's URL-elicitation forwarding."""
+
+import json
+import sys
+
+
+def send(frame):
+    print(json.dumps(frame, separators=(",", ":")), flush=True)
+
+
+def main():
+    url = sys.argv[1]
+    tool_request_id = None
+    for line in sys.stdin:
+        frame = json.loads(line)
+        method = frame.get("method")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": frame["id"], "result": {
+                "protocolVersion": frame["params"]["protocolVersion"],
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "salmon-egg-elicitation-acceptance", "version": "1"},
+            }})
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": frame["id"], "result": {"tools": [{
+                "name": "request_url", "description": "Ask for a harmless local test-page confirmation using URL elicitation.",
+                "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+            }]}})
+        elif method == "tools/call":
+            tool_request_id = frame["id"]
+            send({"jsonrpc": "2.0", "id": "url-confirmation", "method": "elicitation/create", "params": {
+                "mode": "url", "message": "Confirm the local interoperability test page.",
+                "url": url, "elicitationId": "mcp-url-confirmation",
+            }})
+        elif frame.get("id") == "url-confirmation":
+            accepted = frame.get("result", {}).get("action") == "accept"
+            if accepted:
+                send({"jsonrpc": "2.0", "method": "notifications/elicitation/complete",
+                      "params": {"elicitationId": "mcp-url-confirmation"}})
+            send({"jsonrpc": "2.0", "id": tool_request_id, "result": {
+                "content": [{"type": "text", "text": "URL_ACCEPTED" if accepted else "URL_CANCELLED"}],
+            }})
+        elif "id" in frame:
+            send({"jsonrpc": "2.0", "id": frame["id"], "error": {"code": -32601, "message": "Method not found"}})
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/run-acp-batch-stdio-gate.sh
+++ b/scripts/gates/run-acp-batch-stdio-gate.sh
@@ -18,6 +18,7 @@ timeout --signal=TERM --kill-after=10s 180s "$dotnet_bin" test \
   --project tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj \
   --configuration "$configuration" \
   -p:UseSharedCompilation=false \
+  --filter-class SalmonEgg.Acp.Desktop.Tests.StdioBatchTests \
   --timeout 1m --no-ansi --minimum-expected-tests 2 --output Detailed > "$log_file" 2>&1 || {
     cat "$log_file"
     exit 1

--- a/scripts/gates/run-acp-official-v2-agent-gate.sh
+++ b/scripts/gates/run-acp-official-v2-agent-gate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+output="${1:-$repo_root/artifacts/acp-official-v2-agent}"
+mkdir -p "$output"
+output="$(cd "$output" && pwd)"
+source_dir="$output/rust-sdk"
+source_commit=3a6d0ae88dbaa09fcb74e26761e3643a75b2015e
+if [ ! -d "$source_dir/.git" ]; then
+  git init -q "$source_dir"
+  git -C "$source_dir" remote add origin https://github.com/agentclientprotocol/rust-sdk.git
+fi
+git -C "$source_dir" fetch --depth 1 origin "$source_commit"
+git -C "$source_dir" checkout --detach "$source_commit"
+test "$(git -C "$source_dir" rev-parse HEAD)" = "$source_commit"
+test -z "$(git -C "$source_dir" status --porcelain --untracked-files=no)"
+
+(
+  cd "$source_dir"
+  CARGO_BUILD_JOBS=2 timeout --signal=TERM --kill-after=10s 600s cargo build --locked \
+    -p agent-client-protocol --features unstable_protocol_v2 --example simple_agent_v2
+) > "$output/agent-build.log" 2>&1
+
+export SALMONEGG_OFFICIAL_V2_AGENT="$source_dir/target/debug/examples/simple_agent_v2"
+export DOTNET_PROCESSOR_COUNT=2 DOTNET_CLI_USE_MSBUILD_SERVER=0 MSBUILDDISABLENODEREUSE=1
+cd "$repo_root"
+timeout --signal=TERM --kill-after=10s 180s "${DOTNET_BIN:-dotnet}" test \
+  --project tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj \
+  --configuration Release --no-ansi -p:UseSharedCompilation=false \
+  --filter-class SalmonEgg.Acp.Desktop.Tests.OfficialV2AgentAcceptanceTests \
+  --minimum-expected-tests 1 --output Detailed > "$output/client.log" 2>&1
+cat "$output/client.log"
+python3 - "$output/client.log" <<'PY'
+from pathlib import Path
+import re
+import sys
+text = Path(sys.argv[1]).read_text()
+if not re.search(r'^\s+succeeded:\s+1\s*$', text, re.M) or not re.search(r'^\s+skipped:\s+0\s*$', text, re.M):
+    raise SystemExit('The upstream v2 Agent must run through the production client without skips.')
+PY
+sha256sum "$SALMONEGG_OFFICIAL_V2_AGENT" > "$output/agent.sha256"
+git rev-parse HEAD > "$output/client-commit.txt"
+git -C "$source_dir" rev-parse HEAD > "$output/agent-commit.txt"

--- a/scripts/gates/run-acp-published-bridge-gate.py
+++ b/scripts/gates/run-acp-published-bridge-gate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify an installed acpremote release against the production cancellation test."""
+
+import argparse
+import contextlib
+import ctypes
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+
+def main():
+    if not sys.platform.startswith("linux"):
+        raise SystemExit("This process-ownership gate requires Linux.")
+    # Reap descendants even when a bridge exits before a child it started.
+    if ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "Could not enable child-process ownership for this gate.")
+    signal.signal(signal.SIGTERM, interrupt)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bridge", default="acpremote")
+    parser.add_argument("--output", type=Path, default=Path("artifacts/acp-published-bridge"))
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[2]
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    bridge_path = shutil.which(args.bridge)
+    if bridge_path is None:
+        raise SystemExit("Install acpremote==1.9.0 in an isolated environment before running this gate.")
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    peer_log = output / ("peer-" + str(time.time_ns()) + ".ndjson")
+    command = [bridge_path, "expose", "--host", "127.0.0.1", "--port", str(port),
+               "--stderr-mode", "discard", "--", "python3",
+               str(repo / "scripts/gates/fixtures/cancellation-peer.py"), str(peer_log)]
+    with (output / "bridge.log").open("w") as log:
+        bridge = subprocess.Popen(command, cwd=repo, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            wait_for_bridge(bridge, port)
+            env = os.environ.copy()
+            env["SALMONEGG_ACP_CANCELLATION_BRIDGE_URL"] = f"ws://127.0.0.1:{port}/acp/ws"
+            env["SALMONEGG_ACP_CANCELLATION_PEER_LOG"] = str(peer_log)
+            with (output / "test.log").open("w") as result_log:
+                test = subprocess.Popen([
+                    env.get("DOTNET_BIN", "dotnet"), "test", "--project",
+                    "tests/SalmonEgg.Infrastructure.Tests/SalmonEgg.Infrastructure.Tests.csproj",
+                    "--configuration", "Release", "--no-ansi", "-p:UseSharedCompilation=false",
+                    "--filter-class", "SalmonEgg.Infrastructure.Tests.Transport.ProductionBridgeCancellationTests",
+                    "--minimum-expected-tests", "1", "--output", "Detailed",
+                ], cwd=repo, env=env, stdout=result_log, stderr=subprocess.STDOUT, start_new_session=True)
+                try:
+                    return_code = test.wait(timeout=180)
+                finally:
+                    stop_process_group(test)
+            text = (output / "test.log").read_text()
+            if return_code or not re.search(r"^\s+succeeded:\s+1\s*$", text, re.M) or not re.search(r"^\s+skipped:\s+0\s*$", text, re.M):
+                raise SystemExit("Published bridge gate failed; see test.log. Missing execution is not a pass.")
+            print(json.dumps({"passed": True, "bridge": "acpremote", "peer": "controlled stdio fixture",
+                              "verified": ["cancel forwarding", "terminal response", "subsequent request", "disconnect"]}))
+        finally:
+            stop_process_group(bridge)
+
+
+def stop_process_group(process):
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=6)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=3)
+    # The parent can exit promptly while a descendant ignores TERM. Groups are unique because
+    # every owned root is started with a new session; never inspect or kill unrelated processes.
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        try:
+            pid, _ = os.waitpid(-process.pid, os.WNOHANG)
+            if pid == 0:
+                time.sleep(0.02)
+                continue
+        except ChildProcessError:
+            return
+    raise RuntimeError("An owned bridge process group could not be reaped within its cleanup budget.")
+
+
+def interrupt(_signal, _frame):
+    raise KeyboardInterrupt("Bridge gate interrupted; reclaiming its owned processes.")
+
+
+def wait_for_bridge(bridge, port):
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if bridge.poll() is not None:
+            raise SystemExit("Published bridge exited before readiness; see bridge.log.")
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=1) as response:
+                if response.status == 200:
+                    return
+        except OSError:
+            time.sleep(0.1)
+    raise SystemExit("Published bridge did not become ready within its startup budget.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/SalmonEgg.Acp.Desktop.Tests/OfficialV2AgentAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/OfficialV2AgentAcceptanceTests.cs
@@ -1,0 +1,48 @@
+#pragma warning disable SEACP002 // This opt-in test exercises the upstream draft Agent; product defaults stay on v1.
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Acp.Desktop.Tests;
+
+public sealed class OfficialV2AgentAcceptanceTests
+{
+    [Fact]
+    public async Task OfficialV2Agent_PromptCloseResume_UsesAuthoritativeHistory()
+    {
+        // Arrange
+        var command = Environment.GetEnvironmentVariable("SALMONEGG_OFFICIAL_V2_AGENT");
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(command), "Build the pinned official Rust simple_agent_v2 example and supply its executable.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        var token = timeout.Token;
+        using var transport = new StdioTransport(command!);
+        using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+        await client.InitializeDraftAsync(new InitializeParams(new ClientInfo("salmon-egg-v2-interop", "1"), new ClientCapabilities())
+        { ProtocolVersion = AcpProtocolVersion.V2 }, token);
+        var directory = Path.GetFullPath(Path.GetTempPath());
+        var session = await client.CreateSessionAsync(new SessionNewParams(directory, []), token);
+        var marker = "official-v2-" + Guid.NewGuid().ToString("N");
+
+        // Act
+        var response = await client.SendPromptAsync(new SessionPromptParams(session.SessionId,
+            [new TextContentBlock(marker)]), token);
+        var before = client.GetSessionSnapshot(session.SessionId);
+        await client.CloseSessionAsync(new SessionCloseParams(session.SessionId), token);
+        await client.ResumeSessionAsync(new SessionResumeParams(session.SessionId, directory, [], replayFrom: SessionReplayFrom.Start), token);
+        var after = client.GetSessionSnapshot(session.SessionId);
+
+        // Assert: actual upstream replay must rebuild the same messages exactly once.
+        Assert.Equal(StopReason.EndTurn, response.StopReason);
+        Assert.True(response.HasStopReason);
+        Assert.NotNull(before);
+        Assert.NotNull(after);
+        Assert.NotEmpty(before.Messages);
+        Assert.Equal(before.Messages.Select(message => message.MessageId), after.Messages.Select(message => message.MessageId));
+        Assert.Contains(after.Messages, message => message.Content.OfType<TextContentBlock>().Any(content => content.Text.Contains(marker, StringComparison.Ordinal)));
+        Assert.True(await client.DisconnectAsync());
+    }
+}

--- a/tests/SalmonEgg.Acp.Desktop.Tests/RealAgentAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/RealAgentAcceptanceTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.Text;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Mcp;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Transport;
+using Xunit;
+
+namespace SalmonEgg.Acp.Desktop.Tests;
+
+/// <summary>Opt-in acceptance through the production client, adapter and real Agent process.</summary>
+public sealed class RealAgentAcceptanceTests
+{
+    private const string CommandVariable = "SALMONEGG_REAL_AGENT_COMMAND";
+    private const string ArgumentsVariable = "SALMONEGG_REAL_AGENT_ARGUMENTS";
+
+    [Fact]
+    public async Task RealAgent_InitializeCreateAndPrompt_CompletesThroughProductionClient()
+        => await RunAsync(expectForm: false);
+
+    [Fact]
+    public async Task RealAgent_FormAnswer_ReturnsThroughStandardElicitation()
+    {
+        Assert.SkipUnless(Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_FORM") == "1",
+            "Enable only for a real Agent that supplies standard form elicitation.");
+        await RunAsync(expectForm: true);
+    }
+
+    [Fact]
+    public async Task RealAgent_McpUrlRequest_CompletesTheStandardConsentLifecycle()
+    {
+        // Arrange: the MCP helper triggers a real Agent, rather than replacing the Agent.
+        var command = Environment.GetEnvironmentVariable(CommandVariable);
+        var peer = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_MCP_PEER");
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(command) || string.IsNullOrWhiteSpace(peer),
+            "Set the installed Agent and the local MCP elicitation helper path.");
+        var directory = Path.Combine(Path.GetTempPath(), "salmon-egg-url-agent-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(120));
+        var token = timeout.Token;
+        try
+        {
+            using var transport = new StdioTransport(command!, ReadArguments());
+            using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            var requested = new TaskCompletionSource<ElicitationRequestEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var completed = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.ElicitationRequestReceived += (_, request) => requested.TrySetResult(request);
+            client.ElicitationCompleted += (_, value) => completed.TrySetResult(value.ElicitationId);
+            var permissions = new ConcurrentQueue<Task>();
+            client.PermissionRequestReceived += (_, request) => permissions.Enqueue(request.Respond("cancelled", null));
+            await client.InitializeAsync(new InitializeParams(new ClientInfo("salmon-egg-url-interop", "1"),
+                new ClientCapabilities { Elicitation = new ElicitationCapabilities { Url = new ElicitationUrlCapabilities() } }), token);
+            const string url = "https://example.invalid/salmon-egg-local-acceptance";
+            var session = await client.CreateSessionAsync(new SessionNewParams(directory,
+                [new StdioMcpServer("acceptance", "/usr/bin/python3", [peer!, url], [])]), token);
+
+            // Act: URL consent is answered explicitly; this protocol gate does not open a browser.
+            var pending = client.SendPromptAsync(new SessionPromptParams(session.SessionId,
+                [new TextContentBlock("Call the acceptance MCP request_url tool exactly once. Do not use any other tool or access files. When done reply DONE.")]), token);
+            var received = await requested.Task.WaitAsync(token);
+            var request = Assert.IsType<UrlElicitationRequest>(received.Request);
+            Assert.Equal(url, request.Url);
+            Assert.Equal(session.SessionId, request.Scope.SessionId);
+            Assert.True(await received.Accept(null));
+            var result = await pending;
+
+            // Assert
+            Assert.Equal(request.ElicitationId, await completed.Task.WaitAsync(token));
+            Assert.Equal(ElicitationActions.Accept, received.State.ResponseAction);
+            Assert.True(received.State.IsCompleted);
+            Assert.Equal(StopReason.EndTurn, result.StopReason);
+            await Task.WhenAll(permissions);
+            Assert.True(await client.DisconnectAsync());
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task RunAsync(bool expectForm)
+    {
+        // Arrange
+        var command = Environment.GetEnvironmentVariable(CommandVariable);
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(command), $"Set {CommandVariable} to an installed ACP Agent.");
+        var directory = Path.Combine(Path.GetTempPath(), "salmon-egg-agent-acceptance-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(90));
+        var token = timeout.Token;
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(directory, "AGENTS.md"),
+                "This is an isolated protocol acceptance test. Do not run tools, read other paths or modify files.", token);
+            using var transport = new StdioTransport(command!, ReadArguments());
+            using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            var errors = new ConcurrentQueue<string>();
+            var text = new StringBuilder();
+            var formReceived = new TaskCompletionSource<ElicitationRequestEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.ErrorOccurred += (_, _) => errors.Enqueue("client-error");
+            client.ElicitationRequestReceived += (_, request) => formReceived.TrySetResult(request);
+            client.SessionUpdateReceived += (_, update) =>
+            {
+                if (update.Update is AgentMessageUpdate { Content: TextContentBlock content })
+                {
+                    lock (text) text.Append(content.Text);
+                }
+            };
+
+            // Act
+            var initialized = await client.InitializeAsync(new InitializeParams(
+                new ClientInfo("salmon-egg-real-agent-acceptance", "1"), new ClientCapabilities
+                {
+                    Elicitation = expectForm ? new ElicitationCapabilities { Form = new ElicitationFormCapabilities() } : null
+                }), token);
+            var session = await client.CreateSessionAsync(new SessionNewParams(directory, []), token);
+            var marker = "ACP_ACCEPTANCE_" + Guid.NewGuid().ToString("N");
+            var prompt = "Do not use any tools or access files. Reply with exactly: " + marker;
+            if (expectForm)
+            {
+                var planOption = Assert.Single(session.ConfigOptions ?? [], option =>
+                    option.Options.Any(value => value.Value == "plan"));
+                await client.SetSessionConfigOptionAsync(
+                    new SessionSetConfigOptionParams(session.SessionId, planOption.Id, "plan"), token);
+                prompt = "Use only request_user_input once: ask one choice question with options Blue and Green. "
+                    + "Do not inspect files or call any other tool. After I answer, reply with exactly: " + marker;
+            }
+            var pending = client.SendPromptAsync(new SessionPromptParams(session.SessionId,
+                [new TextContentBlock(prompt)]), token);
+            if (expectForm)
+            {
+                await AnswerFormAsync(await formReceived.Task.WaitAsync(token), session.SessionId);
+            }
+            var result = await pending;
+
+            // Assert: a handshake alone cannot establish that the authenticated Agent actually works.
+            Assert.Equal(AcpProtocolVersion.V1, initialized.ProtocolVersion);
+            Assert.False(string.IsNullOrWhiteSpace(session.SessionId));
+            Assert.True(result.HasStopReason);
+            Assert.Equal(StopReason.EndTurn, result.StopReason);
+            lock (text) Assert.Contains(marker, text.ToString(), StringComparison.Ordinal);
+            Assert.Empty(errors);
+            Assert.True(await client.DisconnectAsync());
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task AnswerFormAsync(ElicitationRequestEventArgs received, string sessionId)
+    {
+        Assert.Equal(sessionId, received.SessionId);
+        var form = Assert.IsType<FormElicitationRequest>(received.Request);
+        Assert.NotEmpty(form.RequestedSchema.Properties);
+        var content = new ElicitationAcceptContent();
+        foreach (var property in form.RequestedSchema.Properties)
+        {
+            var field = Assert.IsType<StringPropertySchema>(property.Value);
+            content.SetString(property.Key, field.OneOf?.FirstOrDefault()?.Const
+                ?? field.Enum?.FirstOrDefault() ?? "Blue");
+        }
+        Assert.True(await received.Accept(content));
+    }
+
+    private static string[] ReadArguments()
+        => (Environment.GetEnvironmentVariable(ArgumentsVariable) ?? string.Empty)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+}

--- a/tests/SalmonEgg.Acp.Desktop.Tests/RealCredentialAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/RealCredentialAcceptanceTests.cs
@@ -49,7 +49,7 @@ public sealed class RealCredentialAcceptanceTests
             var reloaded = await manager.LoadConfigurationAsync(profile.Id);
             Assert.NotNull(reloaded);
             var yaml = await File.ReadAllTextAsync(Path.Combine(paths.ConfigRootPath, "servers", "acceptance.yaml"), token);
-            Assert.DoesNotContain(secret!, yaml, StringComparison.Ordinal);
+            Assert.False(yaml.Contains(secret!, StringComparison.Ordinal), "Profile persistence must never expose the real credential.");
             var factory = new TransportFactory(Log.Logger, new TransportSupportPolicy(new PlatformCapabilityService()), new DesktopStdioTransportFactory());
             using var transport = factory.CreateTransport(reloaded);
             using var client = new AcpClient(new DomainAcpTransportAdapter(transport));

--- a/tests/SalmonEgg.Acp.Desktop.Tests/RealCredentialAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/RealCredentialAcceptanceTests.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Services;
+using SalmonEgg.Infrastructure.Storage;
+using SalmonEgg.Infrastructure.Transport;
+using Serilog;
+using Xunit;
+
+namespace SalmonEgg.Acp.Desktop.Tests;
+
+/// <summary>Verifies explicit credential wiring; the Agent's existing login can also remain available.</summary>
+public sealed class RealCredentialAcceptanceTests
+{
+    [Fact]
+    public async Task RealAgent_BoundCredential_SurvivesProfileReloadAndClearPreventsReconnect()
+    {
+        // Arrange
+        var secret = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_SECRET");
+        var command = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_COMMAND");
+        var name = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_SECRET_ENV");
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(secret) || string.IsNullOrWhiteSpace(command) || string.IsNullOrWhiteSpace(name),
+            "Supply an installed ACP Agent and an explicit per-process credential binding.");
+        var directory = Path.Combine(Path.GetTempPath(), "salmon-egg-credential-acceptance-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(90));
+        var token = timeout.Token;
+        try
+        {
+            var profile = new ServerConfiguration
+            {
+                Id = "acceptance",
+                Name = "Real Agent acceptance",
+                Transport = TransportType.Stdio,
+                StdioCommand = command!,
+                Authentication = new AuthenticationConfig { ApiKey = secret },
+            };
+            profile.CredentialBinding = CredentialBindingPolicy.Create(profile, CredentialSource.ApiKey, CredentialTarget.Environment, name!);
+            var storage = new VolatileSecureStorage();
+            var paths = new ProbePaths(directory);
+            var manager = new ConfigurationManager(storage, new FileSystemAppFileStore(), paths, NullLogger<ConfigurationManager>.Instance);
+            await manager.SaveConfigurationAsync(profile);
+            var reloaded = await manager.LoadConfigurationAsync(profile.Id);
+            Assert.NotNull(reloaded);
+            var yaml = await File.ReadAllTextAsync(Path.Combine(paths.ConfigRootPath, "servers", "acceptance.yaml"), token);
+            Assert.DoesNotContain(secret!, yaml, StringComparison.Ordinal);
+            var factory = new TransportFactory(Log.Logger, new TransportSupportPolicy(new PlatformCapabilityService()), new DesktopStdioTransportFactory());
+            using var transport = factory.CreateTransport(reloaded);
+            using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
+            var text = new StringBuilder();
+            client.SessionUpdateReceived += (_, update) =>
+            {
+                if (update.Update is AgentMessageUpdate { Content: TextContentBlock content })
+                    lock (text) text.Append(content.Text);
+            };
+
+            // Act: the configured real Agent uses its normal credential environment, never an ACP metadata secret.
+            await client.InitializeAsync(new InitializeParams(new ClientInfo("salmon-egg-credential-interop", "1"), new ClientCapabilities()), token);
+            var invocation = Assert.IsAssignableFrom<IStdioInvocationSource>(transport).StdioInvocation;
+            Assert.NotNull(invocation);
+            Assert.True(invocation.Environment.TryGetValue(name!, out var injected) && injected == secret,
+                "The effective launch snapshot must contain the explicit binding.");
+            var session = await client.CreateSessionAsync(new SessionNewParams(directory, []), token);
+            var marker = "CREDENTIAL_BOUND_" + Guid.NewGuid().ToString("N");
+            await client.SendPromptAsync(new SessionPromptParams(session.SessionId,
+                [new TextContentBlock("Do not use tools or access files. Reply with exactly: " + marker)]), token);
+            lock (text) Assert.Contains(marker, text.ToString(), StringComparison.Ordinal);
+            Assert.True(await client.DisconnectAsync());
+            reloaded.Authentication = null;
+            await manager.SaveConfigurationAsync(reloaded);
+            var cleared = await manager.LoadConfigurationAsync(profile.Id);
+
+            // Assert: clearing retains the explicit binding, and cannot fall back to an inherited secret.
+            Assert.NotNull(cleared);
+            var resolution = CredentialBindingResolver.Resolve(cleared);
+            Assert.False(resolution.IsSuccess);
+            Assert.Equal(CredentialBindingValidationError.MissingCredential, resolution.ErrorKind);
+            Assert.Throws<InvalidOperationException>(() => factory.CreateTransport(cleared));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private sealed class ProbePaths(string root) : IAppDataService
+    {
+        public string AppDataRootPath => root;
+        public string ConfigRootPath => Path.Combine(root, "config");
+        public string LogsDirectoryPath => Path.Combine(root, "logs");
+        public string CacheRootPath => Path.Combine(root, "cache");
+        public string ExportsDirectoryPath => Path.Combine(root, "exports");
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/ChatElicitationRoutingTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/Interactions/ChatElicitationRoutingTests.cs
@@ -204,9 +204,24 @@ public sealed class ChatElicitationRoutingTests
         launcher.Setup(x => x.OpenAsync(It.IsAny<ExternalUriTarget>(), It.IsAny<CancellationToken>())).ReturnsAsync(ExternalUriOpenResult.Dispatched);
         using var previous = ElicitationInteractionViewModelFactory.Create(oldArgs!, _ => Task.CompletedTask, uriLauncher: launcher.Object);
         using var current = ElicitationInteractionViewModelFactory.Create(newArgs!, _ => Task.CompletedTask, uriLauncher: launcher.Object);
+        var expired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        previous.PropertyChanged += OnPreviousChanged;
+
+        void OnPreviousChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName == nameof(previous.FullUrl) && previous.FullUrl.Length == 0) expired.TrySetResult();
+        }
 
         // Act
-        await oldClient.DisconnectAsync();
+        try
+        {
+            await oldClient.DisconnectAsync();
+            await expired.Task.WaitAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            previous.PropertyChanged -= OnPreviousChanged;
+        }
         oldTransport.Raise(t => t.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
             """{"jsonrpc":"2.0","method":"elicitation/complete","params":{"elicitationId":"opaque"}}"""));
         await previous.SubmitCommand.ExecuteAsync(null);


### PR DESCRIPTION
新增可重复执行的真实 ACP 互操作门禁：使用本次构建的生产 SDK、stdio transport 和 adapter，验证已安装第三方 Agent 的 initialize/session/new/prompt、标准表单、经 MCP 发起的 URL consent/completion，以及官方 Rust V2 Agent 的 prompt/close/resume replay。真实 Agent 用例需要显式配置命令与凭据，不在无凭据 CI 冒充执行。

CI 新增固定发行版 acpremote 1.9.0 的 WebSocket↔stdio 桥取消门禁：真实 bridge 子进程、原始ID、cancel terminal response、后续请求和断连均使用既有 ProductionBridgeCancellationTests，缺执行或skip都会失败。它验固定可部署发行版，不代表未提供的生产部署。

本机实际结果：Codex 1.10.0、Hermes 0.21.1、Pi ACP 0.0.33、OpenCode 1.3.15 的真实客户端对话通过；Claude adapter 0.75.1握手可用，但此次模型回复超时，按用户授权跳过该LLM验收。Codex表单和URL标准交互通过，官方RustV2例程通过，bridge 1/1零skip。本地五种Agent均对V2协商返回V1；V2例程是官方独立实现，不称第三方LLM产品。

真实凭据额外验证：原配置保存/读取和 TransportFactory 的有效启动快照包含 CODEX_API_KEY，真实 Codex prompt通过；清除凭据后仍保留绑定并在 TransportFactory 创建连接前拒绝。现有Agent登录可能同时存在，因此不将prompt成功当作该key独占被使用的证明。测试使用 VolatileSecureStorage seam，不声明原生keyring跨重启验收。

Refs #144, #146, #148, #149, #154。
