### PR TITLE
feat(acp): project experimental V2 sessions through the chat lifecycle

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -89,6 +89,8 @@ Linux/macOS 暂不广告终端登录：当前 Porta.Pty 对 Unix 信号退出不
 `SALMONEGG_EXPERIMENTAL_ACP_V2=1`；客户端创建和 initialize 使用同一开关，Agent 可以降级为 V1。
 该开关不会修改持久化配置或默认协议版本。官方 Rust `simple_agent_v2` 可以验证真实协议互通，
 但它是 echo 示例，不代表第三方 LLM Agent 或全部原生平台的产品验收。
+WASM 没有宿主进程环境；构建时显式加 `-p:SalmonEggExperimentalAcpV2=true`，通过 Uno 原生
+`WasmShellMonoEnvironment` 将同一变量传入运行时。普通构建不包含该变量。
 
 ### Windows 用户
 ```bash

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -83,6 +83,13 @@ Linux/macOS 暂不广告终端登录：当前 Porta.Pty 对 Unix 信号退出不
 
 ## 快速开始
 
+### ACP V2 实验连接
+
+默认连接仍使用稳定 V1。需要评估 V2 时，在启动应用的进程环境中显式设置
+`SALMONEGG_EXPERIMENTAL_ACP_V2=1`；客户端创建和 initialize 使用同一开关，Agent 可以降级为 V1。
+该开关不会修改持久化配置或默认协议版本。官方 Rust `simple_agent_v2` 可以验证真实协议互通，
+但它是 echo 示例，不代表第三方 LLM Agent 或全部原生平台的产品验收。
+
 ### Windows 用户
 ```bash
 # 方式 1: 使用构建脚本（Desktop）

--- a/SalmonEgg/SalmonEgg/DependencyInjection.cs
+++ b/SalmonEgg/SalmonEgg/DependencyInjection.cs
@@ -533,6 +533,10 @@ public static class DependencyInjection
                 : new UnsupportedTerminalSessionManager());
 #endif
         services.AddSingleton<ITransportErrorMessageFormatter, TransportErrorMessageFormatter>();
+        // Explicit process opt-in, never inferred from the SDK's modeled-version ceiling.
+        // Every connection factory and initialize path consumes this same immutable policy.
+        services.AddSingleton(new SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy(
+            string.Equals(Environment.GetEnvironmentVariable("SALMONEGG_EXPERIMENTAL_ACP_V2"), "1", StringComparison.Ordinal)));
         services.AddSingleton<IAcpClientFactory, AcpClientFactory>();
 
         // ACP setup wizard. The catalog is pure data and safe everywhere; every probing, installing and
@@ -648,7 +652,8 @@ public static class DependencyInjection
                 sp.GetRequiredService<IAcpConnectionPoolManager>(),
                 sp.GetRequiredService<IAcpConnectionDependencySnapshotProvider>(),
                 platformCapabilities: sp.GetRequiredService<IPlatformCapabilityService>(),
-                localizer: sp.GetRequiredService<IStringLocalizer<CoreStrings>>());
+                localizer: sp.GetRequiredService<IStringLocalizer<CoreStrings>>(),
+                protocolExperiment: sp.GetRequiredService<SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy>());
         });
         services.AddSingleton(sp =>
         {

--- a/SalmonEgg/SalmonEgg/SalmonEgg.csproj
+++ b/SalmonEgg/SalmonEgg/SalmonEgg.csproj
@@ -58,6 +58,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-browserwasm'">
+    <!-- Uno's native runtime environment projection is the explicit WASM experiment switch.
+         Default builds omit it; this never changes the SDK stable protocol default. -->
+    <WasmShellMonoEnvironment Include="SALMONEGG_EXPERIMENTAL_ACP_V2" Value="1"
+                              Condition="'$(SalmonEggExperimentalAcpV2)' == 'true'" />
     <WasmShellNativeFileReference Include="Platforms\WebAssembly\WasmScripts\salmon-egg-wasm-storage.js" />
     <WasmShellNativeFileReference Include="Platforms\WebAssembly\WasmScripts\salmon-egg-wasm-shell.js" />
     <WasmShellNativeFileReference Include="Platforms\WebAssembly\WasmScripts\salmon-egg-wasm-notifications.js" />

--- a/scripts/gates/run-acp-official-v2-agent-gate.sh
+++ b/scripts/gates/run-acp-official-v2-agent-gate.sh
@@ -29,14 +29,14 @@ timeout --signal=TERM --kill-after=10s 180s "${DOTNET_BIN:-dotnet}" test \
   --project tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj \
   --configuration Release --no-ansi -p:UseSharedCompilation=false \
   --filter-class SalmonEgg.Acp.Desktop.Tests.OfficialV2AgentAcceptanceTests \
-  --minimum-expected-tests 1 --output Detailed > "$output/client.log" 2>&1
+  --minimum-expected-tests 2 --output Detailed > "$output/client.log" 2>&1
 cat "$output/client.log"
 python3 - "$output/client.log" <<'PY'
 from pathlib import Path
 import re
 import sys
 text = Path(sys.argv[1]).read_text()
-if not re.search(r'^\s+succeeded:\s+1\s*$', text, re.M) or not re.search(r'^\s+skipped:\s+0\s*$', text, re.M):
+if not re.search(r'^\s+succeeded:\s+2\s*$', text, re.M) or not re.search(r'^\s+skipped:\s+0\s*$', text, re.M):
     raise SystemExit('The upstream v2 Agent must run through the production client without skips.')
 PY
 sha256sum "$SALMONEGG_OFFICIAL_V2_AGENT" > "$output/agent.sha256"

--- a/scripts/gates/wasm-official-v2-agent-smoke.mjs
+++ b/scripts/gates/wasm-official-v2-agent-smoke.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { chromium } from "playwright";
+import {
+  normalizeBaseUrl, clearBrowserOriginStorage, createInstrumentedContext, openApp, assertNoFatalConsoleMessages
+} from "./wasm-smoke-lib/browser-app.mjs";
+import { navigateToSettingsSection } from "./wasm-smoke-lib/settings-shell.mjs";
+import { createWebSocketProfile, createRemoteDirectory, ensureAcpProfilesReady, clickProfileConnectionToggle }
+  from "./wasm-smoke-lib/acp-ui-fixture.mjs";
+import {
+  selectComboBoxItem, clickVisibleNavigationTarget, typeIntoVisibleTextField,
+  clickStartComposerSendButton, waitForSemanticText, collectVisibleInteractiveDebug, waitForControlEnabledState
+} from "./wasm-smoke-lib/ui-affordances.mjs";
+
+const baseUrl = normalizeBaseUrl(process.argv[2], "wasm-official-v2-agent-smoke.mjs");
+const agentUrl = process.env.SALMONEGG_OFFICIAL_V2_WS_URL;
+assert.ok(agentUrl, "Supply the released bridge URL fronting the unmodified official Rust V2 Agent.");
+const browser = await chromium.launch({ headless: true, executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined });
+const frames = [];
+const marker = `official-v2-gui-${Date.now()}`;
+const profile = `Official V2 ${Date.now()}`;
+const directory = `V2 project ${Date.now()}`;
+const cwd = process.env.SALMONEGG_OFFICIAL_V2_CWD || "/tmp";
+const artifacts = process.env.WASM_SMOKE_ARTIFACTS_DIR;
+
+function record(direction, event) {
+  const text = typeof event.payload === "string" ? event.payload : event.payload.toString("utf8");
+  try {
+    const parsed = JSON.parse(text);
+    for (const frame of Array.isArray(parsed) ? parsed : [parsed]) frames.push({ direction, frame });
+  } catch {
+    throw new Error("The official bridge sent a non-JSON ACP frame.");
+  }
+}
+
+async function awaitFrame(predicate, label) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const match = frames.find(predicate);
+    if (match) return match.frame;
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  throw new Error(`No ${label} was observed on the actual browser WebSocket.`);
+}
+
+try {
+  await clearBrowserOriginStorage(browser, baseUrl);
+  const { context, page, fatalConsoleMessages } = await createInstrumentedContext(browser);
+  page.on("websocket", socket => {
+    if (socket.url() === agentUrl) {
+      socket.on("framesent", frame => record("client", frame));
+      socket.on("framereceived", frame => record("agent", frame));
+    }
+  });
+  try {
+    await openApp(page, baseUrl);
+    await navigateToSettingsSection(page,
+      { labels: ["ACP Agent", "ACP / Agent"], automationIds: ["SettingsNav.AgentAcp"] },
+      /ACP Agent|ACP connection profiles/, "ACP Agent settings");
+    await createWebSocketProfile(page, profile, agentUrl);
+    await createRemoteDirectory(page, directory, cwd);
+    await ensureAcpProfilesReady(page);
+    await clickProfileConnectionToggle(page, profile);
+    const initialize = await awaitFrame(item => item.direction === "client" && item.frame.method === "initialize", "V2 offer");
+    assert.equal(initialize.params.protocolVersion, 2, "Only the explicitly opted-in artifact may enter this gate.");
+    assert.ok(initialize.params.info);
+    assert.equal(initialize.params.clientInfo, undefined);
+    const initialized = await awaitFrame(item => item.direction === "agent" && item.frame.id === initialize.id, "negotiated V2 response");
+    assert.equal(initialized.result.protocolVersion, 2);
+
+    await clickVisibleNavigationTarget(page, { labels: ["Start", "开始"], automationIds: ["MainNav.Start"] });
+    await selectComboBoxItem(page, "AgentSelectorHost", profile, { verifySelectionText: false, keyboardSelectVisibleItem: true });
+    await selectComboBoxItem(page, "ProjectSelectorHost", directory, { verifySelectionText: false, keyboardSelectVisibleItem: true });
+    const created = await awaitFrame(item => item.direction === "client" && item.frame.method === "session/new", "session creation");
+    assert.equal(created.params.cwd, cwd);
+    await awaitFrame(item => item.direction === "agent" && item.frame.id === created.id, "created session response");
+    await typeIntoVisibleTextField(page, { selector: "#uno-semantics-root textarea" }, marker, "V2 prompt");
+    await clickStartComposerSendButton(page);
+    const prompt = await awaitFrame(item => item.direction === "client" && item.frame.method === "session/prompt", "prompt");
+    const accepted = await awaitFrame(item => item.direction === "agent" && item.frame.id === prompt.id, "prompt acknowledgement");
+    assert.equal(accepted.result.stopReason, undefined, "V2 acknowledgement is not a terminal prompt result.");
+    const idle = await awaitFrame(item => item.direction === "agent" && item.frame.method === "session/update"
+      && item.frame.params.update.sessionUpdate === "state_update" && item.frame.params.update.state === "idle", "ending idle");
+    assert.equal(idle.params.update.stopReason, "end_turn");
+    await waitForSemanticText(page, new RegExp(`Echo: ${marker}`), "official Agent response visible in ChatView", 30_000);
+    await waitForControlEnabledState(page, { automationIds: ["ChatInputArea.Input"] }, true, "input enabled after authoritative idle", 30_000);
+    assert.equal(frames.filter(item => item.direction === "client" && item.frame.method === "session/prompt").length, 1);
+    assert.equal(frames.filter(item => item.direction === "client" && item.frame.method === "session/load").length, 0);
+    assertNoFatalConsoleMessages(fatalConsoleMessages);
+    if (artifacts) {
+      await mkdir(artifacts, { recursive: true });
+      await writeFile(`${artifacts}/result.json`, JSON.stringify({ passed: true, agent: "official Rust simple_agent_v2", llm: false,
+        negotiatedVersion: 2, marker, accepted: true, idle: true, inputEnabled: true }, null, 2));
+      await writeFile(`${artifacts}/wire.json`, JSON.stringify(frames, null, 2));
+      await page.screenshot({ path: `${artifacts}/final.png` });
+    }
+    console.log("Official ACP V2 Agent WASM application gate passed");
+  } catch (error) {
+    if (artifacts) {
+      await mkdir(artifacts, { recursive: true });
+      await page.screenshot({ path: `${artifacts}/failure.png` });
+      await writeFile(`${artifacts}/failure.json`, JSON.stringify({ error: String(error), frames,
+        controls: await page.evaluate(collectVisibleInteractiveDebug), fatalConsoleMessages }, null, 2));
+    }
+    throw error;
+  } finally {
+    await context.close();
+  }
+} finally {
+  await browser.close();
+}

--- a/scripts/gates/wasm-official-v2-agent-smoke.mjs
+++ b/scripts/gates/wasm-official-v2-agent-smoke.mjs
@@ -8,7 +8,7 @@ import { navigateToSettingsSection } from "./wasm-smoke-lib/settings-shell.mjs";
 import { createWebSocketProfile, createRemoteDirectory, ensureAcpProfilesReady, clickProfileConnectionToggle }
   from "./wasm-smoke-lib/acp-ui-fixture.mjs";
 import {
-  selectComboBoxItem, clickVisibleNavigationTarget, typeIntoVisibleTextField,
+  clickVisibleNavigationTarget, typeIntoVisibleTextField, waitForNativeControlFocus,
   clickStartComposerSendButton, waitForSemanticText, collectVisibleInteractiveDebug, waitForControlEnabledState
 } from "./wasm-smoke-lib/ui-affordances.mjs";
 
@@ -69,8 +69,28 @@ try {
     assert.equal(initialized.result.protocolVersion, 2);
 
     await clickVisibleNavigationTarget(page, { labels: ["Start", "开始"], automationIds: ["MainNav.Start"] });
-    await selectComboBoxItem(page, "AgentSelectorHost", profile, { verifySelectionText: false, keyboardSelectVisibleItem: true });
-    await selectComboBoxItem(page, "ProjectSelectorHost", directory, { verifySelectionText: false, keyboardSelectVisibleItem: true });
+    // Connecting the unique profile already selects it through the authoritative connection owner.
+    // Opening and reselecting the same native ComboBox is unnecessary and races its close animation.
+    await waitForControlEnabledState(page, { automationIds: ["AgentSelectorHost"] }, true, "connected Agent selector");
+    // The isolated profile has one eligible remote directory. Native closed-ComboBox keyboard
+    // selection avoids depending on transient popup label mirrors. The wire cwd assertion below
+    // is the authoritative result of this input, so a wrong selection cannot pass.
+    await page.evaluate(() => window.__salmoneggSmoke.semantic.focusControl({ automationIds: ["ProjectSelectorHost"], labels: [] }));
+    await waitForNativeControlFocus(page, { automationIds: ["ProjectSelectorHost"], labels: [] }, "project selector");
+    await page.keyboard.press("F4");
+    await page.waitForFunction(() => {
+      const state = window.__salmoneggSmoke.semantic.describe({ automationIds: ["ProjectSelectorHost"], labels: [] });
+      const element = state?.id ? document.getElementById(state.id) : null;
+      const popup = element?.getAttribute("aria-controls");
+      return state?.expanded === true && popup && document.getElementById(popup)?.children.length > 0;
+    }, undefined, { timeout: 10_000 });
+    await page.keyboard.press("End");
+    await page.waitForFunction(() => {
+      const state = window.__salmoneggSmoke.semantic.describe({ automationIds: ["ProjectSelectorHost"], labels: [] });
+      const element = state?.id ? document.getElementById(state.id) : null;
+      return Boolean(element?.getAttribute("aria-activedescendant"));
+    }, undefined, { timeout: 10_000 });
+    await page.keyboard.press("Enter");
     const created = await awaitFrame(item => item.direction === "client" && item.frame.method === "session/new", "session creation");
     assert.equal(created.params.cwd, cwd);
     await awaitFrame(item => item.direction === "agent" && item.frame.id === created.id, "created session response");
@@ -80,10 +100,12 @@ try {
     const accepted = await awaitFrame(item => item.direction === "agent" && item.frame.id === prompt.id, "prompt acknowledgement");
     assert.equal(accepted.result.stopReason, undefined, "V2 acknowledgement is not a terminal prompt result.");
     const idle = await awaitFrame(item => item.direction === "agent" && item.frame.method === "session/update"
-      && item.frame.params.update.sessionUpdate === "state_update" && item.frame.params.update.state === "idle", "ending idle");
+      && item.frame.params.sessionId === prompt.params.sessionId
+      && item.frame.params.update.sessionUpdate === "state_update" && item.frame.params.update.state === "idle"
+      && item.frame.params.update.stopReason === "end_turn", "ending idle for this prompt session");
     assert.equal(idle.params.update.stopReason, "end_turn");
     await waitForSemanticText(page, new RegExp(`Echo: ${marker}`), "official Agent response visible in ChatView", 30_000);
-    await waitForControlEnabledState(page, { automationIds: ["ChatInputArea.Input"] }, true, "input enabled after authoritative idle", 30_000);
+    await waitForControlEnabledState(page, { automationIds: ["InputBox"], role: "textarea" }, true, "input enabled after authoritative idle", 30_000);
     assert.equal(frames.filter(item => item.direction === "client" && item.frame.method === "session/prompt").length, 1);
     assert.equal(frames.filter(item => item.direction === "client" && item.frame.method === "session/load").length, 0);
     assertNoFatalConsoleMessages(fatalConsoleMessages);

--- a/src/SalmonEgg.Acp/AcpDraftProtocol.cs
+++ b/src/SalmonEgg.Acp/AcpDraftProtocol.cs
@@ -46,9 +46,9 @@ namespace SalmonEgg.Acp
         /// today, because the client will not negotiate v2 at all.
         /// </summary>
         internal const string Message =
-            "This is ACP v2 draft surface: the wire contract is modeled, but v2 is still an upstream "
-            + "draft and no live SalmonEgg.Acp client negotiates it, so nothing built on this type can "
-            + "talk to a real Agent yet. Shapes may change or be removed as upstream v2 settles. See "
+            "This is ACP v2 draft surface: the wire contract remains experimental and requires "
+            + "explicit client opt-in before V2 negotiation. The default stays on stable V1. "
+            + "Shapes may change or be removed as upstream v2 settles. See "
             + "https://github.com/salmonloop/salmon-egg/blob/main/src/SalmonEgg.Acp/README.md#acp-v2-draft-surface-seacp002";
 
         /// <summary>

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -26,7 +26,7 @@ namespace SalmonEgg.Acp.Client
     public sealed class AcpClient : IAcpClient, IDisposable
     {
         private const string StableV1RuntimeOnlyMessage =
-            "ACP defaults to stable protocolVersion 1. Draft protocolVersion 2 requires an explicit experimental client policy.";
+            "ACP live client support is limited to stable protocolVersion 1 by default. Draft protocolVersion 2 requires an explicit experimental client policy.";
         private const string DisconnectIncompleteMessage =
             "ACP client disconnect has not completed successfully. Wait for it or retry DisconnectAsync before initializing.";
 

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -25,7 +26,7 @@ namespace SalmonEgg.Acp.Client
     public sealed class AcpClient : IAcpClient, IDisposable
     {
         private const string StableV1RuntimeOnlyMessage =
-            "ACP live client support is limited to stable protocolVersion 1 while newer modeled versions remain draft or incomplete.";
+            "ACP defaults to stable protocolVersion 1. Draft protocolVersion 2 requires an explicit experimental client policy.";
         private const string DisconnectIncompleteMessage =
             "ACP client disconnect has not completed successfully. Wait for it or retry DisconnectAsync before initializing.";
 
@@ -117,6 +118,7 @@ namespace SalmonEgg.Acp.Client
         private readonly IAcpClientSessionStore _sessionStore;
         private readonly IAcpTerminalSessionManager _terminalSessionManager;
         private readonly IAcpClientLogger _logger;
+        private readonly HashSet<int> _experimentalProtocolVersions;
         private readonly AcpSessionWorkController _sessionWork = new();
         private readonly ConcurrentDictionary<AcpRequestId, PendingOutboundRequest> _pendingRequests = new();
         // Inbound tool requests (agent -> client) are correlated by request id so we can format responses correctly.
@@ -151,6 +153,9 @@ namespace SalmonEgg.Acp.Client
         // Projection rather than a second field: a copy could drift from the contract actually in use,
         // and the two disagreeing is exactly the class of defect this refactor exists to remove.
         private int ProtocolVersion => _wire.Version;
+
+        /// <inheritdoc />
+        public int NegotiatedProtocolVersion => _isInitialized ? ProtocolVersion : AcpProtocolVersion.Default;
         private AgentInfo? _agentInfo;
         private AgentCapabilities? _agentCapabilities;
         private IReadOnlyList<AuthMethodDefinition>? _authMethods;
@@ -237,6 +242,9 @@ namespace SalmonEgg.Acp.Client
         /// </summary>
         public AgentCapabilities? AgentCapabilities => _agentCapabilities;
 
+        /// <inheritdoc />
+        public bool PublishesConfigurationResponses => true;
+
         /// <summary>
         /// Creates a new <see cref="AcpClient"/> instance.
         /// </summary>
@@ -249,7 +257,24 @@ namespace SalmonEgg.Acp.Client
             IAcpClientLogger? logger = null,
             IAcpClientSessionStore? sessionStore = null,
             IAcpTerminalSessionManager? terminalSessionManager = null)
+            : this(transport, logger, sessionStore, terminalSessionManager, new AcpClientOptions())
         {
+        }
+
+        /// <summary>Creates a client with an explicit experimental-protocol policy.</summary>
+        public AcpClient(
+            IAcpTransport transport,
+            IAcpClientLogger? logger,
+            IAcpClientSessionStore? sessionStore,
+            IAcpTerminalSessionManager? terminalSessionManager,
+            AcpClientOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            _experimentalProtocolVersions = new HashSet<int>(options.ExperimentalProtocolVersions);
+            if (_experimentalProtocolVersions.Any(static version => version != AcpProtocolVersion.V2))
+            {
+                throw new ArgumentOutOfRangeException(nameof(options), "Only ACP v2 is available for explicit experimental evaluation.");
+            }
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             _parser = new MessageParser();
             _validator = new MessageValidator();
@@ -266,7 +291,7 @@ namespace SalmonEgg.Acp.Client
         /// Initializes the connection to the agent.
         /// </summary>
         public Task<InitializeResponse> InitializeAsync(InitializeParams @params, CancellationToken cancellationToken = default)
-            => InitializeCoreAsync(@params, allowDraftRuntime: false, cancellationToken);
+            => InitializeCoreAsync(@params, allowDraftRuntime: _experimentalProtocolVersions.Contains(AcpProtocolVersion.V2), cancellationToken);
 
         // Assembly-internal staging seam: deterministic protocol peers exercise the actual parser,
         // dispatch and lifecycle before the full draft can be enabled by a future feature gate.
@@ -340,6 +365,9 @@ namespace SalmonEgg.Acp.Client
                 {
                     throw new InvalidOperationException("ACP client initialization is already in progress.");
                 }
+                // initialize is self-describing but its nested capabilities still use the offered
+                // surface. A reused client cannot serialize a new handshake through its old wire.
+                _wire = AcpWireFormat.For(@params.ProtocolVersion);
                 // The initialize request belongs to this connection too. Keep this same owner
                 // through the successful handshake instead of introducing it only afterwards.
                 _messageLoopCts = new CancellationTokenSource();
@@ -500,6 +528,19 @@ namespace SalmonEgg.Acp.Client
         public async Task<SessionLoadResponse> LoadSessionAsync(SessionLoadParams @params, CancellationToken cancellationToken = default)
         {
             EnsureInitialized();
+            if (ProtocolVersion == AcpProtocolVersion.V2)
+            {
+                ArgumentNullException.ThrowIfNull(@params);
+                // A product's restore intent is stable; the negotiated wire method is not. V2
+                // restores history with resume/start and must never send its removed load method.
+                var resumed = await ResumeSessionAsync(new SessionResumeParams(@params.SessionId,
+                    @params.Cwd, @params.McpServers, replayFrom: SessionReplayFrom.Start)
+                {
+                    AdditionalDirectories = @params.AdditionalDirectories,
+                    Meta = AcpMetaJson.Clone(@params.Meta)
+                }, cancellationToken).ConfigureAwait(false);
+                return new SessionLoadResponse(modes: null, configOptions: resumed.ConfigOptions) { Meta = AcpMetaJson.Clone(resumed.Meta) };
+            }
             var connectionToken = GetConnectionToken();
             if (!SupportsSessionLoad)
             {
@@ -904,9 +945,8 @@ namespace SalmonEgg.Acp.Client
                 JsonSerializer.SerializeToElement(@params, wire.TypeInfo<SessionSetConfigOptionParams>()));
 
             var response = await SendRequestAsync(request, cancellationToken, connectionToken,
-                responseObserver: wire.Version == AcpProtocolVersion.V2
-                    ? response => ReceiveDraftConfiguration(response, wire, connectionToken, @params.SessionId, isSetResponse: true)
-                    : null).ConfigureAwait(false);
+                responseObserver: response => ReceiveDraftConfiguration(response, wire, connectionToken,
+                    @params.SessionId, isSetResponse: true)).ConfigureAwait(false);
 
             if (response.IsError)
             {
@@ -954,6 +994,17 @@ namespace SalmonEgg.Acp.Client
                 configOptions = created.ConfigOptions ?? [];
             }
             _sessionWork.ReceiveConfigOptions(sessionId!, configOptions, connectionToken, registerSession: !isSetResponse);
+            if (isSetResponse && IsCurrentConnection(connectionToken))
+            {
+                var update = new ConfigOptionUpdate { ConfigOptions = configOptions.ToList() };
+                SessionUpdateReceived?.Invoke(this, new SessionUpdateEventArgs(sessionId!, update)
+                {
+                    View = new AcpSessionUpdateView(configOptions: configOptions
+                        .Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray()),
+                    IsResponseProjection = true,
+                    ConnectionIsCurrent = () => IsCurrentConnection(connectionToken)
+                });
+            }
         }
 
         /// <summary>
@@ -2685,16 +2736,27 @@ namespace SalmonEgg.Acp.Client
                 {
                     return;
                 }
+                AcpSessionUpdateView? view = null;
                 if (connectionToken.CanBeCanceled
                     && !_sessionWork.ReceiveUpdate(
                         updateParams.SessionId,
                         updateParams.Update,
                         connectionToken,
-                        wire.Version == AcpProtocolVersion.V2 ? notification.Params.Value.GetProperty("update") : null))
+                        wire.Version == AcpProtocolVersion.V2 ? notification.Params.Value.GetProperty("update") : null,
+                        out view))
                 {
                     return;
                 }
-                SessionUpdateReceived?.Invoke(this, new SessionUpdateEventArgs(updateParams.SessionId, updateParams.Update));
+                if (view is null && updateParams.Update is ConfigOptionUpdate { ConfigOptions: { } options })
+                {
+                    view = new AcpSessionUpdateView(configOptions: options
+                        .Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray());
+                }
+                SessionUpdateReceived?.Invoke(this, new SessionUpdateEventArgs(updateParams.SessionId, updateParams.Update)
+                {
+                    View = view,
+                    ConnectionIsCurrent = () => IsCurrentConnection(connectionToken)
+                });
             }
             catch (Exception ex)
             {

--- a/src/SalmonEgg.Acp/Client/AcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClient.cs
@@ -1000,7 +1000,8 @@ namespace SalmonEgg.Acp.Client
                 SessionUpdateReceived?.Invoke(this, new SessionUpdateEventArgs(sessionId!, update)
                 {
                     View = new AcpSessionUpdateView(configOptions: configOptions
-                        .Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray()),
+                        .Select(option => JsonSerializer.SerializeToElement(option, wire.TypeInfo<ConfigOption>())).ToImmutableArray(),
+                        configProtocolVersion: wire.Version),
                     IsResponseProjection = true,
                     ConnectionIsCurrent = () => IsCurrentConnection(connectionToken)
                 });
