### PR TITLE
feat(chat): edit agent session configuration through native controls

### DIFF
--- a/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
@@ -24,6 +24,11 @@
         <x:Double x:Key="ChatElicitationHeadingSpacing">4</x:Double>
         <x:Double x:Key="ChatElicitationFieldSpacing">6</x:Double>
         <x:Double x:Key="ChatElicitationActionSpacing">8</x:Double>
+        <x:Double x:Key="SessionSettingsMaxWidth">360</x:Double>
+        <x:Double x:Key="SessionSettingsMaxHeight">440</x:Double>
+        <x:Double x:Key="SessionSettingsRowSpacing">16</x:Double>
+        <x:Double x:Key="SessionSettingsFieldSpacing">6</x:Double>
+        <Thickness x:Key="SessionSettingsRowMargin">0,0,0,16</Thickness>
     </Page.Resources>
 
     <Grid>
@@ -170,7 +175,11 @@
                             </VisualState>
                         </VisualStateGroup>
                     </VisualStateManager.VisualStateGroups>
-                    <Grid x:Name="SessionHeaderMetaGrid" ColumnSpacing="12" RowSpacing="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid x:Name="SessionHeaderMetaGrid" Grid.Column="0" ColumnSpacing="12" RowSpacing="0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition x:Name="SessionHeaderAgentRow" Height="0" />
@@ -224,6 +233,71 @@
                                    MaxLines="1"
                                    MaxWidth="180" />
                     </Grid>
+                    <Button Grid.Column="1"
+                            AutomationProperties.AutomationId="ChatView.SessionSettings"
+                            Content="{x:Bind ViewModel.SessionSettingsText, Mode=OneWay}"
+                            VerticalAlignment="Center"
+                            Visibility="{x:Bind ViewModel.ShowConfigOptionsPanel, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <Button.Flyout>
+                            <Flyout>
+                                <ScrollViewer MaxWidth="{StaticResource SessionSettingsMaxWidth}"
+                                              MaxHeight="{StaticResource SessionSettingsMaxHeight}"
+                                              HorizontalScrollBarVisibility="Disabled"
+                                              HorizontalScrollMode="Disabled">
+                                    <StackPanel Spacing="{StaticResource SessionSettingsRowSpacing}">
+                                        <TextBlock Text="{x:Bind ViewModel.SessionSettingsHint, Mode=OneWay}"
+                                                   TextWrapping="Wrap"
+                                                   Style="{StaticResource CaptionTextBlockStyle}" />
+                                        <ItemsControl ItemsSource="{x:Bind ViewModel.ConfigOptions, Mode=OneWay}"
+                                                      HorizontalContentAlignment="Stretch">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="chatVm:ConfigOptionViewModel">
+                                                    <StackPanel Spacing="{StaticResource SessionSettingsFieldSpacing}"
+                                                                Margin="{StaticResource SessionSettingsRowMargin}">
+                                                        <ComboBox Header="{x:Bind Name, Mode=OneWay}"
+                                                                  AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
+                                                                  AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
+                                                                  ItemsSource="{x:Bind Options, Mode=OneWay}"
+                                                                  DisplayMemberPath="Name"
+                                                                  SelectedItem="{x:Bind SelectedOption, Mode=TwoWay}"
+                                                                  IsEnabled="{x:Bind EditorEnabled, Mode=OneWay}"
+                                                                  HorizontalAlignment="Stretch"
+                                                                  Visibility="{x:Bind IsSelectType, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                        <ToggleSwitch Header="{x:Bind Name, Mode=OneWay}"
+                                                                      AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
+                                                                      AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
+                                                                      OnContent="{x:Bind OnText, Mode=OneWay}"
+                                                                      OffContent="{x:Bind OffText, Mode=OneWay}"
+                                                                      IsOn="{x:Bind BoolValue, Mode=TwoWay}"
+                                                                      IsEnabled="{x:Bind EditorEnabled, Mode=OneWay}"
+                                                                      Visibility="{x:Bind IsBoolType, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                        <TextBlock Text="{x:Bind Description, Mode=OneWay}"
+                                                                   TextWrapping="Wrap"
+                                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                                   Visibility="{x:Bind HasDescription, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                        <TextBlock Text="{x:Bind ChangedText, Mode=OneWay}"
+                                                                   AutomationProperties.Name="{x:Bind ChangedText, Mode=OneWay}"
+                                                                   TextWrapping="Wrap"
+                                                                   Visibility="{x:Bind ChangedWhileEditing, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                        <InfoBar IsOpen="{x:Bind HasError, Mode=OneWay}"
+                                                                 IsClosable="False"
+                                                                 Severity="Error"
+                                                                 Message="{x:Bind ErrorMessage, Mode=OneWay}" />
+                                                        <StackPanel Orientation="Horizontal" Spacing="{StaticResource SessionSettingsFieldSpacing}">
+                                                            <Button Content="{x:Bind ApplyText, Mode=OneWay}"
+                                                                    Command="{x:Bind ApplyCommand}" />
+                                                            <Button Content="{x:Bind ResetText, Mode=OneWay}"
+                                                                    Command="{x:Bind ResetCommand}" />
+                                                        </StackPanel>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </ScrollViewer>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
                 </Grid>
             </Border>
 

--- a/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
+++ b/SalmonEgg/SalmonEgg/Presentation/Views/Chat/ChatView.xaml
@@ -260,6 +260,7 @@
                                                                   ItemsSource="{x:Bind Options, Mode=OneWay}"
                                                                   DisplayMemberPath="Name"
                                                                   SelectedItem="{x:Bind SelectedOption, Mode=TwoWay}"
+                                                                  IsFocusEngagementEnabled="True"
                                                                   IsEnabled="{x:Bind EditorEnabled, Mode=OneWay}"
                                                                   HorizontalAlignment="Stretch"
                                                                   Visibility="{x:Bind IsSelectType, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />

--- a/scripts/gates/wasm-acp-full-chain-smoke.mjs
+++ b/scripts/gates/wasm-acp-full-chain-smoke.mjs
@@ -12,6 +12,7 @@ import {
 import { startAcpWebSocketServer } from "./wasm-smoke-lib/acp-test-server.mjs";
 import { verifyStandalonePermissionQueue } from "./wasm-smoke-lib/permission-flow.mjs";
 import { verifyRemainingFormInputs } from "./wasm-smoke-lib/elicitation-form-flow.mjs";
+import { verifySessionConfiguration } from "./wasm-smoke-lib/session-configuration-flow.mjs";
 import {
   navigateToSettingsSection
 } from "./wasm-smoke-lib/settings-shell.mjs";
@@ -110,6 +111,7 @@ try {
         }
       });
 
+    await verifySessionConfiguration(page, acpServer, initialize);
     elicitationRequests.push(await verifyKnownFormSubmission(page, acpServer));
     elicitationRequests.push(...await verifyRemainingFormInputs(page, acpServer));
     elicitationRequests.push(await verifyUnknownRequiredFieldCancellation(page, acpServer));

