### PR TITLE
feat(macos): verify native URL consent and external browser isolation

### DIFF
--- a/.github/workflows/macos-native-acceptance.yml
+++ b/.github/workflows/macos-native-acceptance.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/gates/macos-desktop-input-probe.swift'
       - 'scripts/gates/run-macos-desktop-input-probe.py'
       - 'scripts/gates/macos-elicitation-consent-smoke.py'
+      - 'scripts/gates/macos-elicitation-reverse-verification.py'
       - 'scripts/gates/macos-native-ui.swift'
       - 'src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs'
 
@@ -50,6 +51,9 @@ jobs:
       - name: Verify native consent and system browser isolation
         timeout-minutes: 5
         run: python3 scripts/gates/macos-elicitation-consent-smoke.py
+      - name: Verify rejection without consent and the rebuilt original
+        timeout-minutes: 12
+        run: python3 scripts/gates/macos-elicitation-reverse-verification.py
       - name: Upload native desktop evidence
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -62,4 +66,8 @@ jobs:
             artifacts/macos-elicitation-consent/*.jsonl
             artifacts/macos-elicitation-consent/*.log
             artifacts/macos-elicitation-consent/*.png
+            artifacts/macos-elicitation-reverse/**/*.json
+            artifacts/macos-elicitation-reverse/**/*.jsonl
+            artifacts/macos-elicitation-reverse/**/*.log
+            artifacts/macos-elicitation-reverse/**/*.png
           if-no-files-found: error

