### PR TITLE
test(auth): verify real-agent credentials without an ambient login

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -81,6 +81,18 @@ Windows 主机运行：
 
 Linux/macOS 暂不广告终端登录：当前 Porta.Pty 对 Unix 信号退出不能提供可靠的正常退出结果。普通会话终端不受此能力限制影响。SDK 默认能力与远程 WebSocket/HTTP 连接也不会广告 `auth.terminal`。
 
+### 真实 Agent 凭据验收
+
+Linux 已安装 `pi`、`pi-acp`、`gnome-keyring-daemon`、`secret-tool` 和 D-Bus 时，可以运行独立验收。通过受保护的环境注入 `SALMONEGG_REAL_AGENT_SECRET`，不要把密钥写入命令行或配置：
+
+```bash
+python3 scripts/gates/run-acp-isolated-credential-gate.py \
+  --endpoint https://your-provider.example/v1 --model your-model \
+  --artifacts artifacts/isolated-credential-acceptance
+```
+
+门禁创建隔离 Pi 配置、D-Bus 和真实 Linux Secret Service：未注入时必须返回需要认证；经 `ConfigurationManager` 保存并用新实例从系统密钥环读回后，真实 Agent 必须回答本轮消息；清除后重新加载的连接必须拒绝缺失凭据。页面和进程使用测试临时目录，结果记录在 artifacts。此测试需要可用的模型服务，不在没有凭据的普通 CI 中假装执行。
+
 ## 快速开始
 
 ### ACP V2 实验连接

--- a/scripts/gates/run-acp-isolated-credential-gate.py
+++ b/scripts/gates/run-acp-isolated-credential-gate.py
@@ -25,6 +25,36 @@ def stop(process):
     except subprocess.TimeoutExpired:
         os.killpg(process.pid, signal.SIGKILL)
         process.wait(timeout=5)