--- a/scripts/gates/wasm-smoke-lib/acp-test-server.mjs
+++ b/scripts/gates/wasm-smoke-lib/acp-test-server.mjs
@@ -28,6 +28,9 @@ export async function startAcpWebSocketServer(options = {}) {
   });
   const sockets = new Set();
   const clientRequests = new Map();
+  let configurationOptions;
+  let configurationFailure;
+  const configurationRequests = [];
 
   const sendSessionNewResponse = (socket, request) => {
     if (!request || !socket || socket.destroyed) {
@@ -169,6 +172,20 @@ export async function startAcpWebSocketServer(options = {}) {
           });
         }
 
+        if (message.method === "session/set_config_option" && configurationOptions) {
+          configurationRequests.push(message);
+          if (configurationFailure) {
+            writeJsonRpc(socket, { jsonrpc: "2.0", id: message.id,
+              error: { code: -32603, message: configurationFailure } });
+            configurationFailure = undefined;
+            continue;
+          }
+          configurationOptions = configurationOptions.map(option => option.id === message.params.configId
+            ? { ...option, currentValue: message.params.value } : option);
+          writeJsonRpc(socket, { jsonrpc: "2.0", id: message.id,
+            result: { configOptions: configurationOptions } });
+        }
+
         if (message.method === "session/cancel" && deferredPrompt?.request
           && deferredPrompt.socket === socket) {
           deferredPrompt.cancellations.push(message);
@@ -197,6 +214,13 @@ export async function startAcpWebSocketServer(options = {}) {
   return {
     url: `ws://127.0.0.1:${port}/acp`,
     sessionId,
+    publishConfiguration: options => {
+      configurationOptions = options;
+      for (const socket of sockets) writeSessionUpdate(socket, sessionId,
+        { sessionUpdate: "config_option_update", configOptions: configurationOptions });
+    },
+    configurationRequests: () => [...configurationRequests],
+    failNextConfiguration: message => { configurationFailure = message; },
     deferNextPrompt: () => {
       if (deferredPrompt) throw new Error("A deferred prompt is already active.");
       let resolve;

--- a/scripts/gates/wasm-smoke-lib/session-configuration-flow.mjs
+++ b/scripts/gates/wasm-smoke-lib/session-configuration-flow.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdir } from "node:fs/promises";
+import {
+  clickVisibleControl,
+  clickVisibleControlWithTrustedPointer,
+  waitForControlEnabledState,
+  waitForLaidOutControl,
+  waitForSemanticText
+} from "./ui-affordances.mjs";
+
+export async function verifySessionConfiguration(page, server, initialize) {
+  assert.deepEqual(initialize.params.clientCapabilities?.session?.configOptions?.boolean, {},
+    "The real initialize must advertise boolean editing before the agent sends a boolean setting.");
+  const selector = { labels: ["Response style"], role: "combobox" };
+  const settings = { automationIds: ["ChatView.SessionSettings"], role: "button" };
+  const grouped = {
+    id: "response-style", name: "Response style", description: "Choose the detail used in this conversation.",
+    type: "select", currentValue: "short",
+    options: [{ group: "standard", name: "Standard", options: [{ value: "short", name: "Brief" }] },
+      { group: "deep", name: "Deep work", options: [{ value: "long", name: "Detailed" }] }]
+  };
+  const flag = { id: "show-plan", name: "Show the plan", description: "Include the current plan.",
+    type: "boolean", currentValue: false };
+  server.publishConfiguration([grouped, flag,
+    { id: "future-setting", name: "Future knob", type: "future", currentValue: { opaque: true } }]);
+  await clickVisibleControlWithTrustedPointer(page, settings, "session settings");
+  await waitForSemanticText(page, /Choose the detail used in this conversation\./, "configuration description");
+  await waitForLaidOutControl(page, selector, "response style selector");
+  if (process.env.WASM_SMOKE_ARTIFACTS_DIR) {
+    await mkdir(process.env.WASM_SMOKE_ARTIFACTS_DIR, { recursive: true });
+    await page.screenshot({ path: `${process.env.WASM_SMOKE_ARTIFACTS_DIR}/session-settings.png` });
+  }
+  const focused = await page.evaluate(options => {
+    const state = window.__salmoneggSmoke.semantic.describe(options);
+    const element = state?.id ? document.getElementById(state.id) : null;
+    element?.focus();
+    return element && document.activeElement === element;
+  }, selector);
+  assert.equal(focused, true, "The native configuration selector must own focus.");
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Tab");
+  const apply = { labels: ["Apply"], role: "button" };
+  const initial = server.configurationRequests().length;
+  server.failNextConfiguration("Backend unavailable");
+  await waitForControlEnabledState(page, apply, true, "apply edited setting");
+  await clickVisibleControl(page, apply, "apply response style");
+  await waitForSemanticText(page, /Could not apply this setting\./, "configuration failure");
+  if (process.env.WASM_SMOKE_ARTIFACTS_DIR)
+    await page.screenshot({ path: `${process.env.WASM_SMOKE_ARTIFACTS_DIR}/session-settings-error.png` });
+  await waitForControlEnabledState(page, apply, true, "retry edited setting");
+  await clickVisibleControl(page, apply, "retry response style");
+  await waitForControlEnabledState(page, apply, false, "accepted response style");
+  assert.equal(server.configurationRequests().length, initial + 2);
+  for (const request of server.configurationRequests().slice(initial)) {
+    assert.equal(request.params.configId, "response-style");
+    assert.equal(request.params.value, "long");
+    assert.equal(request.params.type, undefined, "V1 string values retain the stable wire format.");
+    assert.equal(request.params.sessionId, server.sessionId);
+  }
+  await page.keyboard.press("Escape");
+  server.publishConfiguration([flag]);
+  await clickVisibleControlWithTrustedPointer(page, settings, "boolean session settings");
+  const toggle = { labels: ["Show the plan"], role: "switch" };
+  await waitForLaidOutControl(page, toggle, "plan switch");
+  await clickVisibleControl(page, toggle);
+  await waitForControlEnabledState(page, apply, true, "apply boolean setting");
+  await clickVisibleControl(page, apply, "apply boolean setting");
+  await waitForControlEnabledState(page, apply, false, "accepted boolean setting");
+  const boolean = server.configurationRequests().at(-1);
+  assert.equal(boolean.params.configId, "show-plan");
+  assert.equal(boolean.params.type, "boolean");
+  assert.equal(boolean.params.value, true);
+  await page.keyboard.press("Escape");
+  console.log("WASM session configuration passed: grouped select, retry, boolean and stable V1 wire");
+}

--- a/src/SalmonEgg.Acp/Protocol/ClientCapabilityDefaults.cs
+++ b/src/SalmonEgg.Acp/Protocol/ClientCapabilityDefaults.cs
@@ -14,7 +14,10 @@ namespace SalmonEgg.Acp.Protocol
             => new(
                 session: new ClientSessionCapabilities
                 {
-                    ConfigOptions = new SessionConfigOptionsCapabilities()
+                    ConfigOptions = new SessionConfigOptionsCapabilities
+                    {
+                        Boolean = new BooleanConfigOptionCapabilities()
+                    }
                 },
                 meta: ClientCapabilityMetadata.CreateDefault())
             {

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1491,6 +1491,7 @@ Create the corresponding Markdown file in:
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  </data>
   <data name="SessionConfig_Title" xml:space="preserve">
     <value>Session settings</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1491,5 +1491,31 @@ Create the corresponding Markdown file in:
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  <data name="SessionConfig_Title" xml:space="preserve">
+    <value>Session settings</value>
+  </data>
+  <data name="SessionConfig_Hint" xml:space="preserve">
+    <value>Settings supplied by the agent apply to this conversation.</value>
+  </data>
+  <data name="SessionConfig_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="SessionConfig_Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="SessionConfig_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="SessionConfig_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="SessionConfig_Changed" xml:space="preserve">
+    <value>The agent updated this setting. Your edit is kept; apply it or reset to the agent's value.</value>
+  </data>
+  <data name="SessionConfig_Stale" xml:space="preserve">
+    <value>The conversation or connection changed. Reopen session settings.</value>
+  </data>
+  <data name="SessionConfig_Failed" xml:space="preserve">
+    <value>Could not apply this setting. Your edit is kept; try again.</value>
   </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1491,6 +1491,7 @@ Create the corresponding Markdown file in:
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  </data>
   <data name="SessionConfig_Title" xml:space="preserve">
     <value>Session settings</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1491,5 +1491,31 @@ Create the corresponding Markdown file in:
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  <data name="SessionConfig_Title" xml:space="preserve">
+    <value>Session settings</value>
+  </data>
+  <data name="SessionConfig_Hint" xml:space="preserve">
+    <value>Settings supplied by the agent apply to this conversation.</value>
+  </data>
+  <data name="SessionConfig_Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="SessionConfig_Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="SessionConfig_On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="SessionConfig_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="SessionConfig_Changed" xml:space="preserve">
+    <value>The agent updated this setting. Your edit is kept; apply it or reset to the agent's value.</value>
+  </data>
+  <data name="SessionConfig_Stale" xml:space="preserve">
+    <value>The conversation or connection changed. Reopen session settings.</value>
+  </data>
+  <data name="SessionConfig_Failed" xml:space="preserve">
+    <value>Could not apply this setting. Your edit is kept; try again.</value>
   </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1497,6 +1497,7 @@
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  </data>
   <data name="SessionConfig_Title" xml:space="preserve">
     <value>会话设置</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1497,5 +1497,31 @@
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>Waiting for your action...</value>
+  <data name="SessionConfig_Title" xml:space="preserve">
+    <value>会话设置</value>
+  </data>
+  <data name="SessionConfig_Hint" xml:space="preserve">
+    <value>Agent 提供的设置只应用于当前会话。</value>
+  </data>
+  <data name="SessionConfig_Apply" xml:space="preserve">
+    <value>应用</value>
+  </data>
+  <data name="SessionConfig_Reset" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="SessionConfig_On" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="SessionConfig_Off" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="SessionConfig_Changed" xml:space="preserve">
+    <value>Agent 已更新此项。你的编辑已保留，可以应用或重置为 Agent 的值。</value>
+  </data>
+  <data name="SessionConfig_Stale" xml:space="preserve">
+    <value>会话或连接已改变，请重新打开会话设置。</value>
+  </data>
+  <data name="SessionConfig_Failed" xml:space="preserve">
+    <value>设置未能应用，编辑已保留，请重试。</value>
   </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1497,5 +1497,31 @@
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>等待你操作…</value>
+  <data name="SessionConfig_Title" xml:space="preserve">
+    <value>会话设置</value>
+  </data>
+  <data name="SessionConfig_Hint" xml:space="preserve">
+    <value>Agent 提供的设置只应用于当前会话。</value>
+  </data>
+  <data name="SessionConfig_Apply" xml:space="preserve">
+    <value>应用</value>
+  </data>
+  <data name="SessionConfig_Reset" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="SessionConfig_On" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="SessionConfig_Off" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="SessionConfig_Changed" xml:space="preserve">
+    <value>Agent 已更新此项。你的编辑已保留，可以应用或重置为 Agent 的值。</value>
+  </data>
+  <data name="SessionConfig_Stale" xml:space="preserve">
+    <value>会话或连接已改变，请重新打开会话设置。</value>
+  </data>
+  <data name="SessionConfig_Failed" xml:space="preserve">
+    <value>设置未能应用，编辑已保留，请重试。</value>
   </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1497,6 +1497,7 @@
   </data>
   <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
     <value>等待你操作…</value>
+  </data>
   <data name="SessionConfig_Title" xml:space="preserve">
     <value>会话设置</value>
   </data>

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionConfiguration.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionConfiguration.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.ViewModels.Chat;
+
+public partial class ChatViewModel
+{
+    private InteractionRequestSource? _configurationSource;
+    private ConversationBindingSlice? _configurationBinding;
+
+    public string SessionSettingsText => Localize("SessionConfig_Title", "Session settings");
+    public string SessionSettingsHint => Localize("SessionConfig_Hint", "Settings supplied by the agent apply to this conversation.");
+
+    private void ReconcileSessionConfiguration(IReadOnlyList<ConfigOptionViewModel> projected)
+    {
+        var state = _chatStore.ReadCommittedState();
+        var binding = state?.ResolveBinding(CurrentSessionId);
+        var source = _chatService is { } service
+            ? CaptureInteractionSource(service, _foregroundChatServiceGeneration)
+            : null;
+        if (binding != _configurationBinding || source != _configurationSource)
+        {
+            foreach (var row in ConfigOptions) row.RetireEditor();
+            ConfigOptions.Clear();
+            _configurationBinding = binding;
+            _configurationSource = source;
+        }
+
+        var removed = ConfigOptions.Where(row => !projected.Any(option => option.Id == row.Id && option.ValueType == row.ValueType)).ToArray();
+        foreach (var row in removed)
+        {
+            row.RetireEditor();
+            ConfigOptions.Remove(row);
+        }
+        foreach (var projectedRow in projected)
+        {
+            var row = ConfigOptions.FirstOrDefault(option => option.Id == projectedRow.Id && option.ValueType == projectedRow.ValueType);
+            if (row is not null) row.UpdateAuthoritative(projectedRow);
+            else
+            {
+                row = projectedRow;
+                ConfigOptions.Add(row);
+                if (source is not null && binding is not null)
+                {
+                    row.BindEditor(option => ApplySessionConfigurationAsync(option, source, binding),
+                        () => IsConfigurationCurrent(row, source, binding), _localizer, _uiDispatcher,
+                        ConvergeSessionConfigurationOrder);
+                }
+            }
+            row.RefreshEditor();
+        }
+        ConvergeSessionConfigurationOrder();
+    }
+
+    private void ConvergeSessionConfigurationOrder()
+    {
+        // Moving native containers while a user is editing risks losing their focus/selection.
+        // Once all drafts settle, apply the Agent's current priority order from the same store.
+        if (ConfigOptions.Any(row => row.IsApplying || row.HasChanges)) return;
+        var state = _chatStore.ReadCommittedState();
+        var options = state?.ResolveSessionStateSlice(CurrentSessionId)?.ConfigOptions ?? state?.ConfigOptions;
+        if (options is null) return;
+        var target = 0;
+        foreach (var option in options)
+        {
+            var row = ConfigOptions.FirstOrDefault(row => row.Id == option.Id);
+            if (row is null) continue;
+            var current = ConfigOptions.IndexOf(row);
+            if (current != target) ConfigOptions.Move(current, target);
+            target++;
+        }
+    }
+
+    private bool IsConfigurationCurrent(ConfigOptionViewModel row, InteractionRequestSource source, ConversationBindingSlice binding)
+    {
+        var state = _chatStore.ReadCommittedState();
+        if (state is null || state.IsHydrating || IsRemoteHydrationPending
+            || !IsInteractionBindingCurrent(source, binding)
+            || !ReferenceEquals(_chatService, source.Service)
+            || !source.Service.IsInitialized
+            || state.HydratedConversationId != binding.ConversationId
+            || CurrentSessionId != binding.ConversationId
+            || !ConfigOptions.Contains(row)) return false;
+        var configuration = state.ResolveSessionStateSlice(binding.ConversationId)?.ConfigOptions ?? state.ConfigOptions;
+        return configuration?.Any(option => option.Id == row.Id && (option.ValueType ?? "select") == row.ValueType) == true;
+    }
+
+    private async Task<ConfigOptionApplyOutcome> ApplySessionConfigurationAsync(
+        ConfigOptionViewModel row, InteractionRequestSource source, ConversationBindingSlice binding)
+    {
+        if (!IsConfigurationCurrent(row, source, binding) || !IsConfigurationValueAllowed(row)
+            || string.IsNullOrWhiteSpace(binding.RemoteSessionId)
+            || string.IsNullOrWhiteSpace(binding.ConversationId))
+            return ConfigOptionApplyOutcome.Stale;
+        var request = row.IsBoolType
+            ? new SessionSetConfigOptionParams(binding.RemoteSessionId, row.Id, row.BoolValue)
+            : row.IsSelectType && row.SelectedOption is { } selected && row.Options.Contains(selected)
+                ? new SessionSetConfigOptionParams(binding.RemoteSessionId, row.Id, selected.Value)
+                : null;
+        if (request is null) return ConfigOptionApplyOutcome.Failed;
+        try
+        {
+            var response = await source.Service.SetSessionConfigOptionAsync(request).ConfigureAwait(false);
+            var outcome = ConfigOptionApplyOutcome.Stale;
+            await PostToUiAsync(async () =>
+            {
+                if (!IsConfigurationCurrent(row, source, binding)) return;
+                if (response?.ConfigOptions is null)
+                {
+                    outcome = ConfigOptionApplyOutcome.Failed;
+                    return;
+                }
+                await ApplySessionConfigOptionResponseAsync(binding.ConversationId, response, binding.RemoteSessionId).ConfigureAwait(true);
+                await ApplyCurrentStoreProjectionAsync().ConfigureAwait(true);
+                outcome = ConfigOptionApplyOutcome.Applied;
+            }).ConfigureAwait(false);
+            return outcome;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Session configuration change failed. ConversationId={ConversationId} ConfigId={ConfigId}", binding.ConversationId, row.Id);
+            var outcome = ConfigOptionApplyOutcome.Stale;
+            await PostToUiAsync(() => outcome = IsConfigurationCurrent(row, source, binding)
+                ? ConfigOptionApplyOutcome.Failed : ConfigOptionApplyOutcome.Stale).ConfigureAwait(false);
+            return outcome;
+        }
+    }
+
+    private bool IsConfigurationValueAllowed(ConfigOptionViewModel row)
+    {
+        var state = _chatStore.ReadCommittedState();
+        var options = state?.ResolveSessionStateSlice(CurrentSessionId)?.ConfigOptions ?? state?.ConfigOptions;
+        var option = options?.FirstOrDefault(option => option.Id == row.Id);
+        return option is not null && (option.ValueType == "boolean" && row.IsBoolType
+            || (option.ValueType is null or "select") && row.IsSelectType && row.SelectedOption is { } selected
+                && option.Options.Any(value => value.Value == selected.Value));
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionConfiguration.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionConfiguration.cs
@@ -117,7 +117,9 @@ public partial class ChatViewModel
                     return;
                 }
                 await ApplySessionConfigOptionResponseAsync(binding.ConversationId, response, binding.RemoteSessionId).ConfigureAwait(true);
+                if (!IsConfigurationCurrent(row, source, binding)) return;
                 await ApplyCurrentStoreProjectionAsync().ConfigureAwait(true);
+                if (!IsConfigurationCurrent(row, source, binding)) return;
                 outcome = ConfigOptionApplyOutcome.Applied;
             }).ConfigureAwait(false);
             return outcome;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionPresentation.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.SessionPresentation.cs
@@ -466,14 +466,7 @@ public partial class ChatViewModel
             }
         }
 
-        if (!_sessionOptionsPresenter.ConfigOptionCollectionMatches(ConfigOptions, projection.ConfigOptions))
-        {
-            ConfigOptions.Clear();
-            foreach (var option in projection.ConfigOptions)
-            {
-                ConfigOptions.Add(option);
-            }
-        }
+        ReconcileSessionConfiguration(projection.ConfigOptions);
 
         ShowConfigOptionsPanel = projection.ShowConfigOptionsPanel;
         _modeConfigId = projection.ModeConfigId;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -1767,6 +1767,9 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
             RaiseOverlayStateChanged();
             PendingAskUserRequest?.ReprojectLocalizedState();
             PendingElicitationRequest?.ReprojectLocalizedState();
+            foreach (var option in ConfigOptions) option.ReprojectLocalizedText();
+            OnPropertyChanged(nameof(SessionSettingsText));
+            OnPropertyChanged(nameof(SessionSettingsHint));
             ReprojectConversationOperationFailureMessage();
             // SessionActivationFailureMessage re-localizes from snapshot resource identity on get.
             NotifySessionActivationFailureProjectionChanged();
@@ -3733,6 +3736,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         }
 
         _panelStateCoordinator.ClearPermissionRequests();