--- a/.github/workflows/macos-native-acceptance.yml
+++ b/.github/workflows/macos-native-acceptance.yml
@@ -1,0 +1,38 @@
+name: macOS Native Acceptance
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/macos-native-acceptance.yml'
+      - 'scripts/gates/macos-desktop-input-probe.swift'
+      - 'scripts/gates/run-macos-desktop-input-probe.py'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-native-acceptance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-desktop:
+    name: macOS Native Desktop Input
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - name: Exercise native Cocoa input with the selected Xcode
+        timeout-minutes: 3
+        run: python3 scripts/gates/run-macos-desktop-input-probe.py
+      - name: Upload native desktop evidence
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: macos-native-desktop-input
+          path: |
+            artifacts/macos-native-input/*.json
+            artifacts/macos-native-input/*.log
+          if-no-files-found: error

--- a/.github/workflows/macos-native-acceptance.yml
+++ b/.github/workflows/macos-native-acceptance.yml
@@ -11,7 +11,13 @@ on:
       - 'scripts/gates/macos-elicitation-consent-smoke.py'
       - 'scripts/gates/macos-elicitation-reverse-verification.py'
       - 'scripts/gates/macos-native-ui.swift'
+      - 'scripts/gates/fixtures/native-elicitation-peer.py'
       - 'src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs'
+      - 'src/SalmonEgg.Infrastructure.Desktop/Services/PlatformShellService.cs'
+      - 'src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/**'
+      - 'SalmonEgg/SalmonEgg/DependencyInjection.cs'
+      - 'SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml'
+      - 'SalmonEgg/SalmonEgg/Presentation/Diagnostics/NativeElicitationProbeDriver.cs'
 
 permissions:
   contents: read

--- a/.github/workflows/macos-native-acceptance.yml
+++ b/.github/workflows/macos-native-acceptance.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/macos-native-acceptance.yml'
       - 'scripts/gates/macos-desktop-input-probe.swift'
       - 'scripts/gates/run-macos-desktop-input-probe.py'
+      - 'scripts/gates/macos-elicitation-consent-smoke.py'
+      - 'scripts/gates/macos-native-ui.swift'
+      - 'src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs'
 
 permissions:
   contents: read
@@ -20,13 +23,33 @@ jobs:
   native-desktop:
     name: macOS Native Desktop Input
     runs-on: macos-15
-    timeout-minutes: 5
+    timeout-minutes: 20
+    env:
+      DOTNET_PROCESSOR_COUNT: '2'
+      DOTNET_CLI_USE_MSBUILD_SERVER: '0'
+      MSBUILDDISABLENODEREUSE: '1'
+      UseSharedCompilation: 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
       - name: Exercise native Cocoa input with the selected Xcode
         timeout-minutes: 3
         run: python3 scripts/gates/run-macos-desktop-input-probe.py
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+      - name: Build the current native macOS application
+        timeout-minutes: 10
+        run: |
+          dotnet build SalmonEgg/SalmonEgg/SalmonEgg.csproj -c Debug -f net10.0-desktop \
+            -p:SalmonEggTargetFrameworks=net10.0-desktop -p:SalmonEggAllTargetFrameworks=net10.0-desktop \
+            -p:UseSharedCompilation=false -m:1 --disable-build-servers
+      - name: Verify native consent and system browser isolation
+        timeout-minutes: 5
+        run: python3 scripts/gates/macos-elicitation-consent-smoke.py
       - name: Upload native desktop evidence
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -35,4 +58,7 @@ jobs:
           path: |
             artifacts/macos-native-input/*.json
             artifacts/macos-native-input/*.log
+            artifacts/macos-elicitation-consent/*.json
+            artifacts/macos-elicitation-consent/*.jsonl
+            artifacts/macos-elicitation-consent/*.log
           if-no-files-found: error

--- a/.github/workflows/macos-native-acceptance.yml
+++ b/.github/workflows/macos-native-acceptance.yml
@@ -61,4 +61,5 @@ jobs:
             artifacts/macos-elicitation-consent/*.json
             artifacts/macos-elicitation-consent/*.jsonl
             artifacts/macos-elicitation-consent/*.log
+            artifacts/macos-elicitation-consent/*.png
           if-no-files-found: error

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -301,7 +301,11 @@ python3 scripts/gates/skia-elicitation-consent-smoke.py \
 
 门禁使用隔离 AppData 中的真实 stdio 配置、已恢复的 conversation、生产聊天卡片和 XTest 鼠标输入；独立 DEBUG driver 仅导航到该 conversation 并读取可见控件，不创建测试 UI、不替换 launcher、不代用户同意。依次验证拒绝、取消零外访，打开与重开两次真实沙箱浏览器访问、单次 ACP accept，Agent complete 更新以及断连后清除 URL 和禁用旧操作。外部页面检查 `opener`、`referrer` 为空，页面私密值不进入 ACP 或应用日志。默认浏览器注册只写本次隔离的 XDG 配置，不修改用户设置；浏览器无调试桥、未关闭沙箱，结束时回收本门禁的进程组。协议对端是确定性 fixture，不能代替独立第三方 Agent 验收。
 
-Linux 产品能力注册与此 CI 门禁一同交付；CI 不会动态修改能力。Windows、macOS、iOS、Android 仍需各自原生产品验收后启用 URL 能力；Unix 终端认证另受当前 Porta.Pty 未公开信号退出状态的限制。本门禁不构成终端认证或其它原生平台的验证。源码移除 Linux launcher 注册时，`Native URL capability not advertised` 必须使该门禁失败。
+Linux 产品能力注册与此 CI 门禁一同交付；CI 不会动态修改能力。源码移除 Linux launcher 注册时，`Native URL capability not advertised` 必须使该门禁失败。该门禁不构成终端认证或其它原生平台的验证。
+
+macOS 的 `macOS Native Acceptance` workflow 使用本次 Debug Skia 产物、生产 stdio 链、真实 CGEvent 鼠标操作和 LaunchServices 默认浏览器验证同一 URL 流程：拒绝/取消零外访、打开与重开两次访问且只有一次 ACP accept、Agent 完成通知和断线失效。只有应用真实前台且系统窗口顺序已切回，才执行产品按钮操作。当前 Uno 依赖的 AX 控件树尚不完整，门禁使用独立 Debug 诊断组件只读采样按钮几何，再结合系统 AX 窗口几何定位；这不等于完整读屏验收。临时 Python fixture 的本地网络系统授权通过正常 Allow 按钮处理，不修改 TCC 数据库或全局安全设置。
+
+该 workflow 还临时加入未经用户同意的真实浏览器启动，要求门禁明确失败；随后按字节恢复源码、重新构建，再跑完整流程。证据包含提交、产物散列、进程来源、系统输入、浏览器隔离和恢复散列。Windows、iOS、Android 各自使用独立原生产品门禁；Unix 终端认证仍因当前 Porta.Pty 未公开信号退出状态而关闭。
 
 该 gate 与 Windows FlaUI / WASM Playwright gate 分工不同：
 

--- a/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NativeElicitationProbeDriver.cs
+++ b/SalmonEgg/SalmonEgg/Presentation/Diagnostics/NativeElicitationProbeDriver.cs
@@ -110,10 +110,11 @@ internal static class NativeElicitationProbeDriver
         var bounds = button.TransformToVisual(null).TransformBounds(new Rect(0, 0, button.ActualWidth, button.ActualHeight));
         var scale = button.XamlRoot!.RasterizationScale;
         logger.LogInformation(
-            "NativeElicitationProbe button seq={Sequence} action={Action} enabled={Enabled} x={X} y={Y} width={Width} height={Height}",
+            "NativeElicitationProbe button seq={Sequence} action={Action} enabled={Enabled} x={X} y={Y} width={Width} height={Height} rootHeight={RootHeight} scale={Scale}",
             sequence, action, button.IsEnabled,
             (int)Math.Round(bounds.X * scale), (int)Math.Round(bounds.Y * scale),
-            (int)Math.Round(bounds.Width * scale), (int)Math.Round(bounds.Height * scale));
+            (int)Math.Round(bounds.Width * scale), (int)Math.Round(bounds.Height * scale),
+            (int)Math.Round(button.XamlRoot.Size.Height * scale), scale);
     }
 
     private static bool IsVisible(FrameworkElement element)

--- a/scripts/gates/macos-desktop-input-probe.swift
+++ b/scripts/gates/macos-desktop-input-probe.swift
@@ -1,0 +1,101 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+// This process owns its native window. Input comes through CGEvent rather than NSTextField.stringValue.
+final class DesktopProbe: NSObject, NSApplicationDelegate, NSTextFieldDelegate {
+    private let output: URL
+    private var window: NSWindow?
+    private var input: NSTextField?
+    private var timer: Timer?
+    private var delivered = false
+    private var finished = false
+    private let started = Date()
+
+    init(output: URL) {
+        self.output = output
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        writeResult(passed: false, phase: "window-create")
+        let form = NSWindow(contentRect: NSRect(x: 120, y: 160, width: 500, height: 160),
+                            styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        form.title = "SalmonEgg native desktop acceptance"
+        let field = NSTextField(frame: NSRect(x: 30, y: 55, width: 440, height: 28))
+        field.delegate = self
+        form.contentView?.addSubview(field)
+        self.window = form
+        self.input = field
+        form.makeKeyAndOrderFront(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        form.makeFirstResponder(field)
+        writeResult(passed: false, phase: "native-input")
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        if input?.stringValue == "x" {
+            finish(passed: true, phase: "complete")
+        }
+    }
+
+    private func tick() {
+        if finished { return }
+        if !delivered && window?.isKeyWindow == true {
+            delivered = true
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 7, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: 7, keyDown: false) else {
+                finish(passed: false, phase: "event-allocation")
+                return
+            }
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+        }
+        if Date().timeIntervalSince(started) >= 15 {
+            finish(passed: false, phase: "input-timeout")
+        }
+    }
+
+    private func finish(passed: Bool, phase: String) {
+        if finished { return }
+        finished = true
+        timer?.invalidate()
+        writeResult(passed: passed, phase: phase)
+        window?.close()
+        NSApplication.shared.stop(nil)
+        exit(passed ? 0 : 1)
+    }
+
+    private func writeResult(passed: Bool, phase: String) {
+        let result: [String: Any] = [
+            "processId": ProcessInfo.processInfo.processIdentifier,
+            "phase": phase,
+            "eventPosted": delivered,
+            "nativeTextReceived": input?.stringValue == "x",
+            "eventPostingAccess": CGPreflightPostEventAccess(),
+            "screenCount": NSScreen.screens.count,
+            "privacySettingsChanged": false,
+            "passed": passed
+        ]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: output, options: .atomic)
+            print(String(decoding: data, as: UTF8.self))
+        } catch {
+            fputs("Unable to write native desktop evidence: \(error)\n", stderr)
+            exit(2)
+        }
+    }
+}
+
+guard CommandLine.arguments.count == 2 else {
+    fputs("Expected one result JSON path.\n", stderr)
+    exit(2)
+}
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let probe = DesktopProbe(output: URL(fileURLWithPath: CommandLine.arguments[1]))
+app.delegate = probe
+app.run()

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -133,8 +133,11 @@ def main():
                 return values if count >= 3 else None
 
             x, y, width, height, root_height, scale = map(float, wait(locate, 'No stable enabled native button'))
+            subprocess.run(['screencapture', '-x', str(output / ('before-' + action + '.png'))], check=True, timeout=5)
             attempt = subprocess.run([str(ax_tool), 'pointer', str(app.pid), str((x + width / 2) / scale),
                                       str((y + height / 2) / scale), str(root_height / scale)], capture_output=True, text=True, timeout=5)
+            with (output / 'native-pointer.log').open('a') as log:
+                log.write(attempt.stdout + attempt.stderr)
             assert attempt.returncode == 0, attempt.stderr
 
         def replies(action):

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -117,13 +117,25 @@ def main():
                 and (completed is None or f'completed={completed}' in value)
 
         def click(title):
-            def locate_and_click():
-                attempt = subprocess.run([str(ax_tool), 'click', str(app.pid), title], capture_output=True, text=True, timeout=5)
-                if attempt.returncode == 3:
-                    return False
-                assert attempt.returncode == 0, attempt.stderr
-                return True
-            wait(locate_and_click, 'No native AX button with the requested title')
+            action = {'Decline': 'decline', 'Cancel': 'cancel', 'Open in browser': 'submit',
+                      'Open again': 'reopen', 'Close notice': 'dismiss'}[title]
+            previous, count = None, 0
+
+            def locate():
+                nonlocal previous, count
+                text = stdout.read_text().split('NativeElicitationProbe sample')[-1]
+                found = re.search(rf'button seq=\d+ action={action} enabled=True x=(\d+) y=(\d+) width=(\d+) height=(\d+) rootHeight=(\d+) scale=([0-9.]+)', text)
+                if not found:
+                    return None
+                values = found.groups()
+                count = count + 1 if values == previous else 1
+                previous = values
+                return values if count >= 3 else None
+
+            x, y, width, height, root_height, scale = map(float, wait(locate, 'No stable enabled native button'))
+            attempt = subprocess.run([str(ax_tool), 'pointer', str(app.pid), str((x + width / 2) / scale),
+                                      str((y + height / 2) / scale), str(root_height / scale)], capture_output=True, text=True, timeout=5)
+            assert attempt.returncode == 0, attempt.stderr
 
         def replies(action):
             return [x for x in seed.read_json_lines(peer_log) if x.get('id') == 'native-url-' + action]

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Drive the actual macOS Skia application and LaunchServices browser using native AX/CGEvent."""
+
+import argparse
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+
+def module(path):
+    spec = importlib.util.spec_from_file_location("linux_seed", path)
+    value = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(value)
+    return value
+
+
+def main():
+    if sys.platform != "darwin":
+        raise SystemExit("macOS native URL acceptance requires macOS.")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=Path("artifacts/macos-elicitation-consent"))
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    repo = Path(__file__).resolve().parents[2]
+    helpers = repo / "scripts/gates"
+    seed = module(helpers / "skia-elicitation-consent-smoke.py")
+    app_path = repo / "SalmonEgg/SalmonEgg/bin/Debug/net10.0-desktop/SalmonEgg"
+    assert app_path.is_file(), "Build this tree's Debug Skia product first."
+    ax_tool = output / "native-ui"
+    subprocess.run(["xcrun", "swiftc", str(helpers / "macos-native-ui.swift"), "-framework", "AppKit",
+                    "-framework", "ApplicationServices", "-o", str(ax_tool)], check=True, timeout=90)
+    # LaunchServices may attach to an existing browser; do not close any process already running.
+    original_pids = set(json.loads(subprocess.check_output([str(ax_tool), "pids", "all"], text=True)))
+    reports, visits = [], []
+    private_value = "native-macos-page-private"
+    nonce = os.urandom(16).hex()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_GET(self):
+            if self.path != "/authorize?token=" + nonce:
+                self.send_error(404)
+                return
+            visits.append(self.headers.get("Referer"))
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(("<!doctype html><input id=private value=" + private_value + ">"
+                "<script>fetch('/report',{method:'POST',body:JSON.stringify({opener:window.opener===null,"
+                "referrer:document.referrer,privateValue:document.querySelector('#private').value})});</script>").encode())
+
+        def do_POST(self):
+            reports.append(json.loads(self.rfile.read(int(self.headers["Content-Length"]))))
+            self.send_response(204)
+            self.end_headers()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    appdata = output / "appdata"
+    appdata.mkdir(exist_ok=False)
+    scenario, peer_log, control = output / "scenario.json", output / "peer.jsonl", output / "control.json"
+    project = seed.seed_profile(appdata, scenario, helpers / "fixtures/native-elicitation-peer.py")
+    url = f"http://127.0.0.1:{server.server_port}/authorize?token={nonce}"
+    scenario.write_text(json.dumps({"url": url, "log": str(peer_log), "control": str(control), "cwd": str(project)}))
+    scenario.chmod(0o600)
+    environment = dict(os.environ, SALMONEGG_APPDATA_ROOT=str(appdata), SALMONEGG_GUI="1",
+                       SALMONEGG_NATIVE_ELICITATION_PROBE="1", DOTNET_PROCESSOR_COUNT="2")
+    stdout = output / "stdout.log"
+    app = None
+    try:
+        with stdout.open("w") as log:
+            app = subprocess.Popen([str(app_path)], cwd=app_path.parent, env=environment,
+                stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        provenance = {"commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip(),
+            "app": str(app_path), "sha256": hashlib.sha256(app_path.with_suffix('.dll').read_bytes()).hexdigest(),
+            "pid": app.pid, "peer": "deterministic stdio fixture", "input": "native AX positions and CGEvent clicks"}
+        (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+        deadline = time.monotonic() + 170
+
+        def wait(predicate, message, timeout=30):
+            until = min(deadline, time.monotonic() + timeout)
+            while time.monotonic() < until:
+                assert app.poll() is None, "The current app exited before acceptance."
+                value = predicate()
+                if value:
+                    return value
+                time.sleep(0.1)
+            raise AssertionError(message)
+
+        initialized = wait(lambda: next((x for x in seed.read_json_lines(peer_log) if x.get('method') == 'initialize'), None), 'initialize did not complete')
+        assert initialized['capabilities'].get('elicitation', {}).get('url') == {}, 'macOS URL capability missing'
+        wait(lambda: 'Reason=SessionLoadCompleted' in stdout.read_text(), 'Authoritative session restore did not complete')
+        phase = 0
+
+        def instruct(action):
+            nonlocal phase
+            phase += 1
+            temporary = control.with_suffix('.tmp')
+            temporary.write_text(json.dumps({'phase': phase, 'action': action}))
+            temporary.replace(control)
+
+        def state(stage, completed=None):
+            value = stdout.read_text().split('NativeElicitationProbe sample')[-1]
+            return f'stage={stage} ' in value and 'visible=True' in value and 'url=True' in value and 'host=True' in value \
+                and (completed is None or f'completed={completed}' in value)
+
+        def click(title):
+            def locate_and_click():
+                attempt = subprocess.run([str(ax_tool), 'click', str(app.pid), title], capture_output=True, text=True, timeout=5)
+                if attempt.returncode == 3:
+                    return False
+                assert attempt.returncode == 0, attempt.stderr
+                return True
+            wait(locate_and_click, 'No native AX button with the requested title')
+
+        def replies(action):
+            return [x for x in seed.read_json_lines(peer_log) if x.get('id') == 'native-url-' + action]
+
+        for action, title in [('decline', 'Decline'), ('cancel', 'Cancel')]:
+            instruct(action)
+            wait(lambda: state(action), 'Consent card not visible')
+            assert not visits, 'macOS opened URL before consent'
+            click(title)
+            response = wait(lambda: replies(action), 'Native action did not reply')
+            assert len(response) == 1 and response[0].get('result') == {'action': action}
+            assert not visits
+        instruct('open')
+        wait(lambda: state('open'), 'Open card not visible')
+        assert not visits
+        click('Open in browser')
+        response = wait(lambda: replies('open'), 'No native consent response')
+        assert len(response) == 1 and response[0].get('result') == {'action': 'accept'}
+        wait(lambda: len(reports) == 1, 'System browser did not visit', 45)
+        assert state('open', 'False')
+        click('Open again')
+        wait(lambda: len(reports) == 2, 'System browser did not reopen', 45)
+        assert len(replies('open')) == 1
+        instruct('complete')
+        wait(lambda: state('open', 'True'), 'Agent completion not projected')
+        click('Close notice')
+        instruct('expire')
+        wait(lambda: state('expire'), 'Next request could not occupy the native card')
+        instruct('disconnect')
+
+        def expired():
+            sample = stdout.read_text().split('NativeElicitationProbe sample')[-1]
+            return 'stage=none' in sample or ('stage=expire' in sample and 'url=False' in sample
+                and 'host=False' in sample and 'action=submit enabled=False' in sample)
+
+        wait(expired, 'Disconnect left the original URL or open action active')
+        assert not replies('expire')
+        for action in ('decline', 'cancel', 'open'):
+            assert len(replies(action)) == 1
+        assert reports == [{'opener': True, 'referrer': '', 'privateValue': private_value}] * 2
+        assert visits == [None, None]
+        assert private_value not in stdout.read_text() + peer_log.read_text() and url not in stdout.read_text()
+        report = {'passed': True, 'nativePointerActions': 5, 'browserVisits': 2,
+                  'singleAccept': True, 'agentCompletion': True, 'disconnectExpiry': True, 'privatePageNotReturned': True}
+        (output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
+        print(json.dumps(report))
+    finally:
+        if app is not None:
+            try:
+                os.killpg(app.pid, signal.SIGTERM)
+                app.wait(timeout=5)
+            except ProcessLookupError:
+                pass
+            except subprocess.TimeoutExpired:
+                os.killpg(app.pid, signal.SIGKILL)
+                app.wait(timeout=3)
+            try: os.killpg(app.pid, signal.SIGKILL)
+            except ProcessLookupError: pass
+        # Only terminate newly opened browser processes, never unrelated or pre-existing applications.
+        new_pids = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True))) - original_pids
+        for pid in new_pids:
+            try: os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError: pass
+        until = time.monotonic() + 5
+        while time.monotonic() < until:
+            remaining = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True))) & new_pids
+            if not remaining:
+                break
+            time.sleep(0.1)
+        else:
+            for pid in remaining:
+                try: os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError: pass
+        server.shutdown()
+        server.server_close()
+        scenario.unlink(missing_ok=True)
+
+
+if __name__ == '__main__':
+    sys.dont_write_bytecode = True
+    def interrupt(_signum, _frame):
+        raise KeyboardInterrupt('Native Mac gate interrupted')
+    signal.signal(signal.SIGTERM, interrupt)
+    main()

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -185,44 +185,59 @@ def main():
         assert reports == [{'opener': True, 'referrer': '', 'privateValue': private_value}] * 2
         assert visits == [None, None]
         assert private_value not in stdout.read_text() + peer_log.read_text() and url not in stdout.read_text()
+        persisted = list(appdata.rglob('*'))
+        for path in persisted:
+            if path.is_file():
+                content = path.read_bytes()
+                assert private_value.encode() not in content and nonce.encode() not in content, \
+                    'Private URL or page data persisted in application data: ' + str(path.relative_to(appdata))
         report = {'passed': True, 'nativePointerActions': 5, 'browserVisits': 2,
                   'singleAccept': True, 'agentCompletion': True, 'disconnectExpiry': True, 'privatePageNotReturned': True}
         (output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
         print(json.dumps(report))
     finally:
-        (output / 'browser-observation.json').write_text(json.dumps({'visits': len(visits), 'reports': reports}, indent=2))
-        subprocess.run(['screencapture', '-x', str(output / 'final-screen.png')], timeout=5)
+        try:
+            (output / 'browser-observation.json').write_text(json.dumps({'visits': len(visits), 'reports': reports}, indent=2))
+            subprocess.run(['screencapture', '-x', str(output / 'final-screen.png')], timeout=5)
+            if app is not None:
+                with (output / 'native-controls.json').open('w') as tree:
+                    subprocess.run([str(ax_tool), 'describe', str(app.pid)], stdout=tree, timeout=10)
+        except (OSError, subprocess.SubprocessError) as error:
+            print('Best-effort native diagnostic failed: ' + type(error).__name__, file=sys.stderr)
+        cleanup_errors = []
         if app is not None:
-            with (output / 'native-controls.json').open('w') as tree:
-                subprocess.run([str(ax_tool), 'describe', str(app.pid)], stdout=tree, timeout=10)
             try:
-                os.killpg(app.pid, signal.SIGTERM)
-                app.wait(timeout=5)
-            except ProcessLookupError:
-                pass
-            except subprocess.TimeoutExpired:
-                os.killpg(app.pid, signal.SIGKILL)
-                app.wait(timeout=3)
-            try: os.killpg(app.pid, signal.SIGKILL)
-            except ProcessLookupError: pass
-        # Only terminate newly opened browser processes, never unrelated or pre-existing applications.
-        new_pids = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True))) - original_pids
-        for pid in new_pids:
-            try: os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError: pass
-        until = time.monotonic() + 5
-        while time.monotonic() < until:
-            remaining = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True))) & new_pids
-            if not remaining:
-                break
-            time.sleep(0.1)
-        else:
-            for pid in remaining:
-                try: os.kill(pid, signal.SIGKILL)
+                try: os.killpg(app.pid, signal.SIGTERM)
                 except ProcessLookupError: pass
-        server.shutdown()
-        server.server_close()
-        scenario.unlink(missing_ok=True)
+                try: app.wait(timeout=5)
+                except subprocess.TimeoutExpired: pass
+            finally:
+                try: os.killpg(app.pid, signal.SIGKILL)
+                except ProcessLookupError: pass
+                try: app.wait(timeout=3)
+                except subprocess.TimeoutExpired: cleanup_errors.append('Product process did not exit')
+        # Only terminate newly opened browser processes, never unrelated or pre-existing applications.
+        try:
+            new_pids = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True, timeout=5))) - original_pids
+            for pid in new_pids:
+                try: os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError: pass
+            until = time.monotonic() + 5
+            while time.monotonic() < until:
+                remaining = set(json.loads(subprocess.check_output([str(ax_tool), 'pids', 'all'], text=True, timeout=5))) & new_pids
+                if not remaining:
+                    break
+                time.sleep(0.1)
+            else:
+                for pid in remaining:
+                    try: os.kill(pid, signal.SIGKILL)
+                    except ProcessLookupError: pass
+        finally:
+            try: server.shutdown()
+            finally:
+                server.server_close()
+                scenario.unlink(missing_ok=True)
+        assert not cleanup_errors, '; '.join(cleanup_errors)
 
 
 if __name__ == '__main__':

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -139,7 +139,7 @@ def main():
             assert permission.returncode == 0, 'Could not handle the matching temporary fixture permission prompt'
             subprocess.run(['screencapture', '-x', str(output / ('before-' + action + '.png'))], check=True, timeout=5)
             attempt = subprocess.run([str(ax_tool), 'pointer', str(app.pid), str((x + width / 2) / scale),
-                                      str((y + height / 2) / scale), str(root_height / scale)], capture_output=True, text=True, timeout=5)
+                                      str((y + height / 2) / scale), str(root_height / scale)], capture_output=True, text=True, timeout=10)
             with (output / 'native-pointer.log').open('a') as log:
                 log.write(attempt.stdout + attempt.stderr)
             assert attempt.returncode == 0, attempt.stderr

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -172,6 +172,8 @@ def main():
         print(json.dumps(report))
     finally:
         if app is not None:
+            with (output / 'native-controls.json').open('w') as tree:
+                subprocess.run([str(ax_tool), 'describe', str(app.pid)], stdout=tree, timeout=10)
             try:
                 os.killpg(app.pid, signal.SIGTERM)
                 app.wait(timeout=5)

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -154,10 +154,10 @@ def main():
             click(title)
             response = wait(lambda: replies(action), 'Native action did not reply')
             assert len(response) == 1 and response[0].get('result') == {'action': action}
-            assert not visits
+            assert not visits, 'macOS opened URL before consent'
         instruct('open')
         wait(lambda: state('open'), 'Open card not visible')
-        assert not visits
+        assert not visits, 'macOS opened URL before consent'
         click('Open in browser')
         response = wait(lambda: replies('open'), 'No native consent response')
         assert len(response) == 1 and response[0].get('result') == {'action': 'accept'}

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -190,6 +190,8 @@ def main():
         (output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
         print(json.dumps(report))
     finally:
+        (output / 'browser-observation.json').write_text(json.dumps({'visits': len(visits), 'reports': reports}, indent=2))
+        subprocess.run(['screencapture', '-x', str(output / 'final-screen.png')], timeout=5)
         if app is not None:
             with (output / 'native-controls.json').open('w') as tree:
                 subprocess.run([str(ax_tool), 'describe', str(app.pid)], stdout=tree, timeout=10)

--- a/scripts/gates/macos-elicitation-consent-smoke.py
+++ b/scripts/gates/macos-elicitation-consent-smoke.py
@@ -133,6 +133,10 @@ def main():
                 return values if count >= 3 else None
 
             x, y, width, height, root_height, scale = map(float, wait(locate, 'No stable enabled native button'))
+            permission = subprocess.run([str(ax_tool), 'allow-local-network', 'python-fixture'], capture_output=True, text=True, timeout=10)
+            with (output / 'system-permission.log').open('a') as log:
+                log.write(permission.stdout + permission.stderr)
+            assert permission.returncode == 0, 'Could not handle the matching temporary fixture permission prompt'
             subprocess.run(['screencapture', '-x', str(output / ('before-' + action + '.png'))], check=True, timeout=5)
             attempt = subprocess.run([str(ax_tool), 'pointer', str(app.pid), str((x + width / 2) / scale),
                                       str((y + height / 2) / scale), str(root_height / scale)], capture_output=True, text=True, timeout=5)

--- a/scripts/gates/macos-elicitation-reverse-verification.py
+++ b/scripts/gates/macos-elicitation-reverse-verification.py
@@ -3,7 +3,9 @@
 
 import hashlib
 import json
+import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
 
@@ -28,7 +30,19 @@ def main():
 
     def run(command, name, timeout):
         with (output / name).open("w") as log:
-            return subprocess.run(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, timeout=timeout).returncode
+            process = subprocess.Popen(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+            try:
+                return process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # Give the native gate its signal handler/finally before enforcing the outer bound.
+                os.killpg(process.pid, signal.SIGTERM)
+                try: process.wait(timeout=30)
+                except subprocess.TimeoutExpired: pass
+                raise
+            finally:
+                try: os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError: pass
+                process.wait(timeout=5)
 
     red_exit = None
     try:

--- a/scripts/gates/macos-elicitation-reverse-verification.py
+++ b/scripts/gates/macos-elicitation-reverse-verification.py
@@ -3,7 +3,6 @@
 
 import hashlib
 import json
-import os
 from pathlib import Path
 import subprocess
 import sys

--- a/scripts/gates/macos-elicitation-reverse-verification.py
+++ b/scripts/gates/macos-elicitation-reverse-verification.py
@@ -33,13 +33,12 @@ def main():
             process = subprocess.Popen(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
             try:
                 return process.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                # Give the native gate its signal handler/finally before enforcing the outer bound.
-                os.killpg(process.pid, signal.SIGTERM)
+            finally:
+                # Timeout and SIGTERM interrupt both give the child gate its own cleanup window.
+                try: os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError: pass
                 try: process.wait(timeout=30)
                 except subprocess.TimeoutExpired: pass
-                raise
-            finally:
                 try: os.killpg(process.pid, signal.SIGKILL)
                 except ProcessLookupError: pass
                 process.wait(timeout=5)
@@ -66,4 +65,7 @@ def main():
 
 
 if __name__ == "__main__":
+    def interrupt(_signum, _frame):
+        raise KeyboardInterrupt("Native Mac reverse verification interrupted")
+    signal.signal(signal.SIGTERM, interrupt)
     main()

--- a/scripts/gates/macos-elicitation-reverse-verification.py
+++ b/scripts/gates/macos-elicitation-reverse-verification.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Prove the native macOS consent gate rejects an actual unconsented browser launch."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    if sys.platform != "darwin":
+        raise SystemExit("macOS reverse verification requires the native macOS product.")
+    root = Path(__file__).resolve().parents[2]
+    output = root / "artifacts/macos-elicitation-reverse"
+    output.mkdir(parents=True, exist_ok=True)
+    source = root / "src/SalmonEgg.Presentation.Core/ViewModels/Chat/Elicitation/ElicitationInteractionViewModels.cs"
+    original = source.read_bytes()
+    anchor = b"        _requestState.Changed += OnRequestStateChanged;"
+    assert original.count(anchor) == 1
+    mutant = original.replace(anchor,
+        b"        if (_urlTarget is not null) _ = _uriLauncher.OpenAsync(_urlTarget, CancellationToken.None);\n"
+        + anchor)
+    build = ["dotnet", "build", "SalmonEgg/SalmonEgg/SalmonEgg.csproj", "-c", "Debug", "-f", "net10.0-desktop",
+        "-p:SalmonEggTargetFrameworks=net10.0-desktop", "-p:SalmonEggAllTargetFrameworks=net10.0-desktop",
+        "-p:UseSharedCompilation=false", "-m:1", "--disable-build-servers"]
+    gate = [sys.executable, "scripts/gates/macos-elicitation-consent-smoke.py", "--output"]
+
+    def run(command, name, timeout):
+        with (output / name).open("w") as log:
+            return subprocess.run(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, timeout=timeout).returncode
+
+    red_exit = None
+    try:
+        source.write_bytes(mutant)
+        assert run(build, "mutant-build.log", 600) == 0, "Mutant did not build."
+        red_exit = run([*gate, str(output / "red")], "red.log", 240)
+        assert red_exit != 0 and "macOS opened URL before consent" in (output / "red.log").read_text(), \
+            "The real product gate did not catch the unconsented browser launch."
+    finally:
+        source.write_bytes(original)
+        assert source.read_bytes() == original
+        assert run(build, "restored-build.log", 600) == 0, "Restored product did not rebuild."
+    assert run([*gate, str(output / "restored")], "restored.log", 240) == 0
+    record = {"passed": True, "source": str(source.relative_to(root)),
+        "originalSha256": hashlib.sha256(original).hexdigest(), "mutantSha256": hashlib.sha256(mutant).hexdigest(),
+        "restoredSha256": hashlib.sha256(source.read_bytes()).hexdigest(), "redExit": red_exit,
+        "failure": "macOS opened URL before consent", "restoredGatePassed": True,
+        "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()}
+    (output / "result.json").write_text(json.dumps(record, indent=2) + "\n")
+    print(json.dumps(record))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -1,0 +1,57 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+func attribute(_ element: AXUIElement, _ name: CFString) -> CFTypeRef? {
+    var value: CFTypeRef?
+    return AXUIElementCopyAttributeValue(element, name, &value) == .success ? value : nil
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
+}
+
+func findButton(_ element: AXUIElement, _ title: String, _ depth: Int = 0) -> AXUIElement? {
+    if depth > 30 { return nil }
+    let role = attribute(element, kAXRoleAttribute as CFString) as? String
+    let label = attribute(element, kAXTitleAttribute as CFString) as? String
+        ?? attribute(element, kAXDescriptionAttribute as CFString) as? String
+    let enabled = attribute(element, kAXEnabledAttribute as CFString) as? Bool ?? false
+    if role == kAXButtonRole as String && label == title && enabled { return element }
+    for child in children(element) {
+        if let found = findButton(child, title, depth + 1) { return found }
+    }
+    return nil
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count >= 3 else { exit(2) }
+if arguments[1] == "pids" {
+    let values = NSWorkspace.shared.runningApplications.filter {
+        ["com.apple.Safari", "com.google.Chrome", "org.mozilla.firefox", "com.microsoft.edgemac"].contains($0.bundleIdentifier ?? "")
+    }
+        .map { Int($0.processIdentifier) }
+    print(String(data: try JSONSerialization.data(withJSONObject: values), encoding: .utf8)!)
+    exit(0)
+}
+if arguments[1] == "click", arguments.count == 4, let pid = Int32(arguments[2]) {
+    let target = AXUIElementCreateApplication(pid)
+    AXUIElementSetMessagingTimeout(target, 2)
+    guard let button = findButton(target, arguments[3]),
+          let rawPosition = attribute(button, kAXPositionAttribute as CFString),
+          let rawSize = attribute(button, kAXSizeAttribute as CFString) else {
+        fputs("No enabled native AX button with the requested title.\n", stderr)
+        exit(3)
+    }
+    var position = CGPoint.zero
+    var size = CGSize.zero
+    guard AXValueGetValue(rawPosition as! AXValue, .cgPoint, &position),
+          AXValueGetValue(rawSize as! AXValue, .cgSize, &size), size.width > 0, size.height > 0 else { exit(4) }
+    NSRunningApplication(processIdentifier: pid)?.activate(options: [.activateIgnoringOtherApps])
+    let point = CGPoint(x: position.x + size.width / 2, y: position.y + size.height / 2)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    print("Native AX button located and CGEvent pointer delivered")
+    exit(0)
+}
+exit(2)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -11,6 +11,19 @@ func children(_ element: AXUIElement) -> [AXUIElement] {
     attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
 }
 
+func activate(_ pid: pid_t, _ window: AXUIElement) -> Bool {
+    guard let application = NSRunningApplication(processIdentifier: pid) else { return false }
+    let requested = application.activate(options: [.activateAllWindows])
+    _ = AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+    let deadline = Date().addingTimeInterval(5)
+    while Date() < deadline {
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+    }
+    fputs("Native application did not become foreground after activation request \(requested).\n", stderr)
+    return false
+}
+
 func findButton(_ element: AXUIElement, _ title: String, _ depth: Int = 0) -> AXUIElement? {
     if depth > 30 { return nil }
     let role = attribute(element, kAXRoleAttribute as CFString) as? String
@@ -113,7 +126,7 @@ if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]
     // Uno's native content frame begins below the OS window chrome. The current XamlRoot height
     // and the system AX frame determine that inset; no fixed titlebar pixel value is assumed.
     let point = CGPoint(x: position.x + localX, y: position.y + size.height - height + localY)
-    NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+    guard activate(pid, windows[0]) else { exit(9) }
     print("CGEvent target pid=\(pid) x=\(point.x) y=\(point.y) nativeWindow=\(position) size=\(size) contentHeight=\(height)")
     CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -11,8 +11,18 @@ func children(_ element: AXUIElement) -> [AXUIElement] {
     attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
 }
 
+func isFrontmost(_ pid: pid_t) -> Bool {
+    guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid,
+          let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]
+        else { return false }
+    // NSWorkspace changes before the app-switcher animation finishes. Native z-order must
+    // also expose the actual application window before mouse input can reach its content.
+    let front = windows.first { ($0[kCGWindowLayer as String] as? Int) == 0 }
+    return (front?[kCGWindowOwnerPID as String] as? Int) == Int(pid)
+}
+
 func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
-    if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
+    if isFrontmost(pid) { return true }
     let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
     if ["com.apple.Safari", "com.google.Chrome", "org.mozilla.firefox", "com.microsoft.edgemac"].contains(frontmost) {
         // Opening the system browser makes it frontmost. Return to the preceding product with
@@ -33,7 +43,7 @@ func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
     }
     let deadline = Date().addingTimeInterval(5)
     while Date() < deadline {
-        if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
+        if isFrontmost(pid) { return true }
         RunLoop.current.run(until: Date().addingTimeInterval(0.02))
     }
     fputs("Native application did not become foreground after native application activation.\n", stderr)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -34,6 +34,14 @@ func describeTree(_ element: AXUIElement, _ depth: Int = 0) -> [[String: Any]] {
                        "title": attribute(element, kAXTitleAttribute as CFString) as? String ?? "",
                        "description": attribute(element, kAXDescriptionAttribute as CFString) as? String ?? "",
                        "enabled": attribute(element, kAXEnabledAttribute as CFString) as? Bool ?? false])
+        if let raw = attribute(element, kAXPositionAttribute as CFString), CFGetTypeID(raw) == AXValueGetTypeID() {
+            var point = CGPoint.zero
+            if AXValueGetValue(raw as! AXValue, .cgPoint, &point) { result[result.count - 1]["position"] = [point.x, point.y] }
+        }
+        if let raw = attribute(element, kAXSizeAttribute as CFString), CFGetTypeID(raw) == AXValueGetTypeID() {
+            var size = CGSize.zero
+            if AXValueGetValue(raw as! AXValue, .cgSize, &size) { result[result.count - 1]["size"] = [size.width, size.height] }
+        }
     }
     for child in children(element) { result.append(contentsOf: describeTree(child, depth + 1)) }
     return result
@@ -54,6 +62,26 @@ if arguments[1] == "describe", let pid = Int32(arguments[2]) {
     AXUIElementSetMessagingTimeout(target, 2)
     let result: [String: Any] = ["trusted": AXIsProcessTrusted(), "pid": Int(pid), "tree": describeTree(target)]
     print(String(data: try JSONSerialization.data(withJSONObject: result), encoding: .utf8)!)
+    exit(0)
+}
+if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]),
+   let localX = Double(arguments[3]), let localY = Double(arguments[4]), let height = Double(arguments[5]) {
+    let target = AXUIElementCreateApplication(pid)
+    AXUIElementSetMessagingTimeout(target, 2)
+    guard let windows = attribute(target, kAXWindowsAttribute as CFString) as? [AXUIElement], windows.count == 1,
+          let rawPosition = attribute(windows[0], kAXPositionAttribute as CFString),
+          let rawSize = attribute(windows[0], kAXSizeAttribute as CFString) else { exit(5) }
+    var position = CGPoint.zero
+    var size = CGSize.zero
+    guard AXValueGetValue(rawPosition as! AXValue, .cgPoint, &position),
+          AXValueGetValue(rawSize as! AXValue, .cgSize, &size), size.height >= height else { exit(6) }
+    // Uno's native content frame begins below the OS window chrome. The current XamlRoot height
+    // and the system AX frame determine that inset; no fixed titlebar pixel value is assumed.
+    let point = CGPoint(x: position.x + localX, y: position.y + size.height - height + localY)
+    NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    print("Native system window bounds and read-only product sample used for CGEvent pointer")
     exit(0)
 }
 if arguments[1] == "click", arguments.count == 4, let pid = Int32(arguments[2]) {

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -24,6 +24,21 @@ func findButton(_ element: AXUIElement, _ title: String, _ depth: Int = 0) -> AX
     return nil
 }
 
+func describeTree(_ element: AXUIElement, _ depth: Int = 0) -> [[String: Any]] {
+    if depth > 20 { return [] }
+    let role = attribute(element, kAXRoleAttribute as CFString) as? String ?? "unknown"
+    var result: [[String: Any]] = []
+    if role == kAXButtonRole as String || depth < 3 {
+        // Buttons have public action labels. Do not capture field values, messages or URLs.
+        result.append(["depth": depth, "role": role,
+                       "title": attribute(element, kAXTitleAttribute as CFString) as? String ?? "",
+                       "description": attribute(element, kAXDescriptionAttribute as CFString) as? String ?? "",
+                       "enabled": attribute(element, kAXEnabledAttribute as CFString) as? Bool ?? false])
+    }
+    for child in children(element) { result.append(contentsOf: describeTree(child, depth + 1)) }
+    return result
+}
+
 let arguments = CommandLine.arguments
 guard arguments.count >= 3 else { exit(2) }
 if arguments[1] == "pids" {
@@ -32,6 +47,13 @@ if arguments[1] == "pids" {
     }
         .map { Int($0.processIdentifier) }
     print(String(data: try JSONSerialization.data(withJSONObject: values), encoding: .utf8)!)
+    exit(0)
+}
+if arguments[1] == "describe", let pid = Int32(arguments[2]) {
+    let target = AXUIElementCreateApplication(pid)
+    AXUIElementSetMessagingTimeout(target, 2)
+    let result: [String: Any] = ["trusted": AXIsProcessTrusted(), "pid": Int(pid), "tree": describeTree(target)]
+    print(String(data: try JSONSerialization.data(withJSONObject: result), encoding: .utf8)!)
     exit(0)
 }
 if arguments[1] == "click", arguments.count == 4, let pid = Int32(arguments[2]) {
@@ -47,7 +69,7 @@ if arguments[1] == "click", arguments.count == 4, let pid = Int32(arguments[2]) 
     var size = CGSize.zero
     guard AXValueGetValue(rawPosition as! AXValue, .cgPoint, &position),
           AXValueGetValue(rawSize as! AXValue, .cgSize, &size), size.width > 0, size.height > 0 else { exit(4) }
-    NSRunningApplication(processIdentifier: pid)?.activate(options: [.activateIgnoringOtherApps])
+    NSRunningApplication(processIdentifier: pid)?.activate(options: [])
     let point = CGPoint(x: position.x + size.width / 2, y: position.y + size.height / 2)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -64,6 +64,41 @@ if arguments[1] == "describe", let pid = Int32(arguments[2]) {
     print(String(data: try JSONSerialization.data(withJSONObject: result), encoding: .utf8)!)
     exit(0)
 }
+if arguments[1] == "allow-local-network" {
+    var candidates: [(AXUIElement, [String])] = []
+    for application in NSWorkspace.shared.runningApplications where application.bundleIdentifier == "com.apple.UserNotificationCenter" {
+        let root = AXUIElementCreateApplication(application.processIdentifier)
+        AXUIElementSetMessagingTimeout(root, 2)
+        let windows = attribute(root, kAXWindowsAttribute as CFString) as? [AXUIElement] ?? []
+        for window in windows {
+            var stack = [window]
+            var texts: [String] = []
+            while let element = stack.popLast() {
+                for name in [kAXTitleAttribute, kAXDescriptionAttribute, kAXValueAttribute] {
+                    if let text = attribute(element, name as CFString) as? String { texts.append(text) }
+                }
+                stack.append(contentsOf: children(element))
+            }
+            let text = texts.joined(separator: " ").lowercased()
+            if text.contains("python") && text.contains("local network") { candidates.append((window, texts)) }
+        }
+    }
+    if candidates.isEmpty { print("No Python local-network permission prompt"); exit(0) }
+    guard candidates.count == 1, let button = findButton(candidates[0].0, "Allow"),
+          let rawPosition = attribute(button, kAXPositionAttribute as CFString),
+          let rawSize = attribute(button, kAXSizeAttribute as CFString) else { exit(7) }
+    var point = CGPoint.zero
+    var size = CGSize.zero
+    guard AXValueGetValue(rawPosition as! AXValue, .cgPoint, &point),
+          AXValueGetValue(rawSize as! AXValue, .cgSize, &size) else { exit(8) }
+    point.x += size.width / 2
+    point.y += size.height / 2
+    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    print("Allowed the temporary Python fixture local-network prompt through native UI")
+    exit(0)
+}
 if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]),
    let localX = Double(arguments[3]), let localY = Double(arguments[4]), let height = Double(arguments[5]) {
     let target = AXUIElementCreateApplication(pid)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -11,16 +11,19 @@ func children(_ element: AXUIElement) -> [AXUIElement] {
     attribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
 }
 
-func activate(_ pid: pid_t, _ window: AXUIElement) -> Bool {
-    guard let application = NSRunningApplication(processIdentifier: pid) else { return false }
-    let requested = application.activate(options: [.activateAllWindows])
-    _ = AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
+    if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
+    // An external helper cannot force cooperative app activation on recent macOS. A real
+    // titlebar click is the user's native way to bring an inactive product window forward.
+    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
     let deadline = Date().addingTimeInterval(5)
     while Date() < deadline {
         if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
         RunLoop.current.run(until: Date().addingTimeInterval(0.02))
     }
-    fputs("Native application did not become foreground after activation request \(requested).\n", stderr)
+    fputs("Native application did not become foreground after its titlebar was clicked.\n", stderr)
     return false
 }
 
@@ -126,7 +129,8 @@ if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]
     // Uno's native content frame begins below the OS window chrome. The current XamlRoot height
     // and the system AX frame determine that inset; no fixed titlebar pixel value is assumed.
     let point = CGPoint(x: position.x + localX, y: position.y + size.height - height + localY)
-    guard activate(pid, windows[0]) else { exit(9) }
+    let titlebarPoint = CGPoint(x: position.x + size.width / 2, y: position.y + (size.height - height) / 2)
+    guard activate(pid, titlebarPoint) else { exit(9) }
     print("CGEvent target pid=\(pid) x=\(point.x) y=\(point.y) nativeWindow=\(position) size=\(size) contentHeight=\(height)")
     CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -18,7 +18,23 @@ func isFrontmost(_ pid: pid_t) -> Bool {
     // NSWorkspace changes before the app-switcher animation finishes. Native z-order must
     // also expose the actual application window before mouse input can reach its content.
     let front = windows.first { ($0[kCGWindowLayer as String] as? Int) == 0 }
-    return (front?[kCGWindowOwnerPID as String] as? Int) == Int(pid)
+    guard (front?[kCGWindowOwnerPID as String] as? Int) == Int(pid) else { return false }
+    let application = AXUIElementCreateApplication(pid)
+    AXUIElementSetMessagingTimeout(application, 1)
+    guard let focused = attribute(application, kAXFocusedWindowAttribute as CFString),
+          let windows = attribute(application, kAXWindowsAttribute as CFString) as? [AXUIElement], windows.count == 1
+        else { return false }
+    return CFEqual(focused, windows[0])
+}
+
+func click(_ point: CGPoint) {
+    let source = CGEventSource(stateID: .hidSystemState)
+    for type in [CGEventType.mouseMoved, .leftMouseDown, .leftMouseUp] {
+        let event = CGEvent(mouseEventSource: source, mouseType: type, mouseCursorPosition: point, mouseButton: .left)
+        event?.flags = []
+        event?.setIntegerValueField(.mouseEventClickState, value: 1)
+        event?.post(tap: .cghidEventTap)
+    }
 }
 
 func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
@@ -35,11 +51,9 @@ func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
         up?.post(tap: .cghidEventTap)
         CGEvent(keyboardEventSource: nil, virtualKey: 55, keyDown: false)?.post(tap: .cghidEventTap)
     } else {
-    // An external helper cannot force cooperative app activation on recent macOS. A real
-    // titlebar click is the user's native way to bring an inactive product window forward.
-    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
+        // An external helper cannot force cooperative app activation on recent macOS. A real
+        // titlebar click is the user's native way to bring an inactive product window forward.
+        click(titlebarPoint)
     }
     let deadline = Date().addingTimeInterval(5)
     while Date() < deadline {
@@ -132,9 +146,7 @@ if arguments[1] == "allow-local-network" {
           AXValueGetValue(rawSize as! AXValue, .cgSize, &size) else { exit(8) }
     point.x += size.width / 2
     point.y += size.height / 2
-    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    click(point)
     print("Allowed the temporary Python fixture local-network prompt through native UI")
     exit(0)
 }
@@ -155,9 +167,7 @@ if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]
     let titlebarPoint = CGPoint(x: position.x + size.width / 2, y: position.y + (size.height - height) / 2)
     guard activate(pid, titlebarPoint) else { exit(9) }
     print("CGEvent target pid=\(pid) x=\(point.x) y=\(point.y) nativeWindow=\(position) size=\(size) contentHeight=\(height)")
-    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    click(point)
     print("Native system window bounds and read-only product sample used for CGEvent pointer")
     exit(0)
 }

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -13,17 +13,30 @@ func children(_ element: AXUIElement) -> [AXUIElement] {
 
 func activate(_ pid: pid_t, _ titlebarPoint: CGPoint) -> Bool {
     if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
+    let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
+    if ["com.apple.Safari", "com.google.Chrome", "org.mozilla.firefox", "com.microsoft.edgemac"].contains(frontmost) {
+        // Opening the system browser makes it frontmost. Return to the preceding product with
+        // the native application switcher, rather than clicking a now-covered product window.
+        let down = CGEvent(keyboardEventSource: nil, virtualKey: 48, keyDown: true)
+        let up = CGEvent(keyboardEventSource: nil, virtualKey: 48, keyDown: false)
+        down?.flags = .maskCommand
+        up?.flags = .maskCommand
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
+        CGEvent(keyboardEventSource: nil, virtualKey: 55, keyDown: false)?.post(tap: .cghidEventTap)
+    } else {
     // An external helper cannot force cooperative app activation on recent macOS. A real
     // titlebar click is the user's native way to bring an inactive product window forward.
     CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: titlebarPoint, mouseButton: .left)?.post(tap: .cghidEventTap)
+    }
     let deadline = Date().addingTimeInterval(5)
     while Date() < deadline {
         if NSWorkspace.shared.frontmostApplication?.processIdentifier == pid { return true }
         RunLoop.current.run(until: Date().addingTimeInterval(0.02))
     }
-    fputs("Native application did not become foreground after its titlebar was clicked.\n", stderr)
+    fputs("Native application did not become foreground after native application activation.\n", stderr)
     return false
 }
 

--- a/scripts/gates/macos-native-ui.swift
+++ b/scripts/gates/macos-native-ui.swift
@@ -79,6 +79,8 @@ if arguments[1] == "pointer", arguments.count == 6, let pid = Int32(arguments[2]
     // and the system AX frame determine that inset; no fixed titlebar pixel value is assumed.
     let point = CGPoint(x: position.x + localX, y: position.y + size.height - height + localY)
     NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+    print("CGEvent target pid=\(pid) x=\(point.x) y=\(point.y) nativeWindow=\(position) size=\(size) contentHeight=\(height)")
+    CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
     print("Native system window bounds and read-only product sample used for CGEvent pointer")

--- a/scripts/gates/run-macos-desktop-input-probe.py
+++ b/scripts/gates/run-macos-desktop-input-probe.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Build a Cocoa input probe with the selected Xcode and execute it without altering TCC."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+
+
+def main():
+    if sys.platform != "darwin":
+        raise SystemExit("The Cocoa input probe requires macOS.")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=Path("artifacts/macos-native-input"))
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).with_name("macos-desktop-input-probe.swift")
+    binary = output / "native-input-probe"
+    result = output / "result.json"
+    provenance = {
+        "source": str(source),
+        "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "xcode": subprocess.check_output(["xcodebuild", "-version"], text=True).strip(),
+        "developerDirectory": subprocess.check_output(["xcode-select", "-p"], text=True).strip(),
+    }
+    (output / "provenance.json").write_text(json.dumps(provenance, indent=2) + "\n")
+    with (output / "build.log").open("w") as log:
+        subprocess.run(["xcrun", "swiftc", str(source), "-framework", "AppKit", "-framework", "CoreGraphics", "-o", str(binary)],
+                       stdout=log, stderr=subprocess.STDOUT, check=True, timeout=90)
+    process = None
+    try:
+        with (output / "runtime.log").open("w") as log:
+            process = subprocess.Popen([str(binary), str(result)], stdout=log, stderr=subprocess.STDOUT,
+                                       start_new_session=True)
+            code = process.wait(timeout=30)
+        report = json.loads(result.read_text())
+        print(json.dumps(report))
+        if code != 0 or report.get("passed") is not True or report.get("nativeTextReceived") is not True:
+            raise RuntimeError("The hosted Cocoa window did not receive native keyboard input; platform GUI remains unverified.")
+    finally:
+        if process is not None:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=3)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt("Cocoa probe interrupted")))
+    main()

--- a/src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs
+++ b/src/SalmonEgg.Infrastructure.Desktop/Services/DesktopElicitationUriLauncher.cs
@@ -18,7 +18,7 @@ public sealed class DesktopElicitationUriLauncher : IExternalUriLauncher
     }
 
     // Each additional native target requires its own real handler/isolation gate before advertising.
-    public bool IsSupported => OperatingSystem.IsLinux() && _runtimeProbe.IsDesktopProcessHost
+    public bool IsSupported => (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) && _runtimeProbe.IsDesktopProcessHost
         && _runtimeProbe.HasExternalFileOpener;
 
     public async Task<ExternalUriOpenResult> OpenAsync(ExternalUriTarget target, CancellationToken cancellationToken)


### PR DESCRIPTION
macOS 现在在具有可用系统 opener 的 Skia desktop 上广告 URL elicitation。用户先看到完整地址并明确同意，应用再通过既有 LaunchServices 打开独立系统浏览器；重开不重复发送 ACP accept，完成和断线始终归属原请求。

新增 hosted macOS 产品门禁使用当前构建的应用、生产 stdio、真实 CGEvent 鼠标和系统 Safari，覆盖拒绝/取消零外访、打开/重开、单次回复、完成通知与断线失效。临时撤掉同意保护会导致真实未授权浏览器访问并被门禁拒绝；源码逐字恢复、重建后再跑全链。产物和源码散列均留档。

已验证当前 head 91f50aec 的 run 34692196187：本次构建正向通过，临时撤掉同意保护后按目标原因失败，源码按散列恢复、重新构建后完整流程再通过。另有前两轮独立 runner 正反验证。包含 SIGTERM/超时进程清理和持久化 AppData 的私密 URL/页面值扫描。当前 Uno AX 子树不完整，按钮位置由独立 Debug 只读采样配合系统窗口几何取得；这不冒充完整读屏验收。没有修改 TCC、全局安全设置或已有浏览器进程。Unix terminal 登录保持关闭，原因是既有 PTY 不能区分信号退出。

Refs #146, #154