@@ -2750,7 +2751,8 @@ namespace SalmonEgg.Acp.Client
                 if (view is null && updateParams.Update is ConfigOptionUpdate { ConfigOptions: { } options })
                 {
                     view = new AcpSessionUpdateView(configOptions: options
-                        .Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray());
+                        .Select(option => JsonSerializer.SerializeToElement(option, wire.TypeInfo<ConfigOption>())).ToImmutableArray(),
+                        configProtocolVersion: wire.Version);
                 }
                 SessionUpdateReceived?.Invoke(this, new SessionUpdateEventArgs(updateParams.SessionId, updateParams.Update)
                 {

--- a/src/SalmonEgg.Acp/Client/AcpClientOptions.cs
+++ b/src/SalmonEgg.Acp/Client/AcpClientOptions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>Explicit host policy for protocol versions which are not enabled by default.</summary>
+public sealed class AcpClientOptions
+{
+    /// <summary>
+    /// Experimental major versions this host explicitly permits. Empty by default. This is not a
+    /// version offer: InitializeParams.ProtocolVersion must still request the chosen version and
+    /// the Agent must negotiate it. Unknown and incompletely supported versions remain rejected.
+    /// </summary>
+    public IReadOnlyList<int> ExperimentalProtocolVersions { get; init; } = Array.Empty<int>();
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionDraftExtensions.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionDraftExtensions.cs
@@ -10,8 +10,8 @@ namespace SalmonEgg.Acp.Client;
 
 /// <summary>Opt-in access to ACP v2 session projections and offline history replay.</summary>
 /// <remarks>
-/// These helpers do not enable live v2 negotiation. The public client continues to reject v2 until
-/// its complete lifecycle and feature gates are delivered. Replay consumes recorded update objects
+/// These helpers do not enable live v2 negotiation. The public client requires an explicit
+/// experimental policy separately. Replay consumes recorded update objects
 /// without connecting to an Agent or modifying a client's state.
 /// </remarks>
 [Experimental(AcpDraftProtocol.DiagnosticId, Message = AcpDraftProtocol.Message, UrlFormat = AcpDraftProtocol.UrlFormat)]

--- a/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionProjection.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
 using SalmonEgg.Acp.Content;
 using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
 using SalmonEgg.Acp.Tool;
 
 namespace SalmonEgg.Acp.Client;
@@ -81,6 +83,86 @@ internal sealed class AcpSessionProjection
 
     internal void SetConfigOptions(IReadOnlyList<ConfigOption> configOptions)
         => _configOptions = configOptions.Select(static option => AcpSessionProjectionJson.Store(option)).ToImmutableArray();
+
+    internal AcpSessionUpdateView? CreateView(SessionUpdate update)
+    {
+        if (update is WholeMessageUpdate whole && _messages.TryGetValue(whole.MessageId, out var wholeState))
+        {
+            return MessageView(whole.MessageId, wholeState);
+        }
+        if (update is ContentChunkUpdate { MessageId: { } messageId } && _messages.TryGetValue(messageId, out var message))
+        {
+            return MessageView(messageId, message);
+        }
+        if (update is ToolCallStatusUpdate { ToolCallId: { } toolCallId } && _tools.TryGetValue(toolCallId, out var tool))
+        {
+            return new AcpSessionUpdateView(toolCall: StoreTool(toolCallId, tool));
+        }
+        if (update is ToolCallContentChunkUpdate chunk && _tools.TryGetValue(chunk.ToolCallId, out var chunkTool))
+        {
+            return new AcpSessionUpdateView(toolCall: StoreTool(chunk.ToolCallId, chunkTool));
+        }
+        var terminalId = update switch
+        {
+            TerminalSessionUpdate terminal => terminal.TerminalId,
+            TerminalOutputChunkSessionUpdate terminal => terminal.TerminalId,
+            _ => null
+        };
+        if (terminalId is not null && _terminals.TryGetValue(terminalId, out var terminalState))
+        {
+            var snapshot = terminalState.Snapshot();
+            var exit = snapshot.ExitStatus;
+            return new AcpSessionUpdateView(terminal: new AcpTerminalView(terminalId, snapshot.Command,
+                snapshot.Cwd, snapshot.Output, snapshot.HasExited, exit?.ExitCode, exit?.Signal));
+        }
+        return update switch
+        {
+            StateSessionUpdate work => new AcpSessionUpdateView(workState: work.State.State,
+                stopReason: (work.State as IdleSessionWorkState)?.StopReason),
+            ConfigOptionUpdate => new AcpSessionUpdateView(configOptions: _configOptions),
+            V2PlanUpdate { Plan: PlanItemsUpdateContent items } => new AcpSessionUpdateView(
+                planEntries: items.Entries.Select(static item => AcpSessionProjectionJson.Store(item)).ToImmutableArray()),
+            _ => null
+        };
+    }
+
+    private static AcpSessionUpdateView MessageView(string messageId, MessageState state)
+        => new(message: new AcpMessageView(messageId, state.Kind switch
+        {
+            AcpMessageKind.User => "user",
+            AcpMessageKind.Thought => "thought",
+            _ => "agent"
+        }, state.Content.ToImmutableArray()));
+
+    private static JsonElement StoreTool(string toolCallId, ToolState state)
+    {
+        // Application consumers share the existing stable tool view. Building its complete value
+        // directly preserves opaque structured diffs without requiring them to name draft types.
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("toolCallId", toolCallId);
+            writer.WriteString("title", state.Title);
+            writer.WriteString("kind", state.Kind?.Value);
+            writer.WriteString("status", state.Status?.Value);
+            writer.WritePropertyName("content");
+            writer.WriteStartArray();
+            foreach (var content in state.Content) content.WriteTo(writer);
+            writer.WriteEndArray();
+            writer.WritePropertyName("locations");
+            writer.WriteStartArray();
+            foreach (var location in state.Locations) location.WriteTo(writer);
+            writer.WriteEndArray();
+            writer.WritePropertyName("rawInput");
+            if (state.RawInput is { } input) input.WriteTo(writer); else writer.WriteNullValue();
+            writer.WritePropertyName("rawOutput");
+            if (state.RawOutput is { } output) output.WriteTo(writer); else writer.WriteNullValue();
+            writer.WriteEndObject();
+        }
+        using var document = JsonDocument.Parse(stream.GetBuffer().AsMemory(0, checked((int)stream.Length)));
+        return document.RootElement.Clone();
+    }
 
     private void RetainUnprojected(JsonElement payload)
     {

--- a/src/SalmonEgg.Acp/Client/AcpSessionUpdateView.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionUpdateView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using SalmonEgg.Acp.Content;
@@ -17,6 +18,7 @@ public sealed class AcpSessionUpdateView
 {
     private readonly JsonElement? _toolCall;
     private readonly ImmutableArray<JsonElement>? _configOptions;
+    private readonly int _configProtocolVersion;
     private readonly ImmutableArray<JsonElement>? _planEntries;
 
     internal AcpSessionUpdateView(
@@ -26,7 +28,8 @@ public sealed class AcpSessionUpdateView
         string? workState = null,
         StopReason? stopReason = null,
         ImmutableArray<JsonElement>? configOptions = null,
-        ImmutableArray<JsonElement>? planEntries = null)
+        ImmutableArray<JsonElement>? planEntries = null,
+        int configProtocolVersion = AcpProtocolVersion.V2)
     {
         Message = message;
         _toolCall = toolCall;
@@ -34,6 +37,7 @@ public sealed class AcpSessionUpdateView
         WorkState = workState;
         StopReason = stopReason;
         _configOptions = configOptions;
+        _configProtocolVersion = configProtocolVersion;
         _planEntries = planEntries;
     }
 
@@ -57,7 +61,8 @@ public sealed class AcpSessionUpdateView
 
     /// <summary>Detached configuration options in Agent priority order.</summary>
     public ImmutableArray<ConfigOption> ConfigOptions => _configOptions is { } options
-        ? AcpSessionProjectionJson.ReadArray<ConfigOption>(options) : [];
+        ? options.Select(option => option.Deserialize(AcpWireFormat.For(_configProtocolVersion).TypeInfo<ConfigOption>())!)
+            .ToImmutableArray() : [];
 
     /// <summary>True when the complete plan list is supplied.</summary>
     public bool HasPlanEntries => _planEntries.HasValue;

--- a/src/SalmonEgg.Acp/Client/AcpSessionUpdateView.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionUpdateView.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.Plan;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+
+namespace SalmonEgg.Acp.Client;
+
+/// <summary>
+/// A version-independent application view of a session update. The wire update remains available
+/// separately on its event; this value describes a complete entity after the SDK has applied it.
+/// </summary>
+public sealed class AcpSessionUpdateView
+{
+    private readonly JsonElement? _toolCall;
+    private readonly ImmutableArray<JsonElement>? _configOptions;
+    private readonly ImmutableArray<JsonElement>? _planEntries;
+
+    internal AcpSessionUpdateView(
+        AcpMessageView? message = null,
+        JsonElement? toolCall = null,
+        AcpTerminalView? terminal = null,
+        string? workState = null,
+        StopReason? stopReason = null,
+        ImmutableArray<JsonElement>? configOptions = null,
+        ImmutableArray<JsonElement>? planEntries = null)
+    {
+        Message = message;
+        _toolCall = toolCall;
+        Terminal = terminal;
+        WorkState = workState;
+        StopReason = stopReason;
+        _configOptions = configOptions;
+        _planEntries = planEntries;
+    }
+
+    /// <summary>A complete message after replacement or append, or null when this update is unrelated.</summary>
+    public AcpMessageView? Message { get; }
+
+    /// <summary>A detached complete tool call, or null when this update is unrelated.</summary>
+    public ToolCallStatusUpdate? ToolCall => _toolCall?.Deserialize(AcpWireFormat.For(AcpProtocolVersion.V1).TypeInfo<ToolCallStatusUpdate>());
+
+    /// <summary>A complete Agent-owned terminal description. This never requests a local process.</summary>
+    public AcpTerminalView? Terminal { get; }
+
+    /// <summary>The peer's foreground state, separate from message and background activity.</summary>
+    public string? WorkState { get; }
+
+    /// <summary>The reported ending reason; null preserves an unspecified reason.</summary>
+    public StopReason? StopReason { get; }
+
+    /// <summary>True when this update replaces the configuration list, including an empty list.</summary>
+    public bool HasConfigOptions => _configOptions.HasValue;
+
+    /// <summary>Detached configuration options in Agent priority order.</summary>
+    public ImmutableArray<ConfigOption> ConfigOptions => _configOptions is { } options
+        ? AcpSessionProjectionJson.ReadArray<ConfigOption>(options) : [];
+
+    /// <summary>True when the complete plan list is supplied.</summary>
+    public bool HasPlanEntries => _planEntries.HasValue;
+
+    /// <summary>Detached plan entries, shared by stable and draft wire surfaces.</summary>
+    public ImmutableArray<PlanEntry> PlanEntries => _planEntries is { } entries
+        ? AcpSessionProjectionJson.ReadArray<PlanEntry>(entries) : [];
+}
+
+/// <summary>An immutable message value for application projection, independent of wire version.</summary>
+public sealed class AcpMessageView
+{
+    private readonly ImmutableArray<JsonElement> _content;
+
+    internal AcpMessageView(string messageId, string role, ImmutableArray<JsonElement> content)
+    {
+        MessageId = messageId;
+        Role = role;
+        _content = content;
+    }
+
+    /// <summary>Authoritative Agent-supplied identity.</summary>
+    public string MessageId { get; }
+
+    /// <summary>Application role: user, agent, or thought.</summary>
+    public string Role { get; }
+
+    /// <summary>Complete detached content after any replacement or append.</summary>
+    public ImmutableArray<ContentBlock> Content => AcpSessionProjectionJson.ReadArray<ContentBlock>(_content);
+}
+
+/// <summary>A display-only snapshot of terminal output; it never runs a local command.</summary>
+public sealed class AcpTerminalView
+{
+    internal AcpTerminalView(string terminalId, string? command, string? cwd,
+        ImmutableArray<byte> output, bool hasExited, uint? exitCode, string? signal)
+    {
+        TerminalId = terminalId;
+        Command = command;
+        Cwd = cwd;
+        Output = output;
+        HasExited = hasExited;
+        ExitCode = exitCode;
+        Signal = signal;
+    }
+
+    /// <summary>The Agent-owned terminal identity.</summary>
+    public string TerminalId { get; }
+    /// <summary>The reported command, if any.</summary>
+    public string? Command { get; }
+    /// <summary>The reported working directory, if any.</summary>
+    public string? Cwd { get; }
+    /// <summary>Complete decoded output bytes, preserving partial UTF-8 across chunks.</summary>
+    public ImmutableArray<byte> Output { get; }
+    /// <summary>The complete UTF-8 display value.</summary>
+    public string OutputText => Encoding.UTF8.GetString(Output.AsSpan());
+    /// <summary>Whether the Agent reported an exit-status object, even if its values are unknown.</summary>
+    public bool HasExited { get; }
+    /// <summary>The reported exit code.</summary>
+    public uint? ExitCode { get; }
+    /// <summary>The reported exit signal.</summary>
+    public string? Signal { get; }
+}

--- a/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
+++ b/src/SalmonEgg.Acp/Client/AcpSessionWorkController.cs
@@ -166,10 +166,12 @@ internal sealed class AcpSessionWorkController
         string sessionId,
         SessionUpdate update,
         CancellationToken connectionToken,
-        JsonElement? draftPayload = null)
+        JsonElement? draftPayload,
+        out AcpSessionUpdateView? view)
     {
         lock (_gate)
         {
+            view = null;
             if (!IsCurrent(connectionToken) || _closedSessions.Contains(sessionId))
             {
                 return false;
@@ -180,6 +182,7 @@ internal sealed class AcpSessionWorkController
             {
                 session.Projection ??= new AcpSessionProjection();
                 session.Projection.Apply(update, payload);
+                view = session.Projection.CreateView(update);
             }
 
             if (update is not StateSessionUpdate workUpdate)
@@ -204,6 +207,9 @@ internal sealed class AcpSessionWorkController
             return true;
         }
     }
+
+    internal bool ReceiveUpdate(string sessionId, SessionUpdate update, CancellationToken connectionToken, JsonElement? draftPayload = null)
+        => ReceiveUpdate(sessionId, update, connectionToken, draftPayload, out _);
 
     internal Task<SessionPromptCompletion>? RequestCancellation(string sessionId, CancellationToken connectionToken)
     {

--- a/src/SalmonEgg.Acp/Client/IAcpClient.cs
+++ b/src/SalmonEgg.Acp/Client/IAcpClient.cs
@@ -94,6 +94,15 @@ namespace SalmonEgg.Acp.Client
         /// </summary>
         bool IsConnected { get; }
 
+        /// <summary>The protocol negotiated by the active connection, or the stable default before initialization.</summary>
+        int NegotiatedProtocolVersion => AcpProtocolVersion.Default;
+
+        /// <summary>
+        /// Whether configuration RPC results also arrive through the ordered session update stream.
+        /// Legacy host implementations may retain their response-based application path.
+        /// </summary>
+        bool PublishesConfigurationResponses => false;
+
         /// <summary>
         /// Gets the current Agent information.
         /// </summary>
@@ -294,6 +303,20 @@ namespace SalmonEgg.Acp.Client
         /// The update payload.
         /// </summary>
         public SessionUpdate? Update { get; init; }
+
+        /// <summary>
+        /// Complete entity state projected by the SDK. Hosts consume this view without depending
+        /// on draft wire types; it is absent on legacy external client implementations.
+        /// </summary>
+        public AcpSessionUpdateView? View { get; init; }
+
+        /// <summary>True for authoritative configuration supplied by an RPC response rather than a notification.</summary>
+        public bool IsResponseProjection { get; init; }
+
+        internal Func<bool>? ConnectionIsCurrent { get; init; }
+
+        /// <summary>Whether this captured update still belongs to its receiving connection.</summary>
+        public bool IsCurrent => ConnectionIsCurrent?.Invoke() ?? true;
 
         /// <summary>
         /// Creates new session update event arguments.

--- a/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
+++ b/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
@@ -54,8 +54,8 @@ namespace SalmonEgg.Acp.Protocol
         internal const string LatestRenamedMessage =
             "Renamed to AcpProtocolVersion.HighestModeled. 'Latest' reads as 'the version to use', "
             + "but the value is only the highest version whose wire contracts are modeled, and it is "
-            + "still a draft that a live client refuses to negotiate. Use AcpProtocolVersion.Default "
-            + "for live connections.";
+            + "still a draft requiring explicit experimental client options before negotiation. Use AcpProtocolVersion.Default "
+            + "for stable connections.";
 
         /// <summary>
         /// The single protocol version a client serves without experimental opt-in. ACP negotiates one version per

--- a/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
+++ b/src/SalmonEgg.Acp/Protocol/AcpProtocolVersion.cs
@@ -13,21 +13,21 @@ namespace SalmonEgg.Acp.Protocol
         public const int V1 = 1;
 
         /// <summary>
-        /// Draft ACP v2 wire model. Live client support remains disabled until the complete
-        /// prompt, update, permission, configuration, and batch lifecycles are implemented.
+        /// Draft ACP v2 wire model. Requires explicit experimental client options and a V2 offer;
+        /// stable default initialization continues to use V1.
         /// </summary>
         public const int V2 = 2;
 
         /// <summary>
         /// Stable protocol used by default for production clients and versionless serialization.
-        /// This is the only version a live <see cref="Client.AcpClient"/> will negotiate.
+        /// Experimental negotiation requires an explicit policy separate from this default.
         /// </summary>
         public const int Default = V1;
 
         /// <summary>
         /// Highest protocol version whose wire contracts are modeled by this SDK. Modeled means the
         /// DTOs and serializers exist for development, not that the live client lifecycle is
-        /// complete: initializing a client with this version throws while it is still a draft.
+        /// complete: initialization requires an explicit experimental policy for draft versions.
         /// Use <see cref="Default"/> to pick the version a live connection should negotiate.
         /// </summary>
         public const int HighestModeled = V2;
@@ -58,7 +58,7 @@ namespace SalmonEgg.Acp.Protocol
             + "for live connections.";
 
         /// <summary>
-        /// The single protocol version a live client actually serves. ACP negotiates one version per
+        /// The single protocol version a client serves without experimental opt-in. ACP negotiates one version per
         /// connection and both sides then "act according to its specification", so a client is
         /// compliant while supporting exactly one version: this constant is that version, and it is
         /// the authority both the initialize gate and the post-negotiation check answer to.

--- a/src/SalmonEgg.Acp/PublicSurface.Types.txt
+++ b/src/SalmonEgg.Acp/PublicSurface.Types.txt
@@ -15,13 +15,17 @@
 # Sorted by type name, ordinal. Asserted by PublicSurfaceBaselineTests and DraftProtocolSurfaceTests.
 SalmonEgg.Acp.Client.AcpClient stable
 SalmonEgg.Acp.Client.AcpClientLogLevel stable
+SalmonEgg.Acp.Client.AcpClientOptions stable
 SalmonEgg.Acp.Client.AcpMessageKind draft
 SalmonEgg.Acp.Client.AcpMessageSnapshot draft
+SalmonEgg.Acp.Client.AcpMessageView stable
 SalmonEgg.Acp.Client.AcpPermissionDraftExtensions draft
 SalmonEgg.Acp.Client.AcpPermissionRequestSnapshot draft
 SalmonEgg.Acp.Client.AcpSessionDraftExtensions draft
 SalmonEgg.Acp.Client.AcpSessionSnapshot draft
+SalmonEgg.Acp.Client.AcpSessionUpdateView stable
 SalmonEgg.Acp.Client.AcpTerminalSnapshot draft
+SalmonEgg.Acp.Client.AcpTerminalView stable
 SalmonEgg.Acp.Client.AcpToolCallSnapshot draft
 SalmonEgg.Acp.Client.AcpTransportErrorEventArgs stable
 SalmonEgg.Acp.Client.AcpTransportErrorKind stable

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -256,9 +256,10 @@ cancellation callbacks run asynchronously and cannot delay disconnect. Callback 
 observed without logging their potentially private data.
 
 SalmonEgg currently presents session-scoped requests. Request-scoped requests are explicitly
-cancelled when no conversation surface can present them. Windows, Linux, macOS, Android, and iOS do
-not advertise URL elicitation yet. The separate Linux launcher probe verifies real `xdg-open` and
-browser isolation; it does not substitute for native GUI acceptance or five-platform validation.
+cancelled when no conversation surface can present them. WASM and Linux desktop advertise URL
+elicitation after their product consent-to-browser gates. The Linux gate uses its real card, native
+pointer input and system opener. Other native targets remain disabled until their own installed
+application acceptance passes; Linux success does not establish five-platform validation.
 
 ## ACP v2 draft surface (SEACP002)
 

--- a/src/SalmonEgg.Acp/README.md
+++ b/src/SalmonEgg.Acp/README.md
@@ -20,15 +20,14 @@ JSON-RPC envelopes, message parser/validator, and all JsonConverters are assembl
 ## Protocol versions
 
 The live client runtime defaults to stable ACP v1 (`AcpProtocolVersion.Default`). ACP v2 is
-still an upstream Draft, so the SDK retains explicit v2 wire DTO and serializer coverage for
-development without negotiating v2 in live connections. `AcpProtocolVersion.HighestModeled`
-denotes the highest modeled wire version; it does not mean that the live client lifecycle is
-complete, and initializing a client with it throws. `AcpProtocolVersion.Latest` is the obsolete
+still an upstream Draft. A host can evaluate its full runtime only with explicit client options
+and an offered version of 2; ordinary clients reject that offer. `AcpProtocolVersion.HighestModeled`
+denotes the highest modeled wire version, not the production default. `AcpProtocolVersion.Latest` is the obsolete
 former name of `HighestModeled` and is kept only so 1.0.0 consumers still compile.
 
-Do not enable live v2 connections until prompt acknowledgement/state updates, versioned update
-variants, permission-subject handling, configuration workflows, and JSON-RPC batches are implemented
-and protected by a separate experimental feature flag. The modeled v2 contracts are marked
+Prompt acknowledgement/state updates, versioned entity views, permission subjects, configuration
+workflows and JSON-RPC batches share the existing client owners. Experimental negotiation is
+separate from the stable default. The modeled v2 contracts are marked
 `[Experimental("SEACP002")]`; see [ACP v2 draft surface](#acp-v2-draft-surface-seacp002).
 
 ## Capability support boundaries
@@ -43,7 +42,7 @@ hosts must enable optional capabilities only after implementing their interactio
 | Request cancellation | The SDK sends `$/cancel_request`, recognizes `-32800`, and retains the original request ID until its terminal response or disconnection. Transports preserve caller cancellation; each cancellation notification has a two-second send budget. A terminal response received first wins. | Peer cancellation is best effort. `session/cancel` remains a separate session operation. [#148](https://github.com/salmonloop/salmon-egg/issues/148) still requires the deployed stdio-to-WebSocket bridge acceptance gate. |
 | Form elicitation | SalmonEgg's capability defaults advertise form mode. Hosts handle `ElicitationRequested` and return a typed accept, decline, or cancel response. | The host owns the form UI and must preserve the request's scope and connection ownership. |
 | URL elicitation | The SDK owns consent-response availability, connection lifetime, and completion in `ElicitationRequestEventArgs.State`. URL mode stays off in SDK defaults; SalmonEgg enables it on WASM and Linux desktop through its platform capability service. Linux uses the existing system opener after explicit consent. | The Linux product gate exercises its real card, stdio peer, native pointer input and isolated external browser. Other native platforms and independent real-Agent interoperability remain open in [#154](https://github.com/salmonloop/salmon-egg/issues/154). [#146](https://github.com/salmonloop/salmon-egg/issues/146) tracks the complete elicitation delivery. |
-| ACP v2 | Explicit wire contracts, prompt/work-state lifecycle, configuration lifecycle, message/tool/terminal projections, permission request handling, and version-gated JSON-RPC batches are covered by deterministic protocol peers. Draft SDK helpers support offline history replay and permission reading. Live initialization rejects v2. | Application UI integration and real-Agent interoperability remain incomplete; see [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
+| ACP v2 | Explicit opt-in enables the staged lifecycle while ordinary initialization continues to reject V2. The existing application event stream carries complete entity views without a draft-type dependency. | V2 remains an upstream draft. The official Rust echo Agent is interoperable; LLM Agent/platform acceptance must be reported separately in [#149](https://github.com/salmonloop/salmon-egg/issues/149). |
 
 Internal v2 batch validation follows the upstream schema at
 `5ebaf0aceb04a4ba6574cd63fa6355352dc6d931` and JSON-RPC 2.0 section 6.
@@ -61,7 +60,7 @@ requests. A batch with no remaining retry owner is abandoned after its failed se
 its retained responses, without starting an automatic retry loop.
 `tests/SalmonEgg.Acp.Desktop.Tests` and `scripts/gates/run-acp-batch-stdio-gate.sh` exercise real
 Linux pipes through the production transport and adapter. This gate does not establish
-interoperability with a public v2 Agent, and it does not enable public live v2 initialization.
+interoperability with a public v2 Agent. The separate pinned official Rust Agent gate covers that boundary.
 
 Terminal methods append their arguments to the invocation used by the active stdio connection and
 override its effective environment. SalmonEgg asks for consent before starting a separate PTY,
@@ -79,15 +78,17 @@ default-on-error and skip-invalid-item behavior applies only where the upstream 
 Resource-link icons are available through the experimental `ResourceLinkDraftExtensions` helper,
 so constructing them requires an explicit draft opt-in. Permission subjects reach the staged v2
 handler through the same pending-request owner as v1. Draft session snapshots supply message upserts, streaming
-tool content, and Agent-owned terminal projections; the production application does not consume
-them until its complete v2 feature gate is ready.
+tool content, and Agent-owned terminal projections. The same projection supplies stable
+`AcpSessionUpdateView` values on `SessionUpdateEventArgs`, so application consumers do not have to
+name draft DTOs. Message content replaces one authoritative message, tool views are complete,
+terminal views only display Agent-owned state, and idle ends work even when no reason is supplied.
 
 `SendPromptAsync` always waits for completed foreground work. The internal v2 development path
 records the prompt acknowledgement separately and finishes on an idle `state_update`; cancellation
 keeps accepting trailing updates until that idle arrives. One controller owns session work, including
 unsolicited running/requires-action/idle updates, and uses the connection's existing lifetime token
 to reject stale callbacks. This path is exercised through the actual JSON parser and client handlers,
-not exposed as a public v2 opt-in. V1 still completes from its terminal prompt response.
+available only with explicit experimental client options. V1 still completes from its terminal prompt response.
 
 The pinned [v2 lifecycle](https://github.com/agentclientprotocol/agent-client-protocol/blob/5ebaf0aceb04a4ba6574cd63fa6355352dc6d931/docs/protocol/v2/prompt-lifecycle.mdx)
 says an ending idle must carry a stop reason, while its
@@ -101,7 +102,7 @@ scoped to the supplied session. It uses the same v2 reader and projection as the
 handler without connecting, executing terminal commands, or changing a client's state.
 `client.GetSessionSnapshot(sessionId)` reads the same owner on an internally staged v2 connection;
 it returns null on the public v1 runtime and after session close or disconnect. Suppressing
-`SEACP002` does not enable live v2 initialization.
+`SEACP002` alone does not enable live v2 initialization.
 
 Snapshots expose messages, tool calls, and terminal output in first-seen order. Patch omission
 keeps a value, null clears it, and arrays replace complete content; chunks append. Terminal chunks
@@ -160,11 +161,23 @@ The host explicitly selects an offered option or cancels; failed sends and inval
 the original request for retry, and stale callbacks cannot answer a new request with a reused id.
 Subscriber failures also claim that original request, so an exception after an answer cannot send
 a second response. The nupkg consumer gate verifies optional subjects, opaque custom payloads,
-detached prompt data, and rejection of live v2 before any connection or write.
+detached prompt data, and rejection of unapproved v2 before any connection or write.
 
-Keep the v1 runtime and public API compatible while these gaps are addressed. Enabling v2 needs
-both the upstream stabilization/Agent prerequisites and end-to-end verification of the complete
-lifecycle. Passing DTO tests or suppressing `SEACP002` does not satisfy that requirement.
+The V1 runtime and existing public interfaces remain compatible. To evaluate V2, construct the
+client with `new AcpClientOptions { ExperimentalProtocolVersions = [2] }` as the fifth constructor
+argument and explicitly offer `InitializeParams.ProtocolVersion = 2`. The list is copied at
+construction and defaults to empty. The Agent may choose V1, after which all wire behavior follows
+V1. Other experimental version numbers are rejected. The application exposes this through the
+process-level `SALMONEGG_EXPERIMENTAL_ACP_V2=1` opt-in; the same immutable policy configures both
+client creation and initialization. This is experimental support, not a change to `Default` or
+`RuntimeServed`, and suppressing `SEACP002` does not change that policy.
+
+Configuration replies publish `IsResponseProjection=true` through the existing ordered session
+stream. Hosts that see `PublishesConfigurationResponses` must use that stream rather than reapply
+the returned full list from a delayed await. Wire recorders can distinguish these projections from
+peer notifications. Captured events expose `IsCurrent` so buffered consumers reject a closed
+connection's update. The SDK maps the application's stable history-load intent to V2
+`session/resume` with `replayFrom: { type: "start" }`; V2 never sends the removed `session/load`.
 
 ### Cancellation transport integration
 
@@ -251,8 +264,8 @@ browser isolation; it does not substitute for native GUI acceptance or five-plat
 
 Every v2 draft contract on the public surface carries `[Experimental("SEACP002")]`, so naming one is
 a **compile error** by default rather than a warning. That is deliberate: v2 is still an upstream
-draft, no live client negotiates it (`AcpProtocolVersion.RuntimeServed` is v1), and code built on
-these types cannot reach a real Agent today. The 46 marked types are the `state_update` work-state
+draft and `AcpProtocolVersion.RuntimeServed` remains V1. Naming draft contracts and allowing
+experimental negotiation are separate opt-ins. The 46 marked types are the `state_update` work-state
 family, the whole-message upsert updates, the terminal updates, streaming tool-call content, the
 v2 `plan_update` envelope, permission subjects, the v2 capability markers, the structured diff,
 `ResourceLinkDraftExtensions` for resource-link icons, and six session-projection types (the draft

--- a/src/SalmonEgg.Application/Services/Acp/AcpProtocolExperimentPolicy.cs
+++ b/src/SalmonEgg.Application/Services/Acp/AcpProtocolExperimentPolicy.cs
@@ -1,0 +1,9 @@
+using SalmonEgg.Acp.Protocol;
+
+namespace SalmonEgg.Application.Services.Acp;
+
+/// <summary>Application-scoped opt-in policy. The default never offers or enables a draft protocol.</summary>
+public sealed record AcpProtocolExperimentPolicy(bool EnableDraftV2 = false)
+{
+    public int OfferedProtocolVersion => EnableDraftV2 ? AcpProtocolVersion.V2 : AcpProtocolVersion.Default;
+}

--- a/src/SalmonEgg.Application/Services/Chat/ChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/ChatService.cs
@@ -41,6 +41,7 @@ namespace SalmonEgg.Application.Services.Chat
         private const string OperationCanceledTypeName = "System.OperationCanceledException";
 
         private readonly object _stateGate = new();
+        private readonly object _sessionUpdateGate = new();
         private readonly HashSet<string> _configAuthoritativeSessionIds = new(StringComparer.Ordinal);
         private string? _currentSessionId;
         private Plan? _currentPlan;
@@ -101,6 +102,10 @@ namespace SalmonEgg.Application.Services.Chat
         public event EventHandler<ElicitationCompletedEventArgs>? ElicitationCompleted;
         public event EventHandler<string>? ErrorOccurred;
 
+        public bool PublishesConfigurationResponses => _acpClient.PublishesConfigurationResponses;
+
+        public int NegotiatedProtocolVersion => _acpClient.NegotiatedProtocolVersion;
+
         public ChatService(
             IAcpClient acpClient,
             IErrorLogger errorLogger,
@@ -144,10 +149,11 @@ namespace SalmonEgg.Application.Services.Chat
 
         private void OnSessionUpdateReceived(object? sender, SessionUpdateEventArgs e)
         {
-            // 事件由传输读线程按到达序同步触发;若直接用 async void,session 首建等待点之后的
-            // 续体可能与后续事件交错,打乱 history 追加与事件转发次序。链式管道保证严格串行,
-            // 且链头读改写只发生在同一触发线程上,无需加锁。
-            _sessionUpdatePump = ProcessSessionUpdateSequentiallyAsync(_sessionUpdatePump, e);
+            // Notifications and projected RPC results share one ordered application stream.
+            lock (_sessionUpdateGate)
+            {
+                _sessionUpdatePump = ProcessSessionUpdateSequentiallyAsync(_sessionUpdatePump, e);
+            }
         }
 
         private async Task ProcessSessionUpdateSequentiallyAsync(Task previous, SessionUpdateEventArgs e)
@@ -172,7 +178,12 @@ namespace SalmonEgg.Application.Services.Chat
                     // not a state a session can legitimately be in. Record and skip local tracking.
                     // Forwarding below is deliberately left intact so subscribers still observe it.
                     var session = _sessionManager.GetSession(e.SessionId);
-                    if (session is null)
+                    if (e.IsResponseProjection)
+                    {
+                        // This is an RPC result projected in transport receive order, not another
+                        // peer history entry. It still reaches the same ordered product stream.
+                    }
+                    else if (session is null)
                     {
                         _errorLogger.LogError(new ErrorLogEntry(
                             "Session update received for an untracked session",
@@ -183,7 +194,9 @@ namespace SalmonEgg.Application.Services.Chat
                     }
                     else
                     {
-                        session.AppendHistory(CreateSessionUpdateEntry(e.Update, e.SessionId));
+                        session.AppendHistory(e.View is { } view
+                            ? CreateSessionViewEntry(view, e.Update, e.SessionId)
+                            : CreateSessionUpdateEntry(e.Update, e.SessionId));
                     }
 
                     // CRITICAL PATH: Syncing Agent's internal state (Plan, Mode) with our local variables.
@@ -191,6 +204,11 @@ namespace SalmonEgg.Application.Services.Chat
                     // 共享态的判定与写入必须在 _stateGate 内:pump 与请求路径续体真并发触碰同一字段。
                     lock (_stateGate)
                     {
+                        if (e.View is { HasPlanEntries: true } view
+                            && string.Equals(_currentSessionId, e.SessionId, StringComparison.Ordinal))
+                        {
+                            _currentPlan = new Plan { Entries = view.PlanEntries.ToList() };
+                        }
                         switch (e.Update)
                         {
                             case PlanUpdate planUpdate:
@@ -367,6 +385,36 @@ namespace SalmonEgg.Application.Services.Chat
                 UsageUpdate => "usage_update",
                 _ => "unknown"
             };
+
+        private static SessionUpdateEntry CreateSessionViewEntry(AcpSessionUpdateView view, SessionUpdate update, string sessionId)
+        {
+            var entry = CreateSessionUpdateEntry(update, sessionId);
+            if (view.Message is { } message)
+            {
+                entry.SessionUpdateType = message.Role + "_message";
+                entry.ContentType = "text";
+                entry.TextContent = string.Concat(message.Content.OfType<TextContentBlock>().Select(static content => content.Text));
+            }
+            else if (view.ToolCall is { } tool)
+            {
+                entry.SessionUpdateType = "tool_call_update";
+                entry.ToolCallId = tool.ToolCallId;
+                entry.Title = tool.Title;
+                entry.ToolCallKind = tool.Kind?.ToString();
+                entry.ToolCallStatus = tool.Status?.ToString();
+            }
+            else if (view.WorkState is not null)
+            {
+                entry.SessionUpdateType = "state_update";
+            }
+            else if (view.HasPlanEntries)
+            {
+                entry.SessionUpdateType = "plan_update";
+                entry.PlanEntries = view.PlanEntries.Select(static item => new SessionPlanHistoryEntry(
+                    item.Content, item.Status.ToString(), item.Priority.ToString())).ToArray();
+            }
+            return entry;
+        }
 
         // 以下 Apply*/Capture*/Restore* 系列约定:调用方必须已持 _stateGate。
         // 它们读改写 _currentMode/_currentSessionId/_configAuthoritativeSessionIds 并可能
@@ -1060,6 +1108,11 @@ namespace SalmonEgg.Application.Services.Chat
             try
             {
                 var response = await _acpClient.SetSessionConfigOptionAsync(@params);
+                // The SDK publishes the full response in receive order. Let that already queued
+                // event reach the product before the editing command considers its apply settled.
+                Task updates;
+                lock (_sessionUpdateGate) updates = _sessionUpdatePump;
+                await updates.ConfigureAwait(false);
                 return response;
             }
             catch (Exception ex)

--- a/src/SalmonEgg.Application/Services/Chat/DelayedLoadChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/DelayedLoadChatService.cs
@@ -34,6 +34,10 @@ public sealed class DelayedLoadChatService : IChatService, IStdioInvocationSourc
 
     public bool IsConnected => _inner.IsConnected;
 
+    public bool PublishesConfigurationResponses => _inner.PublishesConfigurationResponses;
+
+    public int NegotiatedProtocolVersion => _inner.NegotiatedProtocolVersion;
+
     public SalmonEgg.Domain.Models.StdioInvocationSnapshot? StdioInvocation
         => (_inner as IStdioInvocationSource)?.StdioInvocation;
 

--- a/src/SalmonEgg.Application/Services/Chat/IChatService.cs
+++ b/src/SalmonEgg.Application/Services/Chat/IChatService.cs
@@ -34,6 +34,12 @@ namespace SalmonEgg.Application.Services.Chat
         /// </summary>
         bool IsConnected { get; }
 
+        /// <summary>The active connection's negotiated ACP version.</summary>
+        int NegotiatedProtocolVersion => AcpProtocolVersion.Default;
+
+        /// <summary>Configuration responses are projected through the ordered update event stream.</summary>
+        bool PublishesConfigurationResponses => false;
+
         /// <summary>
         /// Agent 信息
         /// </summary>

--- a/src/SalmonEgg.Infrastructure/Client/AcpClientFactory.cs
+++ b/src/SalmonEgg.Infrastructure/Client/AcpClientFactory.cs
@@ -12,17 +12,20 @@ public sealed class AcpClientFactory : IAcpClientFactory
     private readonly ISessionManager _sessionManager;
     private readonly ITerminalSessionManager _terminalSessionManager;
     private readonly ITransportErrorMessageFormatter? _transportErrorMessageFormatter;
+    private readonly AcpProtocolExperimentPolicy _protocolExperiment;
 
     public AcpClientFactory(
         IErrorLogger errorLogger,
         ISessionManager sessionManager,
         ITerminalSessionManager terminalSessionManager,
-        ITransportErrorMessageFormatter? transportErrorMessageFormatter = null)
+        ITransportErrorMessageFormatter? transportErrorMessageFormatter = null,
+        AcpProtocolExperimentPolicy? protocolExperiment = null)
     {
         _errorLogger = errorLogger ?? throw new ArgumentNullException(nameof(errorLogger));
         _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _terminalSessionManager = terminalSessionManager ?? throw new ArgumentNullException(nameof(terminalSessionManager));
         _transportErrorMessageFormatter = transportErrorMessageFormatter;
+        _protocolExperiment = protocolExperiment ?? new AcpProtocolExperimentPolicy();
     }
 
     public IAcpClient CreateClient(ITransport transport)
@@ -32,5 +35,9 @@ public sealed class AcpClientFactory : IAcpClientFactory
                 _transportErrorMessageFormatter),
             new DomainAcpClientLogger(_errorLogger),
             new DomainAcpClientSessionStore(_sessionManager),
-            _terminalSessionManager);
+            _terminalSessionManager,
+            new AcpClientOptions
+            {
+                ExperimentalProtocolVersions = _protocolExperiment.EnableDraftV2 ? [SalmonEgg.Acp.Protocol.AcpProtocolVersion.V2] : []
+            });
 }

--- a/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatAction.cs
+++ b/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatAction.cs
@@ -103,6 +103,13 @@ public sealed record HydrateConversationAction(
 
 public sealed record UpsertTranscriptMessageAction(string? ConversationId, ConversationMessageSnapshot Message) : ChatAction;
 
+public sealed record ReplaceProtocolMessageAction(
+    string ConversationId,
+    string ProtocolMessageId,
+    bool IsOutgoing,
+    IImmutableList<ConversationMessageSnapshot> Messages,
+    string? ReplacedLocalMessageId = null) : ChatAction;
+
 public sealed record SetConversationSessionStateAction(
     string? ConversationId,
     IImmutableList<ConversationModeOptionSnapshot> AvailableModes,

--- a/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatReducer.cs
+++ b/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatReducer.cs
@@ -134,6 +134,15 @@ public static class ChatReducer
                             ResolveTranscript(current, upsertMessage.ConversationId),
                             upsertMessage.Message)))
             }),
+            ReplaceProtocolMessageAction replaceMessage => Mutate(current, current with
+            {
+                ConversationContents = UpdateConversationContents(
+                    current.ConversationContents,
+                    replaceMessage.ConversationId,
+                    BuildUpdatedContentSlice(
+                        current.ResolveContentSlice(replaceMessage.ConversationId),
+                        transcript: ReplaceProtocolMessage(ResolveTranscript(current, replaceMessage.ConversationId), replaceMessage)))
+            }),
             SetConversationSessionStateAction setSessionState => Mutate(current, current with
             {
                 ConversationSessionStates = UpdateConversationSessionStates(
@@ -572,6 +581,28 @@ public static class ChatReducer
         }
 
         return current.Add(message);
+    }
+
+    private static IImmutableList<ConversationMessageSnapshot> ReplaceProtocolMessage(
+        IImmutableList<ConversationMessageSnapshot>? transcript, ReplaceProtocolMessageAction replacement)
+    {
+        var current = transcript ?? ImmutableList<ConversationMessageSnapshot>.Empty;
+        var firstIndex = -1;
+        var result = ImmutableList.CreateBuilder<ConversationMessageSnapshot>();
+        foreach (var message in current)
+        {
+            if (message.IsOutgoing == replacement.IsOutgoing
+                && (string.Equals(message.ProtocolMessageId, replacement.ProtocolMessageId, StringComparison.Ordinal)
+                    || (replacement.ReplacedLocalMessageId is not null
+                        && string.Equals(message.Id, replacement.ReplacedLocalMessageId, StringComparison.Ordinal))))
+            {
+                if (firstIndex < 0) firstIndex = result.Count;
+                continue;
+            }
+            result.Add(message);
+        }
+        result.InsertRange(firstIndex < 0 ? result.Count : firstIndex, replacement.Messages);
+        return result.ToImmutable();
     }
 
     private static IImmutableList<ConversationMessageSnapshot> AppendTranscriptDelta(

--- a/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatTurnPhase.cs
+++ b/src/SalmonEgg.Presentation.Core/Mvux/Chat/ChatTurnPhase.cs
@@ -11,5 +11,6 @@ public enum ChatTurnPhase
     Responding,
     Completed,
     Failed,
-    Cancelled
+    Cancelled,
+    WaitingForUser
 }

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en-US.resx
@@ -1489,4 +1489,7 @@ Create the corresponding Markdown file in:
   <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
     <value>Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent.</value>
   </data>
+  <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
+    <value>Waiting for your action...</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.en.resx
@@ -1489,4 +1489,7 @@ Create the corresponding Markdown file in:
   <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
     <value>Could not cancel a request that cannot be displayed. The connection was closed. Reconnect to the agent.</value>
   </data>
+  <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
+    <value>Waiting for your action...</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.resx
@@ -1495,4 +1495,7 @@
   <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
     <value>无法取消未能显示的请求，已断开此连接。请重新连接 Agent。</value>
   </data>
+  <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
+    <value>Waiting for your action...</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
+++ b/src/SalmonEgg.Presentation.Core/Resources/CoreStrings.zh-Hans.resx
@@ -1495,4 +1495,7 @@
   <data name="Elicitation_CancellationFailedDisconnected" xml:space="preserve">
     <value>无法取消未能显示的请求，已断开此连接。请重新连接 Agent。</value>
   </data>
+  <data name="ChatTurnStatus_WaitingForUser" xml:space="preserve">
+    <value>等待你操作…</value>
+  </data>
 </root>

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatCoordinator.cs
@@ -44,6 +44,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
     private readonly Dictionary<PoolConnectionRequestKey, PoolConnectionRequestGate> _poolConnectionGates = new();
     private readonly Dictionary<string, long> _poolProfileDisconnectGenerations = new(StringComparer.Ordinal);
     private CancellationTokenSource? _activeApplyScopeCts;
+    private readonly SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy _protocolExperiment;
 
     public AcpChatCoordinator(
         IAcpChatServiceFactory chatServiceFactory,
@@ -58,9 +59,11 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
         IAcpConnectionDependencySnapshotProvider? connectionDependencySnapshotProvider = null,
         int sessionUpdateBufferLimit = DefaultSessionUpdateBufferLimit,
         IPlatformCapabilityService? platformCapabilities = null,
-        IStringLocalizer<CoreStrings>? localizer = null)
+        IStringLocalizer<CoreStrings>? localizer = null,
+        SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy? protocolExperiment = null)
     {
         _chatServiceFactory = chatServiceFactory ?? throw new ArgumentNullException(nameof(chatServiceFactory));
+        _protocolExperiment = protocolExperiment ?? new SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         if (sessionUpdateBufferLimit <= 0)
         {
@@ -1115,7 +1118,7 @@ public sealed class AcpChatCoordinator : IAcpConnectionCommands
             profileId,
             conversationId,
             initializeTimeout,
-            cancellationToken, _platformCapabilities).ConfigureAwait(false);
+            cancellationToken, _platformCapabilities, _protocolExperiment.OfferedProtocolVersion).ConfigureAwait(false);
     }
 
     private static TimeSpan ResolveInitializeTimeout(ServerConfiguration? profile)

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatServiceAdapter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpChatServiceAdapter.cs
@@ -78,6 +78,10 @@ public sealed class AcpChatServiceAdapter : IChatService, IStdioInvocationSource
 
     public bool IsConnected => _inner.IsConnected;
 
+    public bool PublishesConfigurationResponses => _inner.PublishesConfigurationResponses;
+
+    public int NegotiatedProtocolVersion => _inner.NegotiatedProtocolVersion;
+
     public SalmonEgg.Domain.Models.StdioInvocationSnapshot? StdioInvocation
         => (_inner as IStdioInvocationSource)?.StdioInvocation;
 
@@ -171,8 +175,15 @@ public sealed class AcpChatServiceAdapter : IChatService, IStdioInvocationSource
     public Task<SessionSetModeResponse> SetSessionModeAsync(SessionSetModeParams @params)
         => _inner.SetSessionModeAsync(@params);
 
-    public Task<SessionSetConfigOptionResponse> SetSessionConfigOptionAsync(SessionSetConfigOptionParams @params)
-        => _inner.SetSessionConfigOptionAsync(@params);
+    public async Task<SessionSetConfigOptionResponse> SetSessionConfigOptionAsync(SessionSetConfigOptionParams @params)
+    {
+        var response = await _inner.SetSessionConfigOptionAsync(@params).ConfigureAwait(false);
+        if (PublishesConfigurationResponses)
+        {
+            await _eventAdapter.WaitForAvailableUpdatesAsync().ConfigureAwait(false);
+        }
+        return response;
+    }
 
     public Task CancelSessionAsync(SessionCancelParams @params)
         => _inner.CancelSessionAsync(@params);

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpEventAdapter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpEventAdapter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using SalmonEgg.Domain.Services;
@@ -390,6 +391,20 @@ public sealed class AcpEventAdapter
         }
 
         return WaitForDrainIdleAsync(hydrationAttemptId, cancellationToken);
+    }
+
+    public Task WaitForAvailableUpdatesAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            // A settings apply must not wait for a hydration scope whose release depends on that
+            // same caller. An already scheduled UI drain, however, must finish before it settles.
+            if (!_drainScheduled && !_hydrationScopesByAttemptId.Values.Any(static scope => scope.DrainScheduled))
+            {
+                return Task.CompletedTask;
+            }
+        }
+        return WaitForDrainIdleAsync(cancellationToken);
     }
 
     public Task WaitForDrainIdleAsync(long hydrationAttemptId, CancellationToken cancellationToken = default)

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpEventAdapter.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpEventAdapter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using SalmonEgg.Domain.Services;
@@ -395,16 +394,25 @@ public sealed class AcpEventAdapter
 
     public Task WaitForAvailableUpdatesAsync(CancellationToken cancellationToken = default)
     {
+        var drains = new List<Task>();
         lock (_gate)
         {
             // A settings apply must not wait for a hydration scope whose release depends on that
             // same caller. An already scheduled UI drain, however, must finish before it settles.
-            if (!_drainScheduled && !_hydrationScopesByAttemptId.Values.Any(static scope => scope.DrainScheduled))
+            if (_drainScheduled)
             {
-                return Task.CompletedTask;
+                _drainIdleTcs ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+                drains.Add(_drainIdleTcs.Task);
+            }
+            foreach (var scope in _hydrationScopesByAttemptId.Values)
+            {
+                if (!scope.DrainScheduled) continue;
+                scope.DrainIdleTcs ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+                drains.Add(scope.DrainIdleTcs.Task);
             }
         }
-        return WaitForDrainIdleAsync(cancellationToken);
+        var completed = Task.WhenAll(drains);
+        return cancellationToken.CanBeCanceled ? completed.WaitAsync(cancellationToken) : completed;
     }
 
     public Task WaitForDrainIdleAsync(long hydrationAttemptId, CancellationToken cancellationToken = default)

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeRequestFactory.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeRequestFactory.cs
@@ -5,24 +5,28 @@ namespace SalmonEgg.Presentation.Core.Services.Chat;
 
 internal static class AcpInitializeRequestFactory
 {
-    public static InitializeParams CreateDefault(IPlatformCapabilityService? platformCapabilities = null)
+    public static InitializeParams CreateDefault(IPlatformCapabilityService? platformCapabilities = null,
+        int protocolVersion = AcpProtocolVersion.Default)
         => new()
         {
-            ProtocolVersion = AcpProtocolVersion.Default,
+            ProtocolVersion = protocolVersion,
             ClientInfo = new ClientInfo
             {
                 Name = "SalmonEgg",
                 Title = "SalmonEgg",
                 Version = "1.0.0"
             },
-            ClientCapabilities = CreateCapabilities(platformCapabilities)
+            ClientCapabilities = CreateCapabilities(platformCapabilities, protocolVersion)
         };
 
-    private static ClientCapabilities CreateCapabilities(IPlatformCapabilityService? platformCapabilities)
+    private static ClientCapabilities CreateCapabilities(IPlatformCapabilityService? platformCapabilities, int protocolVersion)
     {
         var defaults = ClientCapabilityDefaults.Create();
         return defaults with
         {
+            Session = protocolVersion == AcpProtocolVersion.V2 ? null : defaults.Session,
+            Fs = protocolVersion == AcpProtocolVersion.V2 ? null : defaults.Fs,
+            Terminal = protocolVersion == AcpProtocolVersion.V2 ? null : defaults.Terminal,
             Elicitation = defaults.Elicitation! with
             {
                 Url = platformCapabilities?.SupportsUrlElicitation == true ? new ElicitationUrlCapabilities() : null

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeTimeout.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpInitializeTimeout.cs
@@ -20,12 +20,13 @@ internal static class AcpInitializeTimeout
         string? conversationId,
         TimeSpan timeout,
         CancellationToken cancellationToken,
-        IPlatformCapabilityService? platformCapabilities = null)
+        IPlatformCapabilityService? platformCapabilities = null,
+        int protocolVersion = AcpProtocolVersion.Default)
     {
         try
         {
             return await chatService
-                .InitializeAsync(AcpInitializeRequestFactory.CreateDefault(platformCapabilities))
+                .InitializeAsync(AcpInitializeRequestFactory.CreateDefault(platformCapabilities, protocolVersion))
                 .WaitAsync(timeout, cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionRecoveryMode.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/AcpSessionRecoveryMode.cs
@@ -11,8 +11,14 @@ public enum AcpSessionRecoveryMode
 
 public static class AcpSessionRecoveryPolicy
 {
-    public static AcpSessionRecoveryMode ResolveForHydration(AgentCapabilities? capabilities)
+    public static AcpSessionRecoveryMode ResolveForHydration(AgentCapabilities? capabilities, int protocolVersion = AcpProtocolVersion.Default)
     {
+        if (protocolVersion == AcpProtocolVersion.V2)
+        {
+            // The stable Load intent asks for authoritative history. The SDK translates it to
+            // V2 session/resume with replayFrom:start under the negotiated version.
+            return capabilities?.SupportsSessionResume == true ? AcpSessionRecoveryMode.Load : AcpSessionRecoveryMode.None;
+        }
         if (capabilities?.SupportsSessionLoading == true)
         {
             return AcpSessionRecoveryMode.Load;

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/ChatTurnStatusPresentationPolicy.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/ChatTurnStatusPresentationPolicy.cs
@@ -51,6 +51,12 @@ internal static class ChatTurnStatusPresentationPolicy
                 "Waiting for agent...",
                 isRunning: true),
 
+            ChatTurnPhase.WaitingForUser => Visible(
+                ChatTurnStatusSource.AcpSessionUpdate,
+                "ChatTurnStatus_WaitingForUser",
+                "Waiting for your action...",
+                isRunning: true),
+
             ChatTurnPhase.Thinking => Visible(
                 ChatTurnStatusSource.AcpSessionUpdate,
                 "ChatTurnStatus_Thinking",

--- a/src/SalmonEgg.Presentation.Core/Services/Chat/DiscoverSessionsConnectionFacade.cs
+++ b/src/SalmonEgg.Presentation.Core/Services/Chat/DiscoverSessionsConnectionFacade.cs
@@ -36,6 +36,7 @@ public sealed class DiscoverSessionsConnectionFacade : IDiscoverSessionsConnecti
     private readonly IAcpChatServiceFactory _chatServiceFactory;
     private readonly ITransportSupportPolicy _transportSupportPolicy;
     private readonly ILogger<DiscoverSessionsConnectionFacade> _logger;
+    private readonly SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy _protocolExperiment;
     private readonly object _connectSync = new();
     private CancellationTokenSource? _connectCts;
     private long _connectVersion;
@@ -51,11 +52,13 @@ public sealed class DiscoverSessionsConnectionFacade : IDiscoverSessionsConnecti
     public DiscoverSessionsConnectionFacade(
         IAcpChatServiceFactory chatServiceFactory,
         ITransportSupportPolicy transportSupportPolicy,
-        ILogger<DiscoverSessionsConnectionFacade> logger)
+        ILogger<DiscoverSessionsConnectionFacade> logger,
+        SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy? protocolExperiment = null)
     {
         _chatServiceFactory = chatServiceFactory ?? throw new ArgumentNullException(nameof(chatServiceFactory));
         _transportSupportPolicy = transportSupportPolicy ?? throw new ArgumentNullException(nameof(transportSupportPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _protocolExperiment = protocolExperiment ?? new SalmonEgg.Application.Services.Acp.AcpProtocolExperimentPolicy();
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -135,7 +138,8 @@ public sealed class DiscoverSessionsConnectionFacade : IDiscoverSessionsConnecti
                     profile.Id,
                     conversationId: null,
                     AcpInitializeTimeout.Resolve(profile),
-                    cancellationToken)
+                    cancellationToken,
+                    protocolVersion: _protocolExperiment.OfferedProtocolVersion)
                 .ConfigureAwait(false);
 
             if (!IsLatestConnectRequest(requestVersion, cancellationToken))

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -325,6 +325,23 @@ public partial class ChatViewModel
                 plan.PlanEntries!.ToImmutableList(), true), isCurrent).ConfigureAwait(true);
             return true;
         }
+        if (view.HasConfigOptions)
+        {
+            var config = _acpSessionUpdateProjector.Project(new SessionUpdateEventArgs(string.Empty,
+                new ConfigOptionUpdate { ConfigOptions = view.ConfigOptions.ToList() }));
+            await PostToUiAsync(async () =>
+            {
+                if (!isCurrent()) return;
+                SetConversationConfigAuthority(conversationId, true);
+                await _chatStore.Dispatch(new MergeConversationSessionStateAction(conversationId,
+                    AvailableModes: config.AvailableModes?.Select(ToConversationModeOptionSnapshot).ToImmutableList(),
+                    SelectedModeId: config.SelectedModeId,
+                    HasSelectedModeId: true,
+                    ConfigOptions: config.ConfigOptions?.Select(ToConversationConfigOptionSnapshot).ToImmutableList(),
+                    ShowConfigOptionsPanel: config.ShowConfigOptionsPanel)).ConfigureAwait(true);
+            }).ConfigureAwait(false);
+            return true;
+        }
         return false;
     }
 

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -54,7 +54,7 @@ namespace SalmonEgg.Presentation.ViewModels.Chat;
 
 public partial class ChatViewModel
 {
-    private void OnSessionUpdateReceived(object? sender, SessionUpdateEventArgs e)
+    private void OnSessionUpdateReceived(object? sender, SessionUpdateEventArgs e, InteractionRequestSource? source = null)
     {
         if (_disposed || _disposeCts.IsCancellationRequested)
         {
@@ -66,10 +66,10 @@ public partial class ChatViewModel
         TrackPendingSessionUpdate(_sessionUpdateWorkQueue.Enqueue(() =>
             generation != Volatile.Read(ref _foregroundChatServiceGeneration) || !ReferenceEquals(service, _chatService) || !e.IsCurrent
                 ? Task.CompletedTask
-                : ProcessSessionUpdateAsync(e, _disposeCts.Token)));
+                : ProcessSessionUpdateAsync(e, _disposeCts.Token, source)));
     }
 
-    private async Task ProcessSessionUpdateAsync(SessionUpdateEventArgs e, CancellationToken cancellationToken)
+    private async Task ProcessSessionUpdateAsync(SessionUpdateEventArgs e, CancellationToken cancellationToken, InteractionRequestSource? source = null)
     {
         try
         {
@@ -78,12 +78,14 @@ public partial class ChatViewModel
             var storeState = await _chatStore.GetCurrentStateAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             if (!e.IsCurrent) return;
+            if (source is not null && !IsInteractionConnectionCurrent(source)) return;
             var activeConversationId = !string.IsNullOrWhiteSpace(storeState.HydratedConversationId)
                 ? storeState.HydratedConversationId
                 : storeState.ActiveTurn?.ConversationId;
             var activeBinding = storeState.ResolveBinding(activeConversationId);
-            var boundConversationId =
-                !string.IsNullOrWhiteSpace(activeConversationId)
+            var boundConversationId = source is not null
+                ? ResolveInteractionConversation(storeState, e.SessionId, source)
+                : !string.IsNullOrWhiteSpace(activeConversationId)
                 && string.Equals(activeBinding?.RemoteSessionId, e.SessionId, StringComparison.Ordinal)
                     ? activeConversationId
                     : _authoritativeRemoteSessionRouter.ResolveConversationId(storeState, e.SessionId);
@@ -103,9 +105,13 @@ public partial class ChatViewModel
             var activeTurn = isActiveTarget
                 ? ResolveSessionUpdateTurn(storeState, activeConversationId, e.SessionId)
                 : null;
+            var targetBinding = storeState.ResolveBinding(targetConversationId);
+            bool IsProjectionCurrent() => e.IsCurrent && !_disposed
+                && (source is null || (IsInteractionConnectionCurrent(source)
+                    && _chatStore.ReadCommittedState()?.ResolveBinding(targetConversationId) == targetBinding));
 
             if (e.View is { } applicationView && await ApplySessionUpdateViewAsync(
-                targetConversationId, applicationView, activeTurn, isActiveTarget).ConfigureAwait(true))
+                targetConversationId, applicationView, activeTurn, isActiveTarget, IsProjectionCurrent).ConfigureAwait(true))
             {
                 RecordTranscriptProjectionObservation(e.SessionId);
             }
@@ -209,16 +215,19 @@ public partial class ChatViewModel
     }
 
     private async Task<bool> ApplySessionUpdateViewAsync(
-        string conversationId, AcpSessionUpdateView view, ActiveTurnState? activeTurn, bool isActiveTarget)
+        string conversationId, AcpSessionUpdateView view, ActiveTurnState? activeTurn, bool isActiveTarget,
+        Func<bool> isCurrent)
     {
+        if (!isCurrent()) return true;
         if (view.Message is { Role: "thought" })
         {
-            await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.Thinking).ConfigureAwait(true);
+            await AdvanceSessionViewPhaseAsync(activeTurn, ChatTurnPhase.Thinking, isCurrent).ConfigureAwait(true);
             return true;
         }
         if (view.Message is { } message)
         {
             var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(true);
+            if (!isCurrent()) return true;
             var transcript = state.ResolveContentSlice(conversationId)?.Transcript ?? ImmutableList<ConversationMessageSnapshot>.Empty;
             var isOutgoing = string.Equals(message.Role, "user", StringComparison.Ordinal);
             var content = message.Content;
@@ -237,11 +246,12 @@ public partial class ChatViewModel
                 items.Add(CreateContentSnapshot(content[index], isOutgoing, id,
                     timestamp: existing?.Timestamp, protocolMessageId: message.MessageId));
             }
-            await _chatStore.Dispatch(new ReplaceProtocolMessageAction(conversationId, message.MessageId,
-                isOutgoing, items.ToImmutable(), existing?.Id)).ConfigureAwait(true);
+            await CommitSessionViewAsync(new ReplaceProtocolMessageAction(conversationId, message.MessageId,
+                isOutgoing, items.ToImmutable(), existing?.Id), isCurrent).ConfigureAwait(true);
+            if (!isCurrent()) return true;
             if (!isOutgoing)
             {
-                await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.Responding).ConfigureAwait(true);
+                await AdvanceSessionViewPhaseAsync(activeTurn, ChatTurnPhase.Responding, isCurrent).ConfigureAwait(true);
                 if (!isActiveTarget) await MarkConversationUnreadAttentionAsync(conversationId, ConversationAttentionSource.AgentMessage).ConfigureAwait(false);
             }
             return true;
@@ -249,6 +259,7 @@ public partial class ChatViewModel
         if (view.ToolCall is { } tool)
         {
             var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(true);
+            if (!isCurrent()) return true;
             var existing = state.ResolveContentSlice(conversationId)?.Transcript
                 .LastOrDefault(item => item.ToolCallId == tool.ToolCallId && item.ContentType == "tool_call");
             var replacement = CreateToolCallSnapshot(tool);
@@ -257,16 +268,18 @@ public partial class ChatViewModel
                 replacement.Id = existing.Id;
                 replacement.Timestamp = existing.Timestamp;
             }
-            await _chatStore.Dispatch(new UpsertTranscriptMessageAction(conversationId, replacement)).ConfigureAwait(true);
-            await AdvanceActiveTurnPhaseAsync(activeTurn,
+            await CommitSessionViewAsync(new UpsertTranscriptMessageAction(conversationId, replacement), isCurrent).ConfigureAwait(true);
+            if (!isCurrent()) return true;
+            await AdvanceSessionViewPhaseAsync(activeTurn,
                 tool.Status == SalmonEgg.Acp.Tool.ToolCallStatus.InProgress ? ChatTurnPhase.ToolRunning : ChatTurnPhase.WaitingForAgent,
-                tool.ToolCallId, tool.Title).ConfigureAwait(true);
+                isCurrent, tool.ToolCallId, tool.Title).ConfigureAwait(true);
             return true;
         }
         if (view.Terminal is { } terminal)
         {
             await PostToUiAsync(() =>
             {
+                if (!isCurrent()) return;
                 var row = _panelStateCoordinator.GetOrCreateTerminalSession(conversationId, terminal.TerminalId);
                 row.DisplayName = terminal.Command ?? terminal.TerminalId;
                 row.Output = terminal.OutputText;
@@ -283,32 +296,49 @@ public partial class ChatViewModel
                 && (activeTurn is null || activeTurn.Phase is ChatTurnPhase.Completed or ChatTurnPhase.Cancelled or ChatTurnPhase.Failed))
             {
                 var turnId = Guid.NewGuid().ToString();
-                await _chatStore.Dispatch(new BeginTurnAction(conversationId, turnId, ChatTurnPhase.WaitingForAgent)).ConfigureAwait(true);
+                await CommitSessionViewAsync(new BeginTurnAction(conversationId, turnId, ChatTurnPhase.WaitingForAgent), isCurrent).ConfigureAwait(true);
+                if (!isCurrent()) return true;
                 activeTurn = (await _chatStore.GetCurrentStateAsync().ConfigureAwait(true)).ActiveTurn;
+                if (!isCurrent()) return true;
             }
             if (activeTurn is not null && workState == "idle")
             {
                 if (view.StopReason == StopReason.Cancelled)
-                    await _chatStore.Dispatch(new CancelTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+                    await CommitSessionViewAsync(new CancelTurnAction(conversationId, activeTurn.TurnId), isCurrent).ConfigureAwait(true);
                 else if (view.StopReason == StopReason.Refusal)
-                    await _chatStore.Dispatch(new FailTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+                    await CommitSessionViewAsync(new FailTurnAction(conversationId, activeTurn.TurnId), isCurrent).ConfigureAwait(true);
                 else
-                    await _chatStore.Dispatch(new CompleteTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+                    await CommitSessionViewAsync(new CompleteTurnAction(conversationId, activeTurn.TurnId), isCurrent).ConfigureAwait(true);
             }
             else if (workState is "running" or "requires_action")
             {
-                await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.WaitingForAgent).ConfigureAwait(true);
+                await AdvanceSessionViewPhaseAsync(activeTurn,
+                    workState == "requires_action" ? ChatTurnPhase.WaitingForUser : ChatTurnPhase.WaitingForAgent,
+                    isCurrent).ConfigureAwait(true);
             }
             return true;
         }
         if (view.HasPlanEntries)
         {
-            await ApplySessionUpdateDeltaAsync(conversationId, _acpSessionUpdateProjector.Project(
-                new SessionUpdateEventArgs(string.Empty, new PlanUpdate(view.PlanEntries.ToList())))).ConfigureAwait(true);
+            var plan = _acpSessionUpdateProjector.Project(new SessionUpdateEventArgs(string.Empty, new PlanUpdate(view.PlanEntries.ToList())));
+            await CommitSessionViewAsync(new ReplacePlanEntriesAction(conversationId,
+                plan.PlanEntries!.ToImmutableList(), true), isCurrent).ConfigureAwait(true);
             return true;
         }
         return false;
     }
+
+    private Task CommitSessionViewAsync(ChatAction action, Func<bool> isCurrent)
+        => PostToUiAsync(async () =>
+        {
+            if (!isCurrent()) return;
+            await _chatStore.Dispatch(action).ConfigureAwait(true);
+        });
+
+    private Task AdvanceSessionViewPhaseAsync(ActiveTurnState? turn, ChatTurnPhase phase,
+        Func<bool> isCurrent, string? toolCallId = null, string? title = null)
+        => turn is null ? Task.CompletedTask : CommitSessionViewAsync(
+            new AdvanceTurnPhaseAction(turn.ConversationId, turn.TurnId, phase, toolCallId, title), isCurrent);
 
     private void RaiseOverlayStateChanged()
     {

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.AcpSessionLifecycle.cs
@@ -61,7 +61,12 @@ public partial class ChatViewModel
             return;
         }
 
-        TrackPendingSessionUpdate(_sessionUpdateWorkQueue.Enqueue(() => ProcessSessionUpdateAsync(e, _disposeCts.Token)));
+        var generation = Volatile.Read(ref _foregroundChatServiceGeneration);
+        var service = _chatService;
+        TrackPendingSessionUpdate(_sessionUpdateWorkQueue.Enqueue(() =>
+            generation != Volatile.Read(ref _foregroundChatServiceGeneration) || !ReferenceEquals(service, _chatService) || !e.IsCurrent
+                ? Task.CompletedTask
+                : ProcessSessionUpdateAsync(e, _disposeCts.Token)));
     }
 
     private async Task ProcessSessionUpdateAsync(SessionUpdateEventArgs e, CancellationToken cancellationToken)
@@ -72,6 +77,7 @@ public partial class ChatViewModel
             RecordSessionUpdateObservation(e.SessionId);
             var storeState = await _chatStore.GetCurrentStateAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+            if (!e.IsCurrent) return;
             var activeConversationId = !string.IsNullOrWhiteSpace(storeState.HydratedConversationId)
                 ? storeState.HydratedConversationId
                 : storeState.ActiveTurn?.ConversationId;
@@ -98,7 +104,12 @@ public partial class ChatViewModel
                 ? ResolveSessionUpdateTurn(storeState, activeConversationId, e.SessionId)
                 : null;
 
-            if (e.Update is AgentMessageUpdate messageUpdate && messageUpdate.Content != null)
+            if (e.View is { } applicationView && await ApplySessionUpdateViewAsync(
+                targetConversationId, applicationView, activeTurn, isActiveTarget).ConfigureAwait(true))
+            {
+                RecordTranscriptProjectionObservation(e.SessionId);
+            }
+            else if (e.Update is AgentMessageUpdate messageUpdate && messageUpdate.Content != null)
             {
                 await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.Responding).ConfigureAwait(true);
                 await HandleAgentContentChunkAsync(targetConversationId, messageUpdate).ConfigureAwait(true);
@@ -195,6 +206,108 @@ public partial class ChatViewModel
         {
             Logger.LogError(ex, "Error processing session update");
         }
+    }
+
+    private async Task<bool> ApplySessionUpdateViewAsync(
+        string conversationId, AcpSessionUpdateView view, ActiveTurnState? activeTurn, bool isActiveTarget)
+    {
+        if (view.Message is { Role: "thought" })
+        {
+            await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.Thinking).ConfigureAwait(true);
+            return true;
+        }
+        if (view.Message is { } message)
+        {
+            var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(true);
+            var transcript = state.ResolveContentSlice(conversationId)?.Transcript ?? ImmutableList<ConversationMessageSnapshot>.Empty;
+            var isOutgoing = string.Equals(message.Role, "user", StringComparison.Ordinal);
+            var content = message.Content;
+            var existing = transcript.FirstOrDefault(item => item.IsOutgoing == isOutgoing
+                && item.ProtocolMessageId == message.MessageId);
+            if (existing is null && isOutgoing && content.Length > 0)
+            {
+                existing = _outgoingUserMessageProjector.ResolveAuthoritativeProjection(transcript,
+                    new UserMessageUpdate { MessageId = message.MessageId, Content = content[0] }, activeTurn).ExistingSnapshot;
+            }
+            var items = ImmutableList.CreateBuilder<ConversationMessageSnapshot>();
+            for (var index = 0; index < content.Length; index++)
+            {
+                var id = index == 0 && existing is not null ? existing.Id
+                    : $"acp:{message.Role}:{message.MessageId.Length}:{message.MessageId}:{index}";
+                items.Add(CreateContentSnapshot(content[index], isOutgoing, id,
+                    timestamp: existing?.Timestamp, protocolMessageId: message.MessageId));
+            }
+            await _chatStore.Dispatch(new ReplaceProtocolMessageAction(conversationId, message.MessageId,
+                isOutgoing, items.ToImmutable(), existing?.Id)).ConfigureAwait(true);
+            if (!isOutgoing)
+            {
+                await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.Responding).ConfigureAwait(true);
+                if (!isActiveTarget) await MarkConversationUnreadAttentionAsync(conversationId, ConversationAttentionSource.AgentMessage).ConfigureAwait(false);
+            }
+            return true;
+        }
+        if (view.ToolCall is { } tool)
+        {
+            var state = await _chatStore.GetCurrentStateAsync().ConfigureAwait(true);
+            var existing = state.ResolveContentSlice(conversationId)?.Transcript
+                .LastOrDefault(item => item.ToolCallId == tool.ToolCallId && item.ContentType == "tool_call");
+            var replacement = CreateToolCallSnapshot(tool);
+            if (existing is not null)
+            {
+                replacement.Id = existing.Id;
+                replacement.Timestamp = existing.Timestamp;
+            }
+            await _chatStore.Dispatch(new UpsertTranscriptMessageAction(conversationId, replacement)).ConfigureAwait(true);
+            await AdvanceActiveTurnPhaseAsync(activeTurn,
+                tool.Status == SalmonEgg.Acp.Tool.ToolCallStatus.InProgress ? ChatTurnPhase.ToolRunning : ChatTurnPhase.WaitingForAgent,
+                tool.ToolCallId, tool.Title).ConfigureAwait(true);
+            return true;
+        }
+        if (view.Terminal is { } terminal)
+        {
+            await PostToUiAsync(() =>
+            {
+                var row = _panelStateCoordinator.GetOrCreateTerminalSession(conversationId, terminal.TerminalId);
+                row.DisplayName = terminal.Command ?? terminal.TerminalId;
+                row.Output = terminal.OutputText;
+                row.ExitCode = terminal.ExitCode;
+                row.IsReleased = terminal.HasExited;
+                row.LastMethod = "session/update";
+                ApplyTerminalSelection(conversationId, _panelStateCoordinator.SelectTerminal(conversationId, row, isActiveTarget));
+            }).ConfigureAwait(false);
+            return true;
+        }
+        if (view.WorkState is { } workState)
+        {
+            if (isActiveTarget && workState is "running" or "requires_action"
+                && (activeTurn is null || activeTurn.Phase is ChatTurnPhase.Completed or ChatTurnPhase.Cancelled or ChatTurnPhase.Failed))
+            {
+                var turnId = Guid.NewGuid().ToString();
+                await _chatStore.Dispatch(new BeginTurnAction(conversationId, turnId, ChatTurnPhase.WaitingForAgent)).ConfigureAwait(true);
+                activeTurn = (await _chatStore.GetCurrentStateAsync().ConfigureAwait(true)).ActiveTurn;
+            }
+            if (activeTurn is not null && workState == "idle")
+            {
+                if (view.StopReason == StopReason.Cancelled)
+                    await _chatStore.Dispatch(new CancelTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+                else if (view.StopReason == StopReason.Refusal)
+                    await _chatStore.Dispatch(new FailTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+                else
+                    await _chatStore.Dispatch(new CompleteTurnAction(conversationId, activeTurn.TurnId)).ConfigureAwait(true);
+            }
+            else if (workState is "running" or "requires_action")
+            {
+                await AdvanceActiveTurnPhaseAsync(activeTurn, ChatTurnPhase.WaitingForAgent).ConfigureAwait(true);
+            }
+            return true;
+        }
+        if (view.HasPlanEntries)
+        {
+            await ApplySessionUpdateDeltaAsync(conversationId, _acpSessionUpdateProjector.Project(
+                new SessionUpdateEventArgs(string.Empty, new PlanUpdate(view.PlanEntries.ToList())))).ConfigureAwait(true);
+            return true;
+        }
+        return false;
     }
 
     private void RaiseOverlayStateChanged()
@@ -3005,6 +3118,11 @@ public partial class ChatViewModel
         SessionSetConfigOptionResponse response,
         string remoteSessionId)
     {
+        if (_chatService?.PublishesConfigurationResponses == true)
+        {
+            await WaitForPendingSessionUpdatesAsync().ConfigureAwait(true);
+            return;
+        }
         if (response?.ConfigOptions == null)
         {
             return;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.CommandWorkflow.cs
@@ -1308,6 +1308,7 @@ public partial class ChatViewModel
 
     private static bool IsDispatchedPromptTurn(ActiveTurnState? activeTurn)
         => activeTurn?.Phase is ChatTurnPhase.WaitingForAgent
+            or ChatTurnPhase.WaitingForUser
             or ChatTurnPhase.Thinking
             or ChatTurnPhase.ToolPending
             or ChatTurnPhase.ToolRunning

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.RemoteConversationLifecycle.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.RemoteConversationLifecycle.cs
@@ -314,7 +314,7 @@ public partial class ChatViewModel
         }
 
         var chatService = resolvedConnection.ChatService;
-        var recoveryMode = AcpSessionRecoveryPolicy.ResolveForHydration(chatService.AgentCapabilities);
+        var recoveryMode = AcpSessionRecoveryPolicy.ResolveForHydration(chatService.AgentCapabilities, chatService.NegotiatedProtocolVersion);
         if (recoveryMode == AcpSessionRecoveryMode.None)
         {
             await PublishConversationFailureAsync(
@@ -1889,7 +1889,7 @@ public partial class ChatViewModel
         }
 
         var chatService = resolvedConnection.ChatService;
-        if (AcpSessionRecoveryPolicy.ResolveForHydration(chatService.AgentCapabilities) == AcpSessionRecoveryMode.None)
+        if (AcpSessionRecoveryPolicy.ResolveForHydration(chatService.AgentCapabilities, chatService.NegotiatedProtocolVersion) == AcpSessionRecoveryMode.None)
         {
             await PublishConversationFailureAsync(
                     failureContext,

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -230,6 +230,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
     private readonly object _remoteSessionRecoveryRequestsSync = new();
     private readonly Dictionary<RemoteSessionRecoveryLeaseKey, RemoteSessionRecoveryRequest> _remoteSessionRecoveryRequests = new();
     private int _foregroundChatServiceGeneration;
+    private EventHandler<SessionUpdateEventArgs>? _sessionUpdateHandler;
     private EventHandler<PermissionRequestEventArgs>? _permissionRequestHandler;
     private EventHandler<ElicitationRequestEventArgs>? _elicitationRequestHandler;
     private HydrationOverlayPhase _hydrationOverlayPhase = HydrationOverlayPhase.None;
@@ -3382,8 +3383,14 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
 
     private void SubscribeToChatService(IChatService chatService)
     {
-        chatService.SessionUpdateReceived += OnSessionUpdateReceived;
         var foregroundGeneration = Volatile.Read(ref _foregroundChatServiceGeneration);
+        _sessionUpdateHandler = (_, update) =>
+        {
+            if (foregroundGeneration == Volatile.Read(ref _foregroundChatServiceGeneration)
+                && ReferenceEquals(chatService, _chatService) && update.IsCurrent)
+                OnSessionUpdateReceived(chatService, update);
+        };
+        chatService.SessionUpdateReceived += _sessionUpdateHandler;
         // Decorators forward events with the inner service as sender. Capture the actual subscribed
         // service and generation here instead of guessing ownership from that forwarded sender.
         _permissionRequestHandler = (_, request) => ProcessPermissionRequest(chatService, foregroundGeneration, request);
@@ -3401,7 +3408,11 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
 
     private void UnsubscribeFromChatService(IChatService chatService)
     {
-        chatService.SessionUpdateReceived -= OnSessionUpdateReceived;
+        if (_sessionUpdateHandler is not null)
+        {
+            chatService.SessionUpdateReceived -= _sessionUpdateHandler;
+            _sessionUpdateHandler = null;
+        }
         if (_permissionRequestHandler is not null)
         {
             chatService.PermissionRequestReceived -= _permissionRequestHandler;

--- a/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
+++ b/src/SalmonEgg.Presentation.Core/ViewModels/Chat/ChatViewModel.cs
@@ -3388,7 +3388,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable, IAcpChatCoordin
         {
             if (foregroundGeneration == Volatile.Read(ref _foregroundChatServiceGeneration)
                 && ReferenceEquals(chatService, _chatService) && update.IsCurrent)
-                OnSessionUpdateReceived(chatService, update);
+                OnSessionUpdateReceived(chatService, update,
+                    update.View is not null ? CaptureInteractionSource(chatService, foregroundGeneration) : null);
         };
         chatService.SessionUpdateReceived += _sessionUpdateHandler;
         // Decorators forward events with the inner service as sender. Capture the actual subscribed

--- a/tests/SalmonEgg.Acp.Desktop.Tests/OfficialV2AgentAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/OfficialV2AgentAcceptanceTests.cs
@@ -4,12 +4,48 @@ using SalmonEgg.Acp.Content;
 using SalmonEgg.Acp.Protocol;
 using SalmonEgg.Infrastructure.Client;
 using SalmonEgg.Infrastructure.Transport;
+using SalmonEgg.Infrastructure.Services;
+using SalmonEgg.Infrastructure.Logging;
+using SalmonEgg.Application.Services.Chat;
+using System.Collections.Concurrent;
 using Xunit;
 
 namespace SalmonEgg.Acp.Desktop.Tests;
 
 public sealed class OfficialV2AgentAcceptanceTests
 {
+    [Fact]
+    public async Task OfficialV2Agent_PublicExperimentalClientAndChatService_ProjectMessagesAndRestoreHistory()
+    {
+        var command = Environment.GetEnvironmentVariable("SALMONEGG_OFFICIAL_V2_AGENT");
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(command), "Build the pinned official Rust simple_agent_v2 example.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        var token = timeout.Token;
+        using var transport = new StdioTransport(command!);
+        using var client = new AcpClient(new DomainAcpTransportAdapter(transport), null, null, null,
+            new AcpClientOptions { ExperimentalProtocolVersions = [AcpProtocolVersion.V2] });
+        using var service = new ChatService(client, new ErrorLogger(), new SessionManager());
+        var updates = new ConcurrentQueue<SessionUpdateEventArgs>();
+        service.SessionUpdateReceived += (_, update) => updates.Enqueue(update);
+        await service.InitializeAsync(new InitializeParams(new ClientInfo("salmon-egg-app-interop", "1"), new ClientCapabilities())
+        { ProtocolVersion = AcpProtocolVersion.V2 }).WaitAsync(token);
+        var directory = Path.GetFullPath(Path.GetTempPath());
+        var session = await service.CreateSessionAsync(new SessionNewParams(directory, [])).WaitAsync(token);
+        var marker = "application-v2-" + Guid.NewGuid().ToString("N");
+
+        var prompt = await service.SendPromptAsync(new SessionPromptParams(session.SessionId, [new TextContentBlock(marker)]), token);
+        await service.CloseSessionAsync(new SessionCloseParams(session.SessionId), token);
+        await service.LoadSessionAsync(new SessionLoadParams(session.SessionId, directory), token);
+
+        Assert.Equal(2, service.NegotiatedProtocolVersion);
+        Assert.Equal(StopReason.EndTurn, prompt.StopReason);
+        Assert.Contains(updates, update => update.View?.Message?.Content.OfType<TextContentBlock>()
+            .Any(content => content.Text.Contains(marker, StringComparison.Ordinal)) == true);
+        Assert.Contains(updates, update => update.View?.WorkState == "idle");
+        Assert.True(await client.DisconnectAsync());
+    }
+
     [Fact]
     public async Task OfficialV2Agent_PromptCloseResume_UsesAuthoritativeHistory()
     {
@@ -20,8 +56,9 @@ public sealed class OfficialV2AgentAcceptanceTests
         timeout.CancelAfter(TimeSpan.FromSeconds(30));
         var token = timeout.Token;
         using var transport = new StdioTransport(command!);
-        using var client = new AcpClient(new DomainAcpTransportAdapter(transport));
-        await client.InitializeDraftAsync(new InitializeParams(new ClientInfo("salmon-egg-v2-interop", "1"), new ClientCapabilities())
+        using var client = new AcpClient(new DomainAcpTransportAdapter(transport), null, null, null,
+            new AcpClientOptions { ExperimentalProtocolVersions = [AcpProtocolVersion.V2] });
+        await client.InitializeAsync(new InitializeParams(new ClientInfo("salmon-egg-v2-interop", "1"), new ClientCapabilities())
         { ProtocolVersion = AcpProtocolVersion.V2 }, token);
         var directory = Path.GetFullPath(Path.GetTempPath());
         var session = await client.CreateSessionAsync(new SessionNewParams(directory, []), token);
@@ -45,4 +82,5 @@ public sealed class OfficialV2AgentAcceptanceTests
         Assert.Contains(after.Messages, message => message.Content.OfType<TextContentBlock>().Any(content => content.Text.Contains(marker, StringComparison.Ordinal)));
         Assert.True(await client.DisconnectAsync());
     }
+
 }

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpConfigurationUpdateViewTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpConfigurationUpdateViewTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+
+namespace SalmonEgg.Acp.Tests.Client;
+
+public sealed class AcpConfigurationUpdateViewTests
+{
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    public async Task SessionConfiguration_UnknownOptionBesideGroupedChoice_KeepsKnownRowsInTheApplicationView(int version, bool responseProjection)
+    {
+        // Arrange: the same grouped/unknown mix used by the real browser gate, under either wire version.
+        var optionsJson = """
+            [{"id":"response-style","name":"Response style","description":"Choose the detail used in this conversation.",
+              "type":"select","currentValue":"short","options":[{"group":"standard","name":"Standard",
+              "options":[{"value":"short","name":"Brief"}]}]},
+             {"id":"future-setting","name":"Future knob","type":"future","currentValue":{"opaque":1e2}}]
+            """;
+        if (version == 2) optionsJson = optionsJson.Replace("\"id\":", "\"configId\":").Replace("\"group\":", "\"groupId\":");
+        var transport = new Mock<IAcpTransport>();
+        transport.SetupGet(value => value.IsConnected).Returns(true);
+        transport.Setup(value => value.ConnectAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        transport.Setup(value => value.SendMessageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((message, _) =>
+            {
+                using var request = JsonDocument.Parse(message);
+                var root = request.RootElement;
+                var result = root.GetProperty("method").ValueEquals("initialize")
+                    ? "{\"protocolVersion\":" + version + ",\"agentCapabilities\":{},\"info\":{\"name\":\"fixture\",\"version\":\"1\"}}"
+                    : "{\"configOptions\":" + optionsJson + "}";
+                transport.Raise(value => value.MessageReceived += null,
+                    new AcpTransportMessageReceivedEventArgs("{\"jsonrpc\":\"2.0\",\"id\":"
+                        + root.GetProperty("id").GetRawText() + ",\"result\":" + result + "}"));
+                return Task.FromResult(true);
+            });
+        using var client = new AcpClient(transport.Object, null, null, null,
+            new AcpClientOptions { ExperimentalProtocolVersions = [2] });
+        await client.InitializeAsync(new(new("config-view-test", "1"), new()) { ProtocolVersion = version }, TestContext.Current.CancellationToken);
+        var received = new TaskCompletionSource<SessionUpdateEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.SessionUpdateReceived += (_, update) => received.TrySetResult(update);
+        // Act / Assert: retaining an unknown sibling must not break the whole application projection.
+        if (responseProjection)
+            await client.SetSessionConfigOptionAsync(new("remote", "response-style", "short"), TestContext.Current.CancellationToken);
+        else
+            transport.Raise(value => value.MessageReceived += null, new AcpTransportMessageReceivedEventArgs(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"remote\",\"update\":"
+                + "{\"sessionUpdate\":\"config_option_update\",\"configOptions\":" + optionsJson + "}}}"));
+        var update = await received.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        var options = Assert.IsType<AcpSessionUpdateView>(update.View).ConfigOptions;
+        Assert.Equal(2, options.Length);
+        Assert.Equal("response-style", options[0].Id);
+        Assert.Equal("Choose the detail used in this conversation.", options[0].Description);
+        Assert.Equal("standard", Assert.Single(options[0].OptionGroups).Group);
+        Assert.Equal("future-setting", options[1].Id);
+        Assert.Equal("future", options[1].Type);
+        Assert.Equal(responseProjection, update.IsResponseProjection);
+        Assert.True(options[1].RawPayload!.Value.TryGetProperty(version == 1 ? "id" : "configId", out _));
+        Assert.Equal("1e2", options[1].RawPayload!.Value.GetProperty("currentValue").GetProperty("opaque").GetRawText());
+        options[0].OptionGroups[0].Options.Clear();
+        Assert.Single(update.View!.ConfigOptions[0].OptionGroups[0].Options);
+    }
+}

--- a/tests/SalmonEgg.Acp.Tests/Client/AcpSessionConfigurationTests.cs
+++ b/tests/SalmonEgg.Acp.Tests/Client/AcpSessionConfigurationTests.cs
@@ -83,6 +83,99 @@ public sealed class AcpSessionConfigurationTests
     }
 
     [Fact]
+    public async Task SetOption_ResponseProjection_IsPublishedBeforeLaterNotifications()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+        var events = new List<SessionUpdateEventArgs>();
+        peer.Client.SessionUpdateReceived += (_, update) => events.Add(update);
+        peer.OnSet = request =>
+        {
+            peer.Reply(request, OptionsResponse(BooleanOptions(true)));
+            peer.Update(BooleanOptions(false));
+        };
+
+        await peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+
+        Assert.Equal(2, events.Count);
+        Assert.True(events[0].IsResponseProjection);
+        Assert.False(events[1].IsResponseProjection);
+        Assert.True(events[0].View!.ConfigOptions[0].CurrentBooleanValue);
+        Assert.False(events[1].View!.ConfigOptions[0].CurrentBooleanValue);
+        await peer.Client.DisconnectAsync();
+        Assert.All(events, static update => Assert.False(update.IsCurrent));
+    }
+
+    [Fact]
+    public async Task V1_SetOption_UsesTheSameOrderedApplicationProjection()
+    {
+        using var peer = await ConfigurationPeer.CreateAsync(version: AcpProtocolVersion.V1);
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        SessionUpdateEventArgs? updated = null;
+        peer.Client.SessionUpdateReceived += (_, update) => updated = update;
+        peer.OnSet = request => peer.Reply(request,
+            """{"configOptions":[{"id":"reasoning","name":"Reasoning","type":"boolean","currentValue":true}]}""");
+
+        await peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+
+        Assert.True(peer.Client.PublishesConfigurationResponses);
+        Assert.NotNull(updated);
+        Assert.True(updated.IsResponseProjection);
+        Assert.True(Assert.Single(updated.View!.ConfigOptions).CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task V2_LoadIntent_UsesResumeWithFullReplay()
+    {
+        using var peer = await ConfigurationPeer.CreateWithSessionAsync();
+
+        await peer.Client.LoadSessionAsync(new SessionLoadParams("one", "/workspace"), TestToken);
+
+        Assert.Equal("session/resume", peer.LastResume!.Method);
+        Assert.Equal("start", peer.LastResume.Params!.Value.GetProperty("replayFrom").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ExplicitExperimentalClient_OffersV2AndUsesThePublicLifecycle()
+    {
+        using var peer = await ConfigurationPeer.CreateAsync(explicitOptIn: true);
+
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        peer.OnSet = request => peer.Reply(request, OptionsResponse(BooleanOptions(true)));
+        await peer.Client.SetSessionConfigOptionAsync(new("one", "reasoning", true), TestToken);
+
+        Assert.Equal(AcpProtocolVersion.V2, peer.Client.NegotiatedProtocolVersion);
+        Assert.True(peer.InitializeRequest!.Params!.Value.TryGetProperty("info", out _));
+        Assert.False(peer.InitializeRequest.Params.Value.TryGetProperty("clientInfo", out _));
+        Assert.True(peer.Client.GetSessionSnapshot("one")!.ConfigOptions[0].CurrentBooleanValue);
+    }
+
+    [Fact]
+    public async Task ExplicitExperimentalClient_AgentDowngrade_ReturnsToStableWire()
+    {
+        using var peer = await ConfigurationPeer.CreateAsync(version: AcpProtocolVersion.V1, explicitOptIn: true);
+        await peer.Client.CreateSessionAsync(new SessionNewParams("/workspace", []), TestToken);
+        peer.OnSet = request => peer.Reply(request, "{\"configOptions\":[]}");
+
+        await peer.Client.SetSessionConfigOptionAsync(new("one", "model", "fast"), TestToken);
+
+        Assert.Equal(2, peer.InitializeRequest!.Params!.Value.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(AcpProtocolVersion.V1, peer.Client.NegotiatedProtocolVersion);
+        Assert.False(peer.LastSet!.Params!.Value.TryGetProperty("type", out _));
+    }
+
+    [Fact]
+    public async Task PublicClient_WithoutExplicitOptIn_RejectsV2BeforeSending()
+    {
+        using var peer = new ConfigurationPeer(null, AcpProtocolVersion.V2, explicitOptIn: false);
+
+        await Assert.ThrowsAsync<AcpException>(() => peer.Client.InitializeAsync(
+            new InitializeParams(new ClientInfo("test", "1"), new ClientCapabilities())
+            { ProtocolVersion = AcpProtocolVersion.V2 }, TestToken));
+
+        Assert.Null(peer.InitializeRequest);
+    }
+
+    [Fact]
     public async Task SetOption_AbandonedAwait_StillCommitsThePeersFinalResponse()
     {
         using var peer = await ConfigurationPeer.CreateWithSessionAsync();
@@ -246,25 +339,32 @@ public sealed class AcpSessionConfigurationTests
     private sealed class ConfigurationPeer : IAcpTransport, IDisposable
     {
         private readonly int _version;
+        private readonly bool _explicitOptIn;
         private readonly MessageParser _parser = new();
         internal AcpClient Client { get; }
         internal List<string> Errors { get; } = [];
         internal JsonRpcRequest? LastSet { get; private set; }
+        internal JsonRpcRequest? LastResume { get; private set; }
+        internal JsonRpcRequest? InitializeRequest { get; private set; }
         internal Action<JsonRpcRequest>? OnSet { get; set; }
         public bool IsConnected { get; private set; } = true;
         public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
         public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
 
-        private ConfigurationPeer(IAcpClientSessionStore? store, int version)
+        internal ConfigurationPeer(IAcpClientSessionStore? store, int version, bool explicitOptIn = false)
         {
             _version = version;
-            Client = new AcpClient(this, sessionStore: store);
+            _explicitOptIn = explicitOptIn;
+            Client = explicitOptIn
+                ? new AcpClient(this, null, store, null, new AcpClientOptions { ExperimentalProtocolVersions = [AcpProtocolVersion.V2] })
+                : new AcpClient(this, sessionStore: store);
             Client.ErrorOccurred += (_, error) => Errors.Add(error);
         }
 
-        internal static async Task<ConfigurationPeer> CreateAsync(IAcpClientSessionStore? store = null, int version = AcpProtocolVersion.V2)
+        internal static async Task<ConfigurationPeer> CreateAsync(IAcpClientSessionStore? store = null, int version = AcpProtocolVersion.V2,
+            bool explicitOptIn = false)
         {
-            var peer = new ConfigurationPeer(store, version);
+            var peer = new ConfigurationPeer(store, version, explicitOptIn);
             await peer.InitializeAsync();
             return peer;
         }
@@ -278,8 +378,9 @@ public sealed class AcpSessionConfigurationTests
 
         internal Task<InitializeResponse> InitializeAsync()
         {
-            var request = new InitializeParams(new ClientInfo("config-test", "1"), new ClientCapabilities()) { ProtocolVersion = _version };
-            return _version == AcpProtocolVersion.V2
+            var request = new InitializeParams(new ClientInfo("config-test", "1"), new ClientCapabilities())
+            { ProtocolVersion = _explicitOptIn ? AcpProtocolVersion.V2 : _version };
+            return _version == AcpProtocolVersion.V2 && !_explicitOptIn
                 ? Client.InitializeDraftAsync(request, TestToken)
                 : Client.InitializeAsync(request, TestToken);
         }
@@ -303,6 +404,7 @@ public sealed class AcpSessionConfigurationTests
             switch (request.Method)
             {
                 case "initialize":
+                    InitializeRequest = request;
                     var initialize = new InitializeResponse(_version, new AgentInfo("config-peer", "1"), new AgentCapabilities
                     {
                         SessionCapabilities = new SessionCapabilities { Resume = new SessionResumeCapabilities(), Close = new SessionCloseCapabilities() }
@@ -315,6 +417,9 @@ public sealed class AcpSessionConfigurationTests
                         : "{\"sessionId\":\"one\"}");
                     break;
                 case "session/resume":
+                    LastResume = request;
+                    Reply(request, "{}");
+                    break;
                 case "session/close":
                     Reply(request, "{}");
                     break;

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatServiceAdapterTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/AcpChatServiceAdapterTests.cs
@@ -20,6 +20,39 @@ namespace SalmonEgg.Presentation.Core.Tests.Chat;
 public sealed class AcpChatServiceAdapterTests
 {
     [Fact]
+    public async Task AvailableUpdates_OriginalScopeDrainingAndNewScopeEmpty_AwaitsOriginalDrain()
+    {
+        var dispatcher = new QueueingUiDispatcher();
+        var observed = new List<SessionUpdateEventArgs>();
+        var events = new AcpEventAdapter(observed.Add, dispatcher);
+        var first = events.BeginHydrationBuffering("first");
+        events.Enqueue(new SessionUpdateEventArgs("first", new PlanUpdate(CreatePlanEntries("response"))));
+        Assert.True(events.MarkHydrated(first, lowTrust: false));
+        events.BeginHydrationBuffering("second");
+
+        var settled = events.WaitForAvailableUpdatesAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(settled.IsCompleted);
+        while (dispatcher.RunNext()) { }
+        await settled;
+        Assert.Equal("first", Assert.Single(observed).SessionId);
+    }
+
+    [Fact]
+    public async Task AvailableUpdates_UnreleasedHydration_DoesNotWaitForItsCallerToReleaseIt()
+    {
+        var dispatcher = new QueueingUiDispatcher();
+        var events = new AcpEventAdapter(_ => { }, dispatcher);
+        events.BeginHydrationBuffering("first");
+        events.Enqueue(new SessionUpdateEventArgs("first", new PlanUpdate(CreatePlanEntries("buffered"))));
+
+        var settled = events.WaitForAvailableUpdatesAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(settled.IsCompletedSuccessfully);
+        await settled;
+    }
+
+    [Fact]
     public void SessionUpdateReceived_BuffersUntilHydrated_ThenPublishes()
     {
         // Arrange

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.VersionedUpdates.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.VersionedUpdates.cs
@@ -1,0 +1,252 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Moq;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Application.Services.Chat;
+using SalmonEgg.Domain.Models.Conversation;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Presentation.Core.Mvux.Chat;
+using SalmonEgg.Presentation.Core.Services.Chat;
+using SalmonEgg.Presentation.Core.Tests.Threading;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat;
+
+public partial class ChatViewModelTests
+{
+    [Fact]
+    public async Task VersionedUpdates_MessageReplacementAndChunks_ReachTheSameProductMessage()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+
+        peer.Update("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":"old"}}""");
+        peer.Update("""{"sessionUpdate":"agent_message","messageId":"a","content":[{"type":"text","text":"new"},{"type":"resource_link","uri":"https://example.test/document","name":"Document"}]}""");
+        peer.Update("""{"sessionUpdate":"agent_message_chunk","messageId":"a","content":{"type":"text","text":" tail"}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var messages = (await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.Transcript;
+        Assert.Equal(3, messages.Count);
+        Assert.Equal(["new", "https://example.test/document", " tail"], messages.Select(static message => message.TextContent));
+        Assert.All(messages, static message => Assert.Equal("a", message.ProtocolMessageId));
+
+        peer.Update("""{"sessionUpdate":"agent_message","messageId":"a","content":[]}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        Assert.Empty((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.Transcript);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_ToolReplacement_ClearsOmittedProjectionFieldsAndStreamsContent()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+
+        peer.Update("""{"sessionUpdate":"tool_call_update","toolCallId":"t","title":"Run","status":"in_progress","rawInput":{"x":1},"content":[{"type":"content","content":{"type":"text","text":"old"}}]}""");
+        peer.Update("""{"sessionUpdate":"tool_call_update","toolCallId":"t","title":null,"rawInput":null,"status":"completed","content":[]}""");
+        peer.Update("""{"sessionUpdate":"tool_call_content_chunk","toolCallId":"t","content":{"type":"content","content":{"type":"text","text":"result"}}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var tool = Assert.Single((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.Transcript);
+        Assert.Equal("t", tool.ToolCallId);
+        Assert.Equal("completed", tool.ToolCallStatus);
+        Assert.Empty(tool.Title);
+        Assert.Null(tool.ToolCallRawInputJson);
+        Assert.Contains("result", tool.TextContent);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_TerminalBytesAndExit_UseDisplayOnlyPanel()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+
+        peer.Update("""{"sessionUpdate":"terminal_update","terminalId":"terminal","command":"echo","output":{"data":"4g=="}}""");
+        peer.Update("""{"sessionUpdate":"terminal_output_chunk","terminalId":"terminal","data":"gqw="}""");
+        peer.Update("""{"sessionUpdate":"terminal_update","terminalId":"terminal","exitStatus":{"exitCode":0}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var terminal = Assert.Single(fixture.ViewModel.TerminalSessions);
+        Assert.Equal("terminal", terminal.TerminalId);
+        Assert.Equal("€", terminal.Output);
+        Assert.Equal((uint)0, terminal.ExitCode);
+        Assert.True(terminal.IsReleased);
+        Assert.DoesNotContain(peer.SentMethods, static method => method.StartsWith("terminal/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_RunningRequiresActionAndUnspecifiedIdle_CompleteTheProductTurn()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+
+        peer.Update("""{"sessionUpdate":"state_update","state":"running"}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        Assert.Equal(ChatTurnPhase.WaitingForAgent, (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!.Phase);
+        peer.Update("""{"sessionUpdate":"state_update","state":"requires_action"}""");
+        peer.Update("""{"sessionUpdate":"state_update","state":"idle"}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        Assert.Equal(ChatTurnPhase.Completed, (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!.Phase);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_UserEcho_ReplacesTheOptimisticMessageWithoutDuplication()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        var timestamp = DateTime.UtcNow;
+        await fixture.DispatchAsync(new UpsertTranscriptMessageAction("conv-1",
+            new ConversationMessageSnapshot { Id = "local", IsOutgoing = true, TextContent = "question", ContentType = "text", Timestamp = timestamp }));
+        await fixture.DispatchAsync(new BeginTurnAction("conv-1", "turn", ChatTurnPhase.WaitingForAgent,
+            PendingUserMessageLocalId: "local", PendingUserMessageText: "question"));
+
+        peer.Update("""{"sessionUpdate":"user_message","messageId":"user-1","content":[{"type":"text","text":"question"}]}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var user = Assert.Single((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.Transcript);
+        Assert.Equal("local", user.Id);
+        Assert.Equal("user-1", user.ProtocolMessageId);
+        Assert.Equal(timestamp, user.Timestamp);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_PlanAndBooleanConfiguration_ReachTheProductStore()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+
+        peer.Update("""{"sessionUpdate":"plan_update","plan":{"type":"items","planId":"p","entries":[{"content":"Step","priority":"medium","status":"pending"}]}}""");
+        peer.Update("""{"sessionUpdate":"config_option_update","configOptions":[{"configId":"auto","name":"Automatic","type":"boolean","currentValue":true}]}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var state = await fixture.ChatStore.GetCurrentStateAsync();
+        Assert.Equal("Step", Assert.Single(state.ResolveContentSlice("conv-1")!.Value.PlanEntries).Content);
+        Assert.True(Assert.Single(state.ResolveSessionStateSlice("conv-1")!.Value.ConfigOptions).BooleanValue);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_ConfigurationResponse_LaterNotificationWinsInTheActualProductQueue()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.AfterConfigResponse = () => peer.Update("""{"sessionUpdate":"config_option_update","configOptions":[{"configId":"auto","name":"Automatic","type":"boolean","currentValue":false}]}""");
+
+        var result = await peer.Service.SetSessionConfigOptionAsync(new("remote-1", "auto", true));
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        Assert.True(Assert.Single(result.ConfigOptions!).CurrentBooleanValue);
+        Assert.False(Assert.Single((await fixture.ChatStore.GetCurrentStateAsync()).ResolveSessionStateSlice("conv-1")!.Value.ConfigOptions).BooleanValue);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_CapturedOldConnectionUpdate_CannotAffectReplacementConversation()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        SessionUpdateEventArgs? captured = null;
+        peer.Service.SessionUpdateReceived += (_, update) => captured = update;
+        peer.Update("""{"sessionUpdate":"agent_message","messageId":"old","content":[{"type":"text","text":"old context"}]}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        Assert.NotNull(captured);
+        await peer.DisconnectClientAsync();
+        await AwaitWithSynchronizationContextAsync(dispatcher,
+            fixture.ViewModel.ReplaceChatServiceAsync(stablePeer.Service, TestContext.Current.CancellationToken));
+        await fixture.DispatchAsync(new HydrateConversationAction("conv-1",
+            ImmutableList<ConversationMessageSnapshot>.Empty, ImmutableList<ConversationPlanEntrySnapshot>.Empty, false));
+        peer.Service.PublishBufferedUpdate(captured);
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var transcript = (await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")?.Transcript;
+        Assert.DoesNotContain(transcript ?? ImmutableList<ConversationMessageSnapshot>.Empty,
+            static message => message.TextContent == "old context");
+    }
+
+    private static async Task DrainVersionedUpdatesAsync(ViewModelFixture fixture, QueueingSynchronizationContext dispatcher)
+    {
+        await dispatcher.RunUntilIdleAsync();
+        await AwaitPermissionUiSignalAsync(dispatcher, WaitForPendingSessionUpdatesAsync(fixture.ViewModel));
+        await dispatcher.RunUntilIdleAsync();
+    }
+
+    private sealed class VersionedUpdatePeer : IAcpTransport
+    {
+        private readonly AcpClient _client;
+        internal AcpChatServiceAdapter Service { get; }
+        internal List<string> SentMethods { get; } = [];
+        internal Action? AfterConfigResponse { get; set; }
+        public bool IsConnected { get; private set; } = true;
+        public event EventHandler<AcpTransportMessageReceivedEventArgs>? MessageReceived;
+        public event EventHandler<AcpTransportErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+        private VersionedUpdatePeer()
+        {
+            _client = new AcpClient(this);
+            AcpChatServiceAdapter? adapter = null;
+            var events = new AcpEventAdapter(update => adapter!.PublishBufferedUpdate(update), new ImmediateUiDispatcher());
+            adapter = new AcpChatServiceAdapter(new ChatService(_client, Mock.Of<IErrorLogger>(), Mock.Of<ISessionManager>()), events);
+            Service = adapter;
+            events.ReleaseUnscopedBufferedUpdates(lowTrust: false);
+        }
+
+        internal static async Task<VersionedUpdatePeer> CreateAsync()
+        {
+            var peer = new VersionedUpdatePeer();
+            await peer._client.InitializeDraftAsync(new InitializeParams(new ClientInfo("view-test", "1"), new ClientCapabilities())
+            { ProtocolVersion = AcpProtocolVersion.V2 }, TestContext.Current.CancellationToken);
+            return peer;
+        }
+
+        internal void Update(string update) => Deliver("{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"remote-1\",\"update\":" + update + "}}");
+        internal Task<bool> DisconnectClientAsync() => _client.DisconnectAsync();
+        private void Deliver(string message) => MessageReceived?.Invoke(this, new(message));
+        public Task<bool> ConnectAsync(CancellationToken cancellationToken = default) { IsConnected = true; return Task.FromResult(true); }
+        public Task<bool> DisconnectAsync() { IsConnected = false; return Task.FromResult(true); }
+        public Task<bool> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var document = JsonDocument.Parse(message);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("method", out var method)) return Task.FromResult(true);
+            SentMethods.Add(method.GetString()!);
+            if (method.ValueEquals("initialize"))
+            {
+                var result = JsonSerializer.Serialize(new InitializeResponse(AcpProtocolVersion.V2,
+                    new AgentInfo("view-peer", "1"), new AgentCapabilities()), AcpWireFormat.For(2).TypeInfo<InitializeResponse>());
+                Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + root.GetProperty("id").GetRawText() + ",\"result\":" + result + "}");
+            }
+            else if (method.ValueEquals("session/set_config_option"))
+            {
+                Deliver("{\"jsonrpc\":\"2.0\",\"id\":" + root.GetProperty("id").GetRawText()
+                    + ",\"result\":{\"configOptions\":[{\"configId\":\"auto\",\"name\":\"Automatic\",\"type\":\"boolean\",\"currentValue\":true}]}}");
+                AfterConfigResponse?.Invoke();
+            }
+            return Task.FromResult(true);
+        }
+        public void Dispose() => Service.Dispose();
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.VersionedUpdates.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/ChatViewModelTests.VersionedUpdates.cs
@@ -96,6 +96,8 @@ public partial class ChatViewModelTests
         await DrainVersionedUpdatesAsync(fixture, dispatcher);
         Assert.Equal(ChatTurnPhase.WaitingForAgent, (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!.Phase);
         peer.Update("""{"sessionUpdate":"state_update","state":"requires_action"}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        Assert.Equal(ChatTurnPhase.WaitingForUser, (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!.Phase);
         peer.Update("""{"sessionUpdate":"state_update","state":"idle"}""");
         await DrainVersionedUpdatesAsync(fixture, dispatcher);
 
@@ -158,6 +160,118 @@ public partial class ChatViewModelTests
 
         Assert.True(Assert.Single(result.ConfigOptions!).CurrentBooleanValue);
         Assert.False(Assert.Single((await fixture.ChatStore.GetCurrentStateAsync()).ResolveSessionStateSlice("conv-1")!.Value.ConfigOptions).BooleanValue);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_BackgroundContentAfterIdle_CannotRestartTheFinishedTurn()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.Update("""{"sessionUpdate":"state_update","state":"running"}""");
+        peer.Update("""{"sessionUpdate":"state_update","state":"idle","stopReason":"end_turn"}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        var oldTurn = (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!;
+
+        peer.Update("""{"sessionUpdate":"tool_call_update","toolCallId":"background","status":"completed"}""");
+        peer.Update("""{"sessionUpdate":"agent_message_chunk","messageId":"background-message","content":{"type":"text","text":"background"}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        Assert.Equal(ChatTurnPhase.Completed, (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!.Phase);
+        peer.Update("""{"sessionUpdate":"state_update","state":"running"}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        var newTurn = (await fixture.ChatStore.GetCurrentStateAsync()).ActiveTurn!;
+        Assert.NotEqual(oldTurn.TurnId, newTurn.TurnId);
+        Assert.Equal(ChatTurnPhase.WaitingForAgent, newTurn.Phase);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_UnknownPlanPreservesKnownPlan_EmptyItemsClearsIt()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        peer.Update("""{"sessionUpdate":"plan_update","plan":{"type":"items","planId":"p","entries":[{"content":"Keep","priority":"medium","status":"pending"}]}}""");
+        peer.Update("""{"sessionUpdate":"plan_update","plan":{"type":"_future","planId":"p","custom":"keep raw"}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        Assert.Equal("Keep", Assert.Single((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.PlanEntries).Content);
+
+        peer.Update("""{"sessionUpdate":"plan_update","plan":{"type":"items","planId":"p","entries":[]}}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        Assert.Empty((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")!.Value.PlanEntries);
+    }
+
+    [Fact]
+    public async Task VersionedUpdates_SameRemoteIdOnDifferentProfiles_UsesTheReceivingConnection()
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        await fixture.UpdateStateAsync(state => state with
+        {
+            HydratedConversationId = "other",
+            Bindings = ImmutableDictionary<string, ConversationBindingSlice>.Empty
+                .Add("conv-1", new("conv-1", "remote-1", "profile"))
+                .Add("other", new("other", "remote-1", "different-profile"))
+        });
+
+        peer.Update("""{"sessionUpdate":"agent_message","messageId":"owned","content":[{"type":"text","text":"original profile"}]}""");
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+
+        var state = await fixture.ChatStore.GetCurrentStateAsync();
+        Assert.Equal("original profile", Assert.Single(state.ResolveContentSlice("conv-1")!.Value.Transcript).TextContent);
+        Assert.Empty(state.ResolveContentSlice("other")?.Transcript ?? ImmutableList<ConversationMessageSnapshot>.Empty);
+    }
+
+    [Theory]
+    [InlineData("message")]
+    [InlineData("tool")]
+    public async Task VersionedUpdates_ConnectionChangesDuringProjectionRead_RejectsTheOldCommit(string kind)
+    {
+        var dispatcher = new QueueingSynchronizationContext();
+        await using var fixture = CreateInteractionViewModel(dispatcher);
+        using var stablePeer = await PermissionUiPeer.CreateAsync();
+        using var peer = await VersionedUpdatePeer.CreateAsync();
+        await AttachPermissionPeerAsync(fixture, dispatcher, stablePeer, peer.Service);
+        var readEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var readCount = 0;
+        fixture.ChatStore.ReadState = async () =>
+        {
+            var captured = fixture.ChatStore.LatestState;
+            if (Interlocked.Increment(ref readCount) == 2)
+            {
+                readEntered.TrySetResult();
+                await release.Task.WaitAsync(TestContext.Current.CancellationToken);
+            }
+            return captured;
+        };
+        peer.Update(kind == "message"
+            ? """{"sessionUpdate":"agent_message","messageId":"old","content":[{"type":"text","text":"stale"}]}"""
+            : """{"sessionUpdate":"tool_call_update","toolCallId":"old-tool","title":"stale"}""");
+        await AwaitPermissionUiSignalAsync(dispatcher, readEntered.Task);
+        try
+        {
+            await peer.DisconnectClientAsync();
+            await AwaitWithSynchronizationContextAsync(dispatcher,
+                fixture.ViewModel.ReplaceChatServiceAsync(stablePeer.Service, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        await DrainVersionedUpdatesAsync(fixture, dispatcher);
+        fixture.ChatStore.ReadState = null;
+
+        Assert.Empty((await fixture.ChatStore.GetCurrentStateAsync()).ResolveContentSlice("conv-1")?.Transcript
+            ?? ImmutableList<ConversationMessageSnapshot>.Empty);
     }
 
     [Fact]

--- a/tests/SalmonEgg.Presentation.Core.Tests/Chat/SessionOptions/AcpProtocolExperimentTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Chat/SessionOptions/AcpProtocolExperimentTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Acp.Serialization;
+using SalmonEgg.Application.Services.Acp;
+using SalmonEgg.Presentation.Core.Services.Chat;
+
+namespace SalmonEgg.Presentation.Core.Tests.Chat.SessionOptions;
+
+public sealed class AcpProtocolExperimentTests
+{
+    [Fact]
+    public void DefaultPolicy_OffersOnlyStableProtocol()
+    {
+        var policy = new AcpProtocolExperimentPolicy();
+        var request = AcpInitializeRequestFactory.CreateDefault();
+
+        Assert.Equal(AcpProtocolVersion.V1, policy.OfferedProtocolVersion);
+        Assert.Equal(AcpProtocolVersion.V1, request.ProtocolVersion);
+        Assert.NotNull(request.ClientCapabilities.Session);
+    }
+
+    [Fact]
+    public void ExplicitPolicy_UsesDraftInitializeShapeWithoutLegacyCapabilities()
+    {
+        var policy = new AcpProtocolExperimentPolicy(EnableDraftV2: true);
+        var request = AcpInitializeRequestFactory.CreateDefault(protocolVersion: policy.OfferedProtocolVersion);
+
+        var wire = JsonSerializer.SerializeToElement(request, AcpJsonContext.Default.InitializeParams);
+
+        Assert.Equal(AcpProtocolVersion.V2, request.ProtocolVersion);
+        Assert.True(wire.TryGetProperty("info", out _));
+        Assert.False(wire.TryGetProperty("clientInfo", out _));
+        var capabilities = wire.GetProperty("capabilities");
+        Assert.False(capabilities.TryGetProperty("session", out _));
+        Assert.False(capabilities.TryGetProperty("fs", out _));
+        Assert.False(capabilities.TryGetProperty("terminal", out _));
+    }
+
+    [Fact]
+    public void DraftColdHydration_UsesFullHistoryIntentWithResumeCapability()
+    {
+        var capabilities = new AgentCapabilities
+        {
+            SessionCapabilities = new SessionCapabilities { Resume = new SessionResumeCapabilities() }
+        };
+
+        var draft = AcpSessionRecoveryPolicy.ResolveForHydration(capabilities, AcpProtocolVersion.V2);
+        var stable = AcpSessionRecoveryPolicy.ResolveForHydration(capabilities, AcpProtocolVersion.V1);
+
+        Assert.Equal(AcpSessionRecoveryMode.Load, draft);
+        Assert.True(AcpSessionRecoveryPolicy.ExpectsHistoryReplayForHydration(draft));
+        Assert.Equal(AcpSessionRecoveryMode.None, stable);
+    }
+}

--- a/tests/SalmonEgg.Presentation.Core.Tests/Start/StartViewModelTests.cs
+++ b/tests/SalmonEgg.Presentation.Core.Tests/Start/StartViewModelTests.cs
@@ -2322,7 +2322,7 @@ public sealed class StartViewModelTests
             });
             await using var chat = CreateChatViewModel(syncContext, preferences, Mock.Of<ISessionManager>());
             chat.ViewModel.AcpProfileList.Add(new ServerConfiguration { Id = "profile-1", Name = "Agent One", Transport = TransportType.StreamableHttp, ServerUrl = "https://example.test" });
-            chat.ViewModel.SelectedAcpProfile = chat.ViewModel.AcpProfileList[0];
+            chat.ViewModel.SelectProfileForDefaultProjection(chat.ViewModel.AcpProfileList[0]);
             var chatService = CreateConnectedChatService();
             chatService
                 .Setup(service => service.CreateSessionAsync(It.IsAny<SessionNewParams>()))


### PR DESCRIPTION
## Problem and behavior

ACP V2 sessions previously had wire models without a complete product update path. Explicitly opted-in clients now negotiate V2 and project whole messages, tools, terminal output, work state, plans and configuration through the existing chat state owner. History restoration uses V2 `session/resume(start)`. Stable V1 remains the default for SDK clients and every normal product build.

Version-neutral SDK views let the application consume these updates without suppressing draft API diagnostics. Configuration responses enter the same ordered event path as notifications; waiting observes only drains already scheduled. Projection commits recheck their originating profile and connection after asynchronous reads and on the UI dispatcher, so replaced connections cannot inject late content. `requires_action` displays the existing turn owner's new waiting-for-user phase without inventing an interaction request.

An experiment requires both the explicit SDK allowlist and a V2 initialization offer. Desktop uses `SALMONEGG_EXPERIMENTAL_ACP_V2=1`; WASM requires `-p:SalmonEggExperimentalAcpV2=true`. Default builds carry neither opt-in.

## Validation

- SDK: 1,302 tests passed; real nupkg compatibility, legacy binary consumer, all 46 draft compile-time diagnostics and documented suppression modes passed.
- Product: full Presentation run 3,635 passed before review corrections; 15 focused cases verify corrected cross-scope drains, connection replacement, background updates after idle and plan clearing. The complete current-commit suite will also run in CI.
- Controlled reverse checks reproduced three failures before correction: one wrong drain scope and two stale projection writes.
- A current V1 browser packet containing grouped choices and an unknown option exposed a version-mismatched configuration view. Views now retain their negotiated configuration wire version; all four V1/V2 notification/response combinations preserve unknown raw fields and detached collections. The failing packet now passes, as does the rebuilt complete configuration/form/URL/permission browser flow on the integrated UI branch.
- Rebased integration: both tests against the pinned, unmodified official Rust V2 Agent passed with the public SDK opt-in, real stdio and the actual ChatService (2 passed, 0 skipped).
- A real-browser run through published acpremote 1.9.0 and the unmodified official Agent passed: V2 offer/result, ACK without stop reason, user/Agent message rendering, ending idle, one prompt and input re-enabled. It used the explicitly opted-in Release artifact; the subsequent configuration view correction is separately verified by the complete integrated UI flow. Current-commit CI remains required before merge.

The official example is an independent echo Agent. Installed Codex, Claude, Hermes, Pi and OpenCode currently negotiate V1; no V2 LLM interoperability is claimed. Interactive session configuration UI is delivered in #210.

Refs #149. Protocol references: https://agentclientprotocol.com/protocol/v2/overview, https://agentclientprotocol.com/protocol/v2/prompt-lifecycle .