+    # The process leader may exit before descendants that inherited its process group.
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def run_owned(command, timeout, **kwargs):
+    process = subprocess.Popen(command, start_new_session=True, **kwargs)
+    try:
+        code = process.wait(timeout=timeout)
+        if code:
+            raise subprocess.CalledProcessError(code, command)
+    finally:
+        stop(process)
+
+
+def reap_owned_children():
+    # Linux makes grandchildren ours when a leader dies. This process has no unrelated children.
+    children = Path(f"/proc/{os.getpid()}/task/{os.getpid()}/children")
+    for value in children.read_text().split():
+        try:
+            os.kill(int(value), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    while True:
+        try:
+            os.waitpid(-1, 0)
+        except ChildProcessError:
+            break
 
 
 def run_inside_bus(args):
@@ -75,9 +105,9 @@ def main(args):
     args.artifacts = args.artifacts.resolve()
     args.artifacts.mkdir(parents=True, exist_ok=True)
     with (args.artifacts / "build.log").open("w") as log:
-        subprocess.run([args.dotnet, "build", "tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj",
+        run_owned([args.dotnet, "build", "tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj",
                         "--configuration", "Release", "-m:1", "--disable-build-servers", "-p:UseSharedCompilation=false"],
-                       cwd=args.repo, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=180)
+                       cwd=args.repo, stdout=log, stderr=subprocess.STDOUT, timeout=180)
     # Control sockets must fit sun_path. These are ephemeral files, not the durable evidence.
     with tempfile.TemporaryDirectory(prefix="se-credential-") as temporary:
         root = Path(temporary)
@@ -99,16 +129,9 @@ def main(args):
             SALMONEGG_CREDENTIAL_SANDBOX=str(root), SALMONEGG_ISOLATED_PI_DIR=str(agent), PI_CODING_AGENT_DIR=str(agent),
             XDG_DATA_HOME=str(root / "data"), XDG_RUNTIME_DIR=str(root / "runtime"), XDG_CONFIG_HOME=str(root / "config"),
             DOTNET_PROCESSOR_COUNT="2", DOTNET_CLI_USE_MSBUILD_SERVER="0", MSBUILDDISABLENODEREUSE="1")
-        subprocess.run(["dbus-run-session", "--", sys.executable, str(Path(__file__).resolve()), "--inside-bus",
+        run_owned(["dbus-run-session", "--", sys.executable, str(Path(__file__).resolve()), "--inside-bus",
             "--repo", str(args.repo), "--artifacts", str(args.artifacts), "--dotnet", args.dotnet,
-            "--endpoint", args.endpoint, "--model", args.model, "--api", args.api], env=env, check=True, timeout=190)
-    while True:
-        try:
-            pid, _ = os.waitpid(-1, os.WNOHANG)
-            if not pid:
-                break
-        except ChildProcessError:
-            break
+            "--endpoint", args.endpoint, "--model", args.model, "--api", args.api], env=env, timeout=190)
     (args.artifacts / "acceptance.json").write_text(json.dumps({
         "head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=args.repo, text=True).strip(),
         "workingTree": subprocess.check_output(["git", "status", "--short"], cwd=args.repo, text=True),
@@ -122,6 +145,10 @@ def main(args):
 
 
 if __name__ == "__main__":
+    def interrupt(_signal, _frame):
+        raise KeyboardInterrupt("Isolated credential gate interrupted")
+
+    signal.signal(signal.SIGTERM, interrupt)
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", type=Path, default=Path.cwd())
     parser.add_argument("--artifacts", type=Path, required=True)
@@ -130,4 +157,9 @@ if __name__ == "__main__":
     parser.add_argument("--model", required=True)
     parser.add_argument("--api", choices=["openai-completions", "openai-responses", "anthropic-messages"], default="openai-completions")
     parser.add_argument("--inside-bus", action="store_true", help=argparse.SUPPRESS)
-    main(parser.parse_args())
+    arguments = parser.parse_args()
+    try:
+        main(arguments)
+    finally:
+        if sys.platform == "linux" and not arguments.inside_bus:
+            reap_owned_children()

--- a/scripts/gates/run-acp-isolated-credential-gate.py
+++ b/scripts/gates/run-acp-isolated-credential-gate.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Run opt-in Pi acceptance against an isolated native Secret Service and Agent directory."""
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def stop(process):
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+def run_inside_bus(args):
+    root = Path(os.environ["SALMONEGG_CREDENTIAL_SANDBOX"])
+    keyring = subprocess.Popen(["gnome-keyring-daemon", "--foreground", "--unlock", "--components=secrets",
+        "--control-directory=" + str(root / "keyring-control")], stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    keyring.stdin.write(b"ephemeral-acceptance-keyring\n")
+    keyring.stdin.close()
+    try:
+        deadline = time.monotonic() + 10
+        while True:
+            owner = subprocess.check_output(["dbus-send", "--session", "--print-reply", "--dest=org.freedesktop.DBus",
+                "/org/freedesktop/DBus", "org.freedesktop.DBus.NameHasOwner", "string:org.freedesktop.secrets"], text=True, timeout=5)
+            if "boolean true" in owner:
+                break
+            assert keyring.poll() is None, "The isolated keyring exited"
+            if time.monotonic() >= deadline:
+                raise TimeoutError("The isolated Secret Service did not start")
+            time.sleep(0.05)
+        with (args.artifacts / "client.log").open("w") as log:
+            test = subprocess.Popen([args.dotnet, "test", "--project",
+                "tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj", "--configuration", "Release",
+                "--no-build", "--no-restore", "--no-ansi", "--filter-class",
+                "SalmonEgg.Acp.Desktop.Tests.IsolatedCredentialAcceptanceTests", "--minimum-expected-tests", "1", "--output", "Detailed"],
+                cwd=args.repo, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+            try:
+                code = test.wait(timeout=155)
+            finally:
+                stop(test)
+        assert code == 0, "The real Agent/keyring test failed; inspect client.log"
+        result = (args.artifacts / "client.log").read_text()
+        assert "succeeded: 1" in result and "skipped: 0" in result, "The acceptance test did not execute"
+    finally:
+        stop(keyring)
+
+
+def main(args):
+    if args.inside_bus:
+        run_inside_bus(args)
+        return
+    assert sys.platform == "linux", "This gate requires the real Linux Secret Service"
+    for command in ["pi-acp", "pi", "gnome-keyring-daemon", "secret-tool", "dbus-run-session", "dbus-send"]:
+        assert shutil.which(command), "Missing prerequisite: " + command
+    secret = os.environ.get("SALMONEGG_REAL_AGENT_SECRET")
+    assert secret, "Supply SALMONEGG_REAL_AGENT_SECRET through a secure environment"
+    assert ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) == 0
+    args.artifacts = args.artifacts.resolve()
+    args.artifacts.mkdir(parents=True, exist_ok=True)
+    with (args.artifacts / "build.log").open("w") as log:
+        subprocess.run([args.dotnet, "build", "tests/SalmonEgg.Acp.Desktop.Tests/SalmonEgg.Acp.Desktop.Tests.csproj",
+                        "--configuration", "Release", "-m:1", "--disable-build-servers", "-p:UseSharedCompilation=false"],
+                       cwd=args.repo, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=180)
+    # Control sockets must fit sun_path. These are ephemeral files, not the durable evidence.
+    with tempfile.TemporaryDirectory(prefix="se-credential-") as temporary:
+        root = Path(temporary)
+        agent = root / "pi-agent"
+        agent.mkdir()
+        model = {"id": args.model, "reasoning": False, "input": ["text"], "contextWindow": 32768, "maxTokens": 512}
+        provider = {"baseUrl": args.endpoint, "api": args.api, "apiKey": "$SALMONEGG_PI_ACCEPTANCE_KEY", "models": [model]}
+        (agent / "models.json").write_text(json.dumps({"providers": {"salmon-acceptance": provider}}))
+        (agent / "settings.json").write_text(json.dumps({"defaultProvider": "salmon-acceptance", "defaultModel": args.model,
+            "defaultThinkingLevel": "off", "quietStartup": True, "defaultProjectTrust": "never",
+            "enableAnalytics": False, "enableInstallTelemetry": False}))
+        for name in ["data", "runtime", "config", "keyring-control"]:
+            (root / name).mkdir(mode=0o700)
+        env = dict(os.environ)
+        for name in list(env):
+            if name.endswith(("_API_KEY", "_AUTH_TOKEN", "_ACCESS_TOKEN")) or name == "SALMONEGG_PI_ACCEPTANCE_KEY":
+                env.pop(name)
+        env.update(SALMONEGG_REAL_AGENT_SECRET=secret, SALMONEGG_REAL_AGENT_COMMAND=shutil.which("pi-acp"),
+            SALMONEGG_CREDENTIAL_SANDBOX=str(root), SALMONEGG_ISOLATED_PI_DIR=str(agent), PI_CODING_AGENT_DIR=str(agent),
+            XDG_DATA_HOME=str(root / "data"), XDG_RUNTIME_DIR=str(root / "runtime"), XDG_CONFIG_HOME=str(root / "config"),
+            DOTNET_PROCESSOR_COUNT="2", DOTNET_CLI_USE_MSBUILD_SERVER="0", MSBUILDDISABLENODEREUSE="1")
+        subprocess.run(["dbus-run-session", "--", sys.executable, str(Path(__file__).resolve()), "--inside-bus",
+            "--repo", str(args.repo), "--artifacts", str(args.artifacts), "--dotnet", args.dotnet,
+            "--endpoint", args.endpoint, "--model", args.model, "--api", args.api], env=env, check=True, timeout=190)
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+            if not pid:
+                break
+        except ChildProcessError:
+            break
+    (args.artifacts / "acceptance.json").write_text(json.dumps({
+        "head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=args.repo, text=True).strip(),
+        "workingTree": subprocess.check_output(["git", "status", "--short"], cwd=args.repo, text=True),
+        "piVersion": subprocess.check_output(["pi", "--version"], text=True, timeout=10).strip(),
+        "adapter": shutil.which("pi-acp"), "model": args.model,
+        "testSourceSha256": hashlib.sha256((args.repo / "tests/SalmonEgg.Acp.Desktop.Tests/IsolatedCredentialAcceptanceTests.cs").read_bytes()).hexdigest(),
+        "requiresAuthWithoutKey": True, "nativeKeyringReload": True,
+        "realPrompt": True, "clearRejectsReconnect": True,
+    }, indent=2) + "\n")
+    print("Real Pi acceptance passed: auth required, native keyring reload, bound prompt, cleared credential refusal")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--artifacts", type=Path, required=True)
+    parser.add_argument("--dotnet", default="dotnet")
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--api", choices=["openai-completions", "openai-responses", "anthropic-messages"], default="openai-completions")
+    parser.add_argument("--inside-bus", action="store_true", help=argparse.SUPPRESS)
+    main(parser.parse_args())

--- a/scripts/gates/run-acp-isolated-credential-gate.py
+++ b/scripts/gates/run-acp-isolated-credential-gate.py
@@ -45,16 +45,23 @@ def run_owned(command, timeout, **kwargs):
 def reap_owned_children():
     # Linux makes grandchildren ours when a leader dies. This process has no unrelated children.
     children = Path(f"/proc/{os.getpid()}/task/{os.getpid()}/children")
-    for value in children.read_text().split():
-        try:
-            os.kill(int(value), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-    while True:
-        try:
-            os.waitpid(-1, 0)
-        except ChildProcessError:
-            break
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        for value in children.read_text().split():
+            try:
+                os.kill(int(value), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        while True:
+            try:
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                if not pid:
+                    break
+            except ChildProcessError:
+                return
+        # A killed parent can make its independent-session descendants newly adoptable.
+        time.sleep(0.02)
+    raise RuntimeError("Owned credential processes did not exit within the cleanup deadline")
 
 
 def run_inside_bus(args):

--- a/tests/SalmonEgg.Acp.Desktop.Tests/IsolatedCredentialAcceptanceTests.cs
+++ b/tests/SalmonEgg.Acp.Desktop.Tests/IsolatedCredentialAcceptanceTests.cs
@@ -1,0 +1,123 @@
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using SalmonEgg.Acp.Client;
+using SalmonEgg.Acp.Content;
+using SalmonEgg.Acp.JsonRpc;
+using SalmonEgg.Acp.Protocol;
+using SalmonEgg.Domain.Models;
+using SalmonEgg.Domain.Services;
+using SalmonEgg.Infrastructure.Client;
+using SalmonEgg.Infrastructure.Services;
+using SalmonEgg.Infrastructure.Storage;
+using SalmonEgg.Infrastructure.Transport;
+using Serilog;
+using Xunit;
+
+namespace SalmonEgg.Acp.Desktop.Tests;
+
+public sealed class IsolatedCredentialAcceptanceTests
+{
+    [Fact]
+    public async Task PiAgent_WithoutAmbientLogin_RequiresAndConsumesTheBoundSecret()
+    {
+        // Arrange: an isolated Pi directory contains only non-secret provider configuration.
+        var secret = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_SECRET");
+        var agentDirectory = Environment.GetEnvironmentVariable("SALMONEGG_ISOLATED_PI_DIR");
+        var command = Environment.GetEnvironmentVariable("SALMONEGG_REAL_AGENT_COMMAND");
+        Assert.SkipWhen(!OperatingSystem.IsLinux() || string.IsNullOrWhiteSpace(secret)
+            || string.IsNullOrWhiteSpace(agentDirectory) || string.IsNullOrWhiteSpace(command),
+            "Run the isolated Pi/Secret Service acceptance wrapper on Linux.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(120));
+        var token = timeout.Token;
+        var directory = Path.Combine(Path.GetTempPath(), "salmon-egg-isolated-credential-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var storage = new LinuxSecretServiceSecureStorage();
+        var paths = new ProbePaths(directory);
+        var manager = new ConfigurationManager(storage, new FileSystemAppFileStore(), paths, NullLogger<ConfigurationManager>.Instance);
+        var factory = new TransportFactory(Log.Logger, new TransportSupportPolicy(new PlatformCapabilityService()), new DesktopStdioTransportFactory());
+        var profile = new ServerConfiguration
+        {
+            Id = "isolated-credential-" + Guid.NewGuid().ToString("N"),
+            Name = "Isolated real Pi acceptance",
+            Transport = TransportType.Stdio,
+            StdioCommand = command!,
+            StdioEnvironment = new(StringComparer.Ordinal) { ["PI_CODING_AGENT_DIR"] = agentDirectory! }
+        };
+        try
+        {
+            using (var unauthenticatedTransport = factory.CreateTransport(profile))
+            using (var unauthenticated = new AcpClient(new DomainAcpTransportAdapter(unauthenticatedTransport)))
+            {
+                await unauthenticated.InitializeAsync(Initialize(), token);
+                var failure = await Assert.ThrowsAsync<AcpException>(
+                    () => unauthenticated.CreateSessionAsync(new SessionNewParams(directory, []), token));
+                Assert.Equal(JsonRpcErrorCode.AuthenticationRequired, failure.ErrorCode);
+                Assert.True(await unauthenticated.DisconnectAsync());
+            }
+
+            // Act: use the production OS keyring and reload through a new persistence owner.
+            profile.Authentication = new AuthenticationConfig { ApiKey = secret };
+            profile.CredentialBinding = CredentialBindingPolicy.Create(profile, CredentialSource.ApiKey,
+                CredentialTarget.Environment, "SALMONEGG_PI_ACCEPTANCE_KEY");
+            await manager.SaveConfigurationAsync(profile);
+            manager = new ConfigurationManager(new LinuxSecretServiceSecureStorage(), new FileSystemAppFileStore(), paths,
+                NullLogger<ConfigurationManager>.Instance);
+            var reloaded = await manager.LoadConfigurationAsync(profile.Id);
+            Assert.NotNull(reloaded);
+            Assert.True(reloaded.Authentication?.ApiKey == secret, "The native keyring must restore the exact credential.");
+            using (var transport = factory.CreateTransport(reloaded))
+            using (var client = new AcpClient(new DomainAcpTransportAdapter(transport)))
+            {
+                var text = new StringBuilder();
+                client.SessionUpdateReceived += (_, update) =>
+                {
+                    if (update.Update is AgentMessageUpdate { Content: TextContentBlock content })
+                        lock (text) text.Append(content.Text);
+                };
+                await client.InitializeAsync(Initialize(), token);
+                var session = await client.CreateSessionAsync(new SessionNewParams(directory, []), token);
+                var marker = "ISOLATED_CREDENTIAL_" + Guid.NewGuid().ToString("N");
+                var response = await client.SendPromptAsync(new SessionPromptParams(session.SessionId,
+                    [new TextContentBlock("Do not use tools, inspect files or modify anything. Reply with exactly: " + marker)]), token);
+                Assert.Equal(StopReason.EndTurn, response.StopReason);
+                lock (text) Assert.True(text.ToString().Contains(marker, StringComparison.Ordinal), "The real Agent must answer this request.");
+                Assert.True(await client.DisconnectAsync());
+            }
+
+            // Assert: clearing survives reload and cannot reuse an ambient credential.
+            reloaded.Authentication = null;
+            await manager.SaveConfigurationAsync(reloaded);
+            var cleared = await manager.LoadConfigurationAsync(profile.Id);
+            Assert.NotNull(cleared);
+            Assert.Throws<InvalidOperationException>(() => factory.CreateTransport(cleared));
+            foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                Assert.False((await File.ReadAllTextAsync(file, token)).Contains(secret!, StringComparison.Ordinal),
+                    "The credential must not enter plaintext product files.");
+            }
+        }
+        finally
+        {
+            var saved = await manager.LoadConfigurationAsync(profile.Id);
+            if (saved is not null)
+            {
+                saved.Authentication = null;
+                await manager.SaveConfigurationAsync(saved);
+            }
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static InitializeParams Initialize()
+        => new(new ClientInfo("salmon-egg-isolated-credential-acceptance", "1"), new ClientCapabilities());
+
+    private sealed class ProbePaths(string root) : IAppDataService
+    {
+        public string AppDataRootPath => root;
+        public string ConfigRootPath => Path.Combine(root, "config");
+        public string LogsDirectoryPath => Path.Combine(root, "logs");
+        public string CacheRootPath => Path.Combine(root, "cache");
+        public string ExportsDirectoryPath => Path.Combine(root, "exports");
+    }
+}


### PR DESCRIPTION
The previous real-Agent credential smoke allowed an existing Agent login and used volatile storage. This opt-in gate proves the missing boundary with an installed Pi ACP adapter and the production Linux Secret Service: an isolated Agent configuration first returns `AuthenticationRequired`, then a credential saved by `ConfigurationManager` and reloaded by a new manager allows a real model reply. Clearing and reloading the same profile makes the transport factory refuse reconnection.

The wrapper owns an isolated D-Bus/keyring session, passes the secret only through a protected environment, leaves the user's Agent login untouched, checks plaintext product files for the credential, and cleans its processes and temporary data. It records the commit, model, adapter path and test source hash. The model endpoint/key are explicit prerequisites; ordinary CI without those prerequisites does not pretend to run this external acceptance.

Validation: Release build has 0 warnings and 0 errors. Real Pi 0.84.1 with pi-acp 0.0.33 and deepseek-v4-flash passed the complete test (1 passed, 0 skipped), including the native keyring reload. Both the initial bounded harness and the committed wrapper were executed; a cleanup revision-conflict probe was corrected to reload the current profile before clearing it. No product logic is changed.

Refs #144. Existing transport canary and profile tests remain the deterministic CI coverage.