+        foreach (var option in ConfigOptions) option.RetireEditor();
 
         if (_chatService != null)
         {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.Editing.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.Editing.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Localization;
+using SalmonEgg.Presentation.Core.Resources;
+using SalmonEgg.Presentation.Core.Services;
+
+namespace SalmonEgg.Presentation.ViewModels.Chat;
+
+internal enum ConfigOptionApplyOutcome { Applied, Failed, Stale }
+
+public partial class ConfigOptionViewModel
+{
+    private Func<ConfigOptionViewModel, Task<ConfigOptionApplyOutcome>>? _apply;
+    private Func<bool>? _isCurrent;
+    private IStringLocalizer<CoreStrings>? _localizer;
+    private IUiDispatcher? _uiDispatcher;
+    private Action? _editingSettled;
+    private string? _errorKey;
+    private bool _projecting;
+    private long _editRevision;
+
+    [ObservableProperty]
+    private bool _isApplying;
+
+    [ObservableProperty]
+    private bool _changedWhileEditing;
+
+    public string ApplyText => Text("SessionConfig_Apply", "Apply");
+    public string ResetText => Text("SessionConfig_Reset", "Reset");
+    public string OnText => Text("SessionConfig_On", "On");
+    public string OffText => Text("SessionConfig_Off", "Off");
+    public string ChangedText => Text("SessionConfig_Changed", "The agent updated this setting. Your edit is kept; apply it or reset to the agent's value.");
+    public string? ErrorMessage => _errorKey is null ? null : Text(_errorKey, _errorKey switch
+    {
+        "SessionConfig_Stale" => "The conversation or connection changed. Reopen session settings.",
+        _ => "Could not apply this setting. Your edit is kept; try again."
+    });
+    public bool HasError => _errorKey is not null;
+    public bool EditorEnabled => !IsApplying && _apply is not null && _isCurrent?.Invoke() == true;
+    public bool HasChanges => IsBoolType ? Value is bool value && BoolValue != value
+        : IsSelectType && !string.Equals(SelectedOption?.Value, Value as string, StringComparison.Ordinal);
+    public bool CanApply => EditorEnabled && HasChanges && (IsBoolType
+        || IsSelectType && SelectedOption is { } selected && Options.Contains(selected));
+    public bool CanReset => EditorEnabled && (HasChanges || HasError || ChangedWhileEditing);
+
+    internal void BindEditor(
+        Func<ConfigOptionViewModel, Task<ConfigOptionApplyOutcome>> apply,
+        Func<bool> isCurrent,
+        IStringLocalizer<CoreStrings>? localizer,
+        IUiDispatcher uiDispatcher,
+        Action editingSettled)
+    {
+        _apply = apply ?? throw new ArgumentNullException(nameof(apply));
+        _isCurrent = isCurrent ?? throw new ArgumentNullException(nameof(isCurrent));
+        _localizer = localizer;
+        _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
+        _editingSettled = editingSettled ?? throw new ArgumentNullException(nameof(editingSettled));
+        RefreshEditor();
+    }
+
+    internal void RetireEditor()
+    {
+        _apply = null;
+        _isCurrent = null;
+        _editingSettled = null;
+        RefreshEditor();
+    }
+
+    internal void UpdateAuthoritative(ConfigOptionViewModel current)
+    {
+        var preserveDraft = HasChanges || IsApplying;
+        var previousSelection = SelectedOption;
+        var selectedValue = previousSelection?.Value;
+        var booleanValue = BoolValue;
+        var previousValue = Value;
+        _projecting = true;
+        try
+        {
+            Name = current.Name;
+            Description = current.Description;
+            Category = current.Category;
+            Value = current.Value;
+            if (!Options.SequenceEqual(current.Options, OptionValueEqualityComparer.Instance))
+            {
+                Options = current.Options;
+            }
+            SelectedOption = Options.FirstOrDefault(option => option.Value == (preserveDraft ? selectedValue : Value as string))
+                ?? (preserveDraft ? previousSelection : null);
+            BoolValue = preserveDraft ? booleanValue : Value is true;
+            if (preserveDraft && !IsApplying && (!Equals(previousValue, Value)
+                || IsSelectType && SelectedOption is { } selected && !Options.Contains(selected))) ChangedWhileEditing = true;
+        }
+        finally { _projecting = false; }
+        RefreshEditor();
+    }
+
+    internal void RefreshEditor()
+    {
+        OnPropertyChanged(nameof(EditorEnabled));
+        OnPropertyChanged(nameof(HasChanges));
+        OnPropertyChanged(nameof(CanApply));
+        OnPropertyChanged(nameof(CanReset));
+        ApplyCommand.NotifyCanExecuteChanged();
+        ResetCommand.NotifyCanExecuteChanged();
+    }
+
+    internal void ReprojectLocalizedText()
+    {
+        OnPropertyChanged(nameof(ApplyText));
+        OnPropertyChanged(nameof(ResetText));
+        OnPropertyChanged(nameof(OnText));
+        OnPropertyChanged(nameof(OffText));
+        OnPropertyChanged(nameof(ChangedText));
+        OnPropertyChanged(nameof(ErrorMessage));
+    }
+
+    [RelayCommand(CanExecute = nameof(CanApply))]
+    private async Task ApplyAsync()
+    {
+        if (_uiDispatcher is null) return;
+        await _uiDispatcher.EnqueueAsync(ApplyOnUiAsync).ConfigureAwait(false);
+    }
+
+    private async Task ApplyOnUiAsync()
+    {
+        if (!CanApply || _apply is null) return;
+        var revision = _editRevision;
+        SetError(null);
+        IsApplying = true;
+        try
+        {
+            var outcome = await _apply(this).ConfigureAwait(false);
+            await _uiDispatcher!.EnqueueAsync(() =>
+            {
+                if (outcome == ConfigOptionApplyOutcome.Applied)
+                {
+                    if (_editRevision == revision) ResetDraft();
+                }
+                else SetError(outcome == ConfigOptionApplyOutcome.Stale ? "SessionConfig_Stale" : "SessionConfig_Failed");
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            await _uiDispatcher!.EnqueueAsync(() =>
+            {
+                IsApplying = false;
+                _editingSettled?.Invoke();
+            }).ConfigureAwait(false);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanReset))]
+    private void Reset()
+    {
+        if (!CanReset) return;
+        ResetDraft();
+        _editingSettled?.Invoke();
+    }
+
+    private void ResetDraft()
+    {
+        _projecting = true;
+        try
+        {
+            SelectedOption = Options.FirstOrDefault(option => option.Value == Value as string);
+            BoolValue = Value is true;
+            ChangedWhileEditing = false;
+            SetError(null);
+        }
+        finally { _projecting = false; }
+        RefreshEditor();
+    }
+
+    private void SetError(string? key)
+    {
+        _errorKey = key;
+        OnPropertyChanged(nameof(ErrorMessage));
+        OnPropertyChanged(nameof(HasError));
+        RefreshEditor();
+    }
+
+    private string Text(string key, string fallback)
+    {
+        var localized = _localizer?[key];
+        return localized is null || localized.ResourceNotFound ? fallback : localized.Value;
+    }
+
+    partial void OnSelectedOptionChanged(OptionValueViewModel? value)
+    {
+        if (!_projecting) _editRevision++;
+        RefreshEditor();
+    }
+
+    partial void OnBoolValueChanged(bool value)
+    {
+        if (!_projecting) _editRevision++;
+        RefreshEditor();
+    }
+
+    partial void OnIsApplyingChanged(bool value) => RefreshEditor();
+    partial void OnChangedWhileEditingChanged(bool value) => RefreshEditor();
+
+    private sealed class OptionValueEqualityComparer : System.Collections.Generic.IEqualityComparer<OptionValueViewModel>
+    {
+        public static OptionValueEqualityComparer Instance { get; } = new();
+        public bool Equals(OptionValueViewModel? left, OptionValueViewModel? right)
+            => left?.Value == right?.Value && left?.Name == right?.Name && left?.Description == right?.Description;
+        public int GetHashCode(OptionValueViewModel value) => HashCode.Combine(value.Value, value.Name, value.Description);
+    }
+}

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ConfigOptionViewModel.cs
@@ -33,6 +33,7 @@ public partial class ConfigOptionViewModel : ObservableObject
     /// 配置选项的描述
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasDescription))]
     private string? _description;
 
     /// <summary>
@@ -45,6 +46,8 @@ public partial class ConfigOptionViewModel : ObservableObject
     /// 配置选项的值类型（string, number, boolean, array 等）
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBoolType))]
+    [NotifyPropertyChangedFor(nameof(IsSelectType))]
     private string _valueType = "string";
 
     /// <summary>
@@ -106,7 +109,9 @@ public partial class ConfigOptionViewModel : ObservableObject
     /// <summary>
     /// 判断是否为选择类型
     /// </summary>
-    public bool IsSelectType => HasOptions;
+    public bool IsSelectType => ValueType == "select";
+
+    public bool HasDescription => !string.IsNullOrWhiteSpace(Description);
 
     /// <summary>
     /// 获取显示用的值文本

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/SessionOptions/ChatSessionOptionsPresenter.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/SessionOptions/ChatSessionOptionsPresenter.cs
@@ -199,7 +199,7 @@ public sealed class ChatSessionOptionsPresenter
             Name = option.Name,
             Description = option.Description,
             Category = option.Category,
-            ValueType = option.ValueType ?? "string",
+            ValueType = option.ValueType ?? "select",
             IsRequired = true,
             Value = option.ValueType == "boolean" ? option.BooleanValue : option.SelectedValue ?? string.Empty,
             TextValue = option.SelectedValue ?? string.Empty,

--- a/tests/SalmonEgg.Acp.Tests/Protocol/InitializeTypesTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Protocol/InitializeTypesTests.cs
@@ -29,6 +29,18 @@ public sealed class InitializeTypesTests
     }
 
     [Fact]
+    public void ClientCapabilityDefaults_BooleanSettings_AdvertisesStableClientCapability()
+    {
+        // Arrange / Act
+        var json = JsonSerializer.SerializeToElement(ClientCapabilityDefaults.Create(), AcpJsonContext.Default.ClientCapabilities);
+
+        // Assert
+        var boolean = json.GetProperty("session").GetProperty("configOptions").GetProperty("boolean");
+        Assert.Equal(JsonValueKind.Object, boolean.ValueKind);
+        Assert.Empty(boolean.EnumerateObject());
+    }
+
+    [Fact]
     public void ClientCapabilityDefaults_Should_Advertise_AskUser_Extension_In_Meta()
     {
         var capabilities = ClientCapabilityDefaults.Create();

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.SessionConfiguration.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.SessionConfiguration.cs
@@ -1,0 +1,317 @@
+using System.Collections.Immutable;
+using Moq;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models.Conversation;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Localization;
+using SalmonEgg.Presentation.ViewModels.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SessionConfiguration_Apply_UsesTypedValueAndCommitsAgentResponse(bool boolean)
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        var response = new TaskCompletionSource<SessionSetConfigOptionResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        SessionSetConfigOptionParams? sent = null;
+        service.Setup(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>()))
+            .Returns<SessionSetConfigOptionParams>(request => { sent = request; return response.Task; });
+        await PrepareConfigurationAsync(fixture, service.Object, boolean);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        if (boolean) row.BoolValue = true;
+        else row.SelectedOption = row.Options.Single(option => option.Value == "careful");
+
+        // Act
+        var apply = row.ApplyCommand.ExecuteAsync(null);
+        Assert.NotNull(sent);
+        Assert.True(row.IsApplying);
+        Assert.False(row.EditorEnabled);
+        Assert.Equal("remote", sent.SessionId);
+        Assert.Equal("profile-setting", sent.ConfigId);
+        Assert.Equal(boolean ? null : "careful", sent.Value);
+        Assert.Equal(boolean ? true : (bool?)null, sent.BooleanValue);
+        Assert.Equal(boolean ? false : "fast", row.Value);
+        response.SetResult(new SessionSetConfigOptionResponse { ConfigOptions = [MakeConfigOption(boolean, changed: true)] });
+        await apply;
+
+        // Assert
+        row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        Assert.False(row.IsApplying);
+        Assert.False(row.HasChanges);
+        Assert.False(row.HasError);
+        var option = Assert.Single((await fixture.GetStateAsync()).ResolveSessionStateSlice("conversation")!.Value.ConfigOptions);
+        Assert.Equal(boolean ? true : (bool?)null, option.BooleanValue);
+        Assert.Equal(boolean ? null : "careful", option.SelectedValue);
+    }
+
+    [Fact]
+    public async Task SessionConfiguration_FailedApply_KeepsDraftForRetryAndLocalizesError()
+    {
+        // Arrange
+        var localizer = new MutableTestCoreStringLocalizer();
+        localizer.Set("zh-Hans", "SessionConfig_Failed", "设置未能应用，编辑已保留，请重试。");
+        await using var fixture = CreateInteractionViewModel(localizer: localizer);
+        var service = CreateConnectedChatService();
+        service.SetupSequence(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>()))
+            .ThrowsAsync(new InvalidOperationException("private backend details"))
+            .ReturnsAsync(new SessionSetConfigOptionResponse { ConfigOptions = [MakeConfigOption(false, true)] });
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+
+        // Act / Assert
+        await row.ApplyCommand.ExecuteAsync(null);
+        Assert.Equal("fast", row.Value);
+        Assert.Equal("careful", row.SelectedOption?.Value);
+        Assert.True(row.HasChanges);
+        Assert.True(row.ApplyCommand.CanExecute(null));
+        Assert.Equal("设置未能应用，编辑已保留，请重试。", row.ErrorMessage);
+        await row.ApplyCommand.ExecuteAsync(null);
+        Assert.False(row.HasError);
+        Assert.Equal("careful", row.Value);
+    }
+
+    [Fact]
+    public async Task SessionConfiguration_AuthoritativeRefresh_PreservesDraftAndAllowsExplicitReset()
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+
+        // Act
+        await fixture.DispatchAsync(new SetConversationSessionStateAction("conversation", [], null,
+            ConfigOptions: [MakeConfigSnapshot(false, selected: "agent-choice")], ShowConfigOptionsPanel: true));
+
+        // Assert
+        Assert.Same(row, Assert.Single(fixture.ViewModel.ConfigOptions));
+        Assert.Equal("agent-choice", row.Value);
+        Assert.Equal("careful", row.SelectedOption?.Value);
+        Assert.True(row.ChangedWhileEditing);
+        row.ResetCommand.Execute(null);
+        Assert.Equal("agent-choice", row.SelectedOption?.Value);
+        Assert.False(row.HasChanges);
+        Assert.False(row.ChangedWhileEditing);
+        service.Verify(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("binding")]
+    [InlineData("selection")]
+    [InlineData("connection")]
+    [InlineData("type")]
+    [InlineData("hydration")]
+    public async Task SessionConfiguration_StaleEditor_NeverSendsToReplacement(string change)
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+
+        // Act
+        await ReplaceConfigurationOwnerAsync(fixture, change);
+        await row.ApplyCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(row.ApplyCommand.CanExecute(null));
+        service.Verify(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("binding")]
+    [InlineData("selection")]
+    [InlineData("connection")]
+    public async Task SessionConfiguration_LateResponse_DoesNotOverwriteNewOwner(string change)
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        var response = new TaskCompletionSource<SessionSetConfigOptionResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.Setup(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>())).Returns(response.Task);
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+        var apply = row.ApplyCommand.ExecuteAsync(null);
+
+        // Act
+        await ReplaceConfigurationOwnerAsync(fixture, change);
+        response.SetResult(new SessionSetConfigOptionResponse { ConfigOptions = [MakeConfigOption(false, true)] });
+        await apply;
+
+        // Assert
+        Assert.Equal("fast", Assert.Single((await fixture.GetStateAsync())
+            .ResolveSessionStateSlice("conversation")!.Value.ConfigOptions).SelectedValue);
+    }
+
+    [Fact]
+    public async Task SessionConfiguration_InjectedChoice_IsRejectedByAuthoritativeOptions()
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        var injected = new OptionValueViewModel { Value = "unsupported", Name = "Unsupported" };
+        row.Options.Add(injected);
+        row.SelectedOption = injected;
+
+        // Act
+        await row.ApplyCommand.ExecuteAsync(null);
+
+        // Assert
+        service.Verify(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>()), Times.Never);
+        Assert.True(row.HasError);
+        Assert.Equal("fast", row.Value);
+    }
+
+    [Fact]
+    public async Task SessionConfiguration_ServerRemovedSelection_KeepsDraftUntilExplicitReset()
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        var service = CreateConnectedChatService();
+        await PrepareConfigurationAsync(fixture, service.Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+        var updated = MakeConfigSnapshot(false);
+        updated.Options.RemoveAll(option => option.Value == "careful");
+
+        // Act
+        await fixture.DispatchAsync(new SetConversationSessionStateAction("conversation", [], null,
+            ConfigOptions: [updated], ShowConfigOptionsPanel: true));
+
+        // Assert
+        Assert.False(row.ApplyCommand.CanExecute(null));
+        Assert.True(row.ChangedWhileEditing);
+        Assert.Equal("careful", row.SelectedOption?.Value);
+        row.ResetCommand.Execute(null);
+        Assert.Equal("fast", row.SelectedOption?.Value);
+    }
+
+    [Fact]
+    public async Task SessionConfiguration_BackgroundResponse_MarshalsEditorCompletionToUiDispatcher()
+    {
+        // Arrange
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        var service = CreateConnectedChatService();
+        var response = new TaskCompletionSource<SessionSetConfigOptionResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.Setup(value => value.SetSessionConfigOptionAsync(It.IsAny<SessionSetConfigOptionParams>())).Returns(response.Task);
+        await PrepareConfigurationAsync(fixture, service.Object, dispatcher: dispatcher);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+        var completionOnUi = false;
+        row.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(row.IsApplying) && !row.IsApplying)
+                completionOnUi = dispatcher.HasThreadAccess;
+        };
+
+        // Act
+        var apply = row.ApplyCommand.ExecuteAsync(null);
+        await dispatcher.RunUntilIdleAsync();
+        await Task.Run(() => response.SetResult(new SessionSetConfigOptionResponse
+        { ConfigOptions = [MakeConfigOption(false, true)] }), TestContext.Current.CancellationToken);
+        await dispatcher.RunUntilCompletedAsync(apply);
+
+        // Assert
+        Assert.True(completionOnUi);
+        Assert.False(row.HasError);
+        Assert.False(row.HasChanges);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SessionConfiguration_PriorityChanges_DefersMovesWhileEditingAndConvergesAfterReset(bool editing)
+    {
+        // Arrange
+        await using var fixture = CreateInteractionViewModel();
+        await PrepareConfigurationAsync(fixture, CreateConnectedChatService().Object);
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        var other = new ConversationConfigOptionSnapshot
+        { Id = "another-setting", Name = "Another", ValueType = "boolean", BooleanValue = false };
+        await fixture.DispatchAsync(new SetConversationSessionStateAction("conversation", [], null,
+            ConfigOptions: [MakeConfigSnapshot(false), other], ShowConfigOptionsPanel: true));
+        if (editing) row.SelectedOption = row.Options[1];
+
+        // Act
+        await fixture.DispatchAsync(new SetConversationSessionStateAction("conversation", [], null,
+            ConfigOptions: [other, MakeConfigSnapshot(false)], ShowConfigOptionsPanel: true));
+
+        // Assert
+        if (editing)
+        {
+            Assert.Same(row, fixture.ViewModel.ConfigOptions[0]);
+            row.ResetCommand.Execute(null);
+        }
+        Assert.Equal(["another-setting", "profile-setting"], fixture.ViewModel.ConfigOptions.Select(option => option.Id));
+        Assert.Same(row, fixture.ViewModel.ConfigOptions[1]);
+    }
+
+    private static async Task PrepareConfigurationAsync(ViewModelFixture fixture,
+        SalmonEgg.Application.Services.Chat.IChatService service, bool boolean = false,
+        QueueingSynchronizationContext? dispatcher = null)
+    {
+        var adapter = RegisterInteractionMock(fixture, service, "profile");
+        var replace = fixture.ViewModel.ReplaceChatServiceAsync(adapter, TestContext.Current.CancellationToken);
+        if (dispatcher is not null)
+            await dispatcher.RunUntilCompletedAsync(replace);
+        else await replace;
+        await fixture.UpdateStateAsync(state => state with
+        {
+            HydratedConversationId = "conversation",
+            Bindings = ImmutableDictionary<string, ConversationBindingSlice>.Empty
+                .Add("conversation", new("conversation", "remote", "profile")),
+            ConversationSessionStates = ImmutableDictionary<string, ConversationSessionStateSlice>.Empty
+                .Add("conversation", new([], null, [MakeConfigSnapshot(boolean)], true, [], null, null))
+        });
+    }
+
+    private static Task ReplaceConfigurationOwnerAsync(ViewModelFixture fixture, string change)
+        => change switch
+        {
+            "binding" => fixture.UpdateStateAsync(state => state with
+            { Bindings = state.Bindings!.SetItem("conversation", new("conversation", "replacement", "profile")) }).AsTask(),
+            "selection" => fixture.UpdateStateAsync(state => state with { HydratedConversationId = "other" }).AsTask(),
+            "connection" => fixture.ViewModel.ReplaceChatServiceAsync(CreateConnectedChatService().Object, TestContext.Current.CancellationToken),
+            "hydration" => fixture.UpdateStateAsync(state => state with { IsHydrating = true }).AsTask(),
+            _ => fixture.DispatchAsync(new SetConversationSessionStateAction("conversation", [], null,
+                ConfigOptions: [new ConversationConfigOptionSnapshot { Id = "profile-setting", Name = "Future", ValueType = "future" }],
+                ShowConfigOptionsPanel: false)).AsTask()
+        };
+
+    private static ConversationConfigOptionSnapshot MakeConfigSnapshot(bool boolean, string selected = "fast") => new()
+    {
+        Id = "profile-setting",
+        Name = "Performance",
+        Description = "How carefully the agent should work.",
+        ValueType = boolean ? "boolean" : "select",
+        BooleanValue = boolean ? false : null,
+        SelectedValue = boolean ? null : selected,
+        Options = boolean ? [] : [new() { Value = "fast", Name = "Fast" }, new() { Value = "careful", Name = "Careful" },
+            new() { Value = "agent-choice", Name = "Agent choice" }]
+    };
+
+    private static ConfigOption MakeConfigOption(bool boolean, bool changed) => new()
+    {
+        Id = "profile-setting",
+        Name = "Performance",
+        Description = "How carefully the agent should work.",
+        Type = boolean ? "boolean" : "select",
+        CurrentBooleanValue = boolean ? changed : null,
+        CurrentValue = boolean ? null : changed ? "careful" : "fast",
+        Options = boolean ? [] : [new() { Value = "fast", Name = "Fast" }, new() { Value = "careful", Name = "Careful" }]
+    };
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.SessionConfigurationOrdering.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.SessionConfigurationOrdering.cs
@@ -1,0 +1,126 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Interfaces;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Fact]
+    public async Task SessionConfiguration_ResponseThenUpdate_BlocksDelayedApplyFromRestoringOlderValues()
+    {
+        // Arrange: actual SDK -> ChatService -> buffered event adapter -> ChatViewModel.
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var peer = await ConfigurationUiPeer.CreateAsync(dispatcher);
+        RegisterInteractionService(fixture, peer.Service);
+        await dispatcher.RunUntilCompletedAsync(fixture.ViewModel.ReplaceChatServiceAsync(peer.Service,
+            TestContext.Current.CancellationToken));
+        await fixture.UpdateStateAsync(state => state with
+        {
+            HydratedConversationId = "conversation",
+            Bindings = ImmutableDictionary<string, ConversationBindingSlice>.Empty
+                .Add("conversation", new("conversation", "remote", "profile")),
+            ConversationSessionStates = ImmutableDictionary<string, ConversationSessionStateSlice>.Empty
+                .Add("conversation", new([], null, [MakeConfigSnapshot(false)], true, [], null, null))
+        });
+        var row = Assert.Single(fixture.ViewModel.ConfigOptions);
+        row.SelectedOption = row.Options[1];
+
+        // Act: keep the set call suspended after A is received; B reaches its real projection first.
+        var apply = row.ApplyCommand.ExecuteAsync(null);
+        while (!peer.RequestSent.Task.IsCompleted)
+        {
+            dispatcher.RunAll();
+            await Task.Yield();
+            TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+        }
+        await dispatcher.RunUntilIdleAsync();
+        peer.ReleaseSend.TrySetResult(true);
+        await dispatcher.RunUntilCompletedAsync(apply);
+        await dispatcher.RunUntilIdleAsync();
+
+        // Assert
+        var current = Assert.Single((await fixture.GetStateAsync()).ResolveSessionStateSlice("conversation")!.Value.ConfigOptions);
+        Assert.Equal("agent-choice", current.SelectedValue);
+        Assert.Equal("agent-choice", Assert.Single(fixture.ViewModel.ConfigOptions).Value);
+    }
+
+    private sealed class ConfigurationUiPeer : IAcpTransport
+    {
+        private readonly AcpClient _client;
+        private readonly AcpEventAdapter _adapter;
+
+        private ConfigurationUiPeer(IUiDispatcher dispatcher)
+        {
+            _client = new AcpClient(this, new NullAcpClientLogger());
+            _adapter = new AcpEventAdapter(update => Service!.PublishBufferedUpdate(update), dispatcher);
+            Service = new AcpChatServiceAdapter(new ChatService(_client, Mock.Of<IErrorLogger>(),
+                CreateSessionManagerWithStore().Object), _adapter);
+            _adapter.ReleaseUnscopedBufferedUpdates();
+        }
+
+        public AcpChatServiceAdapter Service { get; }
+        public TaskCompletionSource RequestSent { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> ReleaseSend { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool IsConnected { get; private set; }
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        public static async Task<ConfigurationUiPeer> CreateAsync(IUiDispatcher dispatcher)
+        {
+            var peer = new ConfigurationUiPeer(dispatcher);
+            await peer._client.InitializeAsync(new InitializeParams(new ClientInfo("config-tests", "1"),
+                ClientCapabilityDefaults.Create()), TestContext.Current.CancellationToken);
+            return peer;
+        }
+
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnected = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.FromResult(true);
+        }
+
+        public async Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            using var document = JsonDocument.Parse(message);
+            var request = document.RootElement;
+            var id = request.GetProperty("id").GetRawText();
+            if (request.GetProperty("method").GetString() == "initialize")
+            {
+                Receive($$$$"""{"jsonrpc":"2.0","id":{{{{id}}}},"result":{"protocolVersion":1,"agentCapabilities":{}}}""");
+                return true;
+            }
+            Receive($$$$"""{"jsonrpc":"2.0","id":{{{{id}}}},"result":{"configOptions":[{{{{ConfigJson("careful")}}}}]}}""");
+            Receive($$$$"""{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"remote","update":{"sessionUpdate":"config_option_update","configOptions":[{{{{ConfigJson("agent-choice")}}}}]}}}""");
+            RequestSent.TrySetResult();
+            return await ReleaseSend.Task.WaitAsync(cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            ReleaseSend.TrySetResult(false);
+            IsConnected = false;
+            Service.Dispose();
+        }
+
+        private static string ConfigJson(string value)
+            => $$"""{"id":"profile-setting","name":"Performance","type":"select","currentValue":"{{value}}","options":[{"value":"fast","name":"Fast"},{"value":"careful","name":"Careful"},{"value":"agent-choice","name":"Agent choice"}]}""";
+
+        private void Receive(string message) => MessageReceived?.Invoke(this, new(message));
+    }
+}


### PR DESCRIPTION
会话中的 Agent 自定义配置此前没有可操作界面。现在标题栏提供原生“会话设置”Flyout，按 Agent 配置展示选择项和布尔开关，支持说明、应用、重置和失败重试；编辑草稿不会被后台更新静默覆盖，失效连接/会话的旧行不能发送设置请求。

配置响应与后续通知复用 #211 的同一接收事件顺序；真实 AcpClient→ChatService→Adapter→编辑命令的回归已证明：先收到响应 A、再收到更新 B，即使设置命令迟到才继续，最终界面仍保持 B。正在编辑的输入保留，重置可恢复 Agent 当前值；异步操作期间不搬动原生控件行。

验证：整合树 25 项配置测试通过；作者最终 33 项配置、V2 更新和队列等待测试通过。真实本次 WASM grouped select→失败→retry→boolean及原表单/URL/权限全链通过。移除编辑保留时断言转红；接入有序响应前真实 A/B 回归转红、修复后通过。新增 ComboBox 保留原生手柄焦点规则，原合规断言通过。

远端完整浏览器检查又发现：V1 未知配置项的原始报文被固定按 V2 读取，会让整表无法展示。SDK 配置视图现保留收到时的协议版本，V1/V2 的通知与响应四种组合均通过；未知字段与原始数字保留、读取结果保持隔离。本次 `1369cf50` 对应产品重建后，完整配置/表单/URL/权限浏览器门禁再次通过。

依赖 #211。仍需最新提交 CI 全绿和独立复审后合并；当前 PR 保持草稿。默认连接继续 V1。

Refs #149。
